### PR TITLE
Add basic CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+- package-ecosystem: "gomod"
+  directory: "/"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,28 @@
+# Runs "go vet" and "go test -short".
+# TODO: Might want to skip this stage in case Go files aren't modified.
+on: [ push, pull_request ]
+name: Test
+jobs:
+  unit_tests:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: '50'
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17.x
+    - uses: actions/cache@v2
+      with:
+        path: |
+          ~/go/pkg/mod      # Module download cache
+          ~/.cache/go-build # Build cache (Linux)
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Vet
+      run: go vet ./...
+    - name: Test
+      run: go test -v -short ./...

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Charon is built in [GoLang](https://golang.org/dl/), with [Cobra](https://cobra.
 - [ ] Weak Subjectivity Working for faster syncs
 - [ ] Nginx pass through proxy server
 - [x] GoLang Process
-- [ ] CI/CD to build and test GoLang process
+- [x] CI/CD to build and test GoLang process
 - [ ] Dockerised GoLang Process
 - [ ] GoLang process operating as a passthrough HTTP server
 - [ ] GoLang pass through proxy server

--- a/services/controller/service.go
+++ b/services/controller/service.go
@@ -78,7 +78,7 @@ func (s *Service) Start() {
 		for i := 10; i > 0; i-- {
 			<-sigc
 			if i > 1 {
-				log.Info().Msgf("Already shutting down, interrupt %f more times to panic", i)
+				log.Info().Msgf("Already shutting down, interrupt %d more times to panic", i)
 			}
 		}
 		panic("Panic closing the Charon client")


### PR DESCRIPTION
- Adds dependabot
- Adds `go vet`, a basic linter for obvious mistakes
- Adds `go test -short`, which executes all unit test except those that skip on `!t.Short()`
- Fixes a minor bug flagged by `go vet`