### PR TITLE
add Dockerfile

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+on: [push]
+name: Build
+jobs:
+  buildx:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
+    # TODO: Activate this to allow pushing Docker images.
+    #- name: Login to GitHub Container Registry
+    #  uses: docker/login-action@v1
+    #  with:
+    #    registry: ghcr.io
+    #    username: terorie
+    #    password: ${{ secrets.CR_PAT }}
+
+    - name: Build Docker image # and push
+      uses: docker/build-push-action@v2
+      with:
+        # TODO: Enable this to push builds for the master branch.
+        # push: ${{ github.ref == 'refs/heads/master' }}
+        push: false
+        tags: ghcr.io/od2/hive:latest
+        # Sync Docker buildx caches with GitHub Actions.
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Image digest
+      run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,21 @@
-FROM nginx
-COPY nginx/nginx.conf /etc/nginx/nginx.conf
+#syntax=docker/dockerfile:1.2
+
+# Container for building Go binary.
+FROM golang:1.17-alpine AS builder
+# Cgo support
+RUN apk add --no-cache build-base
+# Copy app.
+WORKDIR /app
+COPY . .
+# Build with Go module and Go build caches.
+RUN \
+   --mount=type=cache,target=/go/pkg \
+   --mount=type=cache,target=/root/.cache/go-build \
+   go build -o charon ./cmd
+
+# Copy final binary into light stage.
+FROM alpine:3
+COPY --from=builder /app/charon /usr/local/bin/
+CMD ["/usr/local/bin/charon"]
+# Used by GitHub to associate container with repo.
+LABEL org.opencontainers.image.source="https://github.com/ObolNetwork/charon"


### PR DESCRIPTION
- Adds an Alpine-based Dockerfile shipping the Charon Go binary
- Image pushing to GitHub Container Registry commented out for now
- Removes the existing NGINX Dockerfile – Not sure what the purpose of it was. It's possible to run this NGINX config entirely in `docker-compose` without having to build it beforehand 🤔  