### PR TITLE
api/server: refactor for runner

### DIFF
--- a/api/server/handler.go
+++ b/api/server/handler.go
@@ -33,7 +33,7 @@ type Handler struct {
 	api.UnimplementedControlPlaneServer
 }
 
-func (h *Handler) GetSelf(_ context.Context, _ *api.GetSelfRequest) (*api.GetSelfResponse, error) {
+func (h Handler) GetSelf(_ context.Context, _ *api.GetSelfRequest) (*api.GetSelfResponse, error) {
 	r := &api.GetSelfResponse{
 		Peer: &api.Peer{
 			PeerId:  h.PeerDB.Local.ID().String(),

--- a/identity/p2p.go
+++ b/identity/p2p.go
@@ -26,6 +26,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+// TODO(corver): Refactor this to just functions (not OO) like Create, Load, LoadOrCreate, remove Must.
+
 // P2PStore stores the P2P identity key.
 type P2PStore struct {
 	KeyPath string

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -33,6 +33,7 @@ type Node struct {
 }
 
 // NewNode starts the libp2p subsystem.
+// TODO(corver): Remove pointer to config.
 func NewNode(cfg *Config, key *ecdsa.PrivateKey, connGater *ConnGater) (*Node, error) {
 	if key == nil {
 		return nil, fmt.Errorf("missing private key")


### PR DESCRIPTION
Preparing for new `runner` pacakge as per https://obol.atlassian.net/browse/OBOL-188.

Refactor the `api/server` package so that life-cycle can be managed by the `runner`. 

Also added a few `TODOs`  and small fixes. 