### PR TITLE
runner: add initial metrics

### DIFF
--- a/runner/metrics.go
+++ b/runner/metrics.go
@@ -1,0 +1,20 @@
+package runner
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	versionGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "runner",
+		Name:      "version",
+		Help:      "Constant gauge with label set to current version",
+	}, []string{"version"})
+
+	startGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "runner",
+		Name:      "start_time_secs",
+		Help:      "Gauge set to the start time of the binary in unix seconds",
+	})
+)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -4,15 +4,17 @@ package runner
 import (
 	"context"
 	"fmt"
+	"path"
+	"time"
+
+	zerologger "github.com/rs/zerolog/log"
+
 	"github.com/obolnetwork/charon/api/server"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/discovery"
 	"github.com/obolnetwork/charon/identity"
 	"github.com/obolnetwork/charon/internal"
 	"github.com/obolnetwork/charon/p2p"
-	zerologger "github.com/rs/zerolog/log"
-	"path"
-	"time"
 )
 
 // log is a convenience handle to the global logger.
@@ -36,6 +38,8 @@ func Run(shutdownCtx context.Context, conf Config) error {
 	nodekey := path.Join(conf.DataDir, nodekeyFile)
 
 	log.Info().Str("version", internal.ReleaseVersion).Msg("Charon starting")
+	versionGauge.WithLabelValues(internal.ReleaseVersion).Set(1)
+	startGauge.SetToCurrentTime()
 
 	// Construct processes and their dependencies
 


### PR DESCRIPTION
As per https://obol.atlassian.net/browse/OBOL-149, adding some basic app-level metrics to the `runner` package.  