### PR TITLE
Fix errorlint linter issues (#65)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,7 +43,6 @@ linters:
   enable-all: true
   disable:
     # Enable these and fix the issues
-    - errorlint
     - forbidigo
     - forcetypeassert
     - gci

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -16,6 +16,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -73,7 +74,8 @@ func initializeConfig(cmd *cobra.Command) error {
 	// if we cannot parse the config file.
 	if err := v.ReadInConfig(); err != nil {
 		// It's okay if there isn't a config file
-		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+		var cfgError viper.ConfigFileNotFoundError
+		if ok := errors.As(err, &cfgError); !ok {
 			return err
 		}
 	}

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -37,7 +37,8 @@ func TestCmdFlags(t *testing.T) {
 			Name:          "version verbose",
 			Args:          slice("version", "--verbose"),
 			VersionConfig: &versionConfig{Verbose: true},
-		}, {
+		},
+		{
 			Name:          "version no verbose",
 			Args:          slice("version", "--verbose=false"),
 			VersionConfig: &versionConfig{Verbose: false},


### PR DESCRIPTION
- Fix issues related to errorlint
- errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13.