### PR TITLE
Fix ineffassign, nlreturn and revive linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,9 +49,6 @@ linters:
     - gochecknoinits # Once config refactor is done.
     - godot
     - gosec
-    - ineffassign
-    - nlreturn
-    - revive
     - stylecheck
     - testpackage # rename internal test files to *_internal_test.go
     - thelper

--- a/api/server/handler.go
+++ b/api/server/handler.go
@@ -44,5 +44,6 @@ func (h Handler) GetSelf(_ context.Context, _ *api.GetSelfRequest) (*api.GetSelf
 		StartTime: timestamppb.New(config.StartTime),
 		PeerCount: uint32(len(h.Node.Network().Peers())),
 	}
+
 	return r, nil
 }

--- a/appctx/appctx.go
+++ b/appctx/appctx.go
@@ -26,9 +26,11 @@ func InterruptContext(ctx context.Context) context.Context {
 	ctx, cancel := context.WithCancel(ctx)
 	signals := make(chan os.Signal, 1)
 	signal.Notify(signals, os.Interrupt)
+
 	go func() {
 		defer cancel()
 		<-signals
 	}()
+
 	return ctx
 }

--- a/cluster/manifest.go
+++ b/cluster/manifest.go
@@ -51,6 +51,7 @@ func (m *Manifest) Pubkey() kyber.Point {
 // ParsedENRs returns the decoded list of ENRs in a manifest.
 func (m *Manifest) ParsedENRs() ([]enr.Record, error) {
 	records := make([]enr.Record, len(m.ENRs))
+
 	for i, enrStr := range m.ENRs {
 		record, err := DecodeENR(enrStr)
 		if err != nil {
@@ -58,6 +59,7 @@ func (m *Manifest) ParsedENRs() ([]enr.Record, error) {
 		}
 		records[i] = *record
 	}
+
 	return records, nil
 }
 
@@ -70,6 +72,7 @@ func (m *Manifest) PeerIDs() ([]peer.ID, error) {
 		return nil, err
 	}
 	ids := make([]peer.ID, len(records))
+
 	for i, record := range records {
 		var err error
 		ids[i], err = PeerIDFromENR(&record)
@@ -77,6 +80,7 @@ func (m *Manifest) PeerIDs() ([]peer.ID, error) {
 			return nil, err
 		}
 	}
+
 	return ids, nil
 }
 
@@ -88,6 +92,7 @@ func PeerIDFromENR(record *enr.Record) (peer.ID, error) {
 		zerologger.Warn().Err(err).
 			Str("enr", recordStr).
 			Msg("ENR missing secp256k1 field")
+
 		return "", err
 	}
 	p2pPubkey := libp2pcrypto.Secp256k1PublicKey(pubkey)
@@ -97,8 +102,10 @@ func PeerIDFromENR(record *enr.Record) (peer.ID, error) {
 		zerologger.Warn().Err(err).
 			Str("enr", recordStr).
 			Msg("Failed to derive libp2p ID")
+
 		return "", err
 	}
+
 	return p2pID, nil
 }
 
@@ -107,6 +114,7 @@ func EncodeENR(record *enr.Record) (string, error) {
 	if err := record.EncodeRLP(&buf); err != nil {
 		return "", err
 	}
+
 	return "enr:" + base64.URLEncoding.EncodeToString(buf.Bytes()), nil
 }
 
@@ -125,6 +133,7 @@ func DecodeENR(enrStr string) (*enr.Record, error) {
 	if rd.Len() > 0 {
 		return nil, fmt.Errorf("leftover garbage bytes in ENR")
 	}
+
 	return &record, nil
 }
 
@@ -160,6 +169,7 @@ func LoadKnownClustersFromDir(dir string) (KnownClusters, error) {
 		pubkeyHex := crypto.BLSPointToHex(cluster.Pubkey())
 		known.clusters[pubkeyHex] = cluster
 	}
+
 	return known, nil
 }
 
@@ -183,5 +193,6 @@ func LoadManifest(filePath string) (*Manifest, error) {
 	}
 	c := new(Manifest)
 	err = json.Unmarshal(buf, c)
+
 	return c, err
 }

--- a/cluster/manifest_test.go
+++ b/cluster/manifest_test.go
@@ -83,6 +83,7 @@ func newRandomENR(t *testing.T) (res string) {
 	require.NoError(t, err)
 	res, err = EncodeENR(&r)
 	require.NoError(t, err)
+
 	return
 }
 
@@ -92,6 +93,7 @@ func newRandomIP() net.IP {
 	if err != nil {
 		panic(err.Error())
 	}
+
 	return buf
 }
 

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -119,6 +119,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 			if err != nil {
 				lastErr = err
 			}
+
 			break
 		}
 	})

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -88,11 +88,13 @@ func TestCmdFlags(t *testing.T) {
 				newBootstrapCmd(func(_ io.Writer, config bootstrapConfig) error {
 					require.NotNil(t, test.BootstrapConfig)
 					require.Equal(t, *test.BootstrapConfig, config)
+
 					return nil
 				}),
 				newRunCmd(func(_ context.Context, config runner.Config) error {
 					require.NotNil(t, test.RunnerConfig)
 					require.Equal(t, *test.RunnerConfig, config)
+
 					return nil
 				}),
 			)

--- a/cmd/new_bootstrap.go
+++ b/cmd/new_bootstrap.go
@@ -119,9 +119,9 @@ func runBootstrapCmd(w io.Writer, config bootstrapConfig) error {
 func getPassword(config bootstrapConfig) (string, error) {
 	if config.PasswordFile != "" {
 		return crypto.ReadPlaintextPassword(config.PasswordFile)
-	} else {
-		return promptPassword()
 	}
+
+	return promptPassword()
 }
 
 func promptPassword() (string, error) {
@@ -172,5 +172,6 @@ func saveKeys(scheme *crypto.TBLSScheme, priShares []*share.PriShare, pubkeyHex 
 			return err
 		}
 	}
+
 	return nil
 }

--- a/cmd/new_version.go
+++ b/cmd/new_version.go
@@ -42,6 +42,7 @@ func newVersionCmd(runFunc func(io.Writer, versionConfig)) *cobra.Command {
 		},
 	}
 	bindVersionFlags(cmd.Flags(), &conf)
+
 	return cmd
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,7 +20,7 @@ import (
 	zerologger "github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	_ "go.uber.org/automaxprocs"
+	_ "go.uber.org/automaxprocs" // Automatically sets GOMAXPROCS to match Linux container CPU quota.
 
 	"github.com/obolnetwork/charon/internal/config"
 )
@@ -62,6 +62,7 @@ func preRunRoot(c *cobra.Command, _ []string) error {
 		return err
 	}
 	zerolog.SetGlobalLevel(lvl)
+
 	return err
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -104,6 +104,7 @@ func runCharon(_ *cobra.Command, _ []string) {
 				Handler: handler,
 				Log:     log.With().Str("component", "api").Logger(),
 			})
+
 			return err
 		})
 	}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -35,5 +35,6 @@ func DerivePubkey(secret kyber.Scalar) *bls12381.KyberG1 {
 func NewKeyPair() (secret kyber.Scalar, pubkey *bls12381.KyberG1) {
 	secret = BLSPairing.G1().Scalar().Pick(BLSPairing.RandomStream())
 	pubkey = DerivePubkey(secret)
+
 	return
 }

--- a/crypto/encoding.go
+++ b/crypto/encoding.go
@@ -49,6 +49,7 @@ func BLSPointFromHex(hexStr string) (kyber.Point, error) {
 	if err := p.UnmarshalBinary(b); err != nil {
 		return nil, err
 	}
+
 	return p, nil
 }
 
@@ -60,6 +61,7 @@ func MustBLSPointFromHex(hexStr string) kyber.Point {
 	if err != nil {
 		panic("invalid BLS point \"" + hexStr + "\": " + err.Error())
 	}
+
 	return point
 }
 
@@ -82,6 +84,7 @@ func (p *BLSPubkeyHex) UnmarshalText(b []byte) error {
 		return fmt.Errorf("expected %d bytes, got %d", expectedLen, n)
 	}
 	p.KyberG1 = bls.NullKyberG1()
+
 	return p.UnmarshalBinary(data)
 }
 
@@ -93,5 +96,6 @@ func (p BLSPubkeyHex) MarshalText() ([]byte, error) {
 	}
 	data := make([]byte, hex.EncodedLen(len(raw)))
 	hex.Encode(data, raw)
+
 	return data, nil
 }

--- a/crypto/keystore.go
+++ b/crypto/keystore.go
@@ -45,6 +45,7 @@ type Keystore struct {
 func NewBLSKeystore(password string) (*Keystore, kyber.Scalar, kyber.Point, error) {
 	privKey, pubKey := bls.NewSchemeOnG1(BLSPairing).NewKeyPair(BLSPairing.RandomStream())
 	k, err := BLSKeyPairToKeystore(privKey, pubKey, password)
+
 	return k, privKey, pubKey, err
 }
 
@@ -64,6 +65,7 @@ func BLSKeyPairToKeystore(scalar kyber.Scalar, pubkey kyber.Point, password stri
 	if err != nil {
 		return nil, fmt.Errorf("failed to encrypt key")
 	}
+
 	return &Keystore{
 		Crypto:  cryptoFields,
 		UUID:    id.String(),
@@ -88,6 +90,7 @@ func TBLSShareToKeystore(scheme *TBLSScheme, priPoly *share.PriShare, password s
 	}
 	keyStore.Description = fmt.Sprintf("Obol Eth2 validator %s i=%d t=%d",
 		pubkeyHex, priPoly.I, scheme.Threshold())
+
 	return keyStore, nil
 }
 
@@ -117,6 +120,7 @@ func (k *Keystore) BLSKeyPair(password string) (kyber.Scalar, kyber.Point, error
 	if !givenPubkey.Equal(derivedPubkey) {
 		return nil, nil, fmt.Errorf("public key mismatch: expected %v, actual %v", givenPubkey, derivedPubkey)
 	}
+
 	return secret, derivedPubkey, nil
 }
 
@@ -136,6 +140,7 @@ func ReadPlaintextPassword(filePath string) (string, error) {
 	if len(password) >= maxPasswordLen {
 		return "", fmt.Errorf("password very long, aborting")
 	}
+
 	return password, nil
 }
 
@@ -155,6 +160,7 @@ func WritePlaintextPassword(filePath string, overwrite bool, password string) er
 	}
 	defer f.Close()
 	_, _ = f.WriteString(password)
+
 	return nil
 }
 
@@ -172,6 +178,7 @@ func (k *Keystore) Save(filePath string) error {
 	if err1 := f.Close(); err1 != nil && err == nil {
 		err = err1
 	}
+
 	return err
 }
 
@@ -185,5 +192,6 @@ func LoadKeystore(filePath string) (*Keystore, error) {
 	if err := json.Unmarshal(data, k); err != nil {
 		return nil, err
 	}
+
 	return k, nil
 }

--- a/crypto/tbls.go
+++ b/crypto/tbls.go
@@ -46,6 +46,7 @@ func (t *TBLSScheme) UnmarshalJSON(data []byte) error {
 		return fmt.Errorf("failed to decode TBLS scheme: %w", err)
 	}
 	*t = *decoded
+
 	return nil
 }
 
@@ -55,6 +56,7 @@ func (t *TBLSScheme) MarshalJSON() ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to encode TBLS scheme: %w", err)
 	}
+
 	return json.Marshal(encoded)
 }
 
@@ -71,6 +73,7 @@ func (t *TBLSScheme) Encode() (TBLSSchemeEncoded, error) {
 	for i, c := range commits {
 		enc[i] = BLSPubkeyHex{c.(*bls.KyberG1)}
 	}
+
 	return enc, nil
 }
 
@@ -81,6 +84,7 @@ func (t TBLSSchemeEncoded) Decode() (*TBLSScheme, error) {
 		points[i] = commit.KyberG1
 	}
 	pubPoly := share.NewPubPoly(BLSKeyGroup, BLSKeyGroup.Point().Base(), points)
+
 	return &TBLSScheme{pubPoly}, nil
 }
 
@@ -91,5 +95,6 @@ func NewTBLSPoly(t uint) (pri *share.PriPoly, pub *share.PubPoly) {
 	secret := BLSKeyGroup.Scalar().Pick(stream)
 	pri = share.NewPriPoly(BLSKeyGroup, int(t), secret, stream)
 	pub = pri.Commit(BLSKeyGroup.Point().Base())
+
 	return
 }

--- a/identity/consensus.go
+++ b/identity/consensus.go
@@ -58,6 +58,7 @@ func (s ConsensusStore) Password() (password string, err error) {
 	if errors.Is(err, os.ErrNotExist) {
 		return s.createNewPassword()
 	}
+
 	return
 }
 
@@ -78,6 +79,7 @@ func (s ConsensusStore) createNewPassword() (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	return password, nil
 }
 
@@ -96,6 +98,7 @@ func (s ConsensusStore) Create() (*ConsensusKey, error) {
 	if err := key.Save(s.KeystorePath); err != nil {
 		return nil, err
 	}
+
 	return &ConsensusKey{
 		PrivKey: privKey,
 		PubKey:  pubKey.(*bls12381.KyberG1),
@@ -116,6 +119,7 @@ func (s ConsensusStore) Load() (*ConsensusKey, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	return &ConsensusKey{
 		PrivKey: priv,
 		PubKey:  pub.(*bls12381.KyberG1),
@@ -128,5 +132,6 @@ func (s ConsensusStore) Get() (*ConsensusKey, error) {
 	if errors.Is(err, os.ErrNotExist) {
 		return s.Create()
 	}
+
 	return key, err
 }

--- a/identity/p2p.go
+++ b/identity/p2p.go
@@ -52,6 +52,7 @@ func (s P2PStore) Create() (*ecdsa.PrivateKey, error) {
 		return nil, err
 	}
 	err = crypto.SaveECDSA(s.KeyPath, key)
+
 	return key, err
 }
 
@@ -66,6 +67,7 @@ func (s P2PStore) Get() (*ecdsa.PrivateKey, error) {
 	if errors.Is(err, os.ErrNotExist) {
 		return s.Create()
 	}
+
 	return key, err
 }
 
@@ -75,5 +77,6 @@ func (s P2PStore) MustGet() *ecdsa.PrivateKey {
 	if err != nil {
 		zerologger.Fatal().Err(err).Msg("Failed to read node key")
 	}
+
 	return key
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ func LoadViper(configPath string) error {
 		viper.SetConfigFile(configPath)
 		return viper.ReadInConfig()
 	}
+
 	return nil
 }
 

--- a/p2p/connector.go
+++ b/p2p/connector.go
@@ -33,5 +33,6 @@ func PinPeers(clusters *cluster.KnownClusters, connMgr connmgr.ConnManager) erro
 			connMgr.Protect(id, tagDVPeer)
 		}
 	}
+
 	return nil
 }

--- a/p2p/gater.go
+++ b/p2p/gater.go
@@ -49,6 +49,7 @@ func NewConnGaterForClusters(clusters cluster.KnownClusters, networks *netutil.N
 			peerIDs[peerID] = struct{}{}
 		}
 	}
+
 	return &ConnGater{
 		PeerIDs:  peerIDs,
 		Networks: networks,

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -61,5 +61,6 @@ func NewNode(cfg Config, key *ecdsa.PrivateKey, connGater *ConnGater) (*Node, er
 		return nil, err
 	}
 	log.Info().Msgf("Starting P2P interface on %v", h.Addrs())
+
 	return &Node{h}, nil
 }

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -24,5 +24,6 @@ import (
 func convertInterfaceToPrivKey(privkey crypto.PrivKey) *ecdsa.PrivateKey {
 	typeAssertedKey := (*ecdsa.PrivateKey)(privkey.(*crypto.Secp256k1PrivateKey))
 	typeAssertedKey.Curve = gcrypto.S256() // Temporary hack, so libp2p Secp256k1 is recognized as geth Secp256k1 in disc v5.1.
+
 	return typeAssertedKey
 }

--- a/runner/tracer/trace.go
+++ b/runner/tracer/trace.go
@@ -86,6 +86,7 @@ func WithJaegerOrNoop(jaegerAddr string) func(*options) {
 	if jaegerAddr == "" {
 		return func(o *options) {}
 	}
+
 	return WithJaeger(jaegerAddr)
 }
 

--- a/validatorapi/metrics.go
+++ b/validatorapi/metrics.go
@@ -36,11 +36,11 @@ var (
 	}, []string{"endpoint", "status_code"})
 )
 
-func incApiErrors(endpoint string, statusCode int) {
+func incAPIErrors(endpoint string, statusCode int) {
 	apiErrors.WithLabelValues(endpoint, strconv.Itoa(statusCode)).Inc()
 }
 
-func observeApiLatency(endpoint string) func() {
+func observeAPILatency(endpoint string) func() {
 	t0 := time.Now()
 	return func() {
 		apiLatency.WithLabelValues(endpoint).Observe(time.Since(t0).Seconds())

--- a/validatorapi/router.go
+++ b/validatorapi/router.go
@@ -99,7 +99,7 @@ type handlerFunc func(ctx context.Context, params map[string]string, body []byte
 func wrap(endpoint string, handler handlerFunc) http.Handler {
 	wrap := func(w http.ResponseWriter, r *http.Request) {
 
-		defer observeApiLatency(endpoint)()
+		defer observeAPILatency(endpoint)()
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -184,7 +184,7 @@ func proxyHandler(target string) (http.HandlerFunc, error) {
 	proxy := httputil.NewSingleHostReverseProxy(targetURL)
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		defer observeApiLatency("proxy")()
+		defer observeAPILatency("proxy")()
 		proxy.ServeHTTP(proxyResponseWriter{w}, r)
 	}, nil
 }
@@ -222,7 +222,7 @@ func writeError(w http.ResponseWriter, endpoint string, err error) {
 		Int("status_code", aerr.StatusCode).
 		Str("message", aerr.Message).
 		Msg("Validator api error response")
-	incApiErrors(endpoint, aerr.StatusCode)
+	incAPIErrors(endpoint, aerr.StatusCode)
 
 	res := errorResponse{
 		Code:    aerr.StatusCode,
@@ -292,6 +292,6 @@ func (w proxyResponseWriter) WriteHeader(statusCode int) {
 		// 2XX isn't an error
 		return
 	}
-	incApiErrors("proxy", statusCode)
+	incAPIErrors("proxy", statusCode)
 	w.ResponseWriter.WriteHeader(statusCode)
 }

--- a/validatorapi/router_test.go
+++ b/validatorapi/router_test.go
@@ -128,6 +128,7 @@ func TestRouter(t *testing.T) {
 						CommitteesAtSlot: 1,                  // 0 fails validation
 					})
 				}
+
 				return res, nil
 			},
 		}
@@ -164,6 +165,7 @@ func TestRouter(t *testing.T) {
 						Slot:           eth2p0.Slot(int(epoch)*slotsPerEpoch + i),
 					})
 				}
+
 				return res, nil
 			},
 		}
@@ -288,5 +290,6 @@ func nest(data interface{}, nests ...string) interface{} {
 			nest: res,
 		}
 	}
+
 	return res
 }


### PR DESCRIPTION
Fix linter issues regarding:
- ineffassign: Detects when assignments to existing variables are not used
- nlreturn: nlreturn checks for a new line before return and branch statements to increase code clarity
- revive: Revive is a fast, configurable, extensible, flexible, and drop-in replacement of golint