### PR TITLE
fix godot gosec linter errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,8 +47,6 @@ linters:
     - forcetypeassert
     - gci
     - gochecknoinits # Once config refactor is done.
-    - godot
-    - gosec
     - stylecheck
     - testpackage # rename internal test files to *_internal_test.go
     - thelper

--- a/cluster/manifest.go
+++ b/cluster/manifest.go
@@ -73,9 +73,9 @@ func (m *Manifest) PeerIDs() ([]peer.ID, error) {
 	}
 	ids := make([]peer.ID, len(records))
 
-	for i, record := range records {
+	for i := range records {
 		var err error
-		ids[i], err = PeerIDFromENR(&record)
+		ids[i], err = PeerIDFromENR(&records[i])
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -154,6 +154,8 @@ func (k *keygen) saveScheme(scheme *crypto.TBLSScheme, pubkeyHex string) {
 	}
 	polyName := filepath.Join(k.outDir, pubkeyHex+"-poly.json")
 	fmt.Println("Writing polynomials to", polyName)
+
+	//nolint:gosec // No need to reduce permissions as it simply saves the public keys
 	err = os.WriteFile(polyName, buf, 0666)
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to save public polynomials")

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -92,7 +92,7 @@ func initializeConfig(cmd *cobra.Command) error {
 	return nil
 }
 
-// bindFlags binds each cobra flag to its associated viper configuration (config file and environment variable)
+// bindFlags binds each cobra flag to its associated viper configuration (config file and environment variable).
 func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	var lastErr error
 

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -36,7 +36,7 @@ func init() {
 	rootCmd.AddCommand(enrCmd)
 }
 
-// Function for printing status of ENR for this instance
+// Function for printing status of ENR for this instance.
 func runENR(_ *cobra.Command, _ []string) {
 	p2pConfig := p2p.DefaultConfig()
 	discoveryConfig := discovery.DefaultConfig()

--- a/cmd/new_bootstrap.go
+++ b/cmd/new_bootstrap.go
@@ -37,7 +37,7 @@ type bootstrapConfig struct {
 	Bootnodes    []string
 }
 
-// newBoostrapCmd returns new bootstrap command with bootstrapConfig
+// newBoostrapCmd returns new bootstrap command with bootstrapConfig.
 func newBootstrapCmd(runFunc func(io.Writer, bootstrapConfig) error) *cobra.Command {
 	var conf bootstrapConfig
 
@@ -66,7 +66,7 @@ func bindBootstrapFlags(flags *pflag.FlagSet, config *bootstrapConfig) {
 }
 
 // runBootstrapCmd runs bootstrap command with the given bootstrapConfig. The bootstrapConfig
-// helps to generate keyshares which are then saved into desired directories in json
+// helps to generate keyshares which are then saved into desired directories in json.
 func runBootstrapCmd(w io.Writer, config bootstrapConfig) error {
 	if config.Shares < 1 {
 		return errors.New("invalid non-positive shares")
@@ -153,6 +153,7 @@ func saveScheme(scheme *crypto.TBLSScheme, filename string) error {
 		return err
 	}
 
+	//nolint:gosec // No need to reduce permissions as it simply saves the public keys
 	return os.WriteFile(filename, buf, 0644)
 }
 

--- a/cmd/new_enr.go
+++ b/cmd/new_enr.go
@@ -38,7 +38,7 @@ func newEnrCmd(runFunc func()) *cobra.Command {
 	return cmd
 }
 
-// Function for printing status of ENR for this instance
+// Function for printing status of ENR for this instance.
 func runNewENR() {
 	p2pConfig := p2p.DefaultConfig()
 	discoveryConfig := discovery.DefaultConfig()

--- a/cmd/new_version.go
+++ b/cmd/new_version.go
@@ -29,7 +29,7 @@ type versionConfig struct {
 	Verbose bool
 }
 
-// newVersionCmd returns the version command
+// newVersionCmd returns the version command.
 func newVersionCmd(runFunc func(io.Writer, versionConfig)) *cobra.Command {
 	var conf versionConfig
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -44,7 +44,7 @@ func Main() {
 }
 
 // Pre-run hook executed by all commands and subcommands unless they declare their own
-// Used to parse and validate global config typically (for now it sets log level)
+// Used to parse and validate global config typically (for now it sets log level).
 func preRunRoot(c *cobra.Command, _ []string) error {
 	// Set config file path from flag.
 	configFileFlag, err := c.Flags().GetString(config.KeyConfigFile)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ import (
 	"github.com/obolnetwork/charon/internal/config"
 )
 
-// versionCmd represents the version command
+// versionCmd represents the version command.
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version and exit",

--- a/p2p/gater_test.go
+++ b/p2p/gater_test.go
@@ -51,7 +51,7 @@ func TestInterceptSecured(t *testing.T) {
 	}
 }
 
-// Tests if node A rejects connection attempt from unknown node B
+// Tests if node A rejects connection attempt from unknown node B.
 func TestP2PConnGating(t *testing.T) {
 	c := ConnGater{
 		PeerIDs:  map[peer.ID]struct{}{},


### PR DESCRIPTION
Fix linter issues related to:
- godot: Simply checks if comments end in a period
- gosec: Inspects source code for security problems