### PR TITLE
app/*: implement custom errors and log packages

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,11 +37,13 @@ issues:
     - "unnecessary leading newline"
     - "block should not start with a whitespace"
     - "only one cuddle assignment"
+    - "only cuddled expressions if assigning variable or using from line above"
 
 linters:
   enable-all: true
   disable:
     # Keep disabled
+    - containedctx
     - exhaustivestruct
     - funlen
     - forcetypeassert

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -1,0 +1,155 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package errors wraps github.com/pkg/errors and adds optional structured fields; similar to structured logging.
+// See app/log/log_test.go for unit tests.
+package errors
+
+import (
+	"fmt"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/rs/zerolog"
+)
+
+// New returns a new error. Note that fields can be added to the resulting Error struct.
+func New(msg string) Error {
+	return Error{
+		err: pkgerrors.New(msg),
+	}
+}
+
+// Wrap returns an annotated error. Note that fields can be added to the resulting Error struct.
+func Wrap(err error, msg string) Error {
+	return Error{
+		err: pkgerrors.Wrap(err, msg),
+	}
+}
+
+// Error wraps a pkg/errors error with optional fields providing structured errors.
+type Error struct {
+	err    error
+	fields []func(*zerolog.Array)
+}
+
+// Str adds the field key with val as a string to the sub-logger context.
+func (e Error) Str(key, val string) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Str(key, val))
+	})
+
+	return e
+}
+
+// Stringer adds the field key with val.String() (or null if val is nil) to the sub-logger context.
+func (e Error) Stringer(key string, val fmt.Stringer) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Stringer(key, val))
+	})
+
+	return e
+}
+
+// Bytes adds the field key with val as a []byte to the sub-logger context.
+func (e Error) Bytes(key string, val []byte) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Bytes(key, val))
+	})
+
+	return e
+}
+
+// Hex adds the field key with val as a hex string to the sub-logger context.
+func (e Error) Hex(key string, val []byte) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Hex(key, val))
+	})
+
+	return e
+}
+
+// Int adds the field key with i as an int to the sub-logger context.
+func (e Error) Int(key string, i int) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Int(key, i))
+	})
+
+	return e
+}
+
+// Int64 adds the field key with i as a int64 to the sub-logger context.
+func (e Error) Int64(key string, i int64) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Int64(key, i))
+	})
+
+	return e
+}
+
+// Uint64 adds the field key with i as an uint64 to the sub-logger context.
+func (e Error) Uint64(key string, i uint64) Error {
+	e.fields = append(e.fields, func(a *zerolog.Array) {
+		a.Dict(zerolog.Dict().Uint64(key, i))
+	})
+
+	return e
+}
+
+func (e Error) Error() string {
+	return e.err.Error()
+}
+
+func (e Error) ExtractFields(a *zerolog.Array) {
+	for _, field := range e.fields {
+		field(a)
+	}
+
+	var next Error
+	if As(e.err, &next) {
+		next.ExtractFields(a)
+	}
+}
+
+func (e Error) MarshalZerologObject(ze *zerolog.Event) {
+	a := zerolog.Arr()
+	e.ExtractFields(a)
+	ze.Array("fields", a)
+	ze.Str("message", e.err.Error())
+}
+
+func (e Error) StackTrace() pkgerrors.StackTrace {
+	type stackTracer interface {
+		StackTrace() pkgerrors.StackTrace
+	}
+
+	//nolint:errorlint
+	st, ok := pkgerrors.Cause(e.err).(stackTracer)
+	if !ok {
+		return nil
+	}
+
+	return st.StackTrace()
+}
+
+// Cause returns the underlying cause of the error and
+// provides compatibility for pkg/error.Causer interface.
+func (e Error) Cause() error {
+	return e.err
+}
+
+// Unwrap returns the underlying error and
+// provides compatibility for Go 1.13 error chains.
+func (e Error) Unwrap() error {
+	return e.err
+}

--- a/app/errors/go113.go
+++ b/app/errors/go113.go
@@ -1,0 +1,53 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import (
+	stderrors "errors"
+)
+
+// This file was copied from github.com/pkg/errors. It ensures this package is compatible
+// with pkg/errors and with Go 1.13 error chains.
+
+// Is reports whether any error in err's chain matches target.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error is considered to match a target if it is equal to that target or if
+// it implements a method Is(error) bool such that Is(target) returns true.
+func Is(err, target error) bool { return stderrors.Is(err, target) }
+
+// As finds the first error in err's chain that matches target, and if so, sets
+// target to that error value and returns true.
+//
+// The chain consists of err itself followed by the sequence of errors obtained by
+// repeatedly calling Unwrap.
+//
+// An error matches target if the error's concrete value is assignable to the value
+// pointed to by target, or if the error has a method As(interface{}) bool such that
+// As(target) returns true. In the latter case, the As method is responsible for
+// setting target.
+//
+// As will panic if target is not a non-nil pointer to either a type that implements
+// error, or to any interface type. As returns false if err is nil.
+func As(err error, target interface{}) bool { return stderrors.As(err, target) }
+
+// Unwrap returns the result of calling the Unwrap method on err, if err's
+// type contains an Unwrap method returning error.
+// Otherwise, Unwrap returns nil.
+func Unwrap(err error) error {
+	return stderrors.Unwrap(err)
+}

--- a/app/log/log.go
+++ b/app/log/log.go
@@ -1,0 +1,142 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/pkgerrors"
+)
+
+var logger zerolog.Logger
+
+//nolint: gochecknoinits
+func init() {
+	InitConsoleLogger()
+}
+
+// InitJSONLogger initialises a JSON logger for production usage.
+func InitJSONLogger() {
+	logger = zerolog.New(os.Stderr).With().Timestamp().Logger()
+	zerolog.DefaultContextLogger = &logger
+}
+
+// InitConsoleLogger initialises a human-friendly colorised logger.
+func InitConsoleLogger(options ...func(w *zerolog.ConsoleWriter)) {
+	logger = zerolog.New(zerolog.NewConsoleWriter(options...)).With().Timestamp().Logger()
+	zerolog.DefaultContextLogger = &logger
+	zerolog.ErrorStackMarshaler = pkgerrors.MarshalStack
+	zerolog.CallerMarshalFunc = func(file string, line int) string {
+		const trimBefore = "charon/"
+		if i := strings.Index(file, trimBefore); i > 0 {
+			file = file[i+len(trimBefore):]
+		}
+
+		return file + ":" + strconv.Itoa(line)
+	}
+}
+
+// WithContext returns a fluent-API to build a child context containing contextual logging fields.
+//
+//   ctx = log.WithContext(ctx).Str("foo", "bar").Ctx() // All subsequent logs using this context will contain "foo=bar".
+//   ...
+//   log.Info(ctx).Msg("something happened") // Contains "foo=bar".
+//nolint:revive
+func WithContext(ctx context.Context) *builder {
+	return &builder{
+		zctx: zerolog.Ctx(ctx).With(),
+		ctx:  ctx,
+	}
+}
+
+// WithComponent is a convenience function that returns a child context with the component contextual logging field set.
+func WithComponent(ctx context.Context, component string) context.Context {
+	return WithContext(ctx).Str("component", component).Ctx()
+}
+
+func Debug(ctx context.Context) *zerolog.Event {
+	return zerolog.Ctx(ctx).Debug().Caller(1)
+}
+
+func Info(ctx context.Context) *zerolog.Event {
+	return zerolog.Ctx(ctx).Info().Stack().Caller(1)
+}
+
+func Warn(ctx context.Context) *zerolog.Event {
+	return zerolog.Ctx(ctx).Warn().Stack().Caller(1)
+}
+
+func Error(ctx context.Context, err error) *zerolog.Event {
+	return zerolog.Ctx(ctx).Error().Stack().Err(err).Caller(1)
+}
+
+// builder is a fluent-style API for a new sub-logger with contextual fields to be associated with final child-context via Ctx.
+type builder struct {
+	zctx zerolog.Context
+	ctx  context.Context
+}
+
+// Ctx returns the final child-context containing the sub-logger.
+func (b *builder) Ctx() context.Context {
+	newLogger := b.zctx.Logger()
+	return (&newLogger).WithContext(b.ctx)
+}
+
+// Str adds the field key with val as a string to the sub-logger context.
+func (b *builder) Str(key, val string) *builder {
+	b.zctx = b.zctx.Str(key, val)
+	return b
+}
+
+// Stringer adds the field key with val.String() (or null if val is nil) to the sub-logger context.
+func (b *builder) Stringer(key string, val fmt.Stringer) *builder {
+	b.zctx = b.zctx.Stringer(key, val)
+	return b
+}
+
+// Bytes adds the field key with val as a []byte to the sub-logger context.
+func (b *builder) Bytes(key string, val []byte) *builder {
+	b.zctx = b.zctx.Bytes(key, val)
+	return b
+}
+
+// Hex adds the field key with val as a hex string to the sub-logger context.
+func (b *builder) Hex(key string, val []byte) *builder {
+	b.zctx = b.zctx.Bytes(key, val)
+	return b
+}
+
+// Int adds the field key with i as an int to the sub-logger context.
+func (b *builder) Int(key string, i int) *builder {
+	b.zctx = b.zctx.Int(key, i)
+	return b
+}
+
+// Int64 adds the field key with i as a int64 to the sub-logger context.
+func (b *builder) Int64(key string, i int64) *builder {
+	b.zctx = b.zctx.Int64(key, i)
+	return b
+}
+
+// Uint64 adds the field key with i as an uint64 to the sub-logger context.
+func (b *builder) Uint64(key string, i uint64) *builder {
+	b.zctx = b.zctx.Uint64(key, i)
+	return b
+}

--- a/app/log/log_test.go
+++ b/app/log/log_test.go
@@ -1,0 +1,131 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+)
+
+func TestWithContext(t *testing.T) {
+	buf := setup(t)
+
+	ctx1 := context.Background()
+	ctx2 := log.WithContext(ctx1).Int("wrap2", 2).Ctx()
+	ctx3 := log.WithContext(ctx2).Str("wrap3", "3").Ctx()
+
+	log.Debug(ctx1).Int("ctx1", 1).Msg("msg1")
+	log.Info(ctx2).Int("ctx2", 2).Msg("msg2")
+	log.Warn(ctx3).Int("ctx3", 3).Msg("msg3")
+
+	expect := `12:00AM DBG app/log/log_test.go:- > msg1 ctx1=1
+12:00AM INF app/log/log_test.go:- > msg2 ctx2=2 wrap2=2
+12:00AM WRN app/log/log_test.go:- > msg3 ctx3=3 wrap2=2 wrap3=3
+`
+	require.Equal(t, expect, buf.String())
+}
+
+func TestErrorWrap(t *testing.T) {
+	buf := setup(t)
+
+	err1 := errors.New("first").Int("1", 1)
+	err2 := errors.Wrap(err1, "second").Int("2", 2)
+	err3 := errors.Wrap(err2, "third").Int("3", 3)
+
+	ctx := context.Background()
+	log.Error(ctx, err1).Msg("err1")
+	log.Error(ctx, err2).Msg("err2")
+	log.Error(ctx, err3).Msg("err3")
+
+	// TODO(corver): Improve console error formatting.
+	expect := `12:00AM ERR app/log/log_test.go:- > err1 error={"fields":[{"1":1}],"message":"first"} stack="errors.go\nlog_test.go\ntesting.go\nasm_arm64.s\n"
+12:00AM ERR app/log/log_test.go:- > err2 error={"fields":[{"2":2},{"1":1}],"message":"second: first"} stack="errors.go\nlog_test.go\ntesting.go\nasm_arm64.s\n"
+12:00AM ERR app/log/log_test.go:- > err3 error={"fields":[{"3":3},{"2":2},{"1":1}],"message":"third: second: first"} stack="errors.go\nlog_test.go\ntesting.go\nasm_arm64.s\n"
+`
+	require.Equal(t, expect, buf.String())
+}
+
+// setup returns a buffer that logs are written to and stubs non-deterministic logging fields.
+func setup(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	var buf bytes.Buffer
+
+	log.InitConsoleLogger(
+		func(w *zerolog.ConsoleWriter) {
+			w.Out = &buf
+			w.NoColor = true
+		})
+
+	// Stub time for test to be deterministic
+	tff := zerolog.TimeFieldFormat
+
+	zerolog.TimeFieldFormat = "-"
+
+	t.Cleanup(func() {
+		zerolog.TimeFieldFormat = tff
+	})
+
+	// Exclude line numbers for test to be deterministic
+	cmf := zerolog.CallerMarshalFunc
+
+	zerolog.CallerMarshalFunc = func(file string, _ int) string {
+		const trimBefore = "charon/"
+		if i := strings.Index(file, trimBefore); i > 0 {
+			file = file[i+len(trimBefore):]
+		}
+
+		return file + ":-"
+	}
+	t.Cleanup(func() {
+		zerolog.CallerMarshalFunc = cmf
+	})
+
+	// Exclude line numbers for test to be deterministic
+	esm := zerolog.ErrorStackMarshaler
+
+	zerolog.ErrorStackMarshaler = func(err error) interface{} {
+		type stackTracer interface {
+			StackTrace() pkgerrors.StackTrace
+		}
+		//nolint:errorlint
+		sterr, ok := err.(stackTracer)
+		if !ok {
+			return nil
+		}
+
+		var buf bytes.Buffer
+		for _, frame := range sterr.StackTrace() {
+			_, _ = fmt.Fprintf(&buf, "%s\n", frame)
+		}
+
+		return buf.String()
+	}
+	t.Cleanup(func() {
+		zerolog.ErrorStackMarshaler = esm
+	})
+
+	return &buf
+}


### PR DESCRIPTION
Add customer `log` and `errors` for the charon app:

**Log**
 - Current structured logging via `zerolog` is cool, but...
 - Proving contextual logging fields via context.Context has a very convoluted API
 - Our current approach is to have zerolog.loggers per package, which is a little tricky since it isn't apparent in which file to define it (maybe log.go). 
 - I want to simplify that and just use an app-level global logger. 
 - The "component" field should be added via the context; `ctx = log.WithContext(ctx).Str("component","foo")`
 - This allows different component to use shared logging logic but (like DB packages)
 - So adding a `app/log` package that we should use everywhere.
 - It has an opinionated API: 
     - Prefer using `context.Context`
     - Only `Debug`, `Info`, `Warn`, `Error` (no fatal or trace)
     - When logging an error, an `err` is required.

**Errors**
- Using `github.com/pkg/errors` is cool, but...
- Just like structured logging, structured errors is just as great.
- Just like we do not do `log.Infof("this is %s", "unstructured")`
- We also should not do `errors.ErrorF("this is also %s", "unstructured")`
- Instead we do to same as with `zerolog`: `errors.New("this is").Str("type","structured")`
- So adding an `app/errors` package that supports this.