### PR TITLE
cluster: refactor new for testing

### DIFF
--- a/cluster/testing.go
+++ b/cluster/testing.go
@@ -1,0 +1,95 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"crypto/ecdsa"
+	"crypto/rand"
+	"net"
+	"testing"
+
+	"github.com/drand/kyber"
+	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/crypto"
+)
+
+// NewForT returns a new random cluster manifest with threshold m and size n.
+// It also returns the peer p2p keys and BLS keyshards.
+// Note that the threshold signatures are stubs at this point.
+func NewForT(t *testing.T, m, n int) (Manifest, []*ecdsa.PrivateKey, []kyber.Scalar) {
+	t.Helper()
+
+	var (
+		members []crypto.BLSPubkeyHex
+		enrs    []string
+		p2pKeys []*ecdsa.PrivateKey
+		blsKeys []kyber.Scalar
+	)
+	for i := 0; i < n; i++ {
+		{
+			// Generate fake BLS shards.
+			privkey, pubkey := crypto.NewKeyPair()
+			members = append(members, crypto.BLSPubkeyHex{Point: pubkey})
+			blsKeys = append(blsKeys, privkey)
+		}
+		{
+			// Generate ENR
+			p2pKey, err := ecdsa.GenerateKey(secp256k1.S256(), rand.Reader)
+			require.NoError(t, err)
+
+			addr := availableLocalAddr(t)
+
+			var r enr.Record
+			r.Set(enr.IPv4(addr.IP))
+			r.Set(enr.TCP(addr.Port))
+			r.SetSeq(1)
+
+			err = enode.SignV4(&r, p2pKey)
+			require.NoError(t, err)
+
+			res, err := EncodeENR(r)
+			require.NoError(t, err)
+
+			enrs = append(enrs, res)
+			p2pKeys = append(p2pKeys, p2pKey)
+		}
+	}
+
+	_, pubPoly := crypto.NewTBLSPoly(m)
+
+	return Manifest{
+		TSS:     crypto.TBLSScheme{PubPoly: pubPoly},
+		Members: members,
+		ENRs:    enrs,
+	}, p2pKeys, blsKeys
+}
+
+// availableLocalAddr returns an available local tcp address.
+func availableLocalAddr(t *testing.T) *net.TCPAddr {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	require.NoError(t, l.Close())
+
+	addr, err := net.ResolveTCPAddr(l.Addr().Network(), l.Addr().String())
+	require.NoError(t, err)
+
+	return addr
+}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -84,7 +84,7 @@ func runBootstrapCmd(w io.Writer, config bootstrapConfig) error {
 	threshold := config.Shares - ((config.Shares - 1) / 3)
 
 	// Create "root" BLS key and polynomials.
-	priPoly, pubPoly := crypto.NewTBLSPoly(uint(threshold))
+	priPoly, pubPoly := crypto.NewTBLSPoly(threshold)
 
 	pubkey := pubPoly.Commit()
 	pubkeyHex := crypto.BLSPointToHex(pubkey)

--- a/crypto/encoding.go
+++ b/crypto/encoding.go
@@ -61,25 +61,24 @@ func BLSPointFromHex(hexStr string) (kyber.Point, error) {
 
 // BLSPubkeyHex wraps a BLS public key with simplified hex serialization.
 type BLSPubkeyHex struct {
-	*bls.KyberG1
+	kyber.Point
 }
 
 // UnmarshalText decodes the given hex serialization of the compressed form BLS12-381 G1 point.
 func (p *BLSPubkeyHex) UnmarshalText(b []byte) error {
 	decodedLen := hex.DecodedLen(len(b))
-	expectedLen := p.MarshalSize()
-	if decodedLen != expectedLen {
+	if decodedLen != new(bls.KyberG1).MarshalSize() {
 		return errors.New("expected marshal length")
 	}
 
-	data := make([]byte, expectedLen)
+	data := make([]byte, decodedLen)
 	if n, err := hex.Decode(data, b); err != nil {
 		return errors.Wrap(err, "decode bls hex")
-	} else if n != expectedLen {
+	} else if n != decodedLen {
 		return errors.New("expected decode length")
 	}
 
-	p.KyberG1 = bls.NullKyberG1()
+	p.Point = bls.NullKyberG1()
 
 	return p.UnmarshalBinary(data)
 }

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -73,11 +73,10 @@ func NewLocalEnode(config Config, p2pConfig charonp2p.Config, key *ecdsa.Private
 	for _, addr := range addrs {
 		if v4 := addr.IP.To4(); v4 != nil {
 			node.Set(enr.IPv4(v4))
-			node.Set(enr.TCP(addr.Port))
 		} else if v6 := addr.IP.To16(); v6 != nil {
 			node.Set(enr.IPv6(v6))
-			node.Set(enr.TCP(addr.Port))
 		}
+		node.Set(enr.TCP(addr.Port))
 	}
 
 	return node, db, nil

--- a/p2p/utils.go
+++ b/p2p/utils.go
@@ -13,3 +13,18 @@
 // limitations under the License.
 
 package p2p
+
+import (
+	"fmt"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+// ShortID returns the short ID string of the peer ID. It was inspired by peer.ID.ShortString() but even shorter.
+func ShortID(id peer.ID) string {
+	pid := id.Pretty()
+	if len(pid) <= 10 {
+		return pid
+	}
+	return fmt.Sprintf("%s*%s>", pid[:2], pid[len(pid)-6:])
+}


### PR DESCRIPTION
Refactors `cluster.NewForT` that returns a random cluster for testing that can bind to available p2p ports.

Also allow `ConnectToPeers` using ENR addresses as part of startup as workaround for missing peer discovery.

Few other small refactors and cleanup:
 - Use crypto interface type `kyper.Point`
 - Improve time in console logger
 - Prefer struct to pointers
 - Add `ShortID` to log short peer IDs.  
 
 