### PR TITLE
p2p: move discovery code to p2p package

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/obolnetwork/charon/app"
 	"github.com/obolnetwork/charon/cluster"
-	"github.com/obolnetwork/charon/discovery"
 	"github.com/obolnetwork/charon/p2p"
 )
 
@@ -48,11 +47,9 @@ func TestPingCluster(t *testing.T) {
 	for i := 0; i < n; i++ {
 
 		conf := app.Config{
-			Discovery: discovery.Config{
-				ListenAddr: availableAddr(t).String(), // Random discv5 address
-			},
 			P2P: p2p.Config{
-				Addrs: []string{addrFromENR(t, records[i])}, // Use p2p address defined in each ENR
+				TCPAddrs: []string{addrFromENR(t, records[i])}, // Use p2p address defined in each ENR
+				UDPAddr:  availableAddr(t).String(),            // Random discv5 address
 			},
 			MonitoringAddr:   availableAddr(t).String(), // Random monitoring address
 			ValidatorAPIAddr: availableAddr(t).String(), // Random validatorapi address

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -24,9 +24,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 
-	// Automatically sets GOMAXPROCS to match Linux container CPU quota.
-	_ "go.uber.org/automaxprocs"
-
 	"github.com/obolnetwork/charon/app"
 )
 

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app"
-	"github.com/obolnetwork/charon/discovery"
 	"github.com/obolnetwork/charon/p2p"
 )
 
@@ -68,11 +67,12 @@ func TestCmdFlags(t *testing.T) {
 			Name: "run command",
 			Args: slice("run"),
 			appConfig: &app.Config{
-				Discovery: discovery.Config{ListenAddr: "127.0.0.1:30309", DBPath: ""},
 				P2P: p2p.Config{
-					Addrs:     []string{"127.0.0.1:13900"},
+					UDPAddr:   "127.0.0.1:30309",
+					TCPAddrs:  []string{"127.0.0.1:13900"},
 					Allowlist: "",
 					Denylist:  "",
+					DBPath:    "",
 				},
 				ManifestFile:     "./charon/manifest.json",
 				DataDir:          "./charon/data",

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -21,16 +21,14 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
-	"github.com/obolnetwork/charon/discovery"
 	"github.com/obolnetwork/charon/identity"
 	"github.com/obolnetwork/charon/p2p"
 )
 
-func newEnrCmd(runFunc func(io.Writer, p2p.Config, discovery.Config, string) error) *cobra.Command {
+func newEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command {
 	var (
-		p2pConfig       p2p.Config
-		discoveryConfig discovery.Config
-		dataDir         string
+		config  p2p.Config
+		dataDir string
 	)
 
 	cmd := &cobra.Command{
@@ -39,25 +37,24 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, discovery.Config, string) err
 		Long:  `Return information on this node's Ethereum Node Record (ENR)`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runFunc(cmd.OutOrStdout(), p2pConfig, discoveryConfig, dataDir)
+			return runFunc(cmd.OutOrStdout(), config, dataDir)
 		},
 	}
 
 	bindGeneralFlags(cmd.Flags(), &dataDir)
-	bindP2PFlags(cmd.Flags(), &p2pConfig)
-	bindDiscoveryFlags(cmd.Flags(), &discoveryConfig)
+	bindP2PFlags(cmd.Flags(), &config)
 
 	return cmd
 }
 
 // Function for printing status of ENR for this instance.
-func runNewENR(w io.Writer, p2pConfig p2p.Config, discoveryConfig discovery.Config, dataDir string) error {
+func runNewENR(w io.Writer, config p2p.Config, dataDir string) error {
 	identityKey, err := identity.LoadOrCreatePrivKey(dataDir)
 	if err != nil {
 		return err
 	}
 
-	localEnode, db, err := discovery.NewLocalEnode(discoveryConfig, p2pConfig, identityKey)
+	localEnode, db, err := p2p.NewLocalEnode(config, identityKey)
 	if err != nil {
 		return errors.Wrap(err, "failed to open peer DB")
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -23,7 +23,6 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/obolnetwork/charon/app"
-	"github.com/obolnetwork/charon/discovery"
 	"github.com/obolnetwork/charon/p2p"
 )
 
@@ -44,7 +43,6 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 
 	bindRunFlags(cmd.Flags(), &conf)
 	bindGeneralFlags(cmd.Flags(), &conf.DataDir)
-	bindDiscoveryFlags(cmd.Flags(), &conf.Discovery)
 	bindP2PFlags(cmd.Flags(), &conf.P2P)
 
 	return cmd
@@ -63,12 +61,9 @@ func bindGeneralFlags(flags *pflag.FlagSet, dataDir *string) {
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
-	flags.StringSliceVar(&config.Addrs, "p2p-tcp-address", []string{"127.0.0.1:13900"}, "Listening TCP addresses (ip and port) for LibP2P traffic")
+	flags.StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", []string{"127.0.0.1:13900"}, "Comma-separated list of listening TCP addresses (ip and port) for LibP2P traffic")
+	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "127.0.0.1:30309", "Listening UDP address (ip and port) for Discv5 discovery")
 	flags.StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
 	flags.StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
-}
-
-func bindDiscoveryFlags(flags *pflag.FlagSet, config *discovery.Config) {
-	flags.StringVar(&config.ListenAddr, "p2p-udp-address", "127.0.0.1:30309", "Listening UDP address (ip and port) for Discv5 discovery")
 	flags.StringVar(&config.DBPath, "p2p-nodedb", "", "Path to store a discv5 node database. Empty default results in in-memory database.")
 }

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -24,16 +24,18 @@ import (
 )
 
 type Config struct {
-	Addrs     []string
+	DBPath    string
+	UDPAddr   string   // discv5 listen address
+	TCPAddrs  []string // lib-p2p listen addresses
 	Allowlist string
 	Denylist  string
 }
 
-// TCPAddrs returns the configured addresses as tcp addresses.
-func (c Config) TCPAddrs() ([]*net.TCPAddr, error) {
-	res := make([]*net.TCPAddr, 0, len(c.Addrs))
+// ParseTCPAddrs returns the configured tcp addresses as typed net tcp addresses.
+func (c Config) ParseTCPAddrs() ([]*net.TCPAddr, error) {
+	res := make([]*net.TCPAddr, 0, len(c.TCPAddrs))
 
-	for _, addr := range c.Addrs {
+	for _, addr := range c.TCPAddrs {
 		tcpAddr, err := resolveListenAddr(addr)
 		if err != nil {
 			return nil, err
@@ -46,7 +48,7 @@ func (c Config) TCPAddrs() ([]*net.TCPAddr, error) {
 
 // Multiaddrs returns the configured addresses as libp2p multiaddrs.
 func (c Config) Multiaddrs() ([]multiaddr.Multiaddr, error) {
-	tcpAddrs, err := c.TCPAddrs()
+	tcpAddrs, err := c.ParseTCPAddrs()
 	if err != nil {
 		return nil, err
 	}

--- a/p2p/config_internal_test.go
+++ b/p2p/config_internal_test.go
@@ -58,7 +58,7 @@ func TestResolveListenAddr(t *testing.T) {
 
 func TestConfig_Multiaddrs(t *testing.T) {
 	c := Config{
-		Addrs: []string{
+		TCPAddrs: []string{
 			"10.0.0.2:0",
 			"[" + net.IPv6linklocalallnodes.String() + "]:0",
 		},

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package discovery provides peer discovery.
-package discovery
+package p2p
 
 import (
 	"crypto/ecdsa"
@@ -23,18 +22,11 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/ethereum/go-ethereum/p2p/netutil"
-
-	charonp2p "github.com/obolnetwork/charon/p2p"
 )
 
-type Config struct {
-	DBPath     string
-	ListenAddr string
-}
-
-// NewListener starts and returns a discv5 UDP implementation.
-func NewListener(config Config, p2pConfig charonp2p.Config, ln *enode.LocalNode, key *ecdsa.PrivateKey) (*discover.UDPv5, error) {
-	udpAddr, err := net.ResolveUDPAddr("udp", config.ListenAddr)
+// NewDiscNode starts and returns a discv5 UDP implementation.
+func NewDiscNode(config Config, ln *enode.LocalNode, key *ecdsa.PrivateKey) (*discover.UDPv5, error) {
+	udpAddr, err := net.ResolveUDPAddr("udp", config.UDPAddr)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +36,7 @@ func NewListener(config Config, p2pConfig charonp2p.Config, ln *enode.LocalNode,
 		return nil, err
 	}
 
-	netlist, err := netutil.ParseNetlist(p2pConfig.Allowlist)
+	netlist, err := netutil.ParseNetlist(config.Allowlist)
 	if err != nil {
 		return nil, err
 	}
@@ -57,13 +49,13 @@ func NewListener(config Config, p2pConfig charonp2p.Config, ln *enode.LocalNode,
 }
 
 // NewLocalEnode returns a local enode and a peer DB or an error.
-func NewLocalEnode(config Config, p2pConfig charonp2p.Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *enode.DB, error) {
+func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *enode.DB, error) {
 	db, err := enode.OpenDB(config.DBPath)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	addrs, err := p2pConfig.TCPAddrs()
+	addrs, err := config.ParseTCPAddrs()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/p2p/gater_internal_test.go
+++ b/p2p/gater_internal_test.go
@@ -59,23 +59,23 @@ func TestP2PConnGating(t *testing.T) {
 	}
 
 	// create node A
-	p2pConfigA := Config{Addrs: []string{"127.0.0.1:3030"}}
+	p2pConfigA := Config{TCPAddrs: []string{"127.0.0.1:3030"}}
 	prvKeyA, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
 	if err != nil {
 		t.Fatal("private key generation for A failed", err)
 	}
-	nodeA, err := NewNode(p2pConfigA, convertPrivKey(prvKeyA), c)
+	nodeA, err := NewP2PNode(p2pConfigA, convertPrivKey(prvKeyA), c)
 	if err != nil {
 		t.Fatal("couldn't instantiate new node A", err)
 	}
 
 	// create node B
-	p2pConfigB := Config{Addrs: []string{"127.0.0.1:3031"}}
+	p2pConfigB := Config{TCPAddrs: []string{"127.0.0.1:3031"}}
 	prvKeyB, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
 	if err != nil {
 		t.Fatal("private key generation for B failed", err)
 	}
-	nodeB, err := NewNode(p2pConfigB, convertPrivKey(prvKeyB), c)
+	nodeB, err := NewP2PNode(p2pConfigB, convertPrivKey(prvKeyB), c)
 	if err != nil {
 		t.Fatal("couldn't instantiate new node B", err)
 	}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -32,8 +32,8 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 )
 
-// NewNode returns a started libp2p node.
-func NewNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater) (host.Host, error) {
+// NewP2PNode returns a started libp2p node.
+func NewP2PNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater) (host.Host, error) {
 	if key == nil {
 		return nil, errors.New("missing private key")
 	}


### PR DESCRIPTION
Peer discovery and p2p is very closely coupled, it even shares config. This PR modes the discv5 code into the p2p package, simplifying the project structure.