### PR TITLE
golangci: improve linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,9 @@ linters-settings:
   cyclop:
     max-complexity: 15
     skip-tests: true
+  forbidigo:
+    forbid:
+      - 'fmt\.Print.*'            # Prevent debug logging
   gci:
     local-prefixes: github.com/obolnetwork/charon
   gocritic:
@@ -9,6 +12,35 @@ linters-settings:
       - ifElseChain
   nlreturn:
     block-size: 2
+  revive:
+    enable-all-rules: true
+    severity: warning
+    rules:
+      # Disabled revive rules
+      - name: banned-characters
+        disabled: true
+      - name: add-constant
+        disabled: true
+      - name: file-header
+        disabled: true
+      - name: function-result-limit
+        disabled: true
+      - name: cyclomatic
+        disabled: true
+      - name: line-length-limit
+        disabled: true
+      - name: max-public-structs
+        disabled: true
+      - name: argument-limit
+        disabled: true
+      - name: function-length
+        disabled: true
+
+      # Some configured revive rules
+      - name: cognitive-complexity
+        arguments: [20]
+      - name: imports-blacklist
+        arguments: ["errors", "github.com/pkg/errors"] # Prefer ./app/errors
   staticcheck:
     go: "1.17"
     checks:
@@ -16,28 +48,21 @@ linters-settings:
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.
   testpackage:
     skip-regexp: internal_test\.go
-  whitespace:
-    multi-if: true
-    multi-func: true
-  wsl:
-    strict-append: false
-    allow-assign-and-anything: true
-    allow-separated-leading-comment: true
-    allow-case-trailing-whitespace: true
-    enforce-err-cuddling: true
+  wrapcheck:
+    ignoreSigs:
+      - github.com/obolnetwork/charon/
 
 issues:
+  fix: true
   exclude-rules:
     - path: '(.+)_test\.go'
       linters:
         - bodyclose
         - noctx
+        - revive
   exclude:
-    # Relax wsl and whitespace linters
-    - "unnecessary leading newline"
-    - "block should not start with a whitespace"
-    - "only one cuddle assignment"
-    - "only cuddled expressions if assigning variable or using from line above"
+    - "error returned from interface method should be wrapped" # Relax wrapcheck
+    - "defer: prefer not to defer chains of function calls" # Relax revive
 
 linters:
   enable-all: true
@@ -50,7 +75,6 @@ linters:
     - gochecknoglobals
     - godox
     - goerr113
-    - gofumpt
     - golint
     - gomnd
     - gomoddirectives
@@ -63,4 +87,4 @@ linters:
     - scopelint
     - tagliatelle
     - varnamelen
-    - wrapcheck
+    - wsl

--- a/app/app.go
+++ b/app/app.go
@@ -66,7 +66,7 @@ type TestConfig struct {
 // Run is the entrypoint for running a charon DVC instance.
 // All processes and their dependencies are constructed and then started.
 // Graceful shutdown is triggered on first process error or when the shutdown context is cancelled.
-//nolint:contextcheck
+//nolint:contextcheck,revive,cyclop
 func Run(ctx context.Context, conf Config) error {
 	_, _ = maxprocs.Set()
 	ctx = log.WithTopic(ctx, "app-start")

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -17,6 +17,7 @@
 package errors
 
 import (
+	// nolint:revive
 	stderrors "errors"
 	"fmt"
 

--- a/app/errors/go113.go
+++ b/app/errors/go113.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:wrapcheck,revive
 package errors
 
 import (

--- a/app/log/config.go
+++ b/app/log/config.go
@@ -22,6 +22,8 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/buffer"
 	"go.uber.org/zap/zapcore"
+
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 var logger = newConsoleLogger()
@@ -41,8 +43,11 @@ func newConsoleLogger() *zap.Logger {
 func InitJSONLogger() error {
 	var err error
 	logger, err = zap.NewProduction()
+	if err != nil {
+		return errors.Wrap(err, "zap logger")
+	}
 
-	return err
+	return nil
 }
 
 // InitLoggerForT initialises a console logger for testing purposes.

--- a/app/tracer/trace_test.go
+++ b/app/tracer/trace_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/obolnetwork/charon/app/tracer"
 )
 
-func TestDefaultNoopTracer(t *testing.T) {
+func TestDefaultNoopTracer(_ *testing.T) {
 	// This just shouldn't panic.
 	ctx, span := tracer.Start(context.Background(), "root")
 	defer span.End()

--- a/cluster/manifest.go
+++ b/cluster/manifest.go
@@ -51,8 +51,8 @@ func (m *Manifest) Pubkey() kyber.Point {
 func (m *Manifest) ParsedENRs() ([]enr.Record, error) {
 	records := make([]enr.Record, 0, len(m.ENRs))
 
-	for _, enr := range m.ENRs {
-		record, err := DecodeENR(enr)
+	for _, enrStr := range m.ENRs {
+		record, err := DecodeENR(enrStr)
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +74,6 @@ func (m *Manifest) PeerIDs() ([]peer.ID, error) {
 	ids := make([]peer.ID, 0, len(records))
 
 	for _, record := range records {
-
 		info, err := PeerInfoFromENR(record)
 		if err != nil {
 			return nil, err
@@ -112,7 +111,7 @@ func PeerInfoFromENR(record enr.Record) (peer.AddrInfo, error) {
 	mAddrStr := fmt.Sprintf("/ip4/%s/tcp/%d", net.IP(ip).String(), port)
 	addr, err := multiaddr.NewMultiaddr(mAddrStr)
 	if err != nil {
-		return peer.AddrInfo{}, err
+		return peer.AddrInfo{}, errors.Wrap(err, "multiaddr")
 	}
 
 	return peer.AddrInfo{
@@ -124,7 +123,7 @@ func PeerInfoFromENR(record enr.Record) (peer.AddrInfo, error) {
 func EncodeENR(record enr.Record) (string, error) {
 	var buf bytes.Buffer
 	if err := record.EncodeRLP(&buf); err != nil {
-		return "", err
+		return "", errors.Wrap(err, "encode rlp")
 	}
 
 	return "enr:" + base64.URLEncoding.EncodeToString(buf.Bytes()), nil
@@ -156,7 +155,7 @@ func DecodeENR(enrStr string) (enr.Record, error) {
 func LoadManifest(file string) (Manifest, error) {
 	buf, err := os.ReadFile(file)
 	if err != nil {
-		return Manifest{}, err
+		return Manifest{}, errors.Wrap(err, "read manifest")
 	}
 
 	var res Manifest

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -16,7 +16,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -25,6 +24,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/obolnetwork/charon/app"
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 const (
@@ -76,7 +76,7 @@ func initializeConfig(cmd *cobra.Command) error {
 		// It's okay if there isn't a config file
 		var cfgError viper.ConfigFileNotFoundError
 		if ok := errors.As(err, &cfgError); !ok {
-			return err
+			return errors.Wrap(err, "read config")
 		}
 	}
 
@@ -85,11 +85,7 @@ func initializeConfig(cmd *cobra.Command) error {
 	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
 
 	// Bind the current command's flags to viper
-	if err := bindFlags(cmd, v); err != nil {
-		return err
-	}
-
-	return nil
+	return bindFlags(cmd, v)
 }
 
 // bindFlags binds each cobra flag to its associated viper configuration (config file and environment variable).
@@ -97,7 +93,6 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) error {
 	var lastErr error
 
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
-
 		// Cobra provided flags take priority
 		if f.Changed {
 			return

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -52,7 +52,7 @@ func bindVersionFlags(flags *pflag.FlagSet, config *versionConfig) {
 }
 
 func runVersionCmd(out io.Writer, config versionConfig) {
-	fmt.Fprintln(out, version.Version)
+	_, _ = fmt.Fprintln(out, version.Version)
 
 	if !config.Verbose {
 		return
@@ -61,17 +61,17 @@ func runVersionCmd(out io.Writer, config versionConfig) {
 	buildInfo, ok := debug.ReadBuildInfo()
 
 	if !ok {
-		fmt.Fprintf(out, "\nFailed to gather build info")
+		_, _ = fmt.Fprintf(out, "\nFailed to gather build info")
 		return
 	}
 
-	fmt.Fprintf(out, "Package: %s\n", buildInfo.Path)
-	fmt.Fprint(out, "Dependencies:\n")
+	_, _ = fmt.Fprintf(out, "Package: %s\n", buildInfo.Path)
+	_, _ = fmt.Fprint(out, "Dependencies:\n")
 
 	for _, dep := range buildInfo.Deps {
 		for dep.Replace != nil {
 			dep = dep.Replace
 		}
-		fmt.Fprintf(out, "\t%v %v\n", dep.Path, dep.Version)
+		_, _ = fmt.Fprintf(out, "\t%v %v\n", dep.Path, dep.Version)
 	}
 }

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -32,9 +32,9 @@ func DerivePubkey(secret kyber.Scalar) *bls12381.KyberG1 {
 }
 
 // NewKeyPair creates a new random key pair.
-func NewKeyPair() (secret kyber.Scalar, pubkey *bls12381.KyberG1) {
-	secret = BLSPairing.G1().Scalar().Pick(BLSPairing.RandomStream())
-	pubkey = DerivePubkey(secret)
+func NewKeyPair() (kyber.Scalar, *bls12381.KyberG1) {
+	secret := BLSPairing.G1().Scalar().Pick(BLSPairing.RandomStream())
+	pubkey := DerivePubkey(secret)
 
-	return
+	return secret, pubkey
 }

--- a/crypto/encoding.go
+++ b/crypto/encoding.go
@@ -34,7 +34,7 @@ func BLSPointToHex(p kyber.Point) string {
 func BLSPointFromHex(hexStr string) (kyber.Point, error) {
 	b, err := hex.DecodeString(hexStr)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "decode hex")
 	}
 
 	var p kyber.Point
@@ -80,7 +80,11 @@ func (p *BLSPubkeyHex) UnmarshalText(b []byte) error {
 
 	p.Point = bls.NullKyberG1()
 
-	return p.UnmarshalBinary(data)
+	if err := p.UnmarshalBinary(data); err != nil {
+		return errors.Wrap(err, "unmarshal")
+	}
+
+	return nil
 }
 
 // MarshalText returns the hex serialization of the compressed form BLS12-381 G1 point.

--- a/crypto/keystore.go
+++ b/crypto/keystore.go
@@ -161,15 +161,10 @@ func ReadPlaintextPassword(filePath string) (string, error) {
 // WritePlaintextPassword saves a password to a file without leading or trailing whitespace.
 //
 // If overwrite is set and a file already exists at the given path, the file contents will be erased.
-func WritePlaintextPassword(filePath string, overwrite bool, password string) error {
-	mode := os.O_WRONLY | os.O_CREATE
-	if overwrite {
-		mode |= os.O_TRUNC
-	} else {
-		mode |= os.O_EXCL
-	}
+func WritePlaintextPassword(filePath string, password string) error {
+	mode := os.O_WRONLY | os.O_CREATE | os.O_EXCL
 
-	f, err := os.OpenFile(filePath, mode, 0600)
+	f, err := os.OpenFile(filePath, mode, 0o600)
 	if err != nil {
 		return errors.Wrap(err, "open file")
 	}
@@ -187,7 +182,7 @@ func (k *Keystore) Save(filePath string) error {
 		return errors.Wrap(err, "marshal keystore")
 	}
 
-	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0600)
+	f, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
 		return errors.Wrap(err, "open file")
 	}
@@ -196,7 +191,11 @@ func (k *Keystore) Save(filePath string) error {
 		return errors.Wrap(err, "write file")
 	}
 
-	return f.Close()
+	if err := f.Close(); err != nil {
+		return errors.Wrap(err, "close file")
+	}
+
+	return nil
 }
 
 // LoadKeystore reads and unmarshals the keystore from the given path.

--- a/crypto/tbls.go
+++ b/crypto/tbls.go
@@ -55,7 +55,12 @@ func (t TBLSScheme) MarshalJSON() ([]byte, error) {
 		return nil, errors.Wrap(err, "encode TBLS scheme")
 	}
 
-	return json.Marshal(encoded)
+	b, err := json.Marshal(encoded)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal scheme")
+	}
+
+	return b, nil
 }
 
 // TBLSSchemeEncoded is the serialized form of TBLSScheme suitable for JSON encoding.

--- a/identity/consensus.go
+++ b/identity/consensus.go
@@ -40,13 +40,13 @@ type ConsensusKey struct {
 }
 
 // Password reads the node password or creates a new random password if none exists.
-func (s ConsensusStore) Password() (password string, err error) {
-	password, err = crypto2.ReadPlaintextPassword(s.PasswordPath)
+func (s ConsensusStore) Password() (string, error) {
+	password, err := crypto2.ReadPlaintextPassword(s.PasswordPath)
 	if errors.Is(err, os.ErrNotExist) {
 		return s.createNewPassword()
 	}
 
-	return
+	return password, nil
 }
 
 func (s ConsensusStore) createNewPassword() (string, error) {
@@ -65,7 +65,7 @@ func (s ConsensusStore) createNewPassword() (string, error) {
 	}
 
 	// Write back to file.
-	err = crypto2.WritePlaintextPassword(s.PasswordPath, false, password)
+	err = crypto2.WritePlaintextPassword(s.PasswordPath, password)
 	if err != nil {
 		return "", errors.Wrap(err, "write password")
 	}

--- a/identity/p2p.go
+++ b/identity/p2p.go
@@ -32,7 +32,7 @@ func LoadOrCreatePrivKey(dataDir string) (*ecdsa.PrivateKey, error) {
 	if errors.Is(err, os.ErrNotExist) {
 		return newSavedPrivKey(keyPath)
 	} else if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "load key")
 	}
 
 	return key, nil
@@ -41,12 +41,12 @@ func LoadOrCreatePrivKey(dataDir string) (*ecdsa.PrivateKey, error) {
 // newSavedPrivKey generates a new key and saves the new node identity.
 func newSavedPrivKey(keyPath string) (*ecdsa.PrivateKey, error) {
 	if err := os.MkdirAll(filepath.Dir(keyPath), 0o755); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "mkdir")
 	}
 
 	key, err := crypto.GenerateKey()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "gen key")
 	}
 
 	err = crypto.SaveECDSA(keyPath, key)

--- a/p2p/gater.go
+++ b/p2p/gater.go
@@ -42,16 +42,16 @@ func NewConnGater(peers []peer.ID) (ConnGater, error) {
 }
 
 // InterceptPeerDial does nothing.
-func (c ConnGater) InterceptPeerDial(_ peer.ID) (allow bool) {
+func (ConnGater) InterceptPeerDial(_ peer.ID) (allow bool) {
 	return true // don't filter peer dials
 }
 
-func (c ConnGater) InterceptAddrDial(_ peer.ID, addr multiaddr.Multiaddr) (allow bool) {
+func (ConnGater) InterceptAddrDial(_ peer.ID, _ multiaddr.Multiaddr) (allow bool) {
 	// TODO should limit dialing to the netlist
 	return true // don't filter address dials
 }
 
-func (c ConnGater) InterceptAccept(_ network.ConnMultiaddrs) (allow bool) {
+func (ConnGater) InterceptAccept(_ network.ConnMultiaddrs) (allow bool) {
 	// TODO should limit accepting from the netlist
 	return true // don't filter incoming connections purely by address
 }
@@ -62,6 +62,6 @@ func (c ConnGater) InterceptSecured(_ network.Direction, id peer.ID, _ network.C
 }
 
 // InterceptUpgraded does nothing.
-func (c ConnGater) InterceptUpgraded(_ network.Conn) (bool, control.DisconnectReason) {
+func (ConnGater) InterceptUpgraded(_ network.Conn) (bool, control.DisconnectReason) {
 	return true, 0
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -82,7 +82,12 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater,
 		}),
 	}
 
-	return libp2p.New(opts...)
+	res, err := libp2p.New(opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "new libp2p node")
+	}
+
+	return res, nil
 }
 
 // logWrapRouting wraps a peerRoutingFunc in debug logging.

--- a/validatorapi/eth2types.go
+++ b/validatorapi/eth2types.go
@@ -20,6 +20,8 @@ import (
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 // errorResponse an error response from the beacon-node api.
@@ -38,13 +40,13 @@ func (r *attesterDutiesRequest) UnmarshalJSON(bytes []byte) error {
 	var strints []string
 
 	if err := json.Unmarshal(bytes, &strints); err != nil {
-		return err
+		return errors.Wrap(err, "unmarshal slice")
 	}
 
 	for _, strint := range strints {
 		i, err := strconv.ParseUint(strint, 10, 64)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "parse index")
 		}
 		*r = append(*r, eth2p0.ValidatorIndex(i))
 	}

--- a/validatorapi/router.go
+++ b/validatorapi/router.go
@@ -41,7 +41,6 @@ import (
 // translates http requests related to the distributed validator to the validatorapi.Handler.
 // All other requests are reserve-proxied to the beacon-node address.
 func NewRouter(h Handler, beaconNodeAddr string) (*mux.Router, error) {
-
 	// Register subset of distributed validator related endpoints
 	endpoints := []struct {
 		Name    string
@@ -131,7 +130,6 @@ func trace(endpoint string, handler http.HandlerFunc) http.Handler {
 // proposerDuties returns a handler function for the proposer duty endpoint.
 func proposerDuties(p eth2client.ProposerDutiesProvider) handlerFunc {
 	return func(ctx context.Context, params map[string]string, body []byte) (interface{}, error) {
-
 		epoch, err := uintParam(params, "epoch")
 		if err != nil {
 			return nil, err
@@ -154,7 +152,6 @@ func proposerDuties(p eth2client.ProposerDutiesProvider) handlerFunc {
 // attesterDuties returns a handler function for the attester duty endpoint.
 func attesterDuties(p eth2client.AttesterDutiesProvider) handlerFunc {
 	return func(ctx context.Context, params map[string]string, body []byte) (interface{}, error) {
-
 		epoch, err := uintParam(params, "epoch")
 		if err != nil {
 			return nil, err
@@ -212,7 +209,6 @@ func writeResponse(ctx context.Context, w http.ResponseWriter, endpoint string, 
 
 // writeError writes a http json error response object.
 func writeError(ctx context.Context, w http.ResponseWriter, endpoint string, err error) {
-
 	var aerr apiError
 	if !errors.As(err, &aerr) {
 		aerr = apiError{


### PR DESCRIPTION
Another iteration on golangci-lint configuration:
- remove `wsl`, it is too strict and unintuitive and doesn't have auto-fix
- add `gofumpt`, this is extension to gofmt and has auto-fix.
- add `revive`, whole set of additional lint rules
- add `wrapcheck`, which is kinda annoying, but required if we want to be able to debug errors. Without ALWAYS wrapping, you get errors like "something went wrong", but you have no idea where it actually originated.