### PR TITLE
cluster/leadercast: simplify isleader function

### DIFF
--- a/cluster/leadercast/leadercast.go
+++ b/cluster/leadercast/leadercast.go
@@ -131,12 +131,7 @@ func (l *LeaderCast) ResolveDuty(ctx context.Context, d types.Duty, data []byte)
 // isLeader is a deterministic LeaderCast election function that returns true if the instance at index (of total)
 // is the LeaderCast for the given duty.
 func isLeader(index, total int, d types.Duty) bool {
-	const slotFactor = 10
-	if d.Type >= slotFactor {
-		panic("invalid duty type")
-	}
-
-	mod := ((d.Slot * 10) + int(d.Type)) % total
+	mod := (d.Slot + int(d.Type)) % total
 
 	return mod == index
 }

--- a/cluster/leadercast/leadercast_internal_test.go
+++ b/cluster/leadercast/leadercast_internal_test.go
@@ -31,29 +31,29 @@ func TestIsLeader(t *testing.T) {
 	}{
 		{
 			Slot:     1,
-			DutyType: types.DutyAttester,
-			Total:    5,
-			Leader:   1,
-		}, {
-			Slot:     1,
-			DutyType: 2,
+			DutyType: 1,
 			Total:    5,
 			Leader:   2,
 		}, {
 			Slot:     1,
-			DutyType: 3,
+			DutyType: 2,
 			Total:    5,
 			Leader:   3,
+		}, {
+			Slot:     1,
+			DutyType: 3,
+			Total:    5,
+			Leader:   4,
+		}, {
+			Slot:     1,
+			DutyType: 1,
+			Total:    2,
+			Leader:   0,
 		}, {
 			Slot:     2,
 			DutyType: 1,
 			Total:    2,
 			Leader:   1,
-		}, {
-			Slot:     2,
-			DutyType: 2,
-			Total:    2,
-			Leader:   0,
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
Simplifies the isLeader function to be more predictable; doing round robin across peers as the slots increase per duty. 