### PR TITLE
app: deterministic simulated duty slots

### DIFF
--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -52,7 +52,7 @@ func TestSimDuties(t *testing.T) {
 			TestConfig: app.TestConfig{
 				Manifest:        &manifest,
 				P2PKey:          p2pKeys[i],
-				SimDutyPeriod:   time.Millisecond * 10,
+				SimDutyPeriod:   time.Second,
 				SimDutyCallback: asserter.Callback(t),
 			},
 			P2P: p2p.Config{


### PR DESCRIPTION
Makes simulated duties deterministic in local time, so nodes started at different times are synced on duties to resolve if run on the same machine (simnet).