### PR TITLE
push to ghcr since docker registry is replaced

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,11 +30,11 @@ jobs:
         NODE_ENV: production
         DOCKER_BUILDKIT: 1
       with:
-        name: ${{ github.repository }}/charon
+        name: ${{ github.repository }}
         username: ${{ github.actor }}
         password: ${{ secrets.CONTAINER_REGISTRY_SECRET }}
         buildargs: GITHUB_SHA=${{ github.sha }}
-        registry: docker.pkg.github.com
+        registry: ghcr.io
         tags: "latest,${{steps.get-version.outputs.version}}"
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
- https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry
- Remove additional `charon` from build name