### PR TITLE
tbls: refactor TSS struct for testing

### DIFF
--- a/tbls/tss_test.go
+++ b/tbls/tss_test.go
@@ -33,7 +33,7 @@ func TestGenerateTSS(t *testing.T) {
 	require.NotNil(t, tss)
 	require.NotNil(t, secrets)
 
-	require.Equal(t, threshold, tss.Threshold())
+	require.Equal(t, threshold, tss.Threshold)
 	require.Equal(t, shares, tss.NumShares)
 }
 
@@ -58,9 +58,7 @@ func TestAggregateSignatures(t *testing.T) {
 	sig, _, err := tbls.AggregateSignatures(tss, partialSigs, msg)
 	require.NoError(t, err)
 
-	pubkey, err := tss.PublicKey()
-	require.NoError(t, err)
-	result, err := tbls.Verify(pubkey, msg, sig)
+	result, err := tbls.Verify(tss.PublicKey, msg, sig)
 	require.NoError(t, err)
 	require.Equal(t, true, result)
 }

--- a/types/manifest_test.go
+++ b/types/manifest_test.go
@@ -69,11 +69,7 @@ func TestManifestJSON(t *testing.T) {
 			tss2 := manifest2.DVs[i]
 			require.Equal(t, tss1.NumShares, tss2.NumShares)
 			require.Equal(t, tss1.Verifier, tss2.Verifier)
-			pk1, err := tss1.PublicKey()
-			require.NoError(t, err)
-			pk2, err := tss2.PublicKey()
-			require.NoError(t, err)
-			require.Equal(t, pk1, pk2)
+			require.Equal(t, tss1.PublicKey, tss2.PublicKey)
 		}
 	}
 }


### PR DESCRIPTION
Refactors the tbls.TSS struct to allow for arbitrary data during testing. This allows using know existing validator public keys when testing the scheduler, ensuring that duties that we calculate match those in mainnet.

category: refactor
ticket: https://github.com/ObolNetwork/charon/issues/145