### PR TITLE
Revert publishing to docker registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,9 @@ jobs:
         version=$(echo "${{ github.sha }}" | cut -c1-8)
         echo "::set-output name=version::$version"
 
-    # - run: echo "${{steps.get-version.outputs.version}}"
-
     # Runs a single command using the runners shell
     - name: Publish to registry
-      uses: elgohr/Publish-Docker-Github-Action@3.02
+      uses: elgohr/Publish-Docker-Github-Action@3.04
       env:
         NODE_ENV: production
         DOCKER_BUILDKIT: 1
@@ -34,7 +32,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.CONTAINER_REGISTRY_SECRET }}
         buildargs: GITHUB_SHA=${{ github.sha }}
-        registry: ghcr.io
+        registry: docker.pkg.github.com
         tags: "latest,${{steps.get-version.outputs.version}}"
     - name: Image digest
       run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
- push to `docker.pkg.github.com` as charon images are not getting published to `ghcr.io`
- hotfix until error `Layer already exists` is resolved