### PR TITLE
revert publishing to ghcr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,15 +23,16 @@ jobs:
 
     # Runs a single command using the runners shell
     - name: Publish to registry
-      uses: elgohr/Publish-Docker-Github-Action@3.04
+      uses: elgohr/Publish-Docker-Github-Action@3.03
       env:
         NODE_ENV: production
         DOCKER_BUILDKIT: 1
       with:
-        name: ${{ github.repository }}
+        name: ${{ github.repository }}/charon
         username: ${{ github.actor }}
         password: ${{ secrets.CONTAINER_REGISTRY_SECRET }}
         buildargs: GITHUB_SHA=${{ github.sha }}
+        # registry: ghcr.io
         registry: docker.pkg.github.com
         tags: "latest,${{steps.get-version.outputs.version}}"
     - name: Image digest


### PR DESCRIPTION
- Downgrade `elgohr/Publish-Docker-Github-Action` to `3.03`. Latest version `3.04` didn't work
- Add imagename as `charon`