### PR TITLE
scheduler: add unit tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,9 @@ repos:
     rev: v4.1.0
     hooks:
       - id: trailing-whitespace # trims trailing whitespace
+        exclude: "testdata"
       - id: end-of-file-fixer # ensures that a file is either empty, or ends with one newline
+        exclude: "testdata"
       - id: mixed-line-ending # ensures that a file doesn't contain a mix of LF and CRLF
       - id: no-commit-to-branch # Protect specific branches (default: main/master) from direct checkins
 

--- a/app/golden/golden.go
+++ b/app/golden/golden.go
@@ -1,0 +1,76 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package golden provides a test utility for asserting blobs against golden files in a testdata folder.
+// This is heavily inspired from https://github.com/sebdah/goldie.
+package golden
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	update = flag.Bool("update", false, "Create or update golden files, instead of comparing them")
+	clean  = flag.Bool("clean", false, "Deletes the testdata folder before updating (noop of update==false)")
+)
+
+var cleanOnce sync.Once
+
+// RequireBytes asserts that a golden testdata file exists containing the exact data.
+func RequireBytes(t *testing.T, data []byte) {
+	t.Helper()
+
+	filename := path.Join("testdata", strings.ReplaceAll(t.Name(), "/", "_"))
+
+	if *update {
+		if *clean {
+			cleanOnce.Do(func() {
+				_ = os.RemoveAll("testdata")
+			})
+		}
+
+		require.NoError(t, os.MkdirAll("testdata", 0o755))
+
+		_ = os.Remove(filename)
+		require.NoError(t, os.WriteFile(filename, data, 0o644)) //nolint:gosec
+
+		return
+	}
+
+	expected, err := os.ReadFile(filename)
+	if os.IsNotExist(err) {
+		t.Fatalf("golden file does not exist, %s, generate by running with -update", filename)
+		return
+	}
+
+	require.Equalf(t, expected, data, "Golden file mismatch, %s", filename)
+}
+
+// RequireJSON asserts that a golden testdata file exists containing the JSON serialised form of the data object.
+func RequireJSON(t *testing.T, data interface{}) {
+	t.Helper()
+
+	b, err := json.MarshalIndent(data, "", " ")
+	require.NoError(t, err)
+
+	RequireBytes(t, b)
+}

--- a/beaconmock/beaconmock.go
+++ b/beaconmock/beaconmock.go
@@ -1,0 +1,99 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package beaconmock provides a mock beacon client primarily for testing.
+package beaconmock
+
+import (
+	"context"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// Interface assertions.
+var (
+	_ eth2client.Service                = (*Mock)(nil)
+	_ eth2client.NodeSyncingProvider    = (*Mock)(nil)
+	_ eth2client.GenesisTimeProvider    = (*Mock)(nil)
+	_ eth2client.ValidatorsProvider     = (*Mock)(nil)
+	_ eth2client.SlotsPerEpochProvider  = (*Mock)(nil)
+	_ eth2client.SlotDurationProvider   = (*Mock)(nil)
+	_ eth2client.AttesterDutiesProvider = (*Mock)(nil)
+	_ eth2client.ProposerDutiesProvider = (*Mock)(nil)
+)
+
+// NewMock returns a new beacon client mock configured with the default and provided options.
+func NewMock(opts ...Option) Mock {
+	mock := defaultMock()
+	for _, opt := range opts {
+		opt(&mock)
+	}
+
+	return mock
+}
+
+// Mock provides a mock beacon client and implements eth2client.Service and many of the erh2client Providers.
+type Mock struct {
+	ProposerDutiesFunc     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
+	AttesterDutiesFunc     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
+	SlotDurationFunc       func(context.Context) (time.Duration, error)
+	SlotsPerEpochFunc      func(context.Context) (uint64, error)
+	ValidatorsFunc         func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
+	ValidatorsByPubKeyFunc func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
+	GenesisTimeFunc        func(context.Context) (time.Time, error)
+	NodeSyncingFunc        func(context.Context) (*eth2v1.SyncState, error)
+}
+
+func (m Mock) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+	return m.ProposerDutiesFunc(ctx, epoch, validatorIndices)
+}
+
+func (m Mock) AttesterDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
+	return m.AttesterDutiesFunc(ctx, epoch, validatorIndices)
+}
+
+func (m Mock) SlotDuration(ctx context.Context) (time.Duration, error) {
+	return m.SlotDurationFunc(ctx)
+}
+
+func (m Mock) SlotsPerEpoch(ctx context.Context) (uint64, error) {
+	return m.SlotsPerEpochFunc(ctx)
+}
+
+func (m Mock) Validators(ctx context.Context, stateID string, validatorIndices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+	return m.ValidatorsFunc(ctx, stateID, validatorIndices)
+}
+
+func (m Mock) ValidatorsByPubKey(ctx context.Context, stateID string, validatorPubKeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+	return m.ValidatorsByPubKeyFunc(ctx, stateID, validatorPubKeys)
+}
+
+func (m Mock) GenesisTime(ctx context.Context) (time.Time, error) {
+	return m.GenesisTimeFunc(ctx)
+}
+
+func (m Mock) NodeSyncing(ctx context.Context) (*eth2v1.SyncState, error) {
+	return m.NodeSyncingFunc(ctx)
+}
+
+func (Mock) Name() string {
+	return "beacon-mock"
+}
+
+func (Mock) Address() string {
+	return "mock-address"
+}

--- a/beaconmock/options.go
+++ b/beaconmock/options.go
@@ -1,0 +1,229 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beaconmock
+
+import (
+	"context"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+// Option defines a functional option to configure the mock beacon client.
+type Option func(*Mock)
+
+type ValidatorSet map[eth2p0.ValidatorIndex]*eth2v1.Validator
+
+// ByPublicKey is a convenience function to return a validator by its public key.
+func (s ValidatorSet) ByPublicKey(pubkey eth2p0.BLSPubKey) (*eth2v1.Validator, bool) {
+	for _, validator := range s {
+		if pubkey == validator.Validator.PublicKey {
+			return validator, true
+		}
+	}
+
+	return nil, false
+}
+
+// PublicKeys is a convenience function to extract the bls public keys from the validators.
+func (s ValidatorSet) PublicKeys() ([]*bls_sig.PublicKey, error) {
+	var resp []*bls_sig.PublicKey
+	for _, validator := range s {
+		pk := new(bls_sig.PublicKey)
+		err := pk.UnmarshalBinary(validator.Validator.PublicKey[:])
+		if err != nil {
+			return nil, errors.Wrap(err, "unmarshal pubkey")
+		}
+
+		resp = append(resp, pk)
+	}
+
+	return resp, nil
+}
+
+// ValidatorSetA defines a set 3 validators.
+var ValidatorSetA = ValidatorSet{
+	1: {
+		Index:   1,
+		Balance: 1,
+		Status:  eth2v1.ValidatorStateActiveOngoing,
+		Validator: &eth2p0.Validator{
+			PublicKey:                  mustPKFromHex("0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490"),
+			EffectiveBalance:           1,
+			ActivationEligibilityEpoch: 1,
+			ActivationEpoch:            2,
+		},
+	},
+	2: {
+		Index:   2,
+		Balance: 2,
+		Status:  eth2v1.ValidatorStateActiveOngoing,
+		Validator: &eth2p0.Validator{
+			PublicKey:                  mustPKFromHex("0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea"),
+			EffectiveBalance:           2,
+			ActivationEligibilityEpoch: 2,
+			ActivationEpoch:            3,
+		},
+	},
+	3: {
+		Index:   3,
+		Balance: 3,
+		Status:  eth2v1.ValidatorStateActiveOngoing,
+		Validator: &eth2p0.Validator{
+			PublicKey:                  mustPKFromHex("0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76"),
+			EffectiveBalance:           3,
+			ActivationEligibilityEpoch: 3,
+			ActivationEpoch:            4,
+		},
+	},
+}
+
+// WithValidatorSet configures the mock with the provided validator set.
+func WithValidatorSet(set ValidatorSet) Option {
+	return func(mock *Mock) {
+		mock.ValidatorsByPubKeyFunc = func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+			resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
+			for _, pubkey := range pubkeys {
+				val, ok := set.ByPublicKey(pubkey)
+				if ok {
+					resp[val.Index] = val
+				}
+			}
+
+			return resp, nil
+		}
+
+		mock.ValidatorsFunc = func(ctx context.Context, stateID string, indexes []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+			resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
+			for _, index := range indexes {
+				val, ok := set[index]
+				if ok {
+					resp[index] = val
+				}
+			}
+
+			return resp, nil
+		}
+	}
+}
+
+// WithGenesis configures the mock with the provided genesis time.
+func WithGenesis(t0 time.Time) Option {
+	return func(mock *Mock) {
+		mock.GenesisTimeFunc = func(_ context.Context) (time.Time, error) {
+			return t0, nil
+		}
+	}
+}
+
+// WithDeterministicDuties configures the mock with to provide deterministic duties based on provided arguments and config.
+// Note it depends on ValidatorsFunc being populated, e.g. via WithValidatorSet.
+func WithDeterministicDuties(factor int) Option {
+	return func(mock *Mock) {
+		mock.AttesterDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
+			vals, err := mock.Validators(ctx, "", indices)
+			if err != nil {
+				return nil, err
+			}
+
+			slotsPerEpoch, err := mock.SlotsPerEpoch(ctx)
+			if err != nil {
+				return nil, err
+			}
+
+			sort.Slice(indices, func(i, j int) bool {
+				return indices[i] < indices[j]
+			})
+
+			var resp []*eth2v1.AttesterDuty
+			for i, index := range indices {
+				val, ok := vals[index]
+				if !ok {
+					continue
+				}
+
+				resp = append(resp, &eth2v1.AttesterDuty{
+					PubKey:                  val.Validator.PublicKey,
+					Slot:                    eth2p0.Slot(slotsPerEpoch*uint64(epoch) + uint64(i*factor)),
+					ValidatorIndex:          index,
+					CommitteeIndex:          eth2p0.CommitteeIndex(i * factor),
+					CommitteeLength:         0,
+					CommitteesAtSlot:        0,
+					ValidatorCommitteeIndex: uint64(i * factor),
+				})
+			}
+
+			return resp, nil
+		}
+	}
+}
+
+// defaultMock returns a minimum viable mock that doesn't panic and returns mostly empty responses.
+// The default slots have 1 second duration and there are 10 slots per epoch (for simple math).
+func defaultMock() Mock {
+	return Mock{
+		ProposerDutiesFunc: func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+			return nil, nil
+		},
+		AttesterDutiesFunc: func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
+			return nil, nil
+		},
+		SlotDurationFunc: func(ctx context.Context) (time.Duration, error) {
+			return time.Second, nil
+		},
+		SlotsPerEpochFunc: func(ctx context.Context) (uint64, error) {
+			return 10, nil
+		},
+		ValidatorsFunc: func(ctx context.Context, stateID string, indices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+			return nil, nil
+		},
+		ValidatorsByPubKeyFunc: func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+			return nil, nil
+		},
+		GenesisTimeFunc: func(ctx context.Context) (time.Time, error) {
+			day := time.Hour * 24
+			return time.Now().Truncate(day).Add(-day), nil // Start of yesterday.
+		},
+		NodeSyncingFunc: func(ctx context.Context) (*eth2v1.SyncState, error) {
+			return &eth2v1.SyncState{
+				HeadSlot:     0,
+				SyncDistance: 0,
+				IsSyncing:    false,
+			}, nil
+		},
+	}
+}
+
+func mustPKFromHex(pubkeyHex string) eth2p0.BLSPubKey {
+	pubkeyHex = strings.TrimPrefix(pubkeyHex, "0x")
+	b, err := hex.DecodeString(pubkeyHex)
+	if err != nil {
+		panic(err)
+	}
+	var resp eth2p0.BLSPubKey
+	n := copy(resp[:], b)
+	if n != 48 {
+		panic("invalid pubkey hex")
+	}
+
+	return resp
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/coinbase/kryptology v1.5.5
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/gorilla/mux v1.8.0
+	github.com/jonboulle/clockwork v0.2.2
 	github.com/libp2p/go-libp2p v0.17.0
 	github.com/libp2p/go-libp2p-core v0.13.0
 	github.com/libp2p/go-libp2p-noise v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -564,6 +564,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
+github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9qUBdQ=
+github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -18,11 +18,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"testing"
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
@@ -40,7 +43,20 @@ type eth2Provider interface {
 	eth2client.ProposerDutiesProvider
 }
 
-func New(pubkeys []bls_sig.PublicKey, eth2Svc eth2client.Service) (*Scheduler, error) {
+// NewForT returns a new scheduler for testing supporting a fake clock.
+func NewForT(t *testing.T, clock clockwork.Clock, pubkeys []*bls_sig.PublicKey, eth2Svc eth2client.Service) *Scheduler {
+	t.Helper()
+
+	s, err := New(pubkeys, eth2Svc)
+	require.NoError(t, err)
+
+	s.clock = clock
+
+	return s
+}
+
+// New returns a new scheduler.
+func New(pubkeys []*bls_sig.PublicKey, eth2Svc eth2client.Service) (*Scheduler, error) {
 	eth2Cl, ok := eth2Svc.(eth2Provider)
 	if !ok {
 		return nil, errors.New("invalid eth2 client service")
@@ -56,8 +72,9 @@ func New(pubkeys []bls_sig.PublicKey, eth2Svc eth2client.Service) (*Scheduler, e
 
 type Scheduler struct {
 	eth2Cl  eth2Provider
-	pubkeys []bls_sig.PublicKey
+	pubkeys []*bls_sig.PublicKey
 	quit    chan struct{}
+	clock   clockwork.Clock
 
 	duties map[types.Duty]types.DutyArgSet
 	subs   []func(context.Context, types.Duty, types.DutyArgSet) error
@@ -77,10 +94,10 @@ func (s *Scheduler) Stop() {
 func (s *Scheduler) Run() error {
 	ctx := log.WithTopic(context.Background(), "sched")
 
-	waitChainStart(ctx, s.eth2Cl)
-	waitBeaconSync(ctx, s.eth2Cl)
+	waitChainStart(ctx, s.eth2Cl, s.clock)
+	waitBeaconSync(ctx, s.eth2Cl, s.clock)
 
-	slotTicker, err := newSlotTicker(ctx, s.eth2Cl)
+	slotTicker, err := newSlotTicker(ctx, s.eth2Cl, s.clock)
 	if err != nil {
 		return err
 	}
@@ -221,7 +238,7 @@ func (s slot) IsLastInEpoch() bool {
 
 // newSlotTicker returns a blocking channel that will be populated with new slots in real time.
 // It is also populated with the current slot immediately.
-func newSlotTicker(ctx context.Context, eth2Cl eth2Provider) (<-chan slot, error) {
+func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clock) (<-chan slot, error) {
 	genesis, err := eth2Cl.GenesisTime(ctx)
 	if err != nil {
 		return nil, err
@@ -237,7 +254,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider) (<-chan slot, error
 		return nil, err
 	}
 
-	chainAge := time.Since(genesis)
+	chainAge := clock.Since(genesis)
 	height := int64(chainAge / slotDuration)
 	startTime := genesis.Add(time.Duration(height) * slotDuration)
 	initial := true
@@ -257,7 +274,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider) (<-chan slot, error
 			startTime = startTime.Add(slotDuration)
 			initial = false
 
-			time.Sleep(time.Until(startTime))
+			clock.Sleep(startTime.Sub(clock.Now()))
 		}
 	}()
 
@@ -266,7 +283,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider) (<-chan slot, error
 
 // resolveActiveDVs returns the active validators for the slot (in two different formats).
 func resolveActiveDVs(ctx context.Context, eth2Cl eth2Provider,
-	pubkeys []bls_sig.PublicKey, slot int64,
+	pubkeys []*bls_sig.PublicKey, slot int64,
 ) ([]types.VIdx, []eth2p0.ValidatorIndex, error) {
 	var e2pks []eth2p0.BLSPubKey
 	for _, pubkey := range pubkeys {
@@ -312,21 +329,22 @@ func resolveActiveDVs(ctx context.Context, eth2Cl eth2Provider,
 	return resp1, resp2, nil
 }
 
-func waitChainStart(ctx context.Context, eth2Cl eth2Provider) {
+func waitChainStart(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clock) {
 	for {
 		genesis, err := eth2Cl.GenesisTime(ctx)
 		if err != nil {
 			log.Error(ctx, "failure getting genesis time", err)
-			time.Sleep(time.Second * 5) // TODO(corver): Improve backoff
+			clock.Sleep(time.Second * 5) // TODO(corver): Improve backoff
 
 			continue
 		}
 
-		if time.Now().Before(genesis) {
-			delta := time.Since(genesis)
+		now := clock.Now()
+		if now.Before(genesis) {
+			delta := genesis.Sub(now)
 			log.Info(ctx, "Sleeping until genesis time",
 				z.Str("genesis", genesis.String()), z.Str("sleep", delta.String()))
-			time.Sleep(delta)
+			clock.Sleep(delta)
 
 			continue
 		}
@@ -335,12 +353,12 @@ func waitChainStart(ctx context.Context, eth2Cl eth2Provider) {
 	}
 }
 
-func waitBeaconSync(ctx context.Context, eth2Cl eth2Provider) {
+func waitBeaconSync(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clock) {
 	for {
 		state, err := eth2Cl.NodeSyncing(ctx)
 		if err != nil {
 			log.Error(ctx, "failure getting sync state", err)
-			time.Sleep(time.Second * 5) // TODO(corver): Improve backoff
+			clock.Sleep(time.Second * 5) // TODO(corver): Improve backoff
 
 			continue
 		}
@@ -348,7 +366,7 @@ func waitBeaconSync(ctx context.Context, eth2Cl eth2Provider) {
 		if state.IsSyncing {
 			log.Info(ctx, "Waiting for beacon node to sync",
 				z.U64("distance", uint64(state.SyncDistance)))
-			time.Sleep(time.Minute) // TODO(corver): Improve backoff
+			clock.Sleep(time.Minute) // TODO(corver): Improve backoff
 
 			continue
 		}

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -22,12 +22,17 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2http "github.com/attestantio/go-eth2-client/http"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/golden"
+	"github.com/obolnetwork/charon/beaconmock"
 	"github.com/obolnetwork/charon/scheduler"
 	"github.com/obolnetwork/charon/types"
 )
@@ -56,7 +61,7 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Use random actual mainnet validators
-	pubkeys := []bls_sig.PublicKey{
+	pubkeys := []*bls_sig.PublicKey{
 		pkFromHex(t, "0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490"),
 		pkFromHex(t, "0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea"),
 		pkFromHex(t, "0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76"),
@@ -88,7 +93,190 @@ func TestIntegration(t *testing.T) {
 	require.NoError(t, s.Run())
 }
 
-func pkFromHex(t *testing.T, pk string) bls_sig.PublicKey {
+// TestSchedulerWait tests the waitChainStart and waitBeaconSync functions.
+func TestSchedulerWait(t *testing.T) {
+	tests := []struct {
+		Name         string
+		GenesisAfter time.Duration
+		GenesisErrs  int
+		SyncedAfter  time.Duration
+		SyncedErrs   int
+		WaitSecs     int
+	}{
+		{
+			Name:     "wait for nothing",
+			WaitSecs: 0,
+		},
+		{
+			Name:         "wait for genesis",
+			GenesisAfter: time.Second * 5,
+			WaitSecs:     5,
+		},
+		{
+			Name:        "wait for sync",
+			SyncedAfter: time.Second,
+			WaitSecs:    60, // We wait in blocks of 1min for sync.
+		},
+		{
+			Name:        "genesis errors",
+			GenesisErrs: 3,
+			WaitSecs:    15, // We backoff in blocks of 5sec for errors.
+		},
+		{
+			Name:       "synced errors",
+			SyncedErrs: 2,
+			WaitSecs:   10, // We backoff in blocks of 5sec for errors.
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var t0 time.Time
+			clock := clockwork.NewFakeClockAt(t0)
+			eth2Cl := beaconmock.NewMock()
+
+			eth2Cl.GenesisTimeFunc = func(context.Context) (time.Time, error) {
+				var err error
+				if test.GenesisErrs > 0 {
+					err = errors.New("mock error")
+					test.GenesisErrs--
+				}
+
+				return t0.Add(test.GenesisAfter), err
+			}
+
+			eth2Cl.NodeSyncingFunc = func(context.Context) (*eth2v1.SyncState, error) {
+				var err error
+				if test.SyncedErrs > 0 {
+					err = errors.New("mock error")
+					test.SyncedErrs--
+				}
+
+				return &eth2v1.SyncState{
+					IsSyncing: clock.Now().Before(t0.Add(test.SyncedAfter)),
+				}, err
+			}
+
+			sched := scheduler.NewForT(t, clock, nil, eth2Cl)
+			sched.Stop() // Just run wait functions, then quit.
+
+			done := make(chan struct{})
+			go func() {
+				err := sched.Run()
+				require.NoError(t, err)
+				close(done)
+			}()
+
+			var elapsed int
+			for {
+				gosched() // Wait for scheduler goroutine to sleep or complete
+
+				select {
+				case <-done:
+					break
+				default:
+					clock.Advance(time.Second)
+					elapsed++
+
+					continue
+				}
+
+				break
+			}
+
+			require.Equal(t, test.WaitSecs, elapsed)
+		})
+	}
+}
+
+//go:generate go test . -run=TestSchedulerDuties -update -clean
+
+// TestSchedulerDuties tests the scheduled duties given a deterministic mock beacon node.
+func TestSchedulerDuties(t *testing.T) {
+	tests := []struct {
+		Name   string
+		Factor int // Determines how duties are spread per epoch
+	}{
+		{
+			Name:   "grouped",
+			Factor: 0,
+		}, {
+			Name:   "spread",
+			Factor: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			var t0 time.Time
+			clock := clockwork.NewFakeClockAt(t0)
+
+			valSet := beaconmock.ValidatorSetA
+			eth2Cl := beaconmock.NewMock(
+				beaconmock.WithValidatorSet(valSet),
+				beaconmock.WithGenesis(t0),
+				beaconmock.WithDeterministicDuties(test.Factor),
+			)
+
+			pubkeys, err := valSet.PublicKeys()
+			require.NoError(t, err)
+
+			sched := scheduler.NewForT(t, clock, pubkeys, eth2Cl)
+
+			dutyChan := make(chan map[types.Duty]types.DutyArgSet)
+			sched.Subscribe(func(ctx context.Context, duty types.Duty, set types.DutyArgSet) error {
+				dutyChan <- map[types.Duty]types.DutyArgSet{duty: set}
+				return nil
+			})
+
+			go func() {
+				err := sched.Run()
+				require.NoError(t, err)
+			}()
+
+			type tuple struct {
+				Duty       string
+				DutyArgSet map[types.VIdx]string
+			}
+			var tuples []tuple
+
+			stopAt := clock.Now().Add(time.Second * 30) // See duties for 30 seconds (3 epochs).
+			for {
+				gosched() // Wait for scheduler goroutine to sleep or complete
+
+				select {
+				case dmap := <-dutyChan:
+					for duty, set := range dmap {
+						dset := make(map[types.VIdx]string)
+						for idx, args := range set {
+							dset[idx] = string(args)
+						}
+
+						tuples = append(tuples, tuple{
+							Duty:       duty.String(),
+							DutyArgSet: dset,
+						})
+					}
+
+					continue
+				default:
+					if !clock.Now().Before(stopAt) {
+						break
+					}
+					clock.Advance(time.Second)
+
+					continue
+				}
+
+				break
+			}
+
+			golden.RequireJSON(t, tuples)
+		})
+	}
+}
+
+func pkFromHex(t *testing.T, pk string) *bls_sig.PublicKey {
 	t.Helper()
 
 	pk = strings.TrimPrefix(pk, "0x")
@@ -96,9 +284,12 @@ func pkFromHex(t *testing.T, pk string) bls_sig.PublicKey {
 	b, err := hex.DecodeString(pk)
 	require.NoError(t, err)
 
-	var pubkey bls_sig.PublicKey
-	err = (&pubkey).UnmarshalBinary(b)
+	pubkey := new(bls_sig.PublicKey)
+	err = pubkey.UnmarshalBinary(b)
 	require.NoError(t, err)
 
 	return pubkey
 }
+
+// gosched sleeps momentarily so that other goroutines can process.
+func gosched() { time.Sleep(1 * time.Millisecond) }

--- a/scheduler/testdata/TestSchedulerDuties_grouped
+++ b/scheduler/testdata/TestSchedulerDuties_grouped
@@ -1,0 +1,34 @@
+[
+ {
+  "Duty": "0/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"0\",\"validator_index\":\"2\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"0\",\"validator_index\":\"3\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ },
+ {
+  "Duty": "10/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"10\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"10\",\"validator_index\":\"2\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"10\",\"validator_index\":\"3\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ },
+ {
+  "Duty": "20/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"20\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"20\",\"validator_index\":\"2\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"20\",\"validator_index\":\"3\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ },
+ {
+  "Duty": "30/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"30\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"30\",\"validator_index\":\"2\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}",
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"30\",\"validator_index\":\"3\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ }
+]

--- a/scheduler/testdata/TestSchedulerDuties_spread
+++ b/scheduler/testdata/TestSchedulerDuties_spread
@@ -1,0 +1,62 @@
+[
+ {
+  "Duty": "0/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ },
+ {
+  "Duty": "1/attester",
+  "DutyArgSet": {
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"1\",\"validator_index\":\"2\",\"committee_index\":\"1\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"1\"}"
+  }
+ },
+ {
+  "Duty": "2/attester",
+  "DutyArgSet": {
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"2\",\"validator_index\":\"3\",\"committee_index\":\"2\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"2\"}"
+  }
+ },
+ {
+  "Duty": "10/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"10\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ },
+ {
+  "Duty": "11/attester",
+  "DutyArgSet": {
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"11\",\"validator_index\":\"2\",\"committee_index\":\"1\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"1\"}"
+  }
+ },
+ {
+  "Duty": "12/attester",
+  "DutyArgSet": {
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"12\",\"validator_index\":\"3\",\"committee_index\":\"2\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"2\"}"
+  }
+ },
+ {
+  "Duty": "20/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"20\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ },
+ {
+  "Duty": "21/attester",
+  "DutyArgSet": {
+   "2": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"21\",\"validator_index\":\"2\",\"committee_index\":\"1\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"1\"}"
+  }
+ },
+ {
+  "Duty": "22/attester",
+  "DutyArgSet": {
+   "3": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"22\",\"validator_index\":\"3\",\"committee_index\":\"2\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"2\"}"
+  }
+ },
+ {
+  "Duty": "30/attester",
+  "DutyArgSet": {
+   "1": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"30\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"0\",\"committees_at_slot\":\"0\",\"validator_committee_index\":\"0\"}"
+  }
+ }
+]


### PR DESCRIPTION
Adds unit tests to the scheduler package.

Also adds some helper test utils:
 - app/golden: for golden file testing
 - beaconmock: beacon client mock
 
category: testing
ticket: https://github.com/ObolNetwork/charon/issues/145