### PR TITLE
cmd: improve gen-simnet command documentation

### DIFF
--- a/cmd/gen_simnet.go
+++ b/cmd/gen_simnet.go
@@ -71,6 +71,7 @@ func newGenSimnetCmd(runFunc func(io.Writer, simnetConfig) error) *cobra.Command
 	cmd := &cobra.Command{
 		Use:   "gen-simnet",
 		Short: "Generates local charon simnet cluster",
+		Long:  "Generate local charon simnet cluster. A simnet is a simulated network that doesn't use actual beacon nodes or validator clients but mocks them instead. It showcases a running charon in isolation.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.OutOrStdout(), conf)
 		},


### PR DESCRIPTION
improves the gen-simnet command docs:
- Adds comments to bash scripts
- Improve command output documentation

Example:
```
Using charon binary in scripts: /usr/local/bin/charon
Created a simnet cluster:

/tmp/charon-simnet/
├─ manifest.json	Cluster manifest defines the cluster; used by all nodes
├─ run_cluster.sh	Convenience script to run all nodes; merges log output :(
├─ node[0-3]/		Directory for each node
│  ├─ p2pkey		P2P networking private key; node authentication
│  ├─ run.sh		Script to run the node
```

category: docs
ticket: none