### PR TITLE
fix docker pull from ghcr

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - xenowits/investigate-ghcr-issue
+      - main
 
 name: Build docker image
 jobs:


### PR DESCRIPTION
- Fix issue regarding pulling images from `ghcr`
- Publish images to `ghcr` instead of `docker registry`
- bump `github action` version