### PR TITLE
*: fix build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,11 +20,6 @@ repos:
       - id: check-licence-header
         types: [ file, go ]
 
-  - repo: https://github.com/corverroos/fiximports
-    rev: 496e5392530966aa8f12e88a289c07782075cf91
-    hooks:
-      - id: go-fiximports # format imports for go source files
-
   - repo: https://github.com/tekwizely/pre-commit-golang
     rev: v1.0.0-beta.5 # cannot use master as it is a mutable reference and is not supported
     hooks:

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -176,7 +176,6 @@ func (s *Scheduler) resolveDuties(ctx context.Context, slot slot) error {
 
 	// Resolve attester duties
 	{
-
 		attDuties, err := s.eth2Cl.AttesterDuties(ctx, slot.Epoch(), vals.Indexes())
 		if err != nil {
 			return err


### PR DESCRIPTION
Current main branch build is broken due to lint issues. This fixes the whitespaces issues. Also remove fiximports pre-commit hook since it doubles up and clashes with golangci-lintls https://github.com/daixiang0/gci

category: fixbuild
ticket: none