### PR TITLE
p2p: move k1.go from app to p2p

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -134,7 +134,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, manifest
 	if p2pKey == nil {
 		var err error
 		var loaded bool
-		p2pKey, loaded, err = LoadOrCreatePrivKey(conf.DataDir)
+		p2pKey, loaded, err = p2p.LoadOrCreatePrivKey(conf.DataDir)
 		if err != nil {
 			return nil, nil, 0, errors.Wrap(err, "load or create peer ID")
 		}
@@ -188,7 +188,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, manifest
 
 // wireMonitoringAPI constructs the monitoring API and registers it with the life cycle manager.
 // It serves prometheus metrics, pprof profiling and the runtime enr.
-func wireMonitoringAPI(cycle *lifecycle.Manager, addr string, localNode *enode.LocalNode) {
+func wireMonitoringAPI(life *lifecycle.Manager, addr string, localNode *enode.LocalNode) {
 	mux := http.NewServeMux()
 
 	// Serve prometheus metrics
@@ -211,8 +211,8 @@ func wireMonitoringAPI(cycle *lifecycle.Manager, addr string, localNode *enode.L
 		Handler: mux,
 	}
 
-	cycle.RegisterStart(lifecycle.AsyncBackground, lifecycle.StartMonitoringAPI, httpServeHook(server.ListenAndServe))
-	cycle.RegisterStop(lifecycle.StopMonitoringAPI, lifecycle.HookFunc(server.Shutdown))
+	life.RegisterStart(lifecycle.AsyncBackground, lifecycle.StartMonitoringAPI, httpServeHook(server.ListenAndServe))
+	life.RegisterStop(lifecycle.StopMonitoringAPI, lifecycle.HookFunc(server.Shutdown))
 }
 
 // wireValidatorAPI constructs the validator API and registers it with the life cycle manager.

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/obolnetwork/charon/app"
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/p2p"
 )
@@ -49,7 +48,7 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command
 
 // Function for printing status of ENR for this instance.
 func runNewENR(w io.Writer, config p2p.Config, dataDir string) error {
-	identityKey, loaded, err := app.LoadOrCreatePrivKey(dataDir)
+	identityKey, loaded, err := p2p.LoadOrCreatePrivKey(dataDir)
 	if err != nil {
 		return err
 	}

--- a/cmd/gen_simnet.go
+++ b/cmd/gen_simnet.go
@@ -119,7 +119,7 @@ func runGenSimnet(out io.Writer, config simnetConfig) error {
 			return errors.Wrap(err, "mkdir")
 		}
 
-		p2pKey, _, err := app.LoadOrCreatePrivKey(nodeDir)
+		p2pKey, _, err := p2p.LoadOrCreatePrivKey(nodeDir)
 		if err != nil {
 			return errors.Wrap(err, "create p2p key")
 		}

--- a/p2p/k1.go
+++ b/p2p/k1.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package app
+package p2p
 
 import (
 	"crypto/ecdsa"


### PR DESCRIPTION
Moves k1.go to p2p since it creates/loads private key for p2p communication.

category: refactoring
ticket: none