### PR TITLE
p2p: remove p2p metrics

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,5 @@
 on:
+  pull_request:
   push:
     branches:
       - main

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -60,13 +60,8 @@ func pingPeer(ctx context.Context, svc *ping.PingService, p peer.ID,
 
 			logFunc(ctx, p, result.Error)
 
-			if result.Error != nil {
-				incPingError(p)
-			} else {
-				observePing(p, result.RTT)
-				if callback != nil {
-					callback(p)
-				}
+			if callback != nil {
+				callback(p)
 			}
 
 			const pingPeriod = time.Second


### PR DESCRIPTION
This is a test PR. I think libp2p has metrics so I think we don't need it on our side. This might be the cause of the error on charon-docker-compose.
Ref: https://github.com/libp2p/go-tcp-transport/blob/master/metrics.go