### PR TITLE
core/validatorapi: add unit test for SubmitAttestation

### DIFF
--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -79,7 +79,7 @@ func TestMemDB(t *testing.T) {
 	duty := core.Duty{Slot: slot, Type: core.DutyAttester}
 
 	// The two validators have similar unsigned data, just the ValidatorCommitteeIndex is different.
-	unsingedA, err := core.EncodeAttesterUnsignedData(&core.AttestationData{
+	unsignedA, err := core.EncodeAttesterUnsignedData(&core.AttestationData{
 		Data: attData,
 		Duty: eth2v1.AttesterDuty{
 			CommitteeLength:         commLen,
@@ -88,7 +88,7 @@ func TestMemDB(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	unsingedB, err := core.EncodeAttesterUnsignedData(&core.AttestationData{
+	unsignedB, err := core.EncodeAttesterUnsignedData(&core.AttestationData{
 		Data: attData,
 		Duty: eth2v1.AttesterDuty{
 			CommitteeLength:         commLen,
@@ -99,11 +99,11 @@ func TestMemDB(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store it
-	err = db.Store(ctx, duty, core.UnsignedDataSet{pubkeysByIdx[vIdxA]: unsingedA, pubkeysByIdx[vIdxB]: unsingedB})
+	err = db.Store(ctx, duty, core.UnsignedDataSet{pubkeysByIdx[vIdxA]: unsignedA, pubkeysByIdx[vIdxB]: unsignedB})
 	require.NoError(t, err)
 
 	// Store one validator again to test idempotent inserts
-	err = db.Store(ctx, duty, core.UnsignedDataSet{pubkeysByIdx[vIdxA]: unsingedA})
+	err = db.Store(ctx, duty, core.UnsignedDataSet{pubkeysByIdx[vIdxA]: unsignedA})
 	require.NoError(t, err)
 
 	// Get and assert the query responses.

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1,0 +1,144 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validatorapi_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/mock"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/validatorapi"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestComponent_ValidSubmitAttestations(t *testing.T) {
+	ctx := context.Background()
+	eth2Svc, err := mock.New(ctx)
+	require.NoError(t, err)
+
+	const (
+		slot        = 123
+		commIdx     = 456
+		vIdxA       = 1
+		vIdxB       = 2
+		valCommIdxA = vIdxA
+		valCommIdxB = vIdxB
+		commLen     = 8
+	)
+
+	pubkeysByIdx := map[eth2p0.ValidatorIndex]core.PubKey{
+		vIdxA: testutil.RandomPubKey(t),
+		vIdxB: testutil.RandomPubKey(t),
+	}
+
+	component, err := validatorapi.NewComponent(eth2Svc, 0)
+	require.NoError(t, err)
+
+	aggBitsA := bitfield.NewBitlist(commLen)
+	aggBitsA.SetBitAt(valCommIdxA, true)
+
+	attA := &eth2p0.Attestation{
+		AggregationBits: aggBitsA,
+		Data: &eth2p0.AttestationData{
+			Slot:   slot,
+			Index:  commIdx,
+			Source: &eth2p0.Checkpoint{},
+			Target: &eth2p0.Checkpoint{},
+		},
+		Signature: eth2p0.BLSSignature{},
+	}
+
+	aggBitsB := bitfield.NewBitlist(commLen)
+	aggBitsB.SetBitAt(valCommIdxB, true)
+
+	attB := &eth2p0.Attestation{
+		AggregationBits: aggBitsB,
+		Data: &eth2p0.AttestationData{
+			Slot:   slot,
+			Index:  commIdx,
+			Source: &eth2p0.Checkpoint{},
+			Target: &eth2p0.Checkpoint{},
+		},
+		Signature: eth2p0.BLSSignature{},
+	}
+
+	atts := []*eth2p0.Attestation{attA, attB}
+
+	component.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error) {
+		return pubkeysByIdx[eth2p0.ValidatorIndex(valCommIdx)], nil
+	})
+
+	component.RegisterParSigDB(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
+		require.Equal(t, core.DutyAttester, duty.Type)
+		require.Equal(t, int64(slot), duty.Slot)
+
+		parSignedDataA := set[pubkeysByIdx[vIdxA]]
+		actAttA, err := core.DecodeAttestationParSignedData(parSignedDataA)
+		require.NoError(t, err)
+		require.Equal(t, attA, actAttA)
+
+		parSignedDataB := set[pubkeysByIdx[vIdxB]]
+		actAttB, err := core.DecodeAttestationParSignedData(parSignedDataB)
+		require.NoError(t, err)
+		require.Equal(t, attB, actAttB)
+
+		return nil
+	})
+
+	err = component.SubmitAttestations(ctx, atts)
+	require.NoError(t, err)
+}
+
+func TestComponent_InvalidSubmitAttestations(t *testing.T) {
+	ctx := context.Background()
+	eth2Svc, err := mock.New(ctx)
+	require.NoError(t, err)
+
+	const (
+		slot       = 123
+		commIdx    = 456
+		vIdx       = 1
+		valCommIdx = vIdx
+		commLen    = 8
+	)
+
+	component, err := validatorapi.NewComponent(eth2Svc, vIdx)
+	require.NoError(t, err)
+
+	aggBits := bitfield.NewBitlist(commLen)
+	aggBits.SetBitAt(valCommIdx, true)
+	aggBits.SetBitAt(valCommIdx+1, true)
+
+	att := &eth2p0.Attestation{
+		AggregationBits: aggBits,
+		Data: &eth2p0.AttestationData{
+			Slot:   slot,
+			Index:  commIdx,
+			Source: &eth2p0.Checkpoint{},
+			Target: &eth2p0.Checkpoint{},
+		},
+		Signature: eth2p0.BLSSignature{},
+	}
+
+	atts := []*eth2p0.Attestation{att}
+
+	err = component.SubmitAttestations(ctx, atts)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Adds Unit tests for validatorapi.go Component.

Category: testing
Ticket: https://github.com/ObolNetwork/charon/issues/179