### PR TITLE
core/parsigex: implement stub in-memor partial signature exchange

### DIFF
--- a/core/parsigex/memory.go
+++ b/core/parsigex/memory.go
@@ -1,0 +1,90 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parsigex
+
+import (
+	"context"
+	"sync"
+
+	"github.com/obolnetwork/charon/core"
+)
+
+type sub func(context.Context, core.Duty, core.ParSignedDataSet) error
+
+// NewMemExFunc returns a function that itself returns in-memory exchange components
+// that exchange partial signatures.
+func NewMemExFunc() func() MemEx {
+	var (
+		mu    sync.Mutex
+		index int
+		subs  = make(map[int][]sub)
+	)
+
+	return func() MemEx {
+		mu.Lock()
+		defer mu.Unlock()
+		i := index
+		index++
+
+		return MemEx{
+			addSub: func(s sub) {
+				mu.Lock()
+				defer mu.Unlock()
+
+				subs[i] = append(subs[i], s)
+			},
+
+			getSubs: func() []sub {
+				mu.Lock()
+				defer mu.Unlock()
+
+				var others []sub // Get other peer's subscriptions.
+				for index, s := range subs {
+					if index == i {
+						continue
+					}
+					others = append(others, s...)
+				}
+
+				return others
+			},
+		}
+	}
+}
+
+// MemEx provides an in-memory implementation of
+// the core workflow's partial signature exchange component.
+type MemEx struct {
+	addSub  func(sub)
+	getSubs func() []sub
+}
+
+// Broadcast broadcasts the partially signed duty data set to all peers.
+func (s MemEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
+	for _, sub := range s.getSubs() {
+		err := sub(ctx, duty, set)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Subscribe registers a callback when a partially signed duty set
+// is received from a peer.
+func (s MemEx) Subscribe(fn func(context.Context, core.Duty, core.ParSignedDataSet) error) {
+	s.addSub(fn)
+}

--- a/core/parsigex/memory_test.go
+++ b/core/parsigex/memory_test.go
@@ -1,0 +1,80 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parsigex_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/parsigex"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+//go:generate go test . -run=TestMemEx -update -clean
+
+func TestMemEx(t *testing.T) {
+	const n = 3
+
+	ctx := context.Background()
+	pubkey := testutil.RandomPubKey(t)
+
+	memExFunc := parsigex.NewMemExFunc()
+
+	var received []tuple
+
+	var exes []parsigex.MemEx
+	for i := 0; i < n; i++ {
+		i := i
+		ex := memExFunc()
+		ex.Subscribe(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
+			require.NotEqual(t, i, set[pubkey].Index, "received from self")
+
+			received = append(received, tuple{
+				Target: i,
+				Source: set[pubkey].Index,
+			})
+
+			return nil
+		})
+		exes = append(exes, ex)
+	}
+
+	for i := 0; i < n; i++ {
+		set := make(core.ParSignedDataSet)
+		set[pubkey] = core.ParSignedData{Index: i}
+
+		err := exes[i].Broadcast(ctx, core.Duty{}, set)
+		require.NoError(t, err)
+	}
+
+	sort.Slice(received, func(i, j int) bool {
+		if received[i].Source != received[j].Source {
+			return received[i].Source < received[j].Source
+		}
+
+		return received[i].Target < received[j].Target
+	})
+
+	testutil.RequireGoldenJSON(t, received)
+}
+
+type tuple struct {
+	Target int
+	Source int
+}

--- a/core/parsigex/testdata/TestMemEx
+++ b/core/parsigex/testdata/TestMemEx
@@ -1,0 +1,26 @@
+[
+ {
+  "Target": 1,
+  "Source": 0
+ },
+ {
+  "Target": 2,
+  "Source": 0
+ },
+ {
+  "Target": 0,
+  "Source": 1
+ },
+ {
+  "Target": 2,
+  "Source": 1
+ },
+ {
+  "Target": 0,
+  "Source": 2
+ },
+ {
+  "Target": 1,
+  "Source": 2
+ }
+]


### PR DESCRIPTION
Implements a stub in-memory partial signature exchange component to be used in testing while the p2p implementation is outstanding.

category: feature
ticket: #167 