### PR TITLE
app: load simnet keys from json file

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -120,9 +120,10 @@ func pingCluster(t *testing.T, test pingTest) {
 			MonitoringAddr:   testutil.AvailableAddr(t).String(), // Random monitoring address
 			ValidatorAPIAddr: testutil.AvailableAddr(t).String(), // Random validatorapi address
 			TestConfig: app.TestConfig{
-				Manifest:     &manifest,
-				P2PKey:       p2pKeys[i],
-				PingCallback: asserter.Callback(t, i),
+				Manifest:      &manifest,
+				P2PKey:        p2pKeys[i],
+				PingCallback:  asserter.Callback(t, i),
+				DisableSimnet: true,
 			},
 			P2P: p2p.Config{
 				UDPBootnodes:    test.Bootnodes,

--- a/app/disk.go
+++ b/app/disk.go
@@ -17,8 +17,16 @@ package app
 import (
 	"encoding/json"
 	"os"
+	"path"
+
+	"github.com/dB2510/kryptology/pkg/signatures/bls/bls_sig"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/tbls/tblsconv"
+)
+
+const (
+	simnetKeysFile = "simnet_keys.json"
 )
 
 // loadManifest reads the cluster manifest from the given file path.
@@ -39,4 +47,58 @@ func loadManifest(conf Config) (Manifest, error) {
 	}
 
 	return res, nil
+}
+
+// loadSimnetKeys returns the keys from the json file in the data directory.
+func loadSimnetKeys(conf Config) ([]*bls_sig.SecretKey, error) {
+	if len(conf.TestConfig.SimnetKeys) != 0 {
+		return conf.TestConfig.SimnetKeys, nil
+	}
+
+	buf, err := os.ReadFile(path.Join(conf.DataDir, simnetKeysFile))
+	if err != nil {
+		return nil, errors.Wrap(err, "read simnetkeys")
+	}
+
+	var rawKeys [][]byte
+	if err := json.Unmarshal(buf, &rawKeys); err != nil {
+		return nil, errors.Wrap(err, "unmarshal keys")
+	}
+
+	var resp []*bls_sig.SecretKey
+	for _, raw := range rawKeys {
+		secret, err := tblsconv.SecretFromBytes(raw)
+		if err != nil {
+			return nil, errors.Wrap(err, "read simnetkeys")
+		}
+
+		resp = append(resp, secret)
+	}
+
+	return resp, nil
+}
+
+// StoreSimnetKeys stores the keys as json file in the directory.
+func StoreSimnetKeys(keys []*bls_sig.SecretKey, dir string) error {
+	var rawKeys [][]byte
+	for _, key := range keys {
+		rawKey, err := tblsconv.SecretToBytes(key)
+		if err != nil {
+			return err
+		}
+
+		rawKeys = append(rawKeys, rawKey)
+	}
+
+	secretsJSON, err := json.MarshalIndent(rawKeys, "", " ")
+	if err != nil {
+		return errors.Wrap(err, "marshal simnet keys")
+	}
+
+	secretsPath := path.Join(dir, simnetKeysFile)
+	if err = os.WriteFile(secretsPath, secretsJSON, 0o600); err != nil {
+		return errors.Wrap(err, "write simnet keys")
+	}
+
+	return nil
 }

--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -20,7 +20,10 @@ import (
 	"path"
 	"testing"
 
+	"github.com/dB2510/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
 func TestLoadManifest(t *testing.T) {
@@ -44,4 +47,26 @@ func TestLoadManifest(t *testing.T) {
 	b2, err := json.Marshal(actual)
 	require.NoError(t, err)
 	require.JSONEq(t, string(b), string(b2))
+}
+
+func TestLoadKeys(t *testing.T) {
+	_, _, shares := NewClusterForT(t, 1, 2, 3, 0)
+
+	var secrets []*bls_sig.SecretKey
+	for _, share := range shares[0] {
+		secret, err := tblsconv.ShareToSecret(share)
+		require.NoError(t, err)
+
+		secrets = append(secrets, secret)
+	}
+
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	err = StoreSimnetKeys(secrets, dir)
+	require.NoError(t, err)
+
+	result, err := loadSimnetKeys(Config{DataDir: dir})
+	require.NoError(t, err)
+	require.Equal(t, secrets, result)
 }

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -60,7 +60,7 @@ func TestSimnetNoNetwork(t *testing.T) {
 				Manifest:           &manifest,
 				P2PKey:             p2pKeys[i],
 				DisablePing:        true,
-				SimnetSecrets:      []*bls_sig.SecretKey{secrets[i]},
+				SimnetKeys:         []*bls_sig.SecretKey{secrets[i]},
 				ParSigExFunc:       parSigExFunc,
 				LcastTransportFunc: lcastTransportFunc,
 				BroadcastCallback: func(ctx context.Context, duty core.Duty, key core.PubKey, data core.AggSignedData) error {

--- a/cmd/gen_simnet.go
+++ b/cmd/gen_simnet.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/dB2510/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/spf13/cobra"
@@ -34,6 +35,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
 const scriptTmpl = `#!/usr/bin/env bash
@@ -110,16 +112,18 @@ func runGenSimnet(out io.Writer, config simnetConfig) error {
 		port++
 		return port
 	}
+	nodeDir := func(i int) string {
+		return fmt.Sprintf("%s/node%d", config.clusterDir, i)
+	}
 
 	var peers []p2p.Peer
 	for i := 0; i < config.numNodes; i++ {
-		nodeDir := fmt.Sprintf("%s/node%d", config.clusterDir, i)
 
-		if err := os.Mkdir(nodeDir, 0o755); err != nil {
+		if err := os.Mkdir(nodeDir(i), 0o755); err != nil {
 			return errors.Wrap(err, "mkdir")
 		}
 
-		p2pKey, _, err := p2p.LoadOrCreatePrivKey(nodeDir)
+		p2pKey, _, err := p2p.LoadOrCreatePrivKey(nodeDir(i))
 		if err != nil {
 			return errors.Wrap(err, "create p2p key")
 		}
@@ -152,29 +156,45 @@ func runGenSimnet(out io.Writer, config simnetConfig) error {
 
 		peers = append(peers, peer)
 
-		if err := writeRunScript(config.clusterDir, nodeDir, charonBin, nextPort(),
+		if err := writeRunScript(config.clusterDir, nodeDir(i), charonBin, nextPort(),
 			tcp.String(), udp.String(), nextPort()); err != nil {
 			return errors.Wrap(err, "write run script")
 		}
 	}
 
-	tss, _, err := tbls.GenerateTSS(config.threshold, config.numNodes, rand.Reader)
+	tss, shares, err := tbls.GenerateTSS(config.threshold, config.numNodes, rand.Reader)
 	if err != nil {
 		return errors.Wrap(err, "generate tss")
 	}
 
-	manifest := app.Manifest{
-		DVs:   []tbls.TSS{tss},
-		Peers: peers,
-	}
-	manifestJSON, err := json.MarshalIndent(manifest, "", " ")
-	if err != nil {
-		return errors.Wrap(err, "json marshal manifest")
+	{ // Write manifest
+		manifest := app.Manifest{
+			DVs:   []tbls.TSS{tss},
+			Peers: peers,
+		}
+		manifestJSON, err := json.MarshalIndent(manifest, "", " ")
+		if err != nil {
+			return errors.Wrap(err, "json marshal manifest")
+		}
+
+		manifestPath := path.Join(config.clusterDir, "manifest.json")
+		if err = os.WriteFile(manifestPath, manifestJSON, 0o600); err != nil {
+			return errors.Wrap(err, "write manifest.json")
+		}
 	}
 
-	manifestPath := path.Join(config.clusterDir, "manifest.json")
-	if err = os.WriteFile(manifestPath, manifestJSON, 0o600); err != nil {
-		return errors.Wrap(err, "write manifest.json")
+	{ // Write shares
+		for i, share := range shares {
+			secret, err := tblsconv.ShareToSecret(share)
+			if err != nil {
+				return err
+			}
+
+			err = app.StoreSimnetKeys([]*bls_sig.SecretKey{secret}, nodeDir(i))
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	err = writeClusterScript(config.clusterDir, config.numNodes)
@@ -189,7 +209,8 @@ func runGenSimnet(out io.Writer, config simnetConfig) error {
 	_, _ = sb.WriteString("├─ manifest.json\tCluster manifest defines the cluster; used by all nodes\n")
 	_, _ = sb.WriteString("├─ run_cluster.sh\tConvenience script to run all nodes; merges log output :(\n")
 	_, _ = sb.WriteString("├─ node[0-3]/\t\tDirectory for each node\n")
-	_, _ = sb.WriteString("│  ├─ p2pkey\t\tP2P networking private key; node authentication\n")
+	_, _ = sb.WriteString("│  ├─ p2pkey\t\tP2P networking private key for node authentication\n")
+	_, _ = sb.WriteString("│  ├─ simnet_keys.json\tSimnet mock validator private share keys for duty signing\n")
 	_, _ = sb.WriteString("│  ├─ run.sh\t\tScript to run the node\n")
 
 	_, _ = fmt.Fprint(out, sb.String())

--- a/tbls/tblsconv/tblsconv.go
+++ b/tbls/tblsconv/tblsconv.go
@@ -132,3 +132,23 @@ func ShareToSecret(share *bls_sig.SecretKeyShare) (*bls_sig.SecretKey, error) {
 
 	return resp, nil
 }
+
+// SecretFromBytes returns a bls secret from bytes.
+func SecretFromBytes(secret []byte) (*bls_sig.SecretKey, error) {
+	resp := new(bls_sig.SecretKey)
+	if err := resp.UnmarshalBinary(secret); err != nil {
+		return nil, errors.Wrap(err, "unmarshal secret")
+	}
+
+	return resp, nil
+}
+
+// SecretToBytes converts a bls secret into bytes.
+func SecretToBytes(secret *bls_sig.SecretKey) ([]byte, error) {
+	resp, err := secret.MarshalBinary()
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal secret")
+	}
+
+	return resp, nil
+}

--- a/tbls/tblsconv/tblsconv_test.go
+++ b/tbls/tblsconv/tblsconv_test.go
@@ -111,6 +111,23 @@ func TestShareToSecret(t *testing.T) {
 	}
 }
 
+func TestSecretToBytes(t *testing.T) {
+	_, shares, err := tbls.GenerateTSS(3, 4, rand.New(rand.NewSource(time.Now().UnixNano())))
+	require.NoError(t, err)
+
+	for _, share := range shares {
+		secret, err := tblsconv.ShareToSecret(share)
+		require.NoError(t, err)
+
+		b, err := tblsconv.SecretToBytes(secret)
+		require.NoError(t, err)
+
+		result, err := tblsconv.SecretFromBytes(b)
+		require.NoError(t, err)
+		require.Equal(t, secret, result)
+	}
+}
+
 func TestShareToSecret_ZeroPadding(t *testing.T) {
 	_, shares, err := tbls.GenerateTSS(3, 4, rand.New(rand.NewSource(96)))
 	require.NoError(t, err)


### PR DESCRIPTION
Loads simnet private share keys from a json file when running a simnet. Store the keys when generating the simnet. Chose very simple file format (json byte array) since simnet keys are not security sensitive.

category: feature
ticket: #216 