### PR TITLE
github/workflows: improve unit test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,17 +1,15 @@
-# Runs "go vet" and "go test -short".
-# TODO: Might want to skip this stage in case Go files aren't modified.
-on: [ pull_request ]
 name: unit tests
+on:
+  pull_request:
+  push:
+    branches:
+      - main
 jobs:
   unit_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: '50'
-    - name: Install Go
-      uses: actions/setup-go@v2
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
       with:
         go-version: '^1.17.1'
     - uses: actions/cache@v2
@@ -19,15 +17,12 @@ jobs:
         path: |
           ~/go/pkg/mod
           ~/.cache/go-build
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-v3
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Test and Run coverage
-      run: go test -coverprofile=coverage.out -covermode=atomic ./... -v -short
+    - run: go test -coverprofile=coverage.out -covermode=atomic ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.1.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out
-    - name: Check Format
-      run: '[ "$(gofmt -l ./ | wc -l)" -eq 0 ]'


### PR DESCRIPTION
Improves the unit test github action.
- Run on pushes to main
- Use same base image as other actions
- Do not run tests in verbose (makes finding failed tests much harder)
- Remove gofmt, since this done by golangci-lint

category: misc
ticket: none
