### PR TITLE
precommit: revert bash change

### DIFF
--- a/.pre-commit/run_tests.sh
+++ b/.pre-commit/run_tests.sh
@@ -4,4 +4,4 @@
 MOD=$(go list -m)
 PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
 
-go test "${PKGS}"
+go test $PKGS


### PR DESCRIPTION
Reverts change to run-tests.sh. Work splitting is actually required, so removing quotes.

category: bug
ticket: none
