### PR TITLE
charon: add codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  status:
+    project:
+      default:
+        branches: [main]
+        informational: true
+    patch:
+      default:
+        only_pulls: true # No patch status on single commits in main.
+        informational: true


### PR DESCRIPTION
Reduces number of calls to codecov. Only do project wide statuses on commits to main, only do patch statuses on pull requests. Previously we did both every time.

category: misc
ticket: none
