### PR TITLE
golangci: relax import shadow

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ issues:
     - "error returned from interface method should be wrapped" # Relax wrapcheck
     - "defer: prefer not to defer chains of function calls" # Relax revive
     - "avoid control coupling" # Relax revive
+    - "shadows an import name" # Relax revive
     - "shadow: declaration of \"err\" shadows declaration" # Relax govet
 
 linters:


### PR DESCRIPTION
Relax revive lint part of golangci-lint, do not report "The name 'bytes' shadows an import name (revive)". `bytes` is a great variable name. 

category: fixbuild
ticket: none
