### PR TITLE
cmd: add flag to disable simnet mock validator

### DIFF
--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -54,6 +54,7 @@ func TestSimnetNoNetwork(t *testing.T) {
 	)
 	for i := 0; i < n; i++ {
 		conf := app.Config{
+			SimnetVMock:      true,
 			MonitoringAddr:   testutil.AvailableAddr(t).String(), // Random monitoring address
 			ValidatorAPIAddr: testutil.AvailableAddr(t).String(), // Random validatorapi address
 			TestConfig: app.TestConfig{

--- a/app/z/zapfield.go
+++ b/app/z/zapfield.go
@@ -105,3 +105,6 @@ func Any(key string, val interface{}) Field {
 		add(zap.Any(key, val))
 	}
 }
+
+// Skip is a noop wrapped zap field similar to zap.Skip.
+var Skip = func(add func(zap.Field)) {}

--- a/cmd/gen_simnet.go
+++ b/cmd/gen_simnet.go
@@ -284,6 +284,7 @@ func writeRunScript(clusterDir string, nodeDir string, charonBin string, monitor
 	flags = append(flags, fmt.Sprintf("--validator-api-address=\"127.0.0.1:%d\"", validatorAPIPort))
 	flags = append(flags, fmt.Sprintf("--p2p-tcp-address=%s", tcpAddr))
 	flags = append(flags, fmt.Sprintf("--p2p-udp-address=%s", udpAddr))
+	flags = append(flags, "--simnet-validator-mock")
 
 	tmpl, err := template.New("").Parse(scriptTmpl)
 	if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,6 +54,7 @@ func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3500", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:8088", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")
 	flags.StringVar(&config.JaegerAddr, "jaeger-address", "", "Listening address for jaeger tracing")
+	flags.BoolVar(&config.SimnetVMock, "simnet-validator-mock", false, "Enables mock validator when running simnet.")
 }
 
 func bindGeneralFlags(flags *pflag.FlagSet, dataDir *string) {

--- a/core/validatorapi/eth2types.go
+++ b/core/validatorapi/eth2types.go
@@ -70,8 +70,12 @@ type proposerDutiesResponse struct {
 	Data          []*eth2v1.ProposerDuty `json:"data"`
 }
 
-type validatorResponse struct {
+type validatorsResponse struct {
 	Data []v1Validator `json:"data"`
+}
+
+type validatorResponse struct {
+	Data v1Validator `json:"data"`
 }
 
 // root wraps eth2p0 root adding proper json marshalling.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,7 @@ Flags:
       --p2p-peerdb string              Path to store a discv5 peer database. Empty default results in in-memory database.
       --p2p-tcp-address strings        Comma-separated list of listening TCP addresses (ip and port) for LibP2P traffic (default [127.0.0.1:13900])
       --p2p-udp-address string         Listening UDP address (ip and port) for Discv5 discovery (default "127.0.0.1:30309")
+      --simnet-validator-mock          Enables mock validator when running simnet.
       --validator-api-address string   Listening address (ip and port) for validator-facing traffic proxying the beacon-node API (default "127.0.0.1:3500")
 
 ````

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -89,14 +89,7 @@ func newHTTPServer(addr string, overrides ...staticOverride) (*http.Server, erro
 		{
 			Path: "/eth/v1/node/syncing",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte(`
-			{
-				"data": {
-    				"head_slot": "1",
-    				"sync_distance": "0",
-    				"is_syncing": false
-  				}
-			}`))
+				_, _ = w.Write([]byte(`{"data": {"head_slot": "1","sync_distance": "0","is_syncing": false}}`))
 			},
 		},
 	}
@@ -105,6 +98,7 @@ func newHTTPServer(addr string, overrides ...staticOverride) (*http.Server, erro
 
 	// Configure above endpoints.
 	for _, e := range endpoints {
+		e := e
 		r.Handle(e.Path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := log.WithTopic(r.Context(), "bmock")
 			ctx = log.WithCtx(ctx, z.Str("path", e.Path))

--- a/testutil/beaconmock/server_test.go
+++ b/testutil/beaconmock/server_test.go
@@ -45,6 +45,14 @@ func TestStatic(t *testing.T) {
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
 	require.NoError(t, err)
 	require.Equal(t, uint64(32), slotsPerEpoch)
+
+	state, err := eth2Cl.NodeSyncing(ctx)
+	require.NoError(t, err)
+	require.False(t, state.IsSyncing)
+
+	version, err := eth2Cl.NodeVersion(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "charon/static_beacon_mock", version)
 }
 
 func TestGenesisTimeOverride(t *testing.T) {


### PR DESCRIPTION
Adds the `simnet-validator-mock` flag. This allows simnets to either use validator mock or real validators.

Also fix a few other small niggles:
- validatormock only attest on DutyAttester
- Add z.Skip, use it to add duration to validatorapi errors
- Add single (undocumented) /eth/v1/beacon/states/{state_id}/validators/{validator_id} endpoint.
- Reduce "Peer routing request failure" logging
- Fix bug in HTTPServer with range iteration values used in closures.

category: feature
ticket: #251 
