### PR TITLE
app/log: improve console logger

### DIFF
--- a/app/log/testdata/TestErrorWrap
+++ b/app/log/testdata/TestErrorWrap
@@ -1,0 +1,6 @@
+00:00 [31mERRO[0m err1: first {"1": 1, "caller": "log_test.go:58"}
+	app/log/log_test.go:53 .TestErrorWrap
+00:00 [31mERRO[0m err2: second: first {"2": 2, "1": 1, "caller": "log_test.go:59"}
+	app/log/log_test.go:53 .TestErrorWrap
+00:00 [31mERRO[0m err3: third: second: first {"3": 3, "2": 2, "1": 1, "caller": "log_test.go:60"}
+	app/log/log_test.go:53 .TestErrorWrap

--- a/app/log/testdata/TestWithContext
+++ b/app/log/testdata/TestWithContext
@@ -1,0 +1,4 @@
+00:00 [35mDEBG[0m msg1 {"ctx1": 1, "caller": "log_test.go:42"}
+00:00 [34mINFO[0m msg2 {"ctx2": 2, "wrap2": 2, "caller": "log_test.go:43"}
+00:00 [33mWARN[0m msg3a {"wrap3": "a", "wrap2": 2, "caller": "log_test.go:44"}
+00:00 [33mWARN[0m msg3b {"wrap3": "b", "wrap2": 2, "caller": "log_test.go:45"}


### PR DESCRIPTION
Improves console logger:
- Trims level to 4 characters, so lines align better.
- Move caller to fields, since we already have topic that denotes code area.

category: feature 
ticket: none
