### PR TITLE
*: add more metrics

### DIFF
--- a/app/log/metrics.go
+++ b/app/log/metrics.go
@@ -1,0 +1,47 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	errorCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "app",
+		Subsystem: "log",
+		Name:      "error_total",
+		Help:      "Total count of logged errors by topic",
+	}, []string{"topic"})
+
+	warnCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   "app",
+		Subsystem:   "log",
+		Name:        "warn_total",
+		Help:        "Total count of logged warnings by topic",
+		ConstLabels: nil,
+	}, []string{"topic"})
+)
+
+func incWarnCounter(ctx context.Context) {
+	warnCounter.WithLabelValues(metricsTopicFromCtx(ctx)).Inc()
+}
+
+func incErrorCounter(ctx context.Context) {
+	errorCounter.WithLabelValues(metricsTopicFromCtx(ctx)).Inc()
+}

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -46,8 +46,14 @@ type Broadcaster struct {
 
 // Broadcast broadcasts the aggregated signed duty data object to the beacon-node.
 func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty,
-	_ core.PubKey, aggData core.AggSignedData,
-) error {
+	pubkey core.PubKey, aggData core.AggSignedData,
+) (err error) {
+	defer func() {
+		if err == nil {
+			instrumentDuty(duty, pubkey)
+		}
+	}()
+
 	switch duty.Type {
 	case core.DutyAttester:
 		att, err := core.DecodeAttestationAggSignedData(aggData)

--- a/core/bcast/metrics.go
+++ b/core/bcast/metrics.go
@@ -1,0 +1,34 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bcast
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/core"
+)
+
+var broadcastCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "core",
+	Subsystem: "bcast",
+	Name:      "broadcast_total",
+	Help:      "The total count of successfully broadcast duties by pubkey and type",
+}, []string{"type", "pubkey"})
+
+// instrumentDuty increments the duty counter.
+func instrumentDuty(duty core.Duty, pubkey core.PubKey) {
+	broadcastCounter.WithLabelValues(duty.Type.String(), pubkey.String()).Inc()
+}

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -1,0 +1,58 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scheduler
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/core"
+)
+
+var (
+	slotGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "current_slot",
+		Help:      "The current slot",
+	})
+
+	epochGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "current_epoch",
+		Help:      "The current epoch",
+	})
+
+	dutyCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "duty_total",
+		Help:      "The total count of duties scheduled by pubkey and type",
+	}, []string{"type", "pubkey"})
+)
+
+// instrumentSlot sets the current slot and epoch metrics.
+func instrumentSlot(slot slot) {
+	slotGauge.Set(float64(slot.Slot))
+	epochGauge.Set(float64(slot.Epoch()))
+}
+
+// instrumentDuty increments the duty counter.
+func instrumentDuty(duty core.Duty, argSet core.FetchArgSet) {
+	for pubkey := range argSet {
+		dutyCounter.WithLabelValues(duty.Type.String(), pubkey.String()).Inc()
+	}
+}

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -120,6 +120,7 @@ func (s *Scheduler) Run() error {
 
 // scheduleSlot resolves upcoming duties and triggers resolved duties for the slot.
 func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) error {
+	instrumentSlot(slot)
 	if slot.Initial {
 		err := s.resolveDuties(ctx, slot)
 		if err != nil {
@@ -133,14 +134,16 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) error {
 			Type: dutyType,
 		}
 
-		dvs, ok := s.duties[duty]
+		argSet, ok := s.duties[duty]
 		if !ok {
 			// Nothing for this duty.
 			continue
 		}
 
+		instrumentDuty(duty, argSet)
+
 		for _, sub := range s.subs {
-			err := sub(ctx, duty, dvs)
+			err := sub(ctx, duty, argSet)
 			if err != nil {
 				// TODO(corver): Improve error handling; possibly call subscription async
 				//  with backoff until duty expires.

--- a/core/validatorapi/metrics.go
+++ b/core/validatorapi/metrics.go
@@ -24,13 +24,15 @@ import (
 
 var (
 	apiLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Namespace: "validatorapi",
+		Namespace: "core",
+		Subsystem: "validatorapi",
 		Name:      "request_latency_seconds",
 		Help:      "The validatorapi request latencies in seconds by endpoint",
 	}, []string{"endpoint"})
 
 	apiErrors = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace: "validatorapi",
+		Namespace: "core",
+		Subsystem: "validatorapi",
 		Name:      "request_error_total",
 		Help:      "The total number of validatorapi request errors",
 	}, []string{"endpoint", "status_code"})


### PR DESCRIPTION
Add metrics to the following packages:
 - app/log: warn and error counts by topic
 - core/scheduler: current epoch and slot, scheduled duty count
 - core/bcast: broadcast count

category: feature 
ticket: none
