### PR TITLE
cmd: add jaeger service name flag

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -67,6 +67,7 @@ type Config struct {
 	ValidatorAPIAddr string
 	BeaconNodeAddr   string
 	JaegerAddr       string
+	JaegerService    string
 	SimnetBMock      bool
 	SimnetVMock      bool
 
@@ -406,7 +407,10 @@ func wireVAPIRouter(life *lifecycle.Manager, conf Config, handler validatorapi.H
 
 // wireTracing constructs the global tracer and registers it with the life cycle manager.
 func wireTracing(life *lifecycle.Manager, conf Config) error {
-	stopjaeger, err := tracer.Init(tracer.WithJaegerOrNoop(conf.JaegerAddr))
+	stopjaeger, err := tracer.Init(
+		tracer.WithJaegerOrNoop(conf.JaegerAddr),
+		tracer.WithJaegerService(conf.JaegerService),
+	)
 	if err != nil {
 		return errors.Wrap(err, "init jaeger tracing")
 	}

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -68,6 +68,7 @@ func TestCmdFlags(t *testing.T) {
 				ValidatorAPIAddr: "127.0.0.1:3500",
 				BeaconNodeAddr:   "http://localhost/",
 				JaegerAddr:       "",
+				JaegerService:    "charon",
 			},
 		},
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -56,6 +56,7 @@ func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3500", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:8088", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")
 	flags.StringVar(&config.JaegerAddr, "jaeger-address", "", "Listening address for jaeger tracing")
+	flags.StringVar(&config.JaegerService, "jaeger-service", "charon", "Service name used for jaeger tracing")
 	flags.BoolVar(&config.SimnetBMock, "simnet-beacon-mock", false, "Enables an internal mock beacon node for running a simnet.")
 	flags.BoolVar(&config.SimnetVMock, "simnet-validator-mock", false, "Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.")
 }

--- a/core/types.go
+++ b/core/types.go
@@ -16,13 +16,17 @@ package core
 
 import (
 	"bytes"
+	"context"
 	"encoding/hex"
 	"fmt"
+	"hash/fnv"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/tracer"
 )
 
 // DutyType enumerates the different types of duties.
@@ -68,6 +72,18 @@ type Duty struct {
 
 func (d Duty) String() string {
 	return fmt.Sprintf("%d/%s", d.Slot, d.Type)
+}
+
+// NewAttesterDuty returns a new attester duty. It is a convenience function that is
+// slightly more readable and concise than the struct literal equivalent:
+//   core.Duty{Slot: slot, Type: core.DutyAttester}
+//   vs
+//   core.NewAttesterDuty(slot)
+func NewAttesterDuty(slot int64) Duty {
+	return Duty{
+		Slot: slot,
+		Type: DutyAttester,
+	}
 }
 
 const (
@@ -190,4 +206,16 @@ type AggSignedData struct {
 
 func (a AggSignedData) Equal(b AggSignedData) bool {
 	return bytes.Equal(a.Data, b.Data) && bytes.Equal(a.Signature, b.Signature)
+}
+
+// DutyTraceRoot returns a copy of the parent context containing a tracing span context rooted
+// to the duty.
+func DutyTraceRoot(ctx context.Context, duty Duty) context.Context {
+	h := fnv.New128a()
+	_, _ = h.Write([]byte(duty.String()))
+
+	var traceID trace.TraceID
+	copy(traceID[:], h.Sum(nil))
+
+	return tracer.RootedCtx(ctx, traceID)
 }

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -15,10 +15,13 @@
 package core_test
 
 import (
+	"context"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/tracer"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/testutil"
 )
@@ -53,4 +56,26 @@ func TestAggSignedData_Equal(t *testing.T) {
 	require.False(t, testAggSignedData1.Equal(testAggSignedData3))
 	require.False(t, testAggSignedData1.Equal(testAggSignedData4))
 	require.False(t, testAggSignedData1.Equal(testAggSignedData5))
+}
+
+func TestWithDutySpanCtx(t *testing.T) {
+	ctx := context.Background()
+	stop, err := tracer.Init(tracer.WithStdOut(io.Discard))
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, stop(context.Background()))
+	}()
+
+	_, span1 := tracer.Start(core.DutyTraceRoot(ctx, core.Duty{}), "span1")
+	_, span2 := tracer.Start(core.DutyTraceRoot(ctx, core.Duty{}), "span2")
+
+	require.Equal(t, "7d0b160d5b04eac85dd1eaf0585c5b82", span1.SpanContext().TraceID().String())
+	require.Equal(t, span1.SpanContext().TraceID(), span2.SpanContext().TraceID())
+	require.NotEqual(t, span1.SpanContext().SpanID(), span2.SpanContext().SpanID())
+
+	require.True(t, span1.SpanContext().IsValid())
+	require.True(t, span1.SpanContext().IsSampled())
+
+	require.True(t, span2.SpanContext().IsValid())
+	require.True(t, span2.SpanContext().IsSampled())
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ Flags:
       --data-dir string                The directory where charon will store all its internal data (default "./charon/data")
   -h, --help                           help for run
       --jaeger-address string          Listening address for jaeger tracing
+      --jaeger-service string          Service name used for jaeger tracing (default "charon")
       --log-format string              Log format; console, logfmt or json (default "console")
       --log-level string               Log level; debug, info, warn or error (default "info")
       --manifest-file string           The path to the manifest file defining distributed validator cluster (default "./charon/manifest.json")


### PR DESCRIPTION
Adds a `--jaeger-service` flag to override jager service name in simnet. Also add support for deterministic duty rooted spans.

category: feature
ticket: #302 
