### PR TITLE
cmd: add bootnode command

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -1,0 +1,115 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/p2p"
+)
+
+type bootnodeConfig struct {
+	DataDir   string
+	HTTPAddr  string
+	P2PConfig p2p.Config
+	LogConfig log.Config
+}
+
+func newBootnodeCmd(runFunc func(context.Context, bootnodeConfig) error) *cobra.Command {
+	var config bootnodeConfig
+
+	cmd := &cobra.Command{
+		Use:   "bootnode",
+		Short: "Starts a p2p-udp discv5 bootnode",
+		Long:  `Starts a p2p-udp discv5 bootnode that charon nodes can use to bootstrap their p2p cluster`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFunc(cmd.Context(), config)
+		},
+	}
+
+	bindDataDirFlag(cmd.Flags(), &config.DataDir)
+	bindBootnodeFlag(cmd.Flags(), &config.HTTPAddr)
+	bindP2PFlags(cmd.Flags(), &config.P2PConfig)
+	bindLogFlags(cmd.Flags(), &config.LogConfig)
+
+	return cmd
+}
+
+// runBootnode starts a p2p-udp discv5 bootnode.
+func runBootnode(ctx context.Context, config bootnodeConfig) error {
+	ctx = log.WithTopic(ctx, "bootnode")
+
+	if err := log.InitLogger(config.LogConfig); err != nil {
+		return err
+	}
+
+	key, err := p2p.LoadPrivKey(config.DataDir)
+	if err != nil {
+		return err
+	}
+
+	localEnode, db, err := p2p.NewLocalEnode(config.P2PConfig, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to open enode")
+	}
+	defer db.Close()
+
+	udpNode, err := p2p.NewUDPNode(config.P2PConfig, localEnode, key, nil)
+	if err != nil {
+		return errors.Wrap(err, "")
+	}
+	defer udpNode.Close()
+
+	serverErr := make(chan error, 1)
+	go func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/enr", func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte(localEnode.Node().String()))
+		})
+		server := http.Server{Addr: config.HTTPAddr, Handler: mux}
+		serverErr <- server.ListenAndServe()
+	}()
+
+	log.Info(ctx, "Bootnode started",
+		z.Str("http_addr", config.HTTPAddr),
+		z.Str("p2p_udp_addr", config.P2PConfig.UDPAddr),
+		z.Str("enr", localEnode.Node().String()),
+	)
+	log.Info(ctx, "Runtime ENR available via http",
+		z.Str("url", fmt.Sprintf("http://%s/enr", config.HTTPAddr)),
+	)
+
+	ticker := time.NewTicker(time.Minute)
+	for {
+		select {
+		case err := <-serverErr:
+			return err
+		case <-ticker.C:
+			log.Info(ctx, "Connected node count", z.Int("n", len(udpNode.AllNodes())))
+		case <-ctx.Done():
+			log.Info(ctx, "Shutting down")
+			return nil
+		}
+	}
+}

--- a/cmd/bootnode_internal_test.go
+++ b/cmd/bootnode_internal_test.go
@@ -1,0 +1,45 @@
+// Copyright © 2021 Obol Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/log"
+)
+
+func TestRunBootnode(t *testing.T) {
+	temp, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	config := bootnodeConfig{
+		DataDir:   temp,
+		LogConfig: log.DefaultConfig(),
+	}
+
+	err = runGenP2PKey(io.Discard, config.P2PConfig, temp)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err = runBootnode(ctx, config)
+	require.NoError(t, err)
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,6 +43,7 @@ func New() *cobra.Command {
 		newEnrCmd(runNewENR),
 		newGenP2PKeyCmd(runGenP2PKey),
 		newRunCmd(app.Run),
+		newBootnodeCmd(runBootnode),
 		newGenSimnetCmd(runGenSimnet),
 	)
 }

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -40,7 +40,7 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command
 		},
 	}
 
-	bindGeneralFlags(cmd.Flags(), &dataDir)
+	bindDataDirFlag(cmd.Flags(), &dataDir)
 	bindP2PFlags(cmd.Flags(), &config)
 
 	return cmd

--- a/cmd/genp2pkey.go
+++ b/cmd/genp2pkey.go
@@ -40,7 +40,7 @@ func newGenP2PKeyCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 		},
 	}
 
-	bindGeneralFlags(cmd.Flags(), &dataDir)
+	bindDataDirFlag(cmd.Flags(), &dataDir)
 	bindP2PFlags(cmd.Flags(), &config)
 
 	return cmd

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -43,7 +43,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 	}
 
 	bindRunFlags(cmd.Flags(), &conf)
-	bindGeneralFlags(cmd.Flags(), &conf.DataDir)
+	bindDataDirFlag(cmd.Flags(), &conf.DataDir)
 	bindP2PFlags(cmd.Flags(), &conf.P2P)
 	bindLogFlags(cmd.Flags(), &conf.Log)
 
@@ -66,8 +66,12 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 	flags.StringVar(&config.Level, "log-level", "info", "Log level; debug, info, warn or error")
 }
 
-func bindGeneralFlags(flags *pflag.FlagSet, dataDir *string) {
+func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 	flags.StringVar(dataDir, "data-dir", "./charon/data", "The directory where charon will store all its internal data")
+}
+
+func bindBootnodeFlag(flags *pflag.FlagSet, httpAddr *string) {
+	flags.StringVar(httpAddr, "bootnode-http-address", "127.0.0.1:8088", "Listening address for the bootnode http server serving runtime ENR")
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {


### PR DESCRIPTION
Adds a bootnode command to run a standalone bootnode. It also serves its runtime ENR via http.

category: feature
ticket: #317 
