### PR TITLE
root: improve dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN chown charon /usr/local/bin/charon
 RUN chmod u+x /usr/local/bin/charon
 WORKDIR "/opt/$USER"
 USER charon
-CMD ["/usr/local/bin/charon","run"]
+ENTRYPOINT ["/usr/local/bin/charon"]
+CMD ["run"]
 # Used by GitHub to associate container with repo.
 LABEL org.opencontainers.image.source="https://github.com/obolnetwork/charon"


### PR DESCRIPTION
Aligns `Dockerfile` with industry best practice:
- `entrypoint` is the binary
- `command` is the default command

This allows changing the command without need to know where the binary lives inside the container.

category: misc
ticket: none
