### PR TITLE
cmd: fix build again

### DIFF
--- a/cmd/bootnode_internal_test.go
+++ b/cmd/bootnode_internal_test.go
@@ -36,6 +36,7 @@ func TestRunBootnode(t *testing.T) {
 		DataDir:   temp,
 		LogConfig: log.DefaultConfig(),
 		P2PConfig: p2p.Config{UDPAddr: testutil.AvailableAddr(t).String()},
+		HTTPAddr:  testutil.AvailableAddr(t).String(),
 	}
 
 	err = runGenP2PKey(io.Discard, config.P2PConfig, temp)


### PR DESCRIPTION
Fixes cmd test `TestRunBootnode` again. Missed the http server bind address.

category: fixbuild
ticket: none
