### PR TITLE
cmd: add flags from env test

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -84,7 +84,7 @@ func initializeConfig(cmd *cobra.Command) error {
 
 	v.SetEnvPrefix(envPrefix)
 	v.AutomaticEnv()
-	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_", ".", "_"))
+	v.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
 	// Bind the current command's flags to viper
 	return bindFlags(cmd, v)


### PR DESCRIPTION
Adds a unit test for viper parsing flags from environment variables.

category: test
ticket: none
