### PR TITLE
golangci: disable complexity checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -44,10 +44,10 @@ linters-settings:
         disabled: true
       - name: function-length
         disabled: true
+      - name: cognitive-complexity
+        disabled: true
 
       # Some configured revive rules
-      - name: cognitive-complexity
-        arguments: [20]
       - name: imports-blacklist
         arguments: ["errors", "github.com/pkg/errors"] # Prefer ./app/errors
   staticcheck:
@@ -83,6 +83,7 @@ linters:
   disable:
     # Keep disabled
     - containedctx
+    - cyclop
     - exhaustivestruct
     - funlen
     - forcetypeassert

--- a/app/app.go
+++ b/app/app.go
@@ -199,7 +199,6 @@ func wireP2P(life *lifecycle.Manager, conf Config, manifest Manifest,
 }
 
 // wireCoreWorkflow wires the core workflow components.
-//nolint:cyclop,revive
 func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config, manifest Manifest, nodeIdx NodeIdx, tcpNode host.Host) error {
 	// Convert and prep public keys and public shares
 	var (

--- a/app/lifecycle/manager.go
+++ b/app/lifecycle/manager.go
@@ -157,7 +157,7 @@ func (m *Manager) Run(appCtx context.Context) error {
 }
 
 // run starts and stops all the provided hooks.
-//nolint:revive,cyclop,contextcheck // Cognitive-complexity is indeed high, think of a way to reduce. Explicit context wrangling.
+//nolint:contextcheck // Explicit context wrangling.
 func run(appCtx context.Context, startHooks, stopHooks []hook) error {
 	// Collect any first error, to return at the end.
 	firstErr := make(chan error, 1)

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -171,7 +171,6 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) error {
 }
 
 // resolveDuties resolves the duties for the slot's epoch, caching the results.
-//nolint:revive
 func (s *Scheduler) resolveDuties(ctx context.Context, slot slot) error {
 	vals, err := resolveActiveValidators(ctx, s.eth2Cl, s.pubkeys, slot.Slot)
 	if err != nil {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -213,7 +213,6 @@ func WithSlotsPerEpoch(slotsPerEpoch int) Option {
 
 // WithDeterministicDuties configures the mock to provide deterministic duties based on provided arguments and config.
 // Note it depends on ValidatorsFunc being populated, e.g. via WithValidatorSet.
-//nolint:revive
 func WithDeterministicDuties(factor int) Option {
 	return func(mock *Mock) {
 		mock.AttesterDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {


### PR DESCRIPTION
We (just me actually) keep on silencing/ignoring complexity checks in the code base. Rather just remove the check.

category: fixbuild
ticket: none
