### PR TITLE
app: fix flapping bind address issue

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -188,15 +187,15 @@ func pingCluster(t *testing.T, test pingTest) {
 		})
 	}
 
-	asserter.Await(t)
-	cancel()
+	eg.Go(func() error {
+		asserter.Await(t)
+		cancel()
+
+		return nil
+	})
 
 	err := eg.Wait()
-	if err != nil && strings.Contains(err.Error(), "bind: address already in use") {
-		// This sometimes happens, not sure how to lock available ports...
-		t.Skip("couldn't bind to available port")
-		return
-	}
+	testutil.SkipIfBindErr(t, err)
 
 	require.NoError(t, err)
 }

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -203,11 +203,7 @@ func testSimnet(t *testing.T, args simnetArgs) {
 	})
 
 	err = eg.Wait()
-	if err != nil && strings.Contains(err.Error(), "bind: address already in use") {
-		// This sometimes happens, not sure how to lock available ports...
-		t.Skip("couldn't bind to available port")
-		return
-	}
+	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 }
 

--- a/cmd/bootnode_internal_test.go
+++ b/cmd/bootnode_internal_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"io"
 	"os"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -46,9 +45,6 @@ func TestRunBootnode(t *testing.T) {
 	cancel()
 
 	err = runBootnode(ctx, config)
-	if err != nil && strings.Contains(err.Error(), "bind: address already in use") {
-		t.Skip("Skipping due to sporadic bind: address already in use")
-		return
-	}
+	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 }

--- a/p2p/discovery_test.go
+++ b/p2p/discovery_test.go
@@ -19,7 +19,6 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/rand"
-	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -48,11 +47,7 @@ func TestExternalHost(t *testing.T) {
 	defer db.Close()
 
 	udpNode, err := p2p.NewUDPNode(ctx, config, localNode, p2pKey, nil)
-	if err != nil && strings.Contains(err.Error(), "bind: address already in use") {
-		// This sometimes happens, not sure how to lock available ports...
-		t.Skip("couldn't bind to available port")
-		return
-	}
+	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 	defer udpNode.Close()
 }

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
+	"strings"
 	"testing"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -189,11 +190,21 @@ func RandomBitList() bitfield.Bitlist {
 	return resp
 }
 
+// SkipIfBindErr skips the test if the error is "bind: address already in use".
+// This is a workaround for the issue related to AvailableAddr.
+func SkipIfBindErr(t *testing.T, err error) {
+	t.Helper()
+
+	if err != nil && strings.Contains(err.Error(), "bind: address already in use") {
+		t.Skip("Skipping test as workaround to sporadic port bind issue")
+	}
+}
+
 // AvailableAddr returns an available local tcp address.
 //
 // Note that this is unfortunately only best-effort. Since the port is not
 // "locked" or "reserved", other processes sometimes grab the port.
-// Suggest checking errors for "bind: address already in use" and skipping the test in that case.
+// Remember to call SkipIfBindErr as workaround for this issue.
 func AvailableAddr(t *testing.T) *net.TCPAddr {
 	t.Helper()
 


### PR DESCRIPTION
Fixes flapping tests due to bind address issue. The wiring of error wasn't correct. Also add a helper method to test for the workaround to testutil. 

category: test
ticket: none
