### PR TITLE
golangci: bump to latest version 

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,5 +13,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0
+          version: v1.45.2
           only-new-issues: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.44.0
+    rev: v1.45.2
     hooks:
       - id: golangci-lint
         args: [ -n ] # See .golangci.yml for config


### PR DESCRIPTION
Golanci-lint on github is failing since it internally uses go1.18. Latest version supports it.

category: fixbuild
ticket: none
