### PR TITLE
*: update .bulldozer.yml to remove unnecessary trigger

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -3,11 +3,10 @@ version: 1
 merge:
   trigger:
     labels: ["merge when ready"]
-    comment_substrings: ["==MERGE_WHEN_READY=="]
-    branches: ["main"]
+    comment_substrings: ["MERGE WHEN READY"]
   ignore:
     labels: ["do not merge"]
-    comment_substrings: ["==DO_NOT_MERGE=="]
+    comment_substrings: ["DO NOT MERGE"]
   method: squash
   options:
     squash:


### PR DESCRIPTION
Removed target branch trigger, and updated label and comment trigger. This issue was letting bulldozer bot to merge any PR if the target is main. Ref: https://github.com/palantir/bulldozer/issues/304

category: bug
ticket: #325
