### PR TITLE
*: fix build, remove nolints

### DIFF
--- a/app/lifecycle/manager.go
+++ b/app/lifecycle/manager.go
@@ -158,7 +158,6 @@ func (m *Manager) Run(appCtx context.Context) error {
 }
 
 // run starts and stops all the provided hooks.
-//nolint:contextcheck // Explicit context wrangling.
 func run(appCtx context.Context, startHooks, stopHooks []hook) error {
 	// Collect any first error, to return at the end.
 	firstErr := make(chan error, 1)

--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -176,7 +176,7 @@ func isTemporaryBeaconErr(err error) bool {
 	// Check for timing errors like:
 	//  - Proposer duties were requested for a future epoch.
 	//  - Cannot create attestation for future slot.
-	if strings.Contains(err.Error(), "future") { //nolint:gosimple // More checks will be added below.
+	if strings.Contains(err.Error(), "future") {
 		return true
 	}
 

--- a/core/leadercast/leadercast.go
+++ b/core/leadercast/leadercast.go
@@ -56,7 +56,7 @@ func (l *LeaderCast) Run(ctx context.Context) error {
 	for {
 		source, duty, data, err := l.transport.AwaitNext(ctx)
 		if errors.Is(err, context.Canceled) && ctx.Err() != nil {
-			return nil //nolint:nilerr
+			return nil
 		} else if err != nil {
 			log.Error(ctx, "await next leader duty", err)
 			continue

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -195,7 +195,7 @@ func newHTTPMock(overrides ...staticOverride) (HTTPMock, *http.Server, error) {
 
 	// Wait for server to be up
 	for {
-		resp, err := http.Get(addr + "/up") //nolint:bodyclose,noctx
+		resp, err := http.Get(addr + "/up")
 		if err == nil && resp.StatusCode == http.StatusOK {
 			break
 		}

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -170,7 +170,7 @@ func run(gitRange string, output string, token string) error {
 func makeIssueFunc(token string) func(int) (string, error) {
 	return func(number int) (string, error) {
 		u := fmt.Sprintf("https://api.github.com/repos/obolnetwork/charon/issues/%d", number)
-		req, err := http.NewRequest("GET", u, nil) //nolint:noctx
+		req, err := http.NewRequest("GET", u, nil)
 		if err != nil {
 			return "", errors.Wrap(err, "new request")
 		}


### PR DESCRIPTION
Removes some `nolint` directives for linters that are now disabled in go1.18 since they are not supported yet.  Once golangci-lint re-enables then, we might neeed to re-add these directives.

category: fixbuild
ticket: none
