### PR TITLE
veriifypr: add synchronize activity

### DIFF
--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -1,7 +1,7 @@
 name: verify-pr
 on:
   pull_request:
-    types: [opened, reopened, edited]
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   verify:


### PR DESCRIPTION
Adds synchronize activity to verify-pr workflow. Since it only reacts when PR body or title gets created or updated, it wasn't syncing with every commit push.

category: bug
ticket: none
