### PR TITLE
bulldozer: use pull request title when merging

### DIFF
--- a/.bulldozer.yml
+++ b/.bulldozer.yml
@@ -10,7 +10,7 @@ merge:
   method: squash
   options:
     squash:
-      title: "github_default_title"
+      title: pull_request_title
       body: pull_request_body
   delete_after_merge: true
   allow_merge_with_no_checks: false


### PR DESCRIPTION
It seems like the "github_default_title" uses the commit message when there is only a single commit. We ALWAYS want to the PR title. Lets hope this includes the PR number as well. 

category: misc
ticket: none
