### PR TITLE
docs/contributing: update contributing.md for bulldozer

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -46,8 +46,7 @@ unsure what to update, open the PR, and we'll discuss during review.
 
 Note that PRs updating dependencies and new Go versions are not accepted. Please file an issue instead.
 
-Note: PRs can only be merged by obol-bulldozer bot. It is author's responsibility to add label `merge when ready`
-after getting approval.
+Note: PRs can only be merged by obol-bulldozer bot. It is author's responsibility to add label `merge when ready` after getting approval.
 
 > TL;DR: Open an Issue with details and motivation behind a PR.
 


### PR DESCRIPTION
Adds note to add `merge when ready` label to merge PR by obol-bulldozer bot.

category: docs
ticket: none
