### PR TITLE
readme: add project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ For source code documentation, there is always the [charon godocs](https://pkg.g
 ## Project Status
 
 The following matrix includes the status of charon's integration with Execution Layer (EL) Clients as well as with Consensus
-Layer (CL) clients on the basis on types of duties:
+Layer (CL) clients on the basis of duties on beacon chain:
 
 ### Attestation
 


### PR DESCRIPTION
Adds project status of charon which includes a matrix of Execution Layer clients and Consensus clients on the basis of duties on beacon chain.

category: docs
ticket: #148 
 
do not merge