### PR TITLE
scheduler: make tests deterministic

### DIFF
--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -225,7 +225,7 @@ func TestSchedulerDuties(t *testing.T) {
 			clock := newTestClock(t0)
 			sched := scheduler.NewForT(t, clock, pubkeys, eth2Cl)
 
-			// Stop scheduler (and slotTicker) after 3 slots
+			// Only test scheduler output for first N slots, so Stop scheduler (and slotTicker) after that.
 			const stopAfter = 3
 			slotDuration, err := eth2Cl.SlotDuration(context.Background())
 			require.NoError(t, err)


### PR DESCRIPTION
Change scheduler tests to be deterministic to mitigate flapping tests.

category: test
ticket: none
