### PR TITLE
github/workflows: fix release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,17 @@ on:
       - 'v*'
 name: Publish Release
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    name: Build docker image
+    name: Publish Release
     steps:
+
+    # Wait for docker build to complete since we need pegged cli-reference.
+    - uses: fountainhead/action-wait-for-check@v1.0.0
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        checkName: Build Docker Image
+
     - uses: actions/checkout@v2
 
     - id: get-tag
@@ -15,7 +22,7 @@ jobs:
         tag=$(echo "${{ github.ref }}" | cut -d / -f 3)
         echo "::set-output name=tag::$tag"
 
-    - run: docker run ghcr.io/obolnetwork/charon:${{steps.get-tag.outputs.tag}} charon run --help > cli-reference.txt
+    - run: docker run ghcr.io/obolnetwork/charon:${{steps.get-tag.outputs.tag}} run --help > cli-reference.txt
 
     - run: cat cli-reference.txt
 


### PR DESCRIPTION
Fixes the release github action:
 - Wait for build to complete (otherwise pulling tagged docker container fails)
 - Fixed cli-reference command

category: misc
ticket: none