### PR TITLE
p2p: support circuit relay via bootnodes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -178,12 +178,12 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, manifest
 		return nil, nil, errors.Wrap(err, "create local enode")
 	}
 
-	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, manifest.ENRs())
+	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, manifest.Peers)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "start discv5 listener")
 	}
 
-	connGater, err := p2p.NewConnGater(manifest.PeerIDs())
+	connGater, err := p2p.NewConnGater(manifest.PeerIDs(), udpNode.Relays)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "connection gater")
 	}
@@ -191,6 +191,12 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, manifest
 	tcpNode, err := p2p.NewTCPNode(conf.P2P, p2pKey, connGater, udpNode, manifest.Peers)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "new p2p node", z.Str("allowlist", conf.P2P.Allowlist))
+	}
+
+	if conf.P2P.BootnodeRelay {
+		for _, relay := range udpNode.Relays {
+			life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartRelay, p2p.NewRelayReserver(tcpNode, relay))
+		}
 	}
 
 	if !conf.TestConfig.DisablePing {

--- a/app/app.go
+++ b/app/app.go
@@ -188,7 +188,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, manifest
 		return nil, nil, errors.Wrap(err, "connection gater")
 	}
 
-	tcpNode, err := p2p.NewTCPNode(conf.P2P, p2pKey, connGater, udpNode, manifest.Peers)
+	tcpNode, err := p2p.NewTCPNode(conf.P2P, p2pKey, connGater, udpNode, manifest.Peers, p2p.EmptyAdvertisedAddrs)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "new p2p node", z.Str("allowlist", conf.P2P.Allowlist))
 	}

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -27,6 +27,7 @@ type OrderStop int
 // Global ordering of start and stop hooks.
 const (
 	StartAggSigDB OrderStart = iota
+	StartRelay
 	StartMonitoringAPI
 	StartValidatorAPI
 	StartP2PPing

--- a/app/lifecycle/orderstart_string.go
+++ b/app/lifecycle/orderstart_string.go
@@ -24,17 +24,18 @@ func _() {
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
 	_ = x[StartAggSigDB-0]
-	_ = x[StartMonitoringAPI-1]
-	_ = x[StartValidatorAPI-2]
-	_ = x[StartP2PPing-3]
-	_ = x[StartLeaderCast-4]
-	_ = x[StartSimulator-5]
-	_ = x[StartScheduler-6]
+	_ = x[StartRelay-1]
+	_ = x[StartMonitoringAPI-2]
+	_ = x[StartValidatorAPI-3]
+	_ = x[StartP2PPing-4]
+	_ = x[StartLeaderCast-5]
+	_ = x[StartSimulator-6]
+	_ = x[StartScheduler-7]
 }
 
-const _OrderStart_name = "AggSigDBMonitoringAPIValidatorAPIP2PPingLeaderCastSimulatorScheduler"
+const _OrderStart_name = "AggSigDBRelayMonitoringAPIValidatorAPIP2PPingLeaderCastSimulatorScheduler"
 
-var _OrderStart_index = [...]uint8{0, 8, 21, 33, 40, 50, 59, 68}
+var _OrderStart_index = [...]uint8{0, 8, 13, 26, 38, 45, 55, 64, 73}
 
 func (i OrderStart) String() string {
 	if i < 0 || i >= OrderStart(len(_OrderStart_index)-1) {

--- a/app/lifecycle/orderstop_string.go
+++ b/app/lifecycle/orderstop_string.go
@@ -23,24 +23,25 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[StopTracing-7]
-	_ = x[StopScheduler-8]
-	_ = x[StopP2PPeerDB-9]
-	_ = x[StopP2PTCPNode-10]
-	_ = x[StopP2PUDPNode-11]
-	_ = x[StopMonitoringAPI-12]
-	_ = x[StopBeaconMock-13]
-	_ = x[StopValidatorAPI-14]
+	_ = x[StopTracing-8]
+	_ = x[StopScheduler-9]
+	_ = x[StopP2PPeerDB-10]
+	_ = x[StopP2PTCPNode-11]
+	_ = x[StopP2PUDPNode-12]
+	_ = x[StopMonitoringAPI-13]
+	_ = x[StopBeaconMock-14]
+	_ = x[StopValidatorAPI-15]
+	_ = x[StopRetryer-16]
 }
 
-const _OrderStop_name = "TracingSchedulerP2PPeerDBP2PTCPNodeP2PUDPNodeMonitoringAPIBeaconMockValidatorAPI"
+const _OrderStop_name = "TracingSchedulerP2PPeerDBP2PTCPNodeP2PUDPNodeMonitoringAPIBeaconMockValidatorAPIRetryer"
 
-var _OrderStop_index = [...]uint8{0, 7, 16, 25, 35, 45, 58, 68, 80}
+var _OrderStop_index = [...]uint8{0, 7, 16, 25, 35, 45, 58, 68, 80, 87}
 
 func (i OrderStop) String() string {
-	i -= 7
+	i -= 8
 	if i < 0 || i >= OrderStop(len(_OrderStop_index)-1) {
-		return "OrderStop(" + strconv.FormatInt(int64(i+7), 10) + ")"
+		return "OrderStop(" + strconv.FormatInt(int64(i+8), 10) + ")"
 	}
 	return _OrderStop_name[_OrderStop_index[i]:_OrderStop_index[i+1]]
 }

--- a/app/manifest_test.go
+++ b/app/manifest_test.go
@@ -62,7 +62,16 @@ func TestManifestJSON(t *testing.T) {
 		require.NoError(t, err)
 
 		// TODO(corver): Figure out how a better way to compare manifest structs.
-		require.Equal(t, manifest.Peers, manifest2.Peers)
+		require.Equal(t, len(manifest.Peers), len(manifest2.Peers))
+		for i := 0; i < len(manifest.Peers); i++ {
+			p1 := manifest.Peers[i]
+			p2 := manifest.Peers[i]
+			require.Equal(t, p1.ID, p2.ID)
+			require.Equal(t, p1.Index, p2.Index)
+			require.Equal(t, p1.ENR, p2.ENR)
+			require.Equal(t, p1.Enode.String(), p2.Enode.String())
+		}
+
 		require.Equal(t, len(manifest.DVs), len(manifest2.DVs))
 		for i := 0; i < len(manifest.DVs); i++ {
 			tss1 := manifest.DVs[i]

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -113,7 +113,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 	p2pErr := make(chan error, 1)
 	go func() {
 		if config.P2PRelay {
-			tcpNode, err := p2p.NewTCPNode(config.P2PConfig, key, p2p.NewOpenGater(), udpNode, nil)
+			tcpNode, err := p2p.NewTCPNode(config.P2PConfig, key, p2p.NewOpenGater(), udpNode, nil, p2p.EmptyAdvertisedAddrs)
 			if err != nil {
 				p2pErr <- err
 				return

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -38,6 +39,7 @@ type BootnodeConfig struct {
 	P2PConfig  p2p.Config
 	LogConfig  log.Config
 	AutoP2PKey bool
+	P2PRelay   bool
 }
 
 func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.Command {
@@ -54,16 +56,17 @@ func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.
 	}
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
-	bindBootnodeFlag(cmd.Flags(), &config.HTTPAddr, &config.AutoP2PKey)
+	bindBootnodeFlag(cmd.Flags(), &config.HTTPAddr, &config.AutoP2PKey, &config.P2PRelay)
 	bindP2PFlags(cmd.Flags(), &config.P2PConfig)
 	bindLogFlags(cmd.Flags(), &config.LogConfig)
 
 	return cmd
 }
 
-func bindBootnodeFlag(flags *pflag.FlagSet, httpAddr *string, autoP2PKey *bool) {
+func bindBootnodeFlag(flags *pflag.FlagSet, httpAddr *string, autoP2PKey, p2pRelay *bool) {
 	flags.StringVar(httpAddr, "bootnode-http-address", "127.0.0.1:16005", "Listening address (ip and port) for the bootnode http server serving runtime ENR")
 	flags.BoolVar(autoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
+	flags.BoolVar(p2pRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
 }
 
 // RunBootnode starts a p2p-udp discv5 bootnode.
@@ -101,6 +104,20 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 		return errors.Wrap(err, "")
 	}
 	defer udpNode.Close()
+
+	if config.P2PRelay {
+		tcpNode, err := p2p.NewTCPNode(config.P2PConfig, key, p2p.NewOpenGater(), udpNode, nil)
+		if err != nil {
+			return err
+		}
+		defer tcpNode.Close()
+
+		relayService, err := relay.New(tcpNode)
+		if err != nil {
+			return errors.Wrap(err, "new relay service")
+		}
+		defer relayService.Close()
+	}
 
 	serverErr := make(chan error, 1)
 	go func() {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -73,12 +73,13 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
 	flags.StringVar(&config.DBPath, "p2p-peerdb", "", "Path to store a discv5 peer database. Empty default results in in-memory database.")
-	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", nil, "Comma-separated list of discv5 bootnode URLs or ENRs. Manifest ENRs are used if empty. Example URL: enode://<hex node id>@10.3.58.6:30303?discport=30301.")
-	flags.BoolVar(&config.UDPBootManifest, "p2p-bootmanifest", false, "Enables using manifest ENRs as discv5 boot nodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
-	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "127.0.0.1:16004", "Listening UDP address (ip and port) for Discv5 discovery.")
+	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", nil, "Comma-separated list of discv5 bootnode URLs or ENRs. Example: enode://<hex node id>@10.3.58.6:30303?discport=30301.")
+	flags.BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", false, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.")
+	flags.BoolVar(&config.UDPBootManifest, "p2p-bootmanifest", false, "Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
+	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "127.0.0.1:16004", "Listening UDP address (ip and port) for discv5 discovery.")
 	flags.StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	flags.StringVar(&config.ExteranlHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
-	flags.StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", []string{"127.0.0.1:16003"}, "Comma-separated list of listening TCP addresses (ip and port) for LibP2P traffic.")
+	flags.StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", []string{"127.0.0.1:16003"}, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.")
 	flags.StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
 	flags.StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
 }

--- a/core/leadercast/transport.go
+++ b/core/leadercast/transport.go
@@ -124,7 +124,8 @@ func (t *p2pTransport) AwaitNext(ctx context.Context) (int, core.Duty, core.Unsi
 }
 
 func sendData(ctx context.Context, t *p2pTransport, p peer.ID, b []byte) error {
-	s, err := t.tcpNode.NewStream(ctx, p, protocol)
+	// Circuit relay connections are transient
+	s, err := t.tcpNode.NewStream(network.WithUseTransient(ctx, "leadercast"), p, protocol)
 	if err != nil {
 		return errors.Wrap(err, "tcpNode stream")
 	}

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -130,7 +130,8 @@ func (m *ParSigEx) Subscribe(fn func(context.Context, core.Duty, core.ParSignedD
 }
 
 func sendData(ctx context.Context, tcpNode host.Host, p peer.ID, b []byte) error {
-	s, err := tcpNode.NewStream(ctx, p, protocol)
+	// Circuit relay connections are transient
+	s, err := tcpNode.NewStream(network.WithUseTransient(ctx, "parsigex"), p, protocol)
 	if err != nil {
 		return errors.Wrap(err, "tcpNode stream")
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,14 +33,15 @@ Flags:
       --manifest-file string           The path to the manifest file defining distributed validator cluster (default "./charon/manifest.json")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:16001")
       --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-bootmanifest               Enables using manifest ENRs as discv5 boot nodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
-      --p2p-bootnodes strings          Comma-separated list of discv5 bootnode URLs or ENRs. Manifest ENRs are used if empty. Example URL: enode://<hex node id>@10.3.58.6:30303?discport=30301.
+      --p2p-bootmanifest               Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
+      --p2p-bootnode-relay             Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
+      --p2p-bootnodes strings          Comma-separated list of discv5 bootnode URLs or ENRs. Example: enode://<hex node id>@10.3.58.6:30303?discport=30301.
       --p2p-denylist string            Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-external-hostname string   The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string         The IP address advertised by libp2p. This may be used to advertise an external IP.
       --p2p-peerdb string              Path to store a discv5 peer database. Empty default results in in-memory database.
-      --p2p-tcp-address strings        Comma-separated list of listening TCP addresses (ip and port) for LibP2P traffic. (default [127.0.0.1:16003])
-      --p2p-udp-address string         Listening UDP address (ip and port) for Discv5 discovery. (default "127.0.0.1:16004")
+      --p2p-tcp-address strings        Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. (default [127.0.0.1:16003])
+      --p2p-udp-address string         Listening UDP address (ip and port) for discv5 discovery. (default "127.0.0.1:16004")
       --simnet-beacon-mock             Enables an internal mock beacon node for running a simnet.
       --simnet-validator-mock          Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.
       --validator-api-address string   Listening address (ip and port) for validator-facing traffic proxying the beacon-node API (default "127.0.0.1:16002")

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -43,6 +43,9 @@ type Config struct {
 	Allowlist string
 	// Allowlist defines csv CIDR blocks for lib-p2p denied connections.
 	Denylist string
+	// BootnodeRelay enables circuit relay via bootnodes if direct connections fail.
+	// Only applicable to charon nodes not bootnodes.
+	BootnodeRelay bool
 }
 
 // ParseTCPAddrs returns the configured tcp addresses as typed net tcp addresses.

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -171,6 +171,7 @@ func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *eno
 
 	node := enode.NewLocalNode(db, key)
 
+	// Configure enode with ip and port for tcp libp2p
 	tcpAddrs, err := config.ParseTCPAddrs()
 	if err != nil {
 		return nil, nil, err
@@ -185,6 +186,7 @@ func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *eno
 		node.Set(enr.TCP(addr.Port))
 	}
 
+	// Configure enode with ip and port for udp discv5
 	udpAddr, err := net.ResolveUDPAddr("udp", config.UDPAddr)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "resolve udp address")
@@ -192,6 +194,7 @@ func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *eno
 	node.SetFallbackIP(udpAddr.IP)
 	node.SetFallbackUDP(udpAddr.Port)
 
+	// Configure enode with external (advertised) IP
 	if config.ExternalIP != "" {
 		ip := net.ParseIP(config.ExternalIP)
 		if ip.To4() == nil && ip.To16() == nil {
@@ -202,6 +205,7 @@ func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *eno
 		node.SetStaticIP(ip)
 	}
 
+	// Configure enode with external (advertised) hostname
 	if config.ExteranlHost != "" {
 		ips, err := net.LookupIP(config.ExteranlHost)
 		if err != nil || len(ips) == 0 {

--- a/p2p/gater_internal_test.go
+++ b/p2p/gater_internal_test.go
@@ -65,7 +65,7 @@ func TestP2PConnGating(t *testing.T) {
 	if err != nil {
 		t.Fatal("private key generation for A failed", err)
 	}
-	nodeA, err := NewTCPNode(p2pConfigA, convertPrivKey(prvKeyA), c, nil, nil)
+	nodeA, err := NewTCPNode(p2pConfigA, convertPrivKey(prvKeyA), c, UDPNode{}, nil)
 	if err != nil {
 		t.Fatal("couldn't instantiate new node A", err)
 	}
@@ -76,7 +76,7 @@ func TestP2PConnGating(t *testing.T) {
 	if err != nil {
 		t.Fatal("private key generation for B failed", err)
 	}
-	nodeB, err := NewTCPNode(p2pConfigB, convertPrivKey(prvKeyB), c, nil, nil)
+	nodeB, err := NewTCPNode(p2pConfigB, convertPrivKey(prvKeyB), c, UDPNode{}, nil)
 	if err != nil {
 		t.Fatal("couldn't instantiate new node B", err)
 	}
@@ -85,6 +85,11 @@ func TestP2PConnGating(t *testing.T) {
 	err = nodeB.Connect(context.Background(), peer.AddrInfo{ID: nodeA.ID(), Addrs: nodeA.Addrs()})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), fmt.Sprintf("gater rejected connection with peer %s and addr %s", nodeA.ID(), nodeA.Addrs()[0]))
+}
+
+func TestOpenGater(t *testing.T) {
+	gater := NewOpenGater()
+	require.True(t, gater.InterceptSecured(0, "", nil))
 }
 
 func convertPrivKey(privkey crypto.PrivKey) *ecdsa.PrivateKey {

--- a/p2p/gater_internal_test.go
+++ b/p2p/gater_internal_test.go
@@ -65,7 +65,7 @@ func TestP2PConnGating(t *testing.T) {
 	if err != nil {
 		t.Fatal("private key generation for A failed", err)
 	}
-	nodeA, err := NewTCPNode(p2pConfigA, convertPrivKey(prvKeyA), c, UDPNode{}, nil)
+	nodeA, err := NewTCPNode(p2pConfigA, convertPrivKey(prvKeyA), c, UDPNode{}, nil, DefaultAdvertisedAddrs)
 	if err != nil {
 		t.Fatal("couldn't instantiate new node A", err)
 	}
@@ -76,7 +76,7 @@ func TestP2PConnGating(t *testing.T) {
 	if err != nil {
 		t.Fatal("private key generation for B failed", err)
 	}
-	nodeB, err := NewTCPNode(p2pConfigB, convertPrivKey(prvKeyB), c, UDPNode{}, nil)
+	nodeB, err := NewTCPNode(p2pConfigB, convertPrivKey(prvKeyB), c, UDPNode{}, nil, DefaultAdvertisedAddrs)
 	if err != nil {
 		t.Fatal("couldn't instantiate new node B", err)
 	}

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -112,14 +112,15 @@ func adaptDiscRouting(udpNode UDPNode, peers []Peer) peerRoutingFunc {
 		}
 
 		resolved := udpNode.Resolve(&node)
-		if resolved == nil || resolved.Seq() == 0 {
+		if resolved == nil {
 			return peer.AddrInfo{}, errors.New("peer not resolved")
 		}
 
 		var mAddrs []ma.Multiaddr
 
+		// If sequence is 0, we haven't discovered it yet.
 		// If tcp port is 0, this node isn't bound to a port.
-		if resolved.TCP() != 0 {
+		if resolved.Seq() != 0 && resolved.TCP() != 0 {
 			mAddr, err := multiAddrFromIPPort(resolved.IP(), resolved.TCP())
 			if err != nil {
 				return peer.AddrInfo{}, err

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -24,19 +24,44 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 )
 
-// Peer represents a charon node in a cluster.
+// Peer represents a peer in the libp2p network, either a charon node or a relay.
 type Peer struct {
 	// ENR defines the networking information of the peer.
 	ENR enr.Record
+
+	// Enode represents the networking host of the peer.
+	Enode enode.Node
 
 	// ID is a libp2p peer identity. It is inferred from the ENR.
 	ID peer.ID
 
 	// Index is the order of this node in the cluster.
+	// This is only applicable to charon nodes, not relays.
 	Index int
 }
 
-// NewPeer returns a new peer from an.
+// newRelayPeer returns a new relay peer.
+func newRelayPeer(nodeAddr string) (Peer, error) {
+	node, err := enode.Parse(enode.V4ID{}, nodeAddr)
+	if err != nil {
+		return Peer{}, errors.Wrap(err, "invalid relay address")
+	}
+
+	p2pPubkey := libp2pcrypto.Secp256k1PublicKey(*node.Pubkey())
+	id, err := peer.IDFromPublicKey(&p2pPubkey)
+	if err != nil {
+		return Peer{}, errors.Wrap(err, "p2p id from pubkey")
+	}
+
+	return Peer{
+		ENR:   *node.Record(),
+		Enode: *node,
+		ID:    id,
+		Index: -1,
+	}, nil
+}
+
+// NewPeer returns a new charon peer.
 func NewPeer(record enr.Record, index int) (Peer, error) {
 	var pubkey enode.Secp256k1
 	if err := record.Load(&pubkey); err != nil {
@@ -49,8 +74,14 @@ func NewPeer(record enr.Record, index int) (Peer, error) {
 		return Peer{}, errors.Wrap(err, "p2p id from pubkey")
 	}
 
+	node, err := enode.New(new(enode.V4ID), &record)
+	if err != nil {
+		return Peer{}, errors.Wrap(err, "new peer enode")
+	}
+
 	return Peer{
 		ENR:   record,
+		Enode: *node,
 		ID:    id,
 		Index: index,
 	}, nil

--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -1,0 +1,76 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	circuit "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
+	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/lifecycle"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+// NewRelayReserver returns a life cycle hook function that continuously
+// reserves a relay circuit until the context is closed.
+func NewRelayReserver(tcpNode host.Host, relay Peer) lifecycle.HookFunc {
+	return func(ctx context.Context) error {
+		ctx = log.WithTopic(ctx, "relay")
+		ctx = log.WithCtx(ctx, z.Str("relay_peer", ShortID(relay.ID)))
+
+		if relay.Enode.TCP() == 0 {
+			log.Debug(ctx, "Relay not accessible")
+			return nil
+		}
+
+		bootAddr, err := multiAddrFromIPPort(relay.Enode.IP(), relay.Enode.TCP())
+		if err != nil {
+			return errors.Wrap(err, "relay address")
+		}
+
+		addrInfo := peer.AddrInfo{
+			ID:    relay.ID,
+			Addrs: []ma.Multiaddr{bootAddr},
+		}
+
+		for ctx.Err() == nil {
+			resv, err := circuit.Reserve(ctx, tcpNode, addrInfo)
+			if err != nil {
+				log.Warn(ctx, "Reserve relay circuit", z.Err(err))
+				time.Sleep(time.Second * 5) // TODO(corver): Improve backoff
+
+				continue
+			}
+
+			log.Debug(ctx, "Relay circuit reserved",
+				z.Any("expire", resv.Expiration))
+
+			select {
+			case <-ctx.Done():
+			case <-time.After(time.Until(resv.Expiration.Add(-time.Minute))):
+				log.Debug(ctx, "Refreshing relay circuit reservation")
+			}
+		}
+
+		return nil
+	}
+}

--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -62,13 +62,18 @@ func NewRelayReserver(tcpNode host.Host, relay Peer) lifecycle.HookFunc {
 			}
 
 			log.Debug(ctx, "Relay circuit reserved",
-				z.Any("expire", resv.Expiration))
+				z.Any("expire", resv.Expiration),
+				z.Any("limit_duration", resv.LimitDuration),
+				z.Any("limit_data_mb", resv.LimitData/(1<<20)),
+			)
 
 			select {
 			case <-ctx.Done():
+				return nil
+			case <-time.After(resv.LimitDuration - time.Second*10):
 			case <-time.After(time.Until(resv.Expiration.Add(-time.Minute))):
-				log.Debug(ctx, "Refreshing relay circuit reservation")
 			}
+			log.Debug(ctx, "Refreshing relay circuit reservation")
 		}
 
 		return nil


### PR DESCRIPTION
Adds support for libp2p circuit relay via bootnodes. Allows clusters with non-publicly accessible charon nodes.

category: feature
ticket: #413 
