### PR TITLE
cmd: wire dkg stub

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/obolnetwork/charon/app"
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/dkg"
 )
 
 const (
@@ -46,6 +47,10 @@ func New() *cobra.Command {
 		newRunCmd(app.Run),
 		newBootnodeCmd(RunBootnode),
 		newCreateClusterCmd(runCreateCluster),
+		newDKGCmd(
+			newDKGJoinCommand(dkg.Join),
+			newDKGLeadCommand(dkg.Lead),
+		),
 	)
 }
 

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -1,0 +1,86 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/obolnetwork/charon/dkg"
+)
+
+func newDKGCmd(cmds ...*cobra.Command) *cobra.Command {
+	dkg := &cobra.Command{
+		Use:   "dkg",
+		Short: "Lead or join a distributed key generation ceremony",
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			return initializeConfig(cmd)
+		},
+	}
+
+	dkg.AddCommand(cmds...)
+
+	titledHelp(dkg)
+
+	return dkg
+}
+
+func newDKGJoinCommand(runFunc func(context.Context, dkg.JoinConfig) error) *cobra.Command {
+	var conf dkg.JoinConfig
+
+	cmd := &cobra.Command{
+		Use:   "join",
+		Short: "Join a dkg ceremony",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFunc(cmd.Context(), conf)
+		},
+	}
+
+	bindDataDirFlag(cmd.Flags(), &conf.DataDir)
+	bindP2PFlags(cmd.Flags(), &conf.P2PConfig)
+	bindLogFlags(cmd.Flags(), &conf.LogConfig)
+	bindDKGFlags(cmd.Flags(), &conf.ClusterConfig)
+
+	return cmd
+}
+
+func newDKGLeadCommand(runFunc func(context.Context, dkg.LeadConfig) error) *cobra.Command {
+	var conf dkg.LeadConfig
+
+	cmd := &cobra.Command{
+		Use:   "lead",
+		Short: "Lead a dkg ceremony",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFunc(cmd.Context(), conf)
+		},
+	}
+
+	bindDataDirFlag(cmd.Flags(), &conf.DataDir)
+	bindP2PFlags(cmd.Flags(), &conf.P2PConfig)
+	bindLogFlags(cmd.Flags(), &conf.LogConfig)
+	bindDKGFlags(cmd.Flags(), &conf.ClusterConfig)
+
+	return cmd
+}
+
+func bindDKGFlags(flags *pflag.FlagSet, config *dkg.ClusterConfig) {
+	flags.IntVar(&config.Validators, "validators", 1, "The number of distributed validators (each requiring 32 ETH) to generate.")
+	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
+}

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -1,0 +1,78 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dkg
+
+import (
+	"encoding/json"
+	"os"
+	"path"
+
+	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+
+	"github.com/obolnetwork/charon/app"
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/testutil/keystore"
+)
+
+// loadManifest loads and returns the manifest from the file on disk.
+func loadManifest(filename string) (app.Manifest, error) {
+	buf, err := os.ReadFile(filename)
+	if err != nil {
+		return app.Manifest{}, errors.Wrap(err, "read manifest")
+	}
+
+	var res app.Manifest
+	err = json.Unmarshal(buf, &res)
+	if err != nil {
+		return app.Manifest{}, errors.Wrap(err, "unmarshal manifest")
+	}
+
+	return res, nil
+}
+
+// writeOutput writes the updated manifest lock file and private share keystores to disk.
+func writeOutput(manifest app.Manifest, datadir string, outs []output) error {
+	clone := manifest
+	var secrets []*bls_sig.SecretKey
+	for _, out := range outs {
+		tss, err := tbls.NewTSS(out.Verifier, len(manifest.Peers))
+		if err != nil {
+			return err
+		}
+
+		clone.DVs = append(clone.DVs, tss)
+
+		secrets = append(secrets, out.Share)
+	}
+
+	err := keystore.StoreKeys(secrets, datadir)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.Marshal(clone)
+	if err != nil {
+		return errors.Wrap(err, "marshal manifest")
+	}
+
+	err = os.WriteFile(path.Join(datadir, "manifest.lock"), b, 0o600)
+	if err != nil {
+		return errors.Wrap(err, "write manifest lock")
+	}
+
+	return nil
+}

--- a/dkg/join.go
+++ b/dkg/join.go
@@ -1,0 +1,100 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dkg
+
+import (
+	"context"
+	"path"
+
+	"github.com/libp2p/go-libp2p-core/host"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/p2p"
+)
+
+// JoinConfig defines the configuration required to join a DKG ceremony.
+type JoinConfig struct {
+	DataDir       string
+	P2PConfig     p2p.Config
+	LogConfig     log.Config
+	ClusterConfig ClusterConfig
+}
+
+// Join starts a libp2p tcp node and generates distributed validator keys and manifest lock file.
+func Join(ctx context.Context, conf JoinConfig) error {
+	ctx = log.WithTopic(ctx, "dkg")
+
+	if err := log.InitLogger(conf.LogConfig); err != nil {
+		return err
+	}
+
+	manifest, err := loadManifest(path.Join(conf.DataDir, "manifest.yml"))
+	if err != nil {
+		return err
+	}
+
+	tcpNode, shutdown, err := setupP2P(conf.DataDir, conf.P2PConfig, manifest.Peers)
+	if err != nil {
+		return err
+	}
+	defer shutdown()
+
+	var outs []output
+	for i := 0; i < conf.ClusterConfig.Validators; i++ {
+		out, err := joinKeyCast(ctx, tcpNode)
+		if err != nil {
+			return err
+		}
+		outs = append(outs, out)
+	}
+
+	err = writeOutput(manifest, conf.DataDir, outs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setupP2P returns a started libp2p tcp node and a shutdown function.
+func setupP2P(datadir string, p2pConf p2p.Config, peers []p2p.Peer) (host.Host, func(), error) {
+	key, err := p2p.LoadPrivKey(datadir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	localEnode, db, err := p2p.NewLocalEnode(p2pConf, key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to open enode")
+	}
+
+	udpNode, err := p2p.NewUDPNode(p2pConf, localEnode, key, nil)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "")
+	}
+
+	tcpNode, err := p2p.NewTCPNode(p2pConf, key, p2p.NewOpenGater(), udpNode, peers, nil)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "")
+	}
+
+	return tcpNode, func() {
+		db.Close()
+		udpNode.Close()
+		_ = tcpNode.Close()
+	}, nil
+}

--- a/dkg/keycastjoin.go
+++ b/dkg/keycastjoin.go
@@ -31,7 +31,7 @@ import (
 )
 
 // joinKeyCast returns the output for a keycast participant identified by the libp2p peer ID.
-//nolint:deadcode // Will be tested and wired in subsequent PRs.
+
 func joinKeyCast(ctx context.Context, tcpNode host.Host) (output, error) {
 	var (
 		outCh = make(chan output, 1)

--- a/dkg/keycastlead.go
+++ b/dkg/keycastlead.go
@@ -53,7 +53,7 @@ type msg struct {
 
 // leadKeyCast generates a new key pair, splits it into shares, and broadcasts one to each participant.
 // It returns the leaders output.
-//nolint:deadcode // Will be tested and wired in subsequent PRs.
+
 func leadKeyCast(ctx context.Context, tcpNode host.Host, peers []p2p.Peer, t int, r io.Reader) (output, error) {
 	pubkey, secret, err := tbls.Keygen()
 	if err != nil {

--- a/dkg/lead.go
+++ b/dkg/lead.go
@@ -57,6 +57,7 @@ func Lead(ctx context.Context, conf LeadConfig) error {
 
 	var outs []output
 	for i := 0; i < conf.ClusterConfig.Validators; i++ {
+		// TODO(corver): DKG needs to distinguish between multiple validator rounds.
 		t := conf.ClusterConfig.Threshold
 		out, err := leadKeyCast(ctx, tcpNode, manifest.Peers, t, rand.Reader)
 		if err != nil {

--- a/dkg/lead.go
+++ b/dkg/lead.go
@@ -1,0 +1,74 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package dkg
+
+import (
+	"context"
+	"crypto/rand"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/p2p"
+)
+
+type ClusterConfig struct {
+	Validators int
+	Threshold  int
+}
+
+type LeadConfig struct {
+	ManifestFile  string
+	DataDir       string
+	P2PConfig     p2p.Config
+	LogConfig     log.Config
+	ClusterConfig ClusterConfig
+}
+
+// Lead starts a libp2p tcp node and generates distributed validator keys and manifest lock file.
+func Lead(ctx context.Context, conf LeadConfig) error {
+	ctx = log.WithTopic(ctx, "dkg")
+
+	if err := log.InitLogger(conf.LogConfig); err != nil {
+		return err
+	}
+
+	manifest, err := loadManifest(conf.ManifestFile)
+	if err != nil {
+		return err
+	}
+
+	tcpNode, shutdown, err := setupP2P(conf.DataDir, conf.P2PConfig, manifest.Peers)
+	if err != nil {
+		return err
+	}
+	defer shutdown()
+
+	var outs []output
+	for i := 0; i < conf.ClusterConfig.Validators; i++ {
+		t := conf.ClusterConfig.Threshold
+		out, err := leadKeyCast(ctx, tcpNode, manifest.Peers, t, rand.Reader)
+		if err != nil {
+			return err
+		}
+		outs = append(outs, out)
+	}
+
+	err = writeOutput(manifest, conf.DataDir, outs)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
Wires a stub dkg into the charon cli, starts lbp2p tcp nodes, and runs stub algorithms, and writes output to disk.

This is a starting point for DKG integration, something to build on, extend, and improve.

category: feature
ticket: #439 
