### PR TITLE
app: add proposer test to simnet

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -266,8 +266,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		opts := []beaconmock.Option{
 			beaconmock.WithSlotDuration(time.Second),
 			beaconmock.WithDeterministicAttesterDuties(100),
-			// TODO(dhruv): remove this when DutyProposer is in place
-			beaconmock.WithNoProposerDuties(),
+			beaconmock.WithDeterministicProposerDuties(100),
 			beaconmock.WithValidatorSet(createMockValidators(pubkeys)),
 		}
 		opts = append(opts, conf.TestConfig.SimnetBMockOpts...)
@@ -482,10 +481,6 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 
 	// Trigger validatormock when scheduler triggers new slot.
 	sched.Subscribe(func(ctx context.Context, duty core.Duty, _ core.FetchArgSet) error {
-		if duty.Type != core.DutyAttester {
-			return nil
-		}
-
 		ctx = log.WithTopic(ctx, "vmock")
 		go func() {
 			addr := "http://" + conf.ValidatorAPIAddr
@@ -499,16 +494,33 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 				return
 			}
 
-			err = validatormock.Attest(ctx, cl.(*eth2http.Service), signer, eth2p0.Slot(duty.Slot), pubshares...)
-			if err != nil {
-				log.Warn(ctx, "Attestation failed", z.Err(err))
-			} else {
-				log.Info(ctx, "Attestation success", z.I64("slot", duty.Slot))
-			}
+			callValidatorMock(ctx, duty, cl, signer, pubshares, addr)
 		}()
 
 		return nil
 	})
 
 	return nil
+}
+
+// callValidatorMock calls appropriate validatormock function to attestation and block proposal.
+func callValidatorMock(ctx context.Context, duty core.Duty, cl eth2client.Service, signer validatormock.SignFunc, pubshares []eth2p0.BLSPubKey, addr string) {
+	switch duty.Type {
+	case core.DutyAttester:
+		err := validatormock.Attest(ctx, cl.(*eth2http.Service), signer, eth2p0.Slot(duty.Slot), pubshares...)
+		if err != nil {
+			log.Warn(ctx, "Attestation failed", z.Err(err))
+		} else {
+			log.Info(ctx, "Attestation success", z.I64("slot", duty.Slot))
+		}
+	case core.DutyProposer:
+		err := validatormock.ProposeBlock(ctx, cl.(*eth2http.Service), signer, eth2p0.Slot(duty.Slot), addr, pubshares...)
+		if err != nil {
+			log.Warn(ctx, "Failed to propose block", z.Err(err))
+		} else {
+			log.Info(ctx, "Block proposed successfully", z.I64("slot", duty.Slot))
+		}
+	default:
+		log.Warn(ctx, "Invalid duty type")
+	}
 }

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -55,11 +55,15 @@ func TestSimnetNoNetwork_TekuVC(t *testing.T) {
 
 	args := newSimnetArgs(t)
 	args = startTeku(t, args, 0)
-	testSimnet(t, args)
+	testSimnet(t, args, false)
+}
+
+func TestSimnetNoNetwork_WithOnlyProposerMockVCs(t *testing.T) {
+	testSimnet(t, newSimnetArgs(t), true)
 }
 
 func TestSimnetNoNetwork_MockVCs(t *testing.T) {
-	testSimnet(t, newSimnetArgs(t))
+	testSimnet(t, newSimnetArgs(t), false)
 }
 
 type simnetArgs struct {
@@ -108,7 +112,7 @@ func newSimnetArgs(t *testing.T) simnetArgs {
 
 // testSimnet spins of a simnet cluster or N charon nodes connected via in-memory transports.
 // It asserts successful end-2-end attestation broadcast from all nodes for 2 slots.
-func testSimnet(t *testing.T, args simnetArgs) {
+func testSimnet(t *testing.T, args simnetArgs, propose bool) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 
@@ -148,6 +152,12 @@ func testSimnet(t *testing.T, args simnetArgs) {
 				},
 			},
 			P2P: p2p.Config{},
+		}
+
+		if propose {
+			conf.TestConfig.SimnetBMockOpts = append(conf.TestConfig.SimnetBMockOpts, beaconmock.WithNoAttesterDuties())
+		} else {
+			conf.TestConfig.SimnetBMockOpts = append(conf.TestConfig.SimnetBMockOpts, beaconmock.WithNoProposerDuties())
 		}
 
 		eg.Go(func() error {

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -71,6 +71,9 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty,
 		}
 
 		return b.eth2Cl.SubmitBeaconBlock(ctx, block)
+	case core.DutyRandao:
+		// Randao is an internal duty, not broadcasted to beacon chain
+		return nil
 	default:
 		return errors.New("unsupported duty type")
 	}


### PR DESCRIPTION
Adds test for block proposer duty in simnet. This is only proposer test without attester duties. Combined test in subsequent PRs.

category: test
ticket: none
