### PR TITLE
dutydb: add shutdown and clean api

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -360,6 +360,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	life.RegisterStart(lifecycle.AsyncBackground, lifecycle.StartScheduler, lifecycle.HookFuncErr(sched.Run))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartAggSigDB, lifecycle.HookFuncCtx(aggSigDB.Run))
 	life.RegisterStop(lifecycle.StopScheduler, lifecycle.HookFuncMin(sched.Stop))
+	life.RegisterStop(lifecycle.StopDutyDB, lifecycle.HookFuncMin(dutyDB.Shutdown))
 	life.RegisterStop(lifecycle.StopRetryer, lifecycle.HookFuncCtx(retryer.Shutdown))
 
 	return nil

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -24,7 +24,7 @@ type OrderStart int
 // OrderStop defines the order hooks are stopped.
 type OrderStop int
 
-// Global ordering of start and stop hooks.
+// Global ordering of start hooks.
 const (
 	StartAggSigDB OrderStart = iota
 	StartRelay
@@ -34,14 +34,18 @@ const (
 	StartLeaderCast
 	StartSimulator
 	StartScheduler
+)
 
-	StopTracing OrderStop = iota
-	StopScheduler
+// Global ordering of stop hooks; follows dependency tree from root to leaves.
+const (
+	StopScheduler OrderStop = iota // High level components...
+	StopRetryer
+	StopDutyDB
+	StopBeaconMock // Close this before validator API, since it can hold long-lived connections.
+	StopValidatorAPI
+	StopTracing // Low level services...
 	StopP2PPeerDB
 	StopP2PTCPNode
 	StopP2PUDPNode
 	StopMonitoringAPI
-	StopBeaconMock // Need to close this before validator API, since it can hold long lived connections.
-	StopValidatorAPI
-	StopRetryer
 )

--- a/app/lifecycle/orderstop_string.go
+++ b/app/lifecycle/orderstop_string.go
@@ -23,25 +23,25 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[StopTracing-8]
-	_ = x[StopScheduler-9]
-	_ = x[StopP2PPeerDB-10]
-	_ = x[StopP2PTCPNode-11]
-	_ = x[StopP2PUDPNode-12]
-	_ = x[StopMonitoringAPI-13]
-	_ = x[StopBeaconMock-14]
-	_ = x[StopValidatorAPI-15]
-	_ = x[StopRetryer-16]
+	_ = x[StopScheduler-0]
+	_ = x[StopRetryer-1]
+	_ = x[StopDutyDB-2]
+	_ = x[StopBeaconMock-3]
+	_ = x[StopValidatorAPI-4]
+	_ = x[StopTracing-5]
+	_ = x[StopP2PPeerDB-6]
+	_ = x[StopP2PTCPNode-7]
+	_ = x[StopP2PUDPNode-8]
+	_ = x[StopMonitoringAPI-9]
 }
 
-const _OrderStop_name = "TracingSchedulerP2PPeerDBP2PTCPNodeP2PUDPNodeMonitoringAPIBeaconMockValidatorAPIRetryer"
+const _OrderStop_name = "SchedulerRetryerDutyDBBeaconMockValidatorAPITracingP2PPeerDBP2PTCPNodeP2PUDPNodeMonitoringAPI"
 
-var _OrderStop_index = [...]uint8{0, 7, 16, 25, 35, 45, 58, 68, 80, 87}
+var _OrderStop_index = [...]uint8{0, 9, 16, 22, 32, 44, 51, 60, 70, 80, 93}
 
 func (i OrderStop) String() string {
-	i -= 8
 	if i < 0 || i >= OrderStop(len(_OrderStop_index)-1) {
-		return "OrderStop(" + strconv.FormatInt(int64(i+8), 10) + ")"
+		return "OrderStop(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _OrderStop_name[_OrderStop_index[i]:_OrderStop_index[i+1]]
 }

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -63,6 +63,7 @@ func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.Unsig
 
 	switch duty.Type {
 	case core.DutyProposer:
+		// Sanity check max one proposer per slot 
 		if len(unsignedSet) > 1 {
 			return errors.New("unexpected proposer data set length", z.Int("n", len(unsignedSet)))
 		}

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -63,7 +63,7 @@ func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.Unsig
 
 	switch duty.Type {
 	case core.DutyProposer:
-		// Sanity check max one proposer per slot 
+		// Sanity check max one proposer per slot
 		if len(unsignedSet) > 1 {
 			return errors.New("unexpected proposer data set length", z.Int("n", len(unsignedSet)))
 		}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -51,8 +51,8 @@ type DutyDB interface {
 	Store(context.Context, Duty, UnsignedDataSet) error
 
 	// AwaitBeaconBlock blocks and returns the proposed beacon block
-	// for the slot when available. It also returns the DV public key.
-	AwaitBeaconBlock(ctx context.Context, slot int64) (PubKey, *spec.VersionedBeaconBlock, error)
+	// for the slot when available.
+	AwaitBeaconBlock(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
 
 	// AwaitAttestation blocks and returns the attestation data
 	// for the slot and committee index when available.
@@ -77,7 +77,7 @@ type Consensus interface {
 // DutyDB and stores partial signed data in the ParSigDB.
 type ValidatorAPI interface {
 	// RegisterAwaitBeaconBlock registers a function to query a unsigned beacon block by slot.
-	RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (PubKey, *spec.VersionedBeaconBlock, error))
+	RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error))
 
 	// RegisterAwaitAttestation registers a function to query attestation data.
 	RegisterAwaitAttestation(func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error))
@@ -154,11 +154,11 @@ type wireFuncs struct {
 	ConsensusPropose                func(context.Context, Duty, UnsignedDataSet) error
 	ConsensusSubscribe              func(func(context.Context, Duty, UnsignedDataSet) error)
 	DutyDBStore                     func(context.Context, Duty, UnsignedDataSet) error
-	DutyDBAwaitBeaconBlock          func(ctx context.Context, slot int64) (PubKey, *spec.VersionedBeaconBlock, error)
+	DutyDBAwaitBeaconBlock          func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
 	DutyDBAwaitAttestation          func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error)
 	DutyDBPubKeyByAttestation       func(ctx context.Context, slot, commIdx, valCommIdx int64) (PubKey, error)
 	VAPIRegisterAwaitAttestation    func(func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error))
-	VAPIRegisterAwaitBeaconBlock    func(func(ctx context.Context, slot int64) (PubKey, *spec.VersionedBeaconBlock, error))
+	VAPIRegisterAwaitBeaconBlock    func(func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error))
 	VAPIRegisterGetDutyFunc         func(func(context.Context, Duty) (FetchArgSet, error))
 	VAPIRegisterPubKeyByAttestation func(func(ctx context.Context, slot, commIdx, valCommIdx int64) (PubKey, error))
 	VAPIRegisterParSigDB            func(func(context.Context, Duty, ParSignedDataSet) error)

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -148,7 +148,7 @@ type Component struct {
 
 	pubKeyByAttFunc func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error)
 	awaitAttFunc    func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error)
-	awaitBlockFunc  func(ctx context.Context, slot int64) (core.PubKey, *spec.VersionedBeaconBlock, error)
+	awaitBlockFunc  func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
 	getDutyFunc     func(ctx context.Context, duty core.Duty) (core.FetchArgSet, error)
 	parSigDBFuncs   []func(context.Context, core.Duty, core.ParSignedDataSet) error
 }
@@ -196,8 +196,8 @@ func (c *Component) RegisterParSigDB(fn func(context.Context, core.Duty, core.Pa
 }
 
 // RegisterAwaitBeaconBlock registers a function to query unsigned block.
-// It supports multiple functions since it is the output of the component.
-func (c *Component) RegisterAwaitBeaconBlock(fn func(ctx context.Context, slot int64) (core.PubKey, *spec.VersionedBeaconBlock, error)) {
+// It supports a single function, since it is an input of the component.
+func (c *Component) RegisterAwaitBeaconBlock(fn func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)) {
 	c.awaitBlockFunc = fn
 }
 
@@ -309,7 +309,7 @@ func (c Component) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, ra
 	//  - Once inserted, the query below will return.
 
 	// Query unsigned block (this is blocking).
-	_, block, err := c.awaitBlockFunc(ctx, int64(slot))
+	block, err := c.awaitBlockFunc(ctx, int64(slot))
 	if err != nil {
 		return nil, err
 	}

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -354,8 +354,8 @@ func TestComponent_BeaconBlockProposal(t *testing.T) {
 		return core.FetchArgSet{pubkey: core.FetchArg{}}, nil
 	})
 
-	component.RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (core.PubKey, *spec.VersionedBeaconBlock, error) {
-		return pubkey, block1, nil
+	component.RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error) {
+		return block1, nil
 	})
 
 	component.RegisterParSigDB(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {

--- a/testutil/verifypr/verifypr_internal_test.go
+++ b/testutil/verifypr/verifypr_internal_test.go
@@ -13,7 +13,6 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
-//nolint:dupl
 package main
 
 import (


### PR DESCRIPTION
Add Shutdown to DutyDB so ValidatorAPI doesn't timeout on shutdown due to blocked DutyDB.Await* requests.

Also remove PubKey from AwaitBlockProposer as per previous TODO. 

Also reorder stop hooks in order of dependency tree.

category: refactor 
ticket: none
feature_set: stable
