### PR TITLE
github/workflows: add GITHUB_TOKEN to build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.CONTAINER_REGISTRY_SECRET }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: docker/build-push-action@v2
       with:


### PR DESCRIPTION
Replaces CONTAINER_REGISTRY_SECRET with GITHUB_TOKEN. It seems that @OisinKyne has configured his Personal Access Token for CONTAINER_REGISTRY_SECRET which is not a good practice for security.

category: fixbuild
ticket: none
