### PR TITLE
app: fix error mkdir ./charon: not a directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,8 +151,7 @@ ormconfig.json
 charon
 !charon/
 keys/
-data/
-charon-cluster/
+.charon/
 coverage.out
 cli-reference.txt
 changelog.md

--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,8 @@ ormconfig.json
 charon
 !charon/
 keys/
+data/
+charon-cluster/
 coverage.out
 cli-reference.txt
 changelog.md

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -79,7 +79,7 @@ func TestCmdFlags(t *testing.T) {
 					Enabled:   nil,
 					Disabled:  nil,
 				},
-				ManifestFile:     "./.charon/manifest.json",
+				ManifestFile:     ".charon/manifest.json",
 				DataDir:          "from_env",
 				MonitoringAddr:   "127.0.0.1:16001",
 				ValidatorAPIAddr: "127.0.0.1:16002",
@@ -91,7 +91,7 @@ func TestCmdFlags(t *testing.T) {
 		{
 			Name:    "gen p2p",
 			Args:    slice("gen-p2pkey"),
-			Datadir: "./.charon/data",
+			Datadir: ".charon/data",
 			P2PConfig: &p2p.Config{
 				UDPAddr:   "127.0.0.1:16004",
 				TCPAddrs:  []string{"127.0.0.1:16003"},

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -79,7 +79,7 @@ func TestCmdFlags(t *testing.T) {
 					Enabled:   nil,
 					Disabled:  nil,
 				},
-				ManifestFile:     "./charon/manifest.json",
+				ManifestFile:     "manifest.json",
 				DataDir:          "from_env",
 				MonitoringAddr:   "127.0.0.1:16001",
 				ValidatorAPIAddr: "127.0.0.1:16002",
@@ -91,7 +91,7 @@ func TestCmdFlags(t *testing.T) {
 		{
 			Name:    "gen p2p",
 			Args:    slice("gen-p2pkey"),
-			Datadir: "./charon/data",
+			Datadir: "data",
 			P2PConfig: &p2p.Config{
 				UDPAddr:   "127.0.0.1:16004",
 				TCPAddrs:  []string{"127.0.0.1:16003"},

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -79,7 +79,7 @@ func TestCmdFlags(t *testing.T) {
 					Enabled:   nil,
 					Disabled:  nil,
 				},
-				ManifestFile:     "manifest.json",
+				ManifestFile:     "./.charon/manifest.json",
 				DataDir:          "from_env",
 				MonitoringAddr:   "127.0.0.1:16001",
 				ValidatorAPIAddr: "127.0.0.1:16002",
@@ -91,7 +91,7 @@ func TestCmdFlags(t *testing.T) {
 		{
 			Name:    "gen p2p",
 			Args:    slice("gen-p2pkey"),
-			Datadir: "data",
+			Datadir: "./.charon/data",
 			P2PConfig: &p2p.Config{
 				UDPAddr:   "127.0.0.1:16004",
 				TCPAddrs:  []string{"127.0.0.1:16003"},

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -114,7 +114,7 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 }
 
 func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
-	flags.StringVar(&config.ClusterDir, "cluster-dir", "charon-cluster", "The target folder to create the cluster in.")
+	flags.StringVar(&config.ClusterDir, "cluster-dir", "./.charon/cluster", "The target folder to create the cluster in.")
 	flags.IntVarP(&config.NumNodes, "nodes", "n", 4, "The number of charon nodes in the cluster.")
 	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
 	flags.BoolVar(&config.Clean, "clean", false, "Delete the cluster directory before generating it.")

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -114,7 +114,7 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 }
 
 func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
-	flags.StringVar(&config.ClusterDir, "cluster-dir", "./charon/cluster", "The target folder to create the cluster in.")
+	flags.StringVar(&config.ClusterDir, "cluster-dir", "charon-cluster", "The target folder to create the cluster in.")
 	flags.IntVarP(&config.NumNodes, "nodes", "n", 4, "The number of charon nodes in the cluster.")
 	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
 	flags.BoolVar(&config.Clean, "clean", false, "Delete the cluster directory before generating it.")

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -114,7 +114,7 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 }
 
 func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
-	flags.StringVar(&config.ClusterDir, "cluster-dir", "./.charon/cluster", "The target folder to create the cluster in.")
+	flags.StringVar(&config.ClusterDir, "cluster-dir", ".charon/cluster", "The target folder to create the cluster in.")
 	flags.IntVarP(&config.NumNodes, "nodes", "n", 4, "The number of charon nodes in the cluster.")
 	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
 	flags.BoolVar(&config.Clean, "clean", false, "Delete the cluster directory before generating it.")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 }
 
 func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
-	flags.StringVar(&config.ManifestFile, "manifest-file", "manifest.json", "The path to the manifest file defining distributed validator cluster")
+	flags.StringVar(&config.ManifestFile, "manifest-file", "./.charon/manifest.json", "The path to the manifest file defining distributed validator cluster")
 	flags.StringVar(&config.BeaconNodeAddr, "beacon-node-endpoint", "http://localhost/", "Beacon node endpoint URL")
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:16002", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:16001", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")
@@ -70,7 +70,7 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 }
 
 func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
-	flags.StringVar(dataDir, "data-dir", "data", "The directory where charon will store all its internal data")
+	flags.StringVar(dataDir, "data-dir", "./.charon/data", "The directory where charon will store all its internal data")
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 }
 
 func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
-	flags.StringVar(&config.ManifestFile, "manifest-file", "./.charon/manifest.json", "The path to the manifest file defining distributed validator cluster")
+	flags.StringVar(&config.ManifestFile, "manifest-file", ".charon/manifest.json", "The path to the manifest file defining distributed validator cluster")
 	flags.StringVar(&config.BeaconNodeAddr, "beacon-node-endpoint", "http://localhost/", "Beacon node endpoint URL")
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:16002", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:16001", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")
@@ -70,7 +70,7 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 }
 
 func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
-	flags.StringVar(dataDir, "data-dir", "./.charon/data", "The directory where charon will store all its internal data")
+	flags.StringVar(dataDir, "data-dir", ".charon/data", "The directory where charon will store all its internal data")
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 }
 
 func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
-	flags.StringVar(&config.ManifestFile, "manifest-file", "./charon/manifest.json", "The path to the manifest file defining distributed validator cluster")
+	flags.StringVar(&config.ManifestFile, "manifest-file", "manifest.json", "The path to the manifest file defining distributed validator cluster")
 	flags.StringVar(&config.BeaconNodeAddr, "beacon-node-endpoint", "http://localhost/", "Beacon node endpoint URL")
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:16002", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:16001", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")
@@ -70,7 +70,7 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 }
 
 func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
-	flags.StringVar(dataDir, "data-dir", "./charon/data", "The directory where charon will store all its internal data")
+	flags.StringVar(dataDir, "data-dir", "data", "The directory where charon will store all its internal data")
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ Usage:
 
 Flags:
       --beacon-node-endpoint string    Beacon node endpoint URL (default "http://localhost/")
-      --data-dir string                The directory where charon will store all its internal data (default "data")
+      --data-dir string                The directory where charon will store all its internal data (default "./.charon/data")
       --feature-set string             Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings    Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings     Comma-separated list of features to enable, overriding the default minimum feature set.
@@ -97,7 +97,7 @@ Flags:
       --jaeger-service string          Service name used for jaeger tracing (default "charon")
       --log-format string              Log format; console, logfmt or json (default "console")
       --log-level string               Log level; debug, info, warn or error (default "info")
-      --manifest-file string           The path to the manifest file defining distributed validator cluster (default "manifest.json")
+      --manifest-file string           The path to the manifest file defining distributed validator cluster (default "./.charon/manifest.json")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:16001")
       --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
       --p2p-bootmanifest               Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ Usage:
 
 Flags:
       --beacon-node-endpoint string    Beacon node endpoint URL (default "http://localhost/")
-      --data-dir string                The directory where charon will store all its internal data (default "./charon/data")
+      --data-dir string                The directory where charon will store all its internal data (default "data")
       --feature-set string             Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings    Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings     Comma-separated list of features to enable, overriding the default minimum feature set.
@@ -97,7 +97,7 @@ Flags:
       --jaeger-service string          Service name used for jaeger tracing (default "charon")
       --log-format string              Log format; console, logfmt or json (default "console")
       --log-level string               Log level; debug, info, warn or error (default "info")
-      --manifest-file string           The path to the manifest file defining distributed validator cluster (default "./charon/manifest.json")
+      --manifest-file string           The path to the manifest file defining distributed validator cluster (default "manifest.json")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:16001")
       --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
       --p2p-bootmanifest               Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -88,7 +88,7 @@ Usage:
 
 Flags:
       --beacon-node-endpoint string    Beacon node endpoint URL (default "http://localhost/")
-      --data-dir string                The directory where charon will store all its internal data (default "./.charon/data")
+      --data-dir string                The directory where charon will store all its internal data (default ".charon/data")
       --feature-set string             Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings    Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings     Comma-separated list of features to enable, overriding the default minimum feature set.
@@ -97,7 +97,7 @@ Flags:
       --jaeger-service string          Service name used for jaeger tracing (default "charon")
       --log-format string              Log format; console, logfmt or json (default "console")
       --log-level string               Log level; debug, info, warn or error (default "info")
-      --manifest-file string           The path to the manifest file defining distributed validator cluster (default "./.charon/manifest.json")
+      --manifest-file string           The path to the manifest file defining distributed validator cluster (default ".charon/manifest.json")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:16001")
       --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
       --p2p-bootmanifest               Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.


### PR DESCRIPTION
When running commands like `./charon gen-p2pkey` or `./charon create-cluster`, users including me got an error:
`Error: mkdir ./charon: not a directory`

This could happen as the default directory name starts with the prefix `./charon`, for example, `./charon/data` for `create-cluster`. Removing the prefix solves this. Directories are always created off of `charon` root.

category: bug
ticket: #427 
