### PR TITLE
app/log: align warn and error APIs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -496,7 +496,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 				eth2http.WithTimeout(time.Second*10), // Allow sufficient time to block while fetching duties.
 			)
 			if err != nil {
-				log.Warn(ctx, "Cannot connect to validatorapi", z.Err(err))
+				log.Warn(ctx, "Cannot connect to validatorapi", err)
 				return
 			}
 
@@ -515,18 +515,18 @@ func callValidatorMock(ctx context.Context, duty core.Duty, cl eth2client.Servic
 	case core.DutyAttester:
 		err := validatormock.Attest(ctx, cl.(*eth2http.Service), signer, eth2p0.Slot(duty.Slot), pubshares...)
 		if err != nil {
-			log.Warn(ctx, "Attestation failed", z.Err(err))
+			log.Warn(ctx, "Attestation failed", err)
 		} else {
 			log.Info(ctx, "Attestation success", z.I64("slot", duty.Slot))
 		}
 	case core.DutyProposer:
 		err := validatormock.ProposeBlock(ctx, cl.(*eth2http.Service), signer, eth2p0.Slot(duty.Slot), addr, pubshares...)
 		if err != nil {
-			log.Warn(ctx, "Failed to propose block", z.Err(err))
+			log.Warn(ctx, "Failed to propose block", err)
 		} else {
 			log.Info(ctx, "Block proposed successfully", z.I64("slot", duty.Slot))
 		}
 	default:
-		log.Warn(ctx, "Invalid duty type")
+		log.Warn(ctx, "Invalid duty type", nil)
 	}
 }

--- a/app/featureset/config.go
+++ b/app/featureset/config.go
@@ -72,7 +72,7 @@ func Init(ctx context.Context, config Config) error {
 			}
 		}
 		if !ok {
-			log.Warn(ctx, "Ignoring unknown enabled feature", z.Str("feature", f))
+			log.Warn(ctx, "Ignoring unknown enabled feature", nil, z.Str("feature", f))
 		}
 	}
 
@@ -85,7 +85,7 @@ func Init(ctx context.Context, config Config) error {
 			}
 		}
 		if !ok {
-			log.Warn(ctx, "Ignoring unknown disabled feature", z.Str("feature", f))
+			log.Warn(ctx, "Ignoring unknown disabled feature", nil, z.Str("feature", f))
 		}
 	}
 

--- a/app/log/log_test.go
+++ b/app/log/log_test.go
@@ -44,8 +44,8 @@ func TestWithContext(t *testing.T) {
 
 	log.Debug(ctx1, "msg1", z.Int("ctx1", 1))
 	log.Info(ctx2, "msg2", z.Int("ctx2", 2))
-	log.Warn(ctx3a, "msg3a")
-	log.Warn(ctx3b, "msg3b")
+	log.Warn(ctx3a, "msg3a", nil)
+	log.Warn(ctx3b, "msg3b", nil)
 
 	testutil.RequireGoldenBytes(t, buf.Bytes())
 }
@@ -58,7 +58,7 @@ func TestErrorWrap(t *testing.T) {
 	err3 := errors.Wrap(err2, "third", z.F64("3", 3))
 
 	ctx := context.Background()
-	log.Error(ctx, "err1", err1)
+	log.Warn(ctx, "err1", err1)
 	log.Error(ctx, "err2", err2)
 	log.Error(ctx, "err3", err3)
 

--- a/app/log/testdata/TestErrorWrap.golden
+++ b/app/log/testdata/TestErrorWrap.golden
@@ -1,4 +1,4 @@
-00:00 [31mERRO[0m err1: first {"1": 1, "caller": "log_test.go:61"}
+00:00 [33mWARN[0m err1: first {"1": 1, "caller": "log_test.go:61"}
 	app/log/log_test.go:56 .TestErrorWrap
 00:00 [31mERRO[0m err2: second: first {"2": 2, "1": 1, "caller": "log_test.go:62"}
 	app/log/log_test.go:56 .TestErrorWrap

--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -33,7 +33,6 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/tracer"
-	"github.com/obolnetwork/charon/app/z"
 )
 
 // lateFactor defines the number of slots duties may be late.
@@ -152,7 +151,7 @@ func (r *Retryer) DoAsync(parent context.Context, slot int64, name string, fn fu
 		}
 
 		if ctx.Err() == nil {
-			log.Warn(ctx, "Temporary failure (will retry) calling "+name, z.Err(err))
+			log.Warn(ctx, "Temporary failure (will retry) calling "+name, err)
 			span.AddEvent("retry.backoff.start")
 			select {
 			case <-backoffFunc():

--- a/core/leadercast/leadercast.go
+++ b/core/leadercast/leadercast.go
@@ -58,23 +58,23 @@ func (l *LeaderCast) Run(ctx context.Context) error {
 		if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 			return nil
 		} else if err != nil {
-			log.Error(ctx, "await next leader duty", err)
+			log.Error(ctx, "Await next leader duty", err)
 			continue
 		}
 
 		if !isLeader(source, l.peers, duty) {
-			log.Warn(ctx, "received duty from non-leader", z.Int("peer", source))
+			log.Warn(ctx, "Received duty from non-leader", nil, z.Int("peer", source))
 			continue
 		}
 
-		log.Debug(ctx, "received duty from leader", z.Int("peer", source), z.Any("duty", duty))
+		log.Debug(ctx, "Received duty from leader", z.Int("peer", source), z.Any("duty", duty))
 
 		var span trace.Span
 		ctx, span = core.StartDutyTrace(ctx, duty, "core/leadercast.Handle")
 
 		for _, sub := range l.subs {
 			if err := sub(ctx, duty, data); err != nil {
-				log.Error(ctx, "subscriber error", err)
+				log.Error(ctx, "Subscriber error", err)
 				continue
 			}
 		}

--- a/core/leadercast/transport.go
+++ b/core/leadercast/transport.go
@@ -69,13 +69,13 @@ func (t *p2pTransport) handle(s network.Stream) {
 	var msg p2pMsg
 	err := json.NewDecoder(s).Decode(&msg)
 	if err != nil {
-		log.Error(ctx, "decode leadercast message", err)
+		log.Error(ctx, "Decode leadercast message", err)
 		return
 	}
 	select {
 	case t.ch <- msg:
 	case <-ctx.Done():
-		log.Warn(ctx, "leadercast transport buffer full")
+		log.Warn(ctx, "Leadercast transport buffer full", nil)
 	}
 }
 
@@ -104,11 +104,11 @@ func (t *p2pTransport) Broadcast(ctx context.Context, fromIdx int, d core.Duty, 
 	}
 
 	if len(errs) == 0 {
-		log.Debug(ctx, "leader broadcast duty success", z.Any("duty", d))
+		log.Debug(ctx, "Leader broadcast duty success", z.Any("duty", d))
 	} else {
 		// len(t.peers)-len(errs)-1 is total number of errors excluding broadcast to self case
-		log.Warn(ctx, "broadcast duty with errors", z.Int("success", len(t.peers)-len(errs)-1),
-			z.Int("errors", len(errs)), z.Str("err_0", errs[0].Error()))
+		log.Warn(ctx, "Broadcast duty with errors", errs[0], z.Int("success", len(t.peers)-len(errs)-1),
+			z.Int("errors", len(errs)))
 	}
 
 	return nil

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -116,8 +116,8 @@ func (m *ParSigEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSi
 		log.Debug(ctx, "parsigex broadcast duty success", z.Any("duty", duty))
 	} else {
 		// len(t.peers)-len(errs)-1 is total number of errors excluding broadcast to self case
-		log.Warn(ctx, "broadcast duty with errors", z.Int("success", len(m.peers)-len(errs)-1),
-			z.Int("errors", len(errs)), z.Str("err_0", errs[0].Error()))
+		log.Warn(ctx, "broadcast duty with errors", errs[0], z.Int("success", len(m.peers)-len(errs)-1),
+			z.Int("errors", len(errs)))
 	}
 
 	return nil

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -151,7 +151,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) error {
 	if s.getResolvedEpoch() != uint64(slot.Epoch()) {
 		err := s.resolveDuties(ctx, slot)
 		if err != nil {
-			log.Warn(ctx, "Resolving duties error (retrying next slot)", z.Err(err))
+			log.Warn(ctx, "Resolving duties error (retrying next slot)", err)
 		}
 	}
 
@@ -191,7 +191,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) error {
 	if slot.IsLastInEpoch() {
 		err := s.resolveDuties(ctx, slot.Next())
 		if err != nil {
-			log.Warn(ctx, "Resolving duties error (retrying next slot)", z.Err(err))
+			log.Warn(ctx, "Resolving duties error (retrying next slot)", err)
 		}
 	}
 
@@ -234,7 +234,7 @@ func (s *Scheduler) resolveDuties(ctx context.Context, slot slot) error {
 
 			pubkey, ok := vals.PubKeyFromIndex(attDuty.ValidatorIndex)
 			if !ok {
-				log.Warn(ctx, "ignoring unexpected attester duty", z.U64("vidx", uint64(attDuty.ValidatorIndex)))
+				log.Warn(ctx, "Ignoring unexpected attester duty", nil, z.U64("vidx", uint64(attDuty.ValidatorIndex)))
 				continue
 			}
 
@@ -274,7 +274,7 @@ func (s *Scheduler) resolveDuties(ctx context.Context, slot slot) error {
 
 			pubkey, ok := vals.PubKeyFromIndex(proDuty.ValidatorIndex)
 			if !ok {
-				log.Warn(ctx, "ignoring unexpected proposer duty", z.U64("vidx", uint64(proDuty.ValidatorIndex)))
+				log.Warn(ctx, "Ignoring unexpected proposer duty", nil, z.U64("vidx", uint64(proDuty.ValidatorIndex)))
 				continue
 			}
 

--- a/dkg/transport.go
+++ b/dkg/transport.go
@@ -53,7 +53,7 @@ func (t p2pTransport) ServeShares(ctx context.Context, handler func(nodeIdx int)
 			}
 		}
 		if !found {
-			log.Warn(ctx, "Ignoring unknown peer", z.Str("peer", p2p.ShortID(s.Conn().RemotePeer())))
+			log.Warn(ctx, "Ignoring unknown peer", nil, z.Str("peer", p2p.ShortID(s.Conn().RemotePeer())))
 			return
 		}
 

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -92,7 +92,7 @@ func queryBootnodeENR(ctx context.Context, bootnodeURL string, backoff time.Dura
 
 		resp, err := client.Do(req)
 		if err != nil {
-			log.Warn(ctx, "Failure querying bootnode ENR, trying again in 5s...", z.Err(err))
+			log.Warn(ctx, "Failure querying bootnode ENR, trying again in 5s...", err)
 			time.Sleep(backoff)
 
 			continue

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -111,7 +111,7 @@ func newPingLogger(peers []peer.ID) func(context.Context, peer.ID, error) {
 		ok := state[p]
 
 		if prev > 0 && now == 0 && ok {
-			log.Warn(ctx, "Peer ping failing", z.Str("peer", ShortID(p)), z.Str("error", err.Error()))
+			log.Warn(ctx, "Peer ping failing", nil, z.Str("peer", ShortID(p)), z.Str("error", err.Error()))
 			state[p] = false
 			first[p] = true
 		} else if prev < hysteresis && now == hysteresis && !ok {

--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -78,7 +78,7 @@ func NewRelayReserver(tcpNode host.Host, relay Peer) lifecycle.HookFunc {
 		for ctx.Err() == nil {
 			resv, err := circuit.Reserve(ctx, tcpNode, addrInfo)
 			if err != nil {
-				log.Warn(ctx, "Reserve relay circuit", z.Err(err))
+				log.Warn(ctx, "Reserve relay circuit", err)
 				time.Sleep(time.Second * 5) // TODO(corver): Improve backoff
 
 				continue

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -153,7 +153,7 @@ func newHTTPServer(addr string, overrides ...staticOverride) (*http.Server, erro
 
 		resp, ok := staticResponses[r.URL.Path]
 		if !ok {
-			log.Warn(ctx, "Unsupported path")
+			log.Warn(ctx, "Unsupported path", nil)
 			w.WriteHeader(http.StatusNotFound)
 
 			return


### PR DESCRIPTION
Aligns `log.Warn` and `log.Error` APIs. Since warn and error are mostly related to logging errors, just at different level, the API should be the same. Using `z.Err(err)` also resulted in inconsistent logging, which is now mitigated by aligned APIs. Also support `nil` errors for both `log.Warn` and `log.Error` that just does logging.
 
category: refactor
ticket: none
feature_set: stable
