### PR TITLE
core/validatorapi: ignore proposer duties error

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -163,7 +163,7 @@ func (c *Component) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, vali
 	for i := 0; i < len(duties); i++ {
 		pubshare, err := c.getPubShareFunc(duties[i].PubKey)
 		if err != nil {
-			// pubshare errors can be ignored since proposer duties are a rare one
+			// pubshare errors can be ignored since proposer duties are rare ones
 			continue
 		}
 		duties[i].PubKey = pubshare

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -163,7 +163,8 @@ func (c *Component) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, vali
 	for i := 0; i < len(duties); i++ {
 		pubshare, err := c.getPubShareFunc(duties[i].PubKey)
 		if err != nil {
-			return nil, err
+			// pubshare errors can be ignored since proposer duties are a rare one
+			continue
 		}
 		duties[i].PubKey = pubshare
 	}


### PR DESCRIPTION
Ignore the error for proposer duties as they are the rare ones. It is spamming in logs since it is being checked in every epoch.

category: bug
ticket: #000
