### PR TITLE
app/log: remove caller from console logs

### DIFF
--- a/app/log/config.go
+++ b/app/log/config.go
@@ -120,8 +120,6 @@ func buildConsoleLogger(level zapcore.Level, ws zapcore.WriteSyncer, opts ...fun
 			encoder, ws,
 			zap.NewAtomicLevelAt(level),
 		),
-		zap.WithCaller(true),
-		zap.AddCallerSkip(1),
 	)
 }
 

--- a/app/log/testdata/TestCopyFields.golden
+++ b/app/log/testdata/TestCopyFields.golden
@@ -1,2 +1,2 @@
-00:00 [34mINFO[0m see source {"source": "source", "caller": "log_test.go:92"}
-00:00 [34mINFO[0m also source {"source": "source", "caller": "log_test.go:93"}
+00:00 [34mINFO[0m see source {"source": "source"}
+00:00 [34mINFO[0m also source {"source": "source"}

--- a/app/log/testdata/TestErrorWrap.golden
+++ b/app/log/testdata/TestErrorWrap.golden
@@ -1,6 +1,6 @@
-00:00 [33mWARN[0m err1: first {"1": 1, "caller": "log_test.go:61"}
+00:00 [33mWARN[0m err1: first {"1": 1}
 	app/log/log_test.go:56 .TestErrorWrap
-00:00 [31mERRO[0m err2: second: first {"2": 2, "1": 1, "caller": "log_test.go:62"}
+00:00 [31mERRO[0m err2: second: first {"2": 2, "1": 1}
 	app/log/log_test.go:56 .TestErrorWrap
-00:00 [31mERRO[0m err3: third: second: first {"3": 3, "2": 2, "1": 1, "caller": "log_test.go:63"}
+00:00 [31mERRO[0m err3: third: second: first {"3": 3, "2": 2, "1": 1}
 	app/log/log_test.go:56 .TestErrorWrap

--- a/app/log/testdata/TestErrorWrapOther.golden
+++ b/app/log/testdata/TestErrorWrapOther.golden
@@ -1,4 +1,4 @@
-00:00 [31mERRO[0m err1: EOF {"caller": "log_test.go:75"}
+00:00 [31mERRO[0m err1: EOF
 	app/log/log_test.go:75 .TestErrorWrapOther
-00:00 [31mERRO[0m err2: wrap: EOF {"caller": "log_test.go:76"}
+00:00 [31mERRO[0m err2: wrap: EOF
 	app/log/log_test.go:72 .TestErrorWrapOther

--- a/app/log/testdata/TestWithContext.golden
+++ b/app/log/testdata/TestWithContext.golden
@@ -1,4 +1,4 @@
-00:00 [35mDEBG[0m msg1 {"ctx1": 1, "caller": "log_test.go:45"}
-00:00 [34mINFO[0m msg2 {"ctx2": 2, "wrap2": 2, "caller": "log_test.go:46"}
-00:00 [33mWARN[0m msg3a {"wrap3": "a", "wrap2": 2, "caller": "log_test.go:47"}
-00:00 [33mWARN[0m msg3b {"wrap3": "b", "wrap2": 2, "caller": "log_test.go:48"}
+00:00 [35mDEBG[0m msg1 {"ctx1": 1}
+00:00 [34mINFO[0m msg2 {"ctx2": 2, "wrap2": 2}
+00:00 [33mWARN[0m msg3a {"wrap3": "a", "wrap2": 2}
+00:00 [33mWARN[0m msg3b {"wrap3": "b", "wrap2": 2}


### PR DESCRIPTION
Removes the `{"caller": "dkg.go:121"}` field from console logs.

Reasoning:
 - The `caller` field present in ALL console logs adds more noise than signal.
 - Removing it reduces noise and focusses the logging on the message.
 - Console logs already include a "topic", so the general caller package/scope is already known.
 - Since we do structured logging, finding the source/caller is as easy as grepping the code base for the message.
 - Proposer production deployments should use JSON log format in any case.

category: refactor
ticket: none
feature_set: stable
