### PR TITLE
cmd: refactor to use create command

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -47,8 +47,8 @@ func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.
 
 	cmd := &cobra.Command{
 		Use:   "bootnode",
-		Short: "Starts a p2p-udp discv5 bootnode",
-		Long:  `Starts a p2p-udp discv5 bootnode that charon nodes can use to bootstrap their p2p cluster`,
+		Short: "Start a discv5 bootnode server",
+		Long:  `Starts a discv5 bootnode that charon nodes can use to bootstrap their p2p cluster`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.Context(), config)

--- a/cmd/bootnode_internal_test.go
+++ b/cmd/bootnode_internal_test.go
@@ -39,7 +39,7 @@ func TestRunBootnode(t *testing.T) {
 		HTTPAddr:  testutil.AvailableAddr(t).String(),
 	}
 
-	err = runGenP2PKey(io.Discard, config.P2PConfig, temp)
+	err = runCreateEnrCmd(io.Discard, config.P2PConfig, temp)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,13 +43,13 @@ func New() *cobra.Command {
 	return newRootCmd(
 		newVersionCmd(runVersionCmd),
 		newEnrCmd(runNewENR),
-		newGenP2PKeyCmd(runGenP2PKey),
 		newRunCmd(app.Run),
 		newBootnodeCmd(RunBootnode),
-		newCreateClusterCmd(runCreateCluster),
 		newDKGCmd(dkg.Run),
 		newCreateCmd(
 			newCreateDKGCmd(runCreateDKG),
+			newCreateEnrCmd(runCreateEnrCmd),
+			newCreateClusterCmd(runCreateCluster),
 		),
 	)
 }

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -89,8 +89,8 @@ func TestCmdFlags(t *testing.T) {
 			},
 		},
 		{
-			Name:    "gen p2p",
-			Args:    slice("gen-p2pkey"),
+			Name:    "create enr",
+			Args:    slice("create", "enr"),
 			Datadir: ".charon/data",
 			P2PConfig: &p2p.Config{
 				UDPAddr:   "127.0.0.1:16004",
@@ -115,13 +115,15 @@ func TestCmdFlags(t *testing.T) {
 
 					return nil
 				}),
-				newGenP2PKeyCmd(func(_ io.Writer, config p2p.Config, datadir string) error {
-					require.NotNil(t, test.P2PConfig)
-					require.Equal(t, *test.P2PConfig, config)
-					require.Equal(t, test.Datadir, datadir)
+				newCreateCmd(
+					newCreateEnrCmd(func(_ io.Writer, config p2p.Config, datadir string) error {
+						require.NotNil(t, test.P2PConfig)
+						require.Equal(t, *test.P2PConfig, config)
+						require.Equal(t, test.Datadir, datadir)
 
-					return nil
-				}),
+						return nil
+					}),
+				),
 			)
 
 			// Set envs (only for duration of the test)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -20,7 +20,8 @@ import "github.com/spf13/cobra"
 func newCreateCmd(cmds ...*cobra.Command) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "create",
-		Short: "Create different artifacts required for running a Charon cluster",
+		Short: "Create artifacts for a distributed validator cluster",
+		Long:  "Create artifacts for a distributed validator cluster. These commands can be used to facilitate the creation of a distributed validator cluster between a group of operators by performing a distributed key generation ceremony, or they can be used to create a local cluster for single operator use cases.",
 	}
 
 	root.AddCommand(cmds...)

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -99,9 +99,9 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 	var conf clusterConfig
 
 	cmd := &cobra.Command{
-		Use:   "create-cluster",
-		Short: "Create a local charon cluster",
-		Long: "Create a local charon cluster including validator keys, charon p2p keys, and a cluster manifest. " +
+		Use:   "cluster",
+		Short: "Creates configuration files and private keys for a local charon cluster",
+		Long: "Creates a local charon cluster configuration including validator keys, charon p2p keys, and a cluster manifest. " +
 			"See flags for supported features.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.OutOrStdout(), conf)

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -100,7 +100,7 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 
 	cmd := &cobra.Command{
 		Use:   "cluster",
-		Short: "Creates configuration files and private keys for a local charon cluster",
+		Short: "Create private keys and configuration files needed to run a distributed validator cluster locally",
 		Long: "Creates a local charon cluster configuration including validator keys, charon p2p keys, and a cluster manifest. " +
 			"See flags for supported features.",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -45,7 +45,7 @@ func newCreateDKGCmd(runFunc func(context.Context, createDKGConfig) error) *cobr
 
 	cmd := &cobra.Command{
 		Use:   "dkg",
-		Short: "Configure DKG by creating a cluster definition file",
+		Short: "Creates a charon DKG configuration file for charon dkg",
 		Long:  `Create a cluster definition file that will be used by all participants of a DKG.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -45,7 +45,7 @@ func newCreateDKGCmd(runFunc func(context.Context, createDKGConfig) error) *cobr
 
 	cmd := &cobra.Command{
 		Use:   "dkg",
-		Short: "Creates a charon DKG configuration file for charon dkg",
+		Short: "Create the configuration for a new Distributed Key Generation ceremony using charon dkg",
 		Long:  `Create a cluster definition file that will be used by all participants of a DKG.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -25,16 +25,16 @@ import (
 	"github.com/obolnetwork/charon/p2p"
 )
 
-func newGenP2PKeyCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command {
+func newCreateEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command {
 	var (
 		config  p2p.Config
 		dataDir string
 	)
 
 	cmd := &cobra.Command{
-		Use:   "gen-p2pkey",
-		Short: "Generates a new p2p key",
-		Long:  `Generates a new p2p authentication key (ecdsa-k1) and saves it to the data directory`,
+		Use:   "enr",
+		Short: "Creates a new enr private key",
+		Long:  `Creates an Ethereum Node Record (ENR) private key to identify charon`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.OutOrStdout(), config, dataDir)
@@ -47,8 +47,8 @@ func newGenP2PKeyCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 	return cmd
 }
 
-// runGenP2PKey stores a new p2pkey to disk and prints the ENR for the provided config.
-func runGenP2PKey(w io.Writer, config p2p.Config, dataDir string) error {
+// runCreateEnrCmd stores a new p2pkey to disk and prints the ENR for the provided config.
+func runCreateEnrCmd(w io.Writer, config p2p.Config, dataDir string) error {
 	key, err := p2p.NewSavedPrivKey(dataDir)
 	if err != nil {
 		return err
@@ -60,7 +60,7 @@ func runGenP2PKey(w io.Writer, config p2p.Config, dataDir string) error {
 	}
 	defer db.Close()
 
-	_, _ = fmt.Fprintf(w, "Created key: %s/p2pkey\n", dataDir)
+	_, _ = fmt.Fprintf(w, "Created ENR private key: %s/p2pkey\n", dataDir)
 	_, _ = fmt.Fprintln(w, localEnode.Node().String())
 
 	return nil

--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -33,8 +33,7 @@ func newCreateEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 
 	cmd := &cobra.Command{
 		Use:   "enr",
-		Short: "Creates a new enr private key",
-		Long:  `Creates an Ethereum Node Record (ENR) private key to identify charon`,
+		Short: "Create an Ethereum Node Record (ENR) private key to identify this charon client",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.OutOrStdout(), config, dataDir)

--- a/cmd/createenr_internal_test.go
+++ b/cmd/createenr_internal_test.go
@@ -29,6 +29,6 @@ func TestRunGenP2P(t *testing.T) {
 	temp, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	err = runGenP2PKey(io.Discard, p2p.Config{}, temp)
+	err = runCreateEnrCmd(io.Discard, p2p.Config{}, temp)
 	require.NoError(t, err)
 }

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -29,7 +29,7 @@ func newDKGCmd(runFunc func(context.Context, dkg.Config) error) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "dkg",
-		Short: "Create distributed validator key shares by participating in a DKG ceremony",
+		Short: "Participate in a Distributed Key Generation ceremony",
 		Long: `Participate in a distributed key generation ceremony for a specific cluster definition that creates
 distributed validator key shares and a final cluster lock configuration. Note that all other cluster operators should run
 this command at the same time.`,

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -33,7 +33,7 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command
 
 	cmd := &cobra.Command{
 		Use:   "enr",
-		Short: "Return this node's ENR",
+		Short: "Print this client's Ethereum Node Record",
 		Long:  `Return information on this node's Ethereum Node Record (ENR)`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,7 +34,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Runs the Charon middleware",
+		Short: "Run the charon middleware client",
 		Long:  "Starts the long-running Charon middleware process to perform distributed validator duties.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)


### PR DESCRIPTION
Refactor `genp2pkey` and `create-cluster` commands to `create enr` and `create cluster` commands, i.e, subcommands of create command.

category: refactor
ticket: #442 
feature_set: stable
