### PR TITLE
cmd: make commands backwards compatible

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,11 +43,11 @@ func New() *cobra.Command {
 	return newRootCmd(
 		newVersionCmd(runVersionCmd),
 		newEnrCmd(runNewENR),
-
+		// TODO(dhruv): remove genp2pkey command once charon-docker-compose and docs are updated
 		newGenP2PKeyCmd(runGenP2PKey),
 		newRunCmd(app.Run),
 		newBootnodeCmd(RunBootnode),
-
+		// TODO(dhruv): replace newCreateClusterCmdNew with newCreateClusterCmd once charon-docker-compose and docs are updated
 		newCreateClusterCmd(runCreateCluster),
 		newDKGCmd(dkg.Run),
 		newCreateCmd(

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -43,13 +43,17 @@ func New() *cobra.Command {
 	return newRootCmd(
 		newVersionCmd(runVersionCmd),
 		newEnrCmd(runNewENR),
+
+		newGenP2PKeyCmd(runGenP2PKey),
 		newRunCmd(app.Run),
 		newBootnodeCmd(RunBootnode),
+
+		newCreateClusterCmd(runCreateCluster),
 		newDKGCmd(dkg.Run),
 		newCreateCmd(
 			newCreateDKGCmd(runCreateDKG),
 			newCreateEnrCmd(runCreateEnrCmd),
-			newCreateClusterCmd(runCreateCluster),
+			newCreateClusterCmdNew(runCreateCluster),
 		),
 	)
 }

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -100,8 +100,8 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 
 	cmd := &cobra.Command{
 		Use:   "create-cluster",
-		Short: "Create a local charon cluster",
-		Long: "Create a local charon cluster including validator keys, charon p2p keys, and a cluster manifest. " +
+		Short: "Create a local charon cluster [DEPRECATED]",
+		Long: "Create a local charon cluster including validator keys, charon p2p keys, and a cluster manifest. [DEPRECATED]" +
 			"See flags for supported features.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.OutOrStdout(), conf)

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -99,6 +99,25 @@ func newCreateClusterCmd(runFunc func(io.Writer, clusterConfig) error) *cobra.Co
 	var conf clusterConfig
 
 	cmd := &cobra.Command{
+		Use:   "create-cluster",
+		Short: "Create a local charon cluster",
+		Long: "Create a local charon cluster including validator keys, charon p2p keys, and a cluster manifest. " +
+			"See flags for supported features.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFunc(cmd.OutOrStdout(), conf)
+		},
+	}
+
+	bindClusterFlags(cmd.Flags(), &conf)
+
+	return cmd
+}
+
+// TODO(dhruv): replace newCreateClusterCmd with newCreateClusterCmdNew once charon-docker-compose are updated.
+func newCreateClusterCmdNew(runFunc func(io.Writer, clusterConfig) error) *cobra.Command {
+	var conf clusterConfig
+
+	cmd := &cobra.Command{
 		Use:   "cluster",
 		Short: "Create private keys and configuration files needed to run a distributed validator cluster locally",
 		Long: "Creates a local charon cluster configuration including validator keys, charon p2p keys, and a cluster manifest. " +

--- a/cmd/genp2pkey.go
+++ b/cmd/genp2pkey.go
@@ -33,8 +33,8 @@ func newGenP2PKeyCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 
 	cmd := &cobra.Command{
 		Use:   "gen-p2pkey",
-		Short: "Generates a new p2p key",
-		Long:  `Generates a new p2p authentication key (ecdsa-k1) and saves it to the data directory`,
+		Short: "Generates a new p2p key [DEPRECATED]",
+		Long:  "Generates a new p2p authentication key (ecdsa-k1) and saves it to the data directory [DEPRECATED]",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runFunc(cmd.OutOrStdout(), config, dataDir)

--- a/cmd/genp2pkey.go
+++ b/cmd/genp2pkey.go
@@ -1,0 +1,67 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/p2p"
+)
+
+func newGenP2PKeyCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.Command {
+	var (
+		config  p2p.Config
+		dataDir string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "gen-p2pkey",
+		Short: "Generates a new p2p key",
+		Long:  `Generates a new p2p authentication key (ecdsa-k1) and saves it to the data directory`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFunc(cmd.OutOrStdout(), config, dataDir)
+		},
+	}
+
+	bindDataDirFlag(cmd.Flags(), &dataDir)
+	bindP2PFlags(cmd.Flags(), &config)
+
+	return cmd
+}
+
+// runGenP2PKey stores a new p2pkey to disk and prints the ENR for the provided config.
+func runGenP2PKey(w io.Writer, config p2p.Config, dataDir string) error {
+	key, err := p2p.NewSavedPrivKey(dataDir)
+	if err != nil {
+		return err
+	}
+
+	localEnode, db, err := p2p.NewLocalEnode(config, key)
+	if err != nil {
+		return errors.Wrap(err, "failed to open peer DB")
+	}
+	defer db.Close()
+
+	_, _ = fmt.Fprintf(w, "Created key: %s/p2pkey\n", dataDir)
+	_, _ = fmt.Fprintln(w, localEnode.Node().String())
+
+	return nil
+}


### PR DESCRIPTION
Make commands backwards compatible until charon-docker-compose and docs are updated.

category: refactor
ticket: #000
feature_set: stable
