### PR TITLE
core/qbft: refactor to explicit justifications

### DIFF
--- a/core/qbft/README.md
+++ b/core/qbft/README.md
@@ -10,8 +10,8 @@ as referenced by the [QBFT spec](https://github.com/ConsenSys/qbft-formal-spec-a
 - Transport abstracted and not provided.
 - Decoupled from process authentication and message signing (not provided).
 - No dependencies.
-- Core algorithm under 500 lines of code.
+- Explicit justifications.
 
 ## TODO
- - Refactor from implicit to explicit justification.
+ - Add dropped messages tests.
  - Add Byzantium tests.

--- a/core/qbft/clock_test.go
+++ b/core/qbft/clock_test.go
@@ -48,6 +48,14 @@ func (c *fakeClock) NewTimer(d time.Duration) (<-chan time.Time, func()) {
 	}
 }
 
+// NowStr returns the current time as a debug string.
+func (c *fakeClock) NowStr() string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.now.Format("04:05.000")
+}
+
 // SinceT0 returns the duration since zero time.
 func (c *fakeClock) SinceT0() time.Duration {
 	c.mu.Lock()

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -36,6 +36,9 @@ type Transport struct {
 	// processes in the system (including this process).
 	Broadcast func(Msg)
 
+	// SendQCommit sends the commit messages to a specific process.
+	SendQCommit func(target int64, qCommit []Msg)
+
 	// Receive returns a stream of messages received
 	// from other processes in the system (including this process).
 	Receive <-chan Msg
@@ -45,13 +48,13 @@ type Transport struct {
 // This remains constant across multiple instances of consensus (calls to Run).
 type Definition struct {
 	// IsLeader is a deterministic leader election function.
-	IsLeader func(instance, round, process int64) bool
+	IsLeader func(instance []byte, round, process int64) bool
 	// NewTimer returns a new timer channel and stop function for the round.
 	NewTimer func(round int64) (<-chan time.Time, func())
-	// IsValid validates messages.
-	IsValid func(instance int64, msg Msg) bool
+	// Decide is called when consensus has been reached on a value.
+	Decide func(instance []byte, value []byte, qcommit []Msg)
 	// LogUponRule allows debug logging of triggered upon rules on message receipt.
-	LogUponRule func(instance, process, round int64, msg Msg, uponRule string)
+	LogUponRule func(instance []byte, process, round int64, msg Msg, uponRule string)
 	// Quorum is the quorum count for the system.
 	Quorum int
 	// Faulty is the maximum faulty process count for the system.
@@ -72,13 +75,22 @@ const (
 
 // Msg defines the inter process messages.
 type Msg struct {
-	Type          MsgType
-	Instance      int64
-	Source        int64
-	Round         int64
-	Value         []byte
+	// Type of the message.
+	Type MsgType
+	// Instance identifies the consensus instance.
+	Instance []byte
+	// Source identifies the process that sent the message.
+	Source int64
+	// Round the message pertains to.
+	Round int64
+	// Value being proposed.
+	Value []byte
+	// PreparedRound is the justified prepared round.
 	PreparedRound int64
+	// PreparedValue is the justified prepared value.
 	PreparedValue []byte
+	// Justify is the set of messages that explicitly justifies this message.
+	Justify []Msg
 }
 
 //go:generate stringer -type=uponRule -trimprefix=upon
@@ -87,18 +99,21 @@ type Msg struct {
 type uponRule int64
 
 const (
-	uponUnknown uponRule = iota
-	uponValidPrePrepare
-	uponQuorumPrepare
-	uponQuorumCommit
-	uponMinRoundChange
-	uponQuorumRoundChange
+	uponNothing uponRule = iota
+	uponJustifiedPrePrepare
+	uponUnjustPrePrepare
+	uponQuorumPrepares
+	uponQuorumCommits
+	uponUnjustRoundChange
+	uponFPlus1RoundChanges
+	uponQuorumRoundChanges
 )
 
-// Run returns the consensus decided value (Qcommit) or a context closed error.
-func Run(ctx context.Context, d Definition, t Transport, instance, process int64, inputValue []byte) (value []byte, err error) {
+// Run executes the consensus algorithm until the context closed.
+//nolint:gocognit // If is indeed a complex algorithm.
+func Run(ctx context.Context, d Definition, t Transport, instance []byte, process int64, inputValue []byte) (err error) {
 	if inputValue == nil {
-		return nil, errors.New("nil input value not supported")
+		return errors.New("nil input value not supported")
 	}
 	defer func() {
 		// Errors are unexpected since this algorithm doesn't do IO
@@ -109,102 +124,167 @@ func Run(ctx context.Context, d Definition, t Transport, instance, process int64
 		}
 	}()
 
+	// === State ===
+
+	var (
+		round           int64 = 1
+		preparedRound   int64
+		preparedValue   []byte
+		preparedJustify []Msg
+		qCommit         []Msg
+		buffer          []Msg
+		dedupIn         = make(map[dedupKey]bool)
+		timerChan       <-chan time.Time
+		stopTimer       func()
+	)
+
 	// === Helpers ==
 
-	// broadcastMsg broadcasts a non-round-change message.
-	broadcastMsg := func(typ MsgType, round int64, value []byte) {
+	// broadcastMsg broadcasts a non-ROUND-CHANGE message for current round.
+	broadcastMsg := func(typ MsgType, value []byte, justify []Msg) {
 		t.Broadcast(Msg{
 			Type:     typ,
 			Instance: instance,
 			Source:   process,
 			Round:    round,
 			Value:    value,
+			Justify:  justify,
 		})
 	}
 
-	// broadcastRoundChange broadcasts a round-change message.
-	broadcastRoundChange := func(round int64, pr int64, pv []byte) {
+	// broadcastRoundChange broadcasts a ROUND-CHANGE message with current state.
+	broadcastRoundChange := func() {
 		t.Broadcast(Msg{
 			Type:          MsgRoundChange,
 			Instance:      instance,
 			Source:        process,
 			Round:         round,
-			PreparedRound: pr,
-			PreparedValue: pv,
+			PreparedRound: preparedRound,
+			PreparedValue: preparedValue,
+			Justify:       preparedJustify,
 		})
 	}
 
-	// === State ===
+	// sendQCommit sends qCommit to the target process.
+	sendQCommit := func(target int64) {
+		if len(qCommit) == 0 {
+			panic("bug: send empty Qcommit")
+		}
+		t.SendQCommit(target, qCommit)
+	}
 
-	var (
-		round         int64 = 1
-		preparedRound int64
-		preparedValue []byte
-		msgs          []Msg
-		dedup         = make(map[dedupKey]bool)
-		timerChan     <-chan time.Time
-		stopTimer     func()
-	)
+	// bufferMsg returns true if the message is unique and was added to the buffer.
+	// It returns false if the message is a duplicate and should be discarded.
+	bufferMsg := func(msg Msg) bool {
+		if dedupIn[key(msg)] {
+			return false
+		}
+		dedupIn[key(msg)] = true
+		buffer = append(buffer, msg)
 
-	// === Algrithm ===
+		return true
+	}
+
+	// trimBuffer drops all older round's buffered messages.
+	trimBuffer := func() {
+		var selected []Msg
+		for _, msg := range buffer {
+			if msg.Round >= round {
+				selected = append(selected, msg)
+			}
+		}
+		buffer = selected
+
+		dedup := make(map[dedupKey]bool)
+		for k := range dedupIn {
+			if k.Round >= round {
+				dedup[k] = true
+			}
+		}
+		dedupIn = dedup
+	}
+
+	// === Algorithm ===
 
 	{ // Algorithm 1:11
-		if d.IsLeader(instance, round, process) {
-			broadcastMsg(MsgPrePrepare, round, inputValue)
+		if d.IsLeader(instance, round, process) { // Note round==1 at this point.
+			broadcastMsg(MsgPrePrepare, inputValue, nil) // Justification is round==1
 		}
 
 		timerChan, stopTimer = d.NewTimer(round)
 	}
 
-	// Handle events until finished.
+	// Handle events until cancelled.
 	for {
 		select {
 		case msg := <-t.Receive:
-			if dedup[key(msg)] {
+			// Just send Qcommit if consensus already decided
+			if len(qCommit) > 0 {
+				if msg.Source != process && msg.Type == MsgRoundChange { // Algorithm 3:17
+					sendQCommit(msg.Source)
+				}
+
 				continue
 			}
-			dedup[key(msg)] = true
 
-			if !d.IsValid(instance, msg) {
+			// Buffer message
+			if !bufferMsg(msg) {
 				continue
 			}
 
-			msgs = append(msgs, msg)
+			// Buffer justifications
+			for _, j := range msg.Justify {
+				if !bufferMsg(j) {
+					continue
+				}
+			}
 
-			rule, ok := classify(d, instance, round, process, msgs, msg)
-			if !ok {
+			rule, justify := classify(d, instance, round, process, buffer, msg)
+			if rule == uponNothing {
 				continue
 			}
 
 			d.LogUponRule(instance, process, round, msg, rule.String())
 
 			switch rule {
-			case uponValidPrePrepare: // Algorithm 2:1
+			case uponJustifiedPrePrepare: // Algorithm 2:1
+				// Applicable to current or future rounds (since justified)
+				round = msg.Round
+				trimBuffer()
+
 				stopTimer()
 				timerChan, stopTimer = d.NewTimer(round)
 
-				broadcastMsg(MsgPrepare, msg.Round, msg.Value)
+				broadcastMsg(MsgPrepare, msg.Value, nil)
 
-			case uponQuorumPrepare: // Algorithm 2:4
-				preparedRound = msg.Round
+			case uponQuorumPrepares: // Algorithm 2:4
+				// Only applicable to current round
+				preparedRound = round /* == msg.Round*/
 				preparedValue = msg.Value
-				broadcastMsg(MsgCommit, msg.Round, msg.Value)
+				preparedJustify = justify
 
-			case uponQuorumCommit: // Algorithm 2:8
+				broadcastMsg(MsgCommit, preparedValue, nil)
+
+			case uponQuorumCommits: // Algorithm 2:8
+				// Applicable to any round (since can be justified)
 				stopTimer()
+				qCommit = justify
 
-				return msg.Value, nil
+				d.Decide(instance, msg.Value, justify)
 
-			case uponMinRoundChange: // Algorithm 3:5
-				round = nextMinRound(d, msgs, round)
+			case uponFPlus1RoundChanges: // Algorithm 3:5
+				// Only applicable to future rounds
+				round = nextMinRound(d, justify, round /* < msg.Round*/)
+				trimBuffer()
 
 				stopTimer()
 				timerChan, stopTimer = d.NewTimer(round)
 
-				broadcastRoundChange(round, preparedRound, preparedValue)
+				broadcastRoundChange()
 
-			case uponQuorumRoundChange: // Algorithm 3:11
-				qrc := filterRoundChange(msgs, msg.Round)
+			case uponQuorumRoundChanges: // Algorithm 3:11
+				// Only applicable to current round
+				qrc := filterRoundChange(justify, round /* == msg.Round*/)
 				_, pv := highestPrepared(qrc)
 
 				value := pv
@@ -212,64 +292,96 @@ func Run(ctx context.Context, d Definition, t Transport, instance, process int64
 					value = inputValue
 				}
 
-				broadcastMsg(MsgPrePrepare, round, value)
+				broadcastMsg(MsgPrePrepare, value, justify)
+
+			case uponUnjustPrePrepare, uponUnjustRoundChange:
+				// Ignore bug or byzantium.
+
 			default:
 				panic("bug: invalid rule")
 			}
+
 		case <-timerChan: // Algorithm 3:1
 			round++
+			trimBuffer()
 
 			stopTimer()
 			timerChan, stopTimer = d.NewTimer(round)
 
-			broadcastRoundChange(round, preparedRound, preparedValue)
-		case <-ctx.Done():
-			// Timeout
-			return nil, ctx.Err()
+			broadcastRoundChange()
+
+		case <-ctx.Done(): // Cancelled
+			return ctx.Err()
 		}
 	}
 }
 
-// classify returns any rule triggered upon receipt of the last message.
-func classify(d Definition, instance, round, process int64, msgs []Msg, msg Msg) (uponRule, bool) {
+// classify returns the rule triggered upon receipt of the last message and its justifications.
+func classify(d Definition, instance []byte, round, process int64, buffer []Msg, msg Msg) (uponRule, []Msg) {
 	switch msg.Type {
 	case MsgPrePrepare:
-		if msg.Round != round {
-			return uponUnknown, false
+		if !isJustifiedPrePrepare(d, instance, msg) {
+			return uponUnjustPrePrepare, nil
 		}
-		if justifyPrePrepare(d, instance, msgs, msg) {
-			return uponValidPrePrepare, true
+
+		// Only ignore old rounds, since PRE-PREPARE is justified we may jump ahead.
+		if msg.Round < round {
+			return uponNothing, nil
 		}
+
+		return uponJustifiedPrePrepare, nil
+
 	case MsgPrepare:
-		prepareCount := countByValue(msgs, MsgPrepare, msg.Value)
-		if prepareCount == d.Quorum {
-			return uponQuorumPrepare, true
+		// Ignore other rounds, since PREPARE isn't justified.
+		if msg.Round != round {
+			return uponNothing, nil
 		}
+		prepares := filterByRoundAndValue(buffer, MsgPrepare, msg.Round, msg.Value)
+		if len(prepares) >= d.Quorum {
+			return uponQuorumPrepares, prepares
+		}
+
 	case MsgCommit:
-		commitCount := countByValue(msgs, MsgCommit, msg.Value)
-		if commitCount == d.Quorum {
-			return uponQuorumCommit, true
+		// Don't ignore any rounds, since COMMIT may be justified with Qcommit.
+		commits := filterByRoundAndValue(buffer, MsgCommit, msg.Round, msg.Value)
+		if len(commits) >= d.Quorum {
+			return uponQuorumCommits, commits
 		}
+
 	case MsgRoundChange:
-		frc := filterHigherRoundChange(msgs, round)
-		if msg.Round > round && len(frc) == d.Faulty+1 {
-			return uponMinRoundChange, true
+		if !isJustifiedRoundChange(d, msg) {
+			return uponUnjustRoundChange, nil
 		}
 
-		qrc := filterRoundChange(msgs, round)
-		if msg.Round == round &&
-			len(qrc) == d.Quorum &&
-			d.IsLeader(instance, msg.Round, process) &&
-			justifyRoundChange(d, msgs, qrc) {
-			return uponQuorumRoundChange, true
+		// Only ignore old rounds.
+		if msg.Round < round {
+			return uponNothing, nil
 		}
 
-		return uponUnknown, false
+		if msg.Round > round {
+			// Jump ahead if we received F+1 higher ROUND-CHANGEs.
+			if frc, ok := getFPlus1RoundChanges(d, buffer, round); ok {
+				return uponFPlus1RoundChanges, frc
+			}
+
+			return uponNothing, nil
+		}
+
+		/* else msg.Round == round */
+
+		if !d.IsLeader(instance, msg.Round, process) {
+			return uponNothing, nil
+		}
+
+		if qrc, ok := getJustifiedQrc(d, buffer, msg.Round); ok {
+			return uponQuorumRoundChanges, qrc
+		}
+
 	default:
 		panic("bug: invalid type")
 	}
 
-	return uponUnknown, false
+	return uponNothing, nil
 }
 
 // highestPrepared implements algorithm 4:5 and returns
@@ -299,10 +411,8 @@ func highestPrepared(qrc []Msg) (int64, []byte) {
 // from received round change messages.
 func nextMinRound(d Definition, msgs []Msg, round int64) int64 {
 	// Get all RoundChange messages with round (rj) higher than current round (ri)
-	frc := filterHigherRoundChange(msgs, round)
-
-	// Sanity check
-	if len(frc) < d.Faulty+1 {
+	frc, ok := getFPlus1RoundChanges(d, msgs, round)
+	if !ok {
 		panic("bug: too few round change messages")
 	}
 
@@ -314,33 +424,40 @@ func nextMinRound(d Definition, msgs []Msg, round int64) int64 {
 		}
 	}
 
+	if rmin <= round {
+		panic("bug: next rmin not after round")
+	}
+
 	return rmin
 }
 
-// justifyRoundChange implements algorithm 4:1 and returns true
-// if the latest round change message was justified.
-func justifyRoundChange(d Definition, all, qrc []Msg) bool {
-	if len(qrc) < d.Quorum {
-		return false
+// isJustifiedRoundChange returns true if the ROUND_CHANGE message's
+// prepared round and value is justified.
+func isJustifiedRoundChange(d Definition, msg Msg) bool {
+	if msg.Type != MsgRoundChange {
+		panic("bug: not a round change message")
 	}
 
-	if qrcNoPrepared(qrc) {
+	if msg.PreparedRound == 0 && msg.PreparedValue == nil && len(msg.Justify) == 0 {
+		// No need to justify null prepared round and value.
 		return true
 	}
 
-	_, ok := qrcHighestPrepared(d, all, qrc)
-	if !ok {
+	// No need to check for all possible combinations, since justified should only contain a one.
+
+	if len(msg.Justify) < d.Quorum {
 		return false
 	}
 
-	return true
+	prepares := filterMsgs(msg.Justify, MsgPrepare, msg.PreparedRound, &msg.PreparedValue, nil, nil)
+
+	return len(msg.Justify) == len(prepares)
 }
 
-// justifyPrePrepare implements algorithm 4:3 and returns true if latest
-// preprepare message is justified.
-func justifyPrePrepare(d Definition, instance int64, msgs []Msg, msg Msg) bool {
+// isJustifiedPrePrepare returns true if the PRE-PREPARE message is justified.
+func isJustifiedPrePrepare(d Definition, instance []byte, msg Msg) bool {
 	if msg.Type != MsgPrePrepare {
-		panic("bug: not d preprepare message")
+		panic("bug: not a preprepare message")
 	}
 
 	if !d.IsLeader(instance, msg.Round, msg.Source) {
@@ -351,91 +468,197 @@ func justifyPrePrepare(d Definition, instance int64, msgs []Msg, msg Msg) bool {
 		return true
 	}
 
-	qrc := filterRoundChange(msgs, msg.Round)
-	if len(qrc) < d.Quorum {
+	pv, ok := containsJustifiedQrc(d, msg.Justify, msg.Round)
+	if !ok {
 		return false
 	}
 
-	if qrcNoPrepared(qrc) {
+	if pv == nil {
+		return true // New value being proposed
+	}
+
+	if bytes.Equal(msg.Value, pv) {
 		return true
 	}
 
-	pv, ok := qrcHighestPrepared(d, msgs, qrc)
-	if !ok {
-		return false
-	} else if !bytes.Equal(pv, msg.Value) {
-		return false
-	}
-
-	return true
+	return false
 }
 
-// qrcNoPrepared implements condition J1 and returns true if all
-// quorom round changes messages (Qrc) have no prepared round or value.
-func qrcNoPrepared(qrc []Msg) bool {
-	for _, msg := range qrc {
-		if msg.Type != MsgRoundChange {
-			panic("bug: invalid Qrc set")
-		}
-		if msg.PreparedRound != 0 || msg.PreparedValue != nil {
-			return false
-		}
+// containsJustifiedQrc implements algorithm 4:1 and returns true and pv if
+// the messages contains a justified quorum ROUND_CHANGEs (Qrc).
+func containsJustifiedQrc(d Definition, justify []Msg, round int64) ([]byte, bool) {
+	qrc := filterRoundChange(justify, round)
+	if len(qrc) < d.Quorum {
+		return nil, false
 	}
 
-	return true
-}
+	// No need to calculate J1 or J2 for all possible combinations,
+	// since justification should only contain one.
 
-// qrcHighestPrepared implements condition J2 and returns true (and pv) if
-// quorum prepare messages with highest pv was received.
-func qrcHighestPrepared(d Definition, all []Msg, qrc []Msg) ([]byte, bool) {
+	// J1: If qrc contains quorum round change messages
+	// with null pv and null pr.
+	allNull := true
+	for _, rc := range qrc {
+		if rc.PreparedRound != 0 || rc.PreparedValue != nil {
+			allNull = false
+			break
+		}
+	}
+	if allNull {
+		return nil, true
+	}
+
+	// J2: if the justification has a quorum of valid prepare messages
+	// with pr and pv equaled to highest pr and pv in qrc (other than null).
 	pr, pv := highestPrepared(qrc)
 	if pr == 0 {
-		return nil, false
+		panic("bug: highest pr=0, but all not null")
 	}
 
-	if countByValue(all, MsgPrepare, pv) < d.Quorum {
-		return nil, false
-	}
+	prepares := filterMsgs(justify, MsgPrepare, pr, &pv, nil, nil)
 
-	return pv, true
+	return pv, len(prepares) >= d.Quorum
 }
 
-// countByValue returns the number of messages matching the type and value.
-func countByValue(msgs []Msg, typ MsgType, value []byte) int {
-	return len(filterMsgs(msgs, typ, nil, &value, nil, nil))
+// getJustifiedQrc implements algorithm 4:1 and returns a justified quorum ROUND_CHANGEs (Qrc).
+func getJustifiedQrc(d Definition, all []Msg, round int64) ([]Msg, bool) {
+	if qrc, ok := quorumNullPrepared(d, all, round); ok {
+		// Return any quorum null pv ROUND_CHANGE messages as Qrc.
+		return qrc, true
+	}
+
+	rc := filterRoundChange(all, round)
+	for _, prepares := range getPrepareQuorums(d, all) {
+		// See if we have quorum ROUND-CHANGE with HIGHEST_PREPARED(qrc) == prepares.Round.
+		var (
+			qrc                []Msg
+			hasHighestPrepared bool
+			pr                 = prepares[0].Round
+			pv                 = prepares[0].Value
+		)
+		for _, msg := range rc {
+			if !bytes.Equal(msg.PreparedValue, pv) {
+				continue
+			}
+			if msg.PreparedRound > pr {
+				continue
+			}
+			if msg.PreparedRound == pr {
+				hasHighestPrepared = true
+			}
+			qrc = append(qrc, msg)
+		}
+		if len(qrc) >= d.Quorum && hasHighestPrepared {
+			return append(qrc, prepares...), true
+		}
+	}
+
+	return nil, false
+}
+
+// getFPlus1RoundChanges returns true and Faulty+1 ROUND-CHANGE messages (Frc) with
+// the rounds higher than the provided round. It returns the highest round
+// per process in order to jump furthest.
+func getFPlus1RoundChanges(d Definition, msgs []Msg, round int64) ([]Msg, bool) {
+	highestBySource := make(map[int64]Msg)
+	for _, msg := range msgs {
+		if msg.Type != MsgRoundChange {
+			continue
+		}
+		if msg.Round <= round {
+			continue
+		}
+		if highestBySource[msg.Source].Round > msg.Round {
+			continue
+		}
+
+		highestBySource[msg.Source] = msg
+
+		if len(highestBySource) == d.Faulty+1 {
+			break
+		}
+	}
+
+	if len(highestBySource) < d.Faulty+1 {
+		return nil, false
+	}
+
+	var resp []Msg
+	for _, msg := range highestBySource {
+		resp = append(resp, msg)
+	}
+
+	return resp, true
+}
+
+// getPrepareQuorums returns all sets of quorum PREPARE messages
+// with identical rounds and values.
+func getPrepareQuorums(d Definition, msgs []Msg) [][]Msg {
+	sets := make(map[string]map[int64]Msg) // map[round+value]map[process]Msg
+	for _, msg := range msgs {
+		if msg.Type != MsgPrepare {
+			continue
+		}
+		key := fmt.Sprintf("%d/%s", msg.Round, msg.Value)
+		msgs, ok := sets[key]
+		if !ok {
+			msgs = make(map[int64]Msg)
+		}
+		msgs[msg.Source] = msg
+		sets[key] = msgs
+	}
+
+	// Return all quorums
+	var quorums [][]Msg
+	for _, msgs := range sets {
+		if len(msgs) < d.Quorum {
+			continue
+		}
+		var quorum []Msg
+		for _, msg := range msgs {
+			quorum = append(quorum, msg)
+		}
+		quorums = append(quorums, quorum)
+	}
+
+	return quorums
+}
+
+// quorumNullPrepared implements condition J1 and returns Qrc and true if a quorum
+// of round changes messages (Qrc) for the round have null prepared round and value.
+func quorumNullPrepared(d Definition, all []Msg, round int64) ([]Msg, bool) {
+	var (
+		nullPr int64
+		nullPv []byte
+	)
+	justify := filterMsgs(all, MsgRoundChange, round, nil, &nullPr, &nullPv)
+
+	return justify, len(justify) >= d.Quorum
+}
+
+// filterByRoundAndValue returns the messages matching the type and value.
+func filterByRoundAndValue(msgs []Msg, typ MsgType, round int64, value []byte) []Msg {
+	return filterMsgs(msgs, typ, round, &value, nil, nil)
 }
 
 // filterRoundChange returns all round change messages for the provided round.
 func filterRoundChange(msgs []Msg, round int64) []Msg {
-	return filterMsgs(msgs, MsgRoundChange, &round, nil, nil, nil)
+	return filterMsgs(msgs, MsgRoundChange, round, nil, nil, nil)
 }
 
-// filterHigherRoundChange returns the all round change messages with round higher than the provided round.
-func filterHigherRoundChange(msgs []Msg, round int64) []Msg {
-	var resp []Msg
-	for _, msg := range filterMsgs(msgs, MsgRoundChange, nil, nil, nil, nil) {
-		if msg.Round <= round {
-			continue
-		}
-		resp = append(resp, msg)
-	}
-
-	return resp
-}
-
-// filterMsgs returns the first message per process matching the provided type
-// and the optional round, value, pr, pv.
-func filterMsgs(msgs []Msg, typ MsgType, round *int64, value *[]byte, pr *int64, pv *[]byte) []Msg {
+// filterMsgs returns one message per process matching the provided type and round
+// and optional value, pr, pv.
+func filterMsgs(msgs []Msg, typ MsgType, round int64, value *[]byte, pr *int64, pv *[]byte) []Msg {
 	var (
 		resp []Msg
-		dups = make(map[int64]bool)
+		dups = make(map[dedupKey]bool)
 	)
 	for _, msg := range msgs {
 		if typ != msg.Type {
 			continue
 		}
 
-		if round != nil && *round != msg.Round {
+		if round != msg.Round {
 			continue
 		}
 
@@ -451,11 +674,10 @@ func filterMsgs(msgs []Msg, typ MsgType, round *int64, value *[]byte, pr *int64,
 			continue
 		}
 
-		if dups[msg.Source] {
+		if dups[key(msg)] {
 			continue
 		}
-
-		dups[msg.Source] = true
+		dups[key(msg)] = true
 		resp = append(resp, msg)
 	}
 

--- a/core/qbft/uponrule_string.go
+++ b/core/qbft/uponrule_string.go
@@ -23,17 +23,19 @@ func _() {
 	// An "invalid array index" compiler error signifies that the constant values have changed.
 	// Re-run the stringer command to generate them again.
 	var x [1]struct{}
-	_ = x[uponUnknown-0]
-	_ = x[uponValidPrePrepare-1]
-	_ = x[uponQuorumPrepare-2]
-	_ = x[uponQuorumCommit-3]
-	_ = x[uponMinRoundChange-4]
-	_ = x[uponQuorumRoundChange-5]
+	_ = x[uponNothing-0]
+	_ = x[uponJustifiedPrePrepare-1]
+	_ = x[uponUnjustPrePrepare-2]
+	_ = x[uponQuorumPrepares-3]
+	_ = x[uponQuorumCommits-4]
+	_ = x[uponUnjustRoundChange-5]
+	_ = x[uponFPlus1RoundChanges-6]
+	_ = x[uponQuorumRoundChanges-7]
 }
 
-const _uponRule_name = "UnknownValidPrePrepareQuorumPrepareQuorumCommitMinRoundChangeQuorumRoundChange"
+const _uponRule_name = "NothingJustifiedPrePrepareUnjustPrePrepareQuorumPreparesQuorumCommitsUnjustRoundChangeFPlus1RoundChangesQuorumRoundChanges"
 
-var _uponRule_index = [...]uint8{0, 7, 22, 35, 47, 61, 78}
+var _uponRule_index = [...]uint8{0, 7, 26, 42, 56, 69, 86, 104, 122}
 
 func (i uponRule) String() string {
 	if i < 0 || i >= uponRule(len(_uponRule_index)-1) {


### PR DESCRIPTION
Refactors QBFT to explicit justifications.

Also:
 - Do not exit when decided, keep running until context cancelled
 - Send Qcommit to others after decided
 - Jump ahead when receiving justified messages
 - Trim old round messages from buffer
 - Add constant period tests
 - Make instance type bytes (to support "any" instance type)

category: refactor 
ticket: #445 
feature_set: alpha
