### PR TITLE
core/qbft: refactor to use generics

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
         exclude: ".pb.go"
 
   - repo: https://github.com/corverroos/fiximports
-    rev: 496e5392530966aa8f12e88a289c07782075cf91
+    rev: 886071dd81a69ab030db85d65803fb2048aa0722
     hooks:
       - id: go-fiximports # format imports for go source files
 

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -52,6 +52,7 @@ type Transport[I any, V Value[V]] struct {
 // Definition defines the consensus system parameters that are external to the qbft algorithm.
 // This remains constant across multiple instances of consensus (calls to Run).
 type Definition[I any, V Value[V]] struct {
+	// NewMsg returns a new message instance.
 	NewMsg func(typ MsgType, instance I, source int64, round int64, value V, pr int64, pv V, justify []Msg[I, V]) Msg[I, V]
 	// IsLeader is a deterministic leader election function.
 	IsLeader func(instance I, round, process int64) bool
@@ -155,30 +156,14 @@ func Run[I any, V Value[V]](ctx context.Context, d Definition[I, V], t Transport
 
 	// broadcastMsg broadcasts a non-ROUND-CHANGE message for current round.
 	broadcastMsg := func(typ MsgType, value V, justify []Msg[I, V]) {
-		t.Broadcast(d.NewMsg(
-			typ,
-			instance,
-			process,
-			round,
-			value,
-			0,
-			zeroVal[V](),
-			justify,
-		))
+		t.Broadcast(d.NewMsg(typ, instance, process, round,
+			value, 0, zeroVal[V](), justify))
 	}
 
 	// broadcastRoundChange broadcasts a ROUND-CHANGE message with current state.
 	broadcastRoundChange := func() {
-		t.Broadcast(d.NewMsg(
-			MsgRoundChange,
-			instance,
-			process,
-			round,
-			zeroVal[V](),
-			preparedRound,
-			preparedValue,
-			preparedJustify,
-		))
+		t.Broadcast(d.NewMsg(MsgRoundChange, instance, process, round,
+			zeroVal[V](), preparedRound, preparedValue, preparedJustify))
 	}
 
 	// sendQCommit sends qCommit to the target process.

--- a/core/qbft/qbft_test.go
+++ b/core/qbft/qbft_test.go
@@ -17,10 +17,8 @@ package qbft_test
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"math/rand"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -153,19 +151,36 @@ func testQBFT(t *testing.T, test test) {
 	var (
 		ctx, cancel = context.WithCancel(context.Background())
 		clock       = new(fakeClock)
-		receives    []chan qbft.Msg
-		broadcast   = make(chan qbft.Msg)
-		resultChan  = make(chan string, n)
+		receives    []chan qbft.Msg[int64, value]
+		broadcast   = make(chan qbft.Msg[int64, value])
+		resultChan  = make(chan value, n)
 		errChan     = make(chan error, n)
 	)
 	defer cancel()
 
-	defs := qbft.Definition{
-		IsLeader: func(instance []byte, round int64, process int64) bool {
-			i, err := strconv.ParseInt(string(instance), 10, 64)
-			require.NoError(t, err)
+	defs := qbft.Definition[int64, value]{
+		NewMsg: func(typ qbft.MsgType, instance int64, source int64, round int64, value value,
+			pr int64, pv value, justify []qbft.Msg[int64, value],
+		) qbft.Msg[int64, value] {
+			var msgs []msg
+			for _, j := range justify {
+				m := j.(msg)
+				msgs = append(msgs, m)
+			}
 
-			return (i+round)%n == process
+			return msg{
+				msgType:  typ,
+				instance: instance,
+				peerIdx:  source,
+				round:    round,
+				value:    int64(value),
+				pr:       pr,
+				pv:       int64(pv),
+				justify:  msgs,
+			}
+		},
+		IsLeader: func(instance int64, round int64, process int64) bool {
+			return (instance+round)%n == process
 		},
 		NewTimer: func(round int64) (<-chan time.Time, func()) {
 			d := time.Second
@@ -175,11 +190,11 @@ func testQBFT(t *testing.T, test test) {
 
 			return clock.NewTimer(d)
 		},
-		Decide: func(instance []byte, value []byte, qcommit []qbft.Msg) {
-			resultChan <- string(value)
+		Decide: func(instance int64, value value, qcommit []qbft.Msg[int64, value]) {
+			resultChan <- value
 		},
-		LogUponRule: func(instance []byte, process, round int64, msg qbft.Msg, rule string) {
-			t.Logf("%s %d => %v@%d -> %v@%d ~= %v", clock.NowStr(), msg.Source, msg.Type, msg.Round, process, round, rule)
+		LogUponRule: func(instance int64, process, round int64, msg qbft.Msg[int64, value], rule string) {
+			t.Logf("%s %d => %v@%d -> %v@%d ~= %v", clock.NowStr(), msg.Source(), msg.Type(), msg.Round(), process, round, rule)
 			if round > 50 {
 				cancel()
 			} else if strings.Contains(rule, "Unjust") {
@@ -191,14 +206,14 @@ func testQBFT(t *testing.T, test test) {
 		Faulty: f,
 	}
 
-	for i := int64(0); i < n; i++ {
-		receive := make(chan qbft.Msg, 1000)
+	for i := int64(1); i <= n; i++ {
+		receive := make(chan qbft.Msg[int64, value], 1000)
 		receives = append(receives, receive)
-		trans := qbft.Transport{
-			Broadcast: func(msg qbft.Msg) {
+		trans := qbft.Transport[int64, value]{
+			Broadcast: func(msg qbft.Msg[int64, value]) {
 				bcastJitter(broadcast, msg, test.BCastJitterMS, clock)
 			},
-			SendQCommit: func(_ int64, qCommit []qbft.Msg) {
+			SendQCommit: func(_ int64, qCommit []qbft.Msg[int64, value]) {
 				for _, msg := range qCommit {
 					broadcast <- msg // Just broadcast
 				}
@@ -223,8 +238,7 @@ func testQBFT(t *testing.T, test test) {
 				}
 			}
 
-			instance := strconv.FormatInt(test.Instance, 10)
-			err := qbft.Run(ctx, defs, trans, []byte(instance), i, []byte(fmt.Sprint(i)))
+			err := qbft.Run(ctx, defs, trans, test.Instance, i, value(i))
 			if err != nil {
 				errChan <- err
 				return
@@ -232,12 +246,12 @@ func testQBFT(t *testing.T, test test) {
 		}(i)
 	}
 
-	var results []string
+	var results []value
 
 	for {
 		select {
 		case msg := <-broadcast:
-			t.Logf("%s %v => %v@%d", clock.NowStr(), msg.Source, msg.Type, msg.Round)
+			t.Logf("%s %v => %v@%d", clock.NowStr(), msg.Source(), msg.Type(), msg.Round())
 			for _, out := range receives {
 				out <- msg
 				if rand.Float64() < 0.1 { // Send 10% messages twice
@@ -248,10 +262,10 @@ func testQBFT(t *testing.T, test test) {
 			if test.ResultRandom {
 				// Ensure that all results are the same at least
 				for _, previous := range results {
-					require.Equal(t, previous, result)
+					require.EqualValues(t, previous, result)
 				}
 			} else {
-				require.Equal(t, fmt.Sprint(test.Result), result)
+				require.EqualValues(t, test.Result, result)
 			}
 
 			results = append(results, result)
@@ -269,7 +283,7 @@ func testQBFT(t *testing.T, test test) {
 }
 
 // bcastJitter delays the message broadcast by between 1x and 2x jitterMS.
-func bcastJitter(broadcast chan qbft.Msg, msg qbft.Msg, jitterMS int, clock *fakeClock) {
+func bcastJitter[I any, V qbft.Value[V]](broadcast chan qbft.Msg[I, V], msg qbft.Msg[I, V], jitterMS int, clock *fakeClock) {
 	if jitterMS == 0 {
 		broadcast <- msg
 		return
@@ -281,4 +295,62 @@ func bcastJitter(broadcast chan qbft.Msg, msg qbft.Msg, jitterMS int, clock *fak
 		<-ch
 		broadcast <- msg
 	}()
+}
+
+var _ qbft.Msg[int64, value] = msg{}
+
+type msg struct {
+	msgType  qbft.MsgType
+	instance int64
+	peerIdx  int64
+	round    int64
+	value    int64
+	pr       int64
+	pv       int64
+	justify  []msg
+}
+
+func (m msg) Type() qbft.MsgType {
+	return m.msgType
+}
+
+func (m msg) Instance() int64 {
+	return m.instance
+}
+
+func (m msg) Source() int64 {
+	return m.peerIdx
+}
+
+func (m msg) Round() int64 {
+	return m.round
+}
+
+func (m msg) Value() value {
+	return value(m.value)
+}
+
+func (m msg) PreparedRound() int64 {
+	return m.pr
+}
+
+func (m msg) PreparedValue() value {
+	return value(m.pv)
+}
+
+func (m msg) Justify() []qbft.Msg[int64, value] {
+	var resp []qbft.Msg[int64, value]
+	for _, msg := range m.justify {
+		resp = append(resp, msg)
+	}
+
+	return resp
+}
+
+var _ qbft.Value[value] = value(0)
+
+type value int64
+
+func (v value) Equal(v2 value) bool {
+	return int64(v) == int64(v2)
 }


### PR DESCRIPTION
Refactors qbft to use generics. This simplified the integration significantly since an external buffer isn't required and casting and conversion and (errors) isn't required.

category: refactor 
ticket: #445 
feature_set: alpha
