### PR TITLE
core/qbft: fix trimming issue

### DIFF
--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -354,7 +354,7 @@ func classify[I any, V Value[V]](d Definition[I, V], instance I, round, process 
 		}
 
 	case MsgRoundChange:
-		if !IsJustifiedRoundChange(d, msg) {
+		if !isJustifiedRoundChange(d, msg) {
 			return uponUnjustRoundChange, nil
 		}
 
@@ -445,14 +445,14 @@ func nextMinRound[I any, V Value[V]](d Definition[I, V], frc []Msg[I, V], round 
 	return rmin
 }
 
-// IsJustifiedRoundChange returns true if the ROUND_CHANGE message's
+// isJustifiedRoundChange returns true if the ROUND_CHANGE message's
 // prepared round and value is justified.
-func IsJustifiedRoundChange[I any, V Value[V]](d Definition[I, V], msg Msg[I, V]) bool {
+func isJustifiedRoundChange[I any, V Value[V]](d Definition[I, V], msg Msg[I, V]) bool {
 	if msg.Type() != MsgRoundChange {
 		panic("bug: not a round change message")
 	}
 
-	// ROUND-CHANGE justification contains PREPARE messages that justifies Pr and Pv.
+	// ROUND-CHANGE justification contains quorum PREPARE messages that justifies Pr and Pv.
 	prepares := msg.Justification()
 	pr := msg.PreparedRound()
 	pv := msg.PreparedValue()

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -199,22 +199,21 @@ func Run[I any, V Value[V]](ctx context.Context, d Definition[I, V], t Transport
 
 	// trimBuffer drops all older round's buffered messages.
 	trimBuffer := func() {
-		// TODO(corver): Fix trimming.
-		// var selected []Msg[I, V]
-		// for _, msg := range buffer {
-		//	if msg.Round() >= round-1 {
-		//		selected = append(selected, msg)
-		//	}
-		// }
-		// buffer = selected
-		//
-		// dedup := make(map[dedupKey]bool)
-		// for k := range dedupIn {
-		//	if k.Round >= round {
-		//		dedup[k] = true
-		//	}
-		// }
-		// dedupIn = dedup
+		var selected []Msg[I, V]
+		for _, msg := range buffer {
+			if msg.Round() >= round-1 {
+				selected = append(selected, msg)
+			}
+		}
+		buffer = selected
+
+		dedup := make(map[dedupKey]bool)
+		for k := range dedupIn {
+			if k.Round >= round {
+				dedup[k] = true
+			}
+		}
+		dedupIn = dedup
 	}
 
 	// === Algorithm ===
@@ -386,15 +385,16 @@ func classify[I any, V Value[V]](d Definition[I, V], instance I, round, process 
 			return uponNothing, nil
 		}
 
+		qrc, ok := getJustifiedQrc(d, buffer, msg.Round())
+		if !ok {
+			panic("bug: unjust Qrc")
+		}
+
 		if !d.IsLeader(instance, msg.Round(), process) {
 			return uponNothing, nil
 		}
 
-		if qrc, ok := getJustifiedQrc(d, buffer, msg.Round()); ok {
-			return uponQuorumRoundChanges, qrc
-		}
-
-		panic("bug: unjust Qrc")
+		return uponQuorumRoundChanges, qrc
 
 	default:
 		panic("bug: invalid type")
@@ -428,23 +428,25 @@ func highestPrepared[I any, V Value[V]](qrc []Msg[I, V]) (int64, V) {
 
 // nextMinRound implements algorithm 3:6 and returns the next minimum round
 // from received round change messages.
-func nextMinRound[I any, V Value[V]](d Definition[I, V], msgs []Msg[I, V], round int64) int64 {
+func nextMinRound[I any, V Value[V]](d Definition[I, V], frc []Msg[I, V], round int64) int64 {
 	// Get all RoundChange messages with round (rj) higher than current round (ri)
-	frc, ok := getFPlus1RoundChanges(d, msgs, round)
-	if !ok {
-		panic("bug: too few round change messages")
+
+	if len(frc) < d.Faulty()+1 {
+		panic("bug: Frc too short")
 	}
 
 	// Get the smallest round in the set.
 	rmin := int64(math.MaxInt64)
 	for _, msg := range frc {
+		if msg.Type() != MsgRoundChange {
+			panic("bug: Frc contain non-round change")
+		} else if msg.Round() <= round {
+			panic("bug: Frc round not in future")
+		}
+
 		if rmin > msg.Round() {
 			rmin = msg.Round()
 		}
-	}
-
-	if rmin <= round {
-		panic("bug: next rmin not after round")
 	}
 
 	return rmin
@@ -541,14 +543,15 @@ func containsJustifiedQrc[I any, V Value[V]](d Definition[I, V], justification [
 }
 
 // getJustifiedQrc implements algorithm 4:1 and returns a justified quorum ROUND_CHANGEs (Qrc).
-func getJustifiedQrc[I any, V Value[V]](d Definition[I, V], all []Msg[I, V], round int64) ([]Msg[I, V], bool) {
-	if qrc, ok := quorumNullPrepared(d, all, round); ok {
+func getJustifiedQrc[I any, V Value[V]](d Definition[I, V], buffer []Msg[I, V], round int64) ([]Msg[I, V], bool) {
+	if qrc, ok := quorumNullPrepared(d, buffer, round); ok {
 		// Return any quorum null pv ROUND_CHANGE messages as Qrc.
 		return qrc, true
 	}
 
-	rc := filterRoundChange(all, round)
-	for _, prepares := range getPrepareQuorums(d, all) {
+	roundChanges := filterRoundChange(buffer, round)
+
+	for _, prepares := range getPrepareQuorums(d, buffer) {
 		// See if we have quorum ROUND-CHANGE with HIGHEST_PREPARED(qrc) == prepares.Round.
 		var (
 			qrc                []Msg[I, V]
@@ -556,14 +559,14 @@ func getJustifiedQrc[I any, V Value[V]](d Definition[I, V], all []Msg[I, V], rou
 			pr                 = prepares[0].Round()
 			pv                 = prepares[0].Value()
 		)
-		for _, msg := range rc {
-			if msg.PreparedRound() > pr {
+		for _, rc := range roundChanges {
+			if rc.PreparedRound() > pr {
 				continue
 			}
-			if msg.PreparedRound() == pr && msg.PreparedValue().Equal(pv) {
+			if rc.PreparedRound() == pr && rc.PreparedValue().Equal(pv) {
 				hasHighestPrepared = true
 			}
-			qrc = append(qrc, msg)
+			qrc = append(qrc, rc)
 		}
 		if len(qrc) >= d.Quorum() && hasHighestPrepared {
 			return append(qrc, prepares...), true
@@ -576,9 +579,9 @@ func getJustifiedQrc[I any, V Value[V]](d Definition[I, V], all []Msg[I, V], rou
 // getFPlus1RoundChanges returns true and Faulty+1 ROUND-CHANGE messages (Frc) with
 // the rounds higher than the provided round. It returns the highest round
 // per process in order to jump furthest.
-func getFPlus1RoundChanges[I any, V Value[V]](d Definition[I, V], msgs []Msg[I, V], round int64) ([]Msg[I, V], bool) {
+func getFPlus1RoundChanges[I any, V Value[V]](d Definition[I, V], buffer []Msg[I, V], round int64) ([]Msg[I, V], bool) {
 	highestBySource := make(map[int64]Msg[I, V])
-	for _, msg := range msgs {
+	for _, msg := range buffer {
 		if msg.Type() != MsgRoundChange {
 			continue
 		}
@@ -618,9 +621,9 @@ type prepareSet[I any, V Value[V]] struct {
 
 // getPrepareQuorums returns all sets of quorum PREPARE messages
 // with identical rounds and values.
-func getPrepareQuorums[I any, V Value[V]](d Definition[I, V], msgs []Msg[I, V]) [][]Msg[I, V] {
+func getPrepareQuorums[I any, V Value[V]](d Definition[I, V], buffer []Msg[I, V]) [][]Msg[I, V] {
 	var sets []prepareSet[I, V]
-	for _, msg := range msgs {
+	for _, msg := range flatten(buffer) { // Flatten to get PREPARES included as ROUND-CHANGE justifications.
 		if msg.Type() != MsgPrepare {
 			continue
 		}
@@ -745,4 +748,18 @@ func zeroVal[V Value[V]]() V {
 
 func isZeroVal[V Value[V]](v V) bool {
 	return v.Equal(zeroVal[V]())
+}
+
+// flatten returns a new list of messages containing all the input messages
+// as well as all their justifications.
+func flatten[I any, V Value[V]](msgs []Msg[I, V]) []Msg[I, V] {
+	var resp []Msg[I, V]
+	for _, msg := range msgs {
+		resp = append(resp, msg)
+		for _, j := range msg.Justification() {
+			resp = append(resp, j)
+		}
+	}
+
+	return resp
 }

--- a/core/qbft/qbft_test.go
+++ b/core/qbft/qbft_test.go
@@ -189,7 +189,7 @@ func testQBFT(t *testing.T, test test) {
 			if round > 50 {
 				cancel()
 			} else if strings.Contains(rule, "Unjust") {
-				t.Logf("Unjustified PRE-PREPARE: %#v", msg)
+				t.Logf("%s: %#v", rule, msg)
 				cancel()
 			}
 		},

--- a/core/qbft/qbft_test.go
+++ b/core/qbft/qbft_test.go
@@ -28,34 +28,6 @@ import (
 	"github.com/obolnetwork/charon/core/qbft"
 )
 
-func TestFormulas(t *testing.T) {
-	// assert given N asserts Q and F.
-	assert := func(t *testing.T, n, q, f int) {
-		t.Helper()
-		d := qbft.Definition[any, value]{Nodes: n}
-		require.Equalf(t, q, d.Quorum(), "Quorum given N=%d", n)
-		require.Equalf(t, f, d.Faulty(), "Faulty given N=%d", n)
-	}
-
-	assert(t, 1, 1, 0)
-	assert(t, 2, 2, 0)
-	assert(t, 3, 2, 0)
-	assert(t, 4, 3, 1)
-	assert(t, 5, 4, 1)
-	assert(t, 6, 4, 1)
-	assert(t, 7, 5, 2)
-	assert(t, 8, 6, 2)
-	assert(t, 9, 6, 2)
-	assert(t, 10, 7, 3)
-	assert(t, 11, 8, 3)
-	assert(t, 12, 8, 3)
-	assert(t, 13, 9, 4)
-	assert(t, 15, 10, 4)
-	assert(t, 17, 12, 5)
-	assert(t, 19, 13, 6)
-	assert(t, 21, 14, 6)
-}
-
 func TestQBFT(t *testing.T) {
 	t.Run("happy 0", func(t *testing.T) {
 		testQBFT(t, test{
@@ -190,7 +162,7 @@ func testQBFT(t *testing.T, test test) {
 	var (
 		ctx, cancel = context.WithCancel(context.Background())
 		clock       = new(fakeClock)
-		receives    []chan qbft.Msg[int64, value]
+		receives    = make(map[int64]chan qbft.Msg[int64, value])
 		broadcast   = make(chan qbft.Msg[int64, value])
 		resultChan  = make(chan []qbft.Msg[int64, value], n)
 		errChan     = make(chan error, n)
@@ -226,12 +198,13 @@ func testQBFT(t *testing.T, test test) {
 
 	for i := int64(1); i <= n; i++ {
 		receive := make(chan qbft.Msg[int64, value], 1000)
-		receives = append(receives, receive)
+		receives[i] = receive
 		trans := qbft.Transport[int64, value]{
 			Broadcast: func(typ qbft.MsgType, instance int64, source int64, round int64, value value,
 				pr int64, pv value, justify []qbft.Msg[int64, value],
 			) {
 				msg := newMsg(typ, instance, source, round, value, pr, pv, justify)
+				receive <- msg // Always send to self first (no jitter, no drops).
 				bcast(broadcast, msg, test.BCastJitterMS, clock)
 			},
 			SendQCommit: func(_ int64, qCommit []qbft.Msg[int64, value]) {
@@ -274,7 +247,10 @@ func testQBFT(t *testing.T, test test) {
 		select {
 		case msg := <-broadcast:
 			t.Logf("%s %v => %v@%d", clock.NowStr(), msg.Source(), msg.Type(), msg.Round())
-			for _, out := range receives {
+			for target, out := range receives {
+				if target == msg.Source() {
+					continue // Do not broadcast to self, we sent to self already.
+				}
 				if p, ok := test.DropProb[msg.Source()]; ok {
 					if rand.Float64() < p {
 						continue // Drop
@@ -405,4 +381,32 @@ type value int64
 
 func (v value) Equal(v2 value) bool {
 	return int64(v) == int64(v2)
+}
+
+func TestFormulas(t *testing.T) {
+	// assert given N asserts Q and F.
+	assert := func(t *testing.T, n, q, f int) {
+		t.Helper()
+		d := qbft.Definition[any, value]{Nodes: n}
+		require.Equalf(t, q, d.Quorum(), "Quorum given N=%d", n)
+		require.Equalf(t, f, d.Faulty(), "Faulty given N=%d", n)
+	}
+
+	assert(t, 1, 1, 0)
+	assert(t, 2, 2, 0)
+	assert(t, 3, 2, 0)
+	assert(t, 4, 3, 1)
+	assert(t, 5, 4, 1)
+	assert(t, 6, 4, 1)
+	assert(t, 7, 5, 2)
+	assert(t, 8, 6, 2)
+	assert(t, 9, 6, 2)
+	assert(t, 10, 7, 3)
+	assert(t, 11, 8, 3)
+	assert(t, 12, 8, 3)
+	assert(t, 13, 9, 4)
+	assert(t, 15, 10, 4)
+	assert(t, 17, 12, 5)
+	assert(t, 19, 13, 6)
+	assert(t, 21, 14, 6)
 }


### PR DESCRIPTION
Fixes buffer trimming issue:
- There is only a few uses for Justification messages: 
  - a) Check if a received PRE-PREPARE is justified (only use justifications of that single message)
  - b) Check if a received ROUND-CHANGE is justified  (only use justifications of that single message)
  - c) Generate justification of a quorum ROUND-CHANGEs (select from all buffered messages and their justifications)
- We only need previously received justifications for (c), and we can get that by `flattening` the buffer.
- Since we do not add old justifications to the buffer anymore
- We can trim all old messages again.

Also make code a bit more explicit and readable.
Also ensure that send-to-self in the test is always first and never drops or jitters.

category: bug
ticket: #445 
