### PR TITLE
github: add feature_flag tag to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,9 +2,9 @@
 📐 Format this PR template as follows:
    - 1️⃣ PR title format (above): `package[/subpackage]: concise overview`
    - 2️⃣ PR body: Replace 'body...' with detailed description of the change.
-   - 3️⃣ category: pick one, delete the rest.
+   - 3️⃣ category: Pick one, delete the rest.
    - 4️⃣ ticket: Replace #000 with link to a GitHub issue (or 'none' if PR is trivial).
-   - 5️⃣ feature_set: pick one (or delete completely if not applicable).
+   - 5️⃣ feature_flag: feature in `featureset` package (or delete completely if not applicable).
 🧑‍🎓 Please review our contribution guide https://github.com/ObolNetwork/charon/blob/main/docs/contributing.md
    - 📜 Sign the Contributor License Agreement (CLA) when prompted.
    - 🌱 Starting with an issue, outlining the problem and proposed solution, is highly encouraged.
@@ -16,4 +16,4 @@ body...
 
 category: bug feature refactor docs test fixbuild misc
 ticket: #000
-feature_set: alpha beta stable
+feature_flag: ?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
    - 2️⃣ PR body: Replace 'body...' with detailed description of the change.
    - 3️⃣ category: Pick one, delete the rest.
    - 4️⃣ ticket: Replace #000 with link to a GitHub issue (or 'none' if PR is trivial).
-   - 5️⃣ feature_flag: feature in `featureset` package (or delete completely if not applicable).
+   - 5️⃣ feature_flag: Feature as per `featureset` package (or delete completely if not applicable).
 🧑‍🎓 Please review our contribution guide https://github.com/ObolNetwork/charon/blob/main/docs/contributing.md
    - 📜 Sign the Contributor License Agreement (CLA) when prompted.
    - 🌱 Starting with an issue, outlining the problem and proposed solution, is highly encouraged.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,8 +85,8 @@ Note: PRs can only be merged by obol-bulldozer bot. It is author's responsibilit
   - Ends with a list of tags (some required, others optional) (`^tag: value of this tag\n`):
   - `category`: required; one of: `refactor`, `bug`, `feature`, `docs`, `release`, `tidy`, `fixbuild`.
   - `ticket`: required; URL of the Github issue just a reference, E.g. `#123` or `none`.
-  - `feature_set`: optional; identifies the highest rollout status targeted by the change; `alpha`, `beta`, `stable`
-- Example:
+  - `feature_flag`: optional; feature flag (as per `app/featureset` package) enabling/disabling this code.
+- Examples:
 ```
 runner/tracer: add jaeger otel exporter
 
@@ -94,7 +94,15 @@ Adds the jaeger exporter to our opentelemetery infra.
 
 category: feature
 ticket: #206
-feature_set: stable
+feature_flag: jaeger_tracing
+```
+```
+docs: improve contributing.md
+
+Fix typos in `contributing.md` and improves language.
+
+category: docs
+ticket: none
 ```
 
 ### Dev tools, git hooks and linters.

--- a/testutil/verifypr/verifypr_internal_test.go
+++ b/testutil/verifypr/verifypr_internal_test.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/obolnetwork/charon/app/featureset"
 )
 
 func TestTitle(t *testing.T) {
@@ -92,6 +94,9 @@ func TestTitle(t *testing.T) {
 }
 
 func TestBody(t *testing.T) {
+	featureset.EnableForT(t, "foo")
+	featureset.EnableForT(t, "bar")
+
 	tests := []struct {
 		Body  string
 		Error string
@@ -141,20 +146,28 @@ func TestBody(t *testing.T) {
 			Error: "instructions not deleted (markdown comments present)",
 		},
 		{
-			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_set: alpha",
+			Body:  "Foo\n\ncategory: bug\nticket: #000",
+			Error: "invalid #000 ticket",
+		},
+		{
+			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_flag: foo",
 			Error: "",
 		},
 		{
-			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_set: beta",
+			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_flag: bar",
 			Error: "",
 		},
 		{
-			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_set: stable",
-			Error: "",
+			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_flag: ?",
+			Error: "invalid ? feature_flag",
 		},
 		{
-			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_set: bad set",
-			Error: "invalid feature_set tag not one of",
+			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_flag: CAPS",
+			Error: "feature flags are snake case",
+		},
+		{
+			Body:  "Foo\n\ncategory: bug\nticket: none\nfeature_flag: unknown",
+			Error: "unknown feature flag",
 		},
 	}
 	for i, test := range tests {


### PR DESCRIPTION
- Removes `feature_set: alpha/beta/stable` PR tag
- Replaces with `feature_flag: foo/bar/qbft_consensus` PR tag
- So instead of linking the PR to the "status" of the feature, rather link the PR to a specific "feature" itself (regardless of status)
- When we generate the change log, we can check what the status of the feature is, and then put the PR in that section (alpha/beta/stable).
- Since the PR (for some feature=foo) might be in alpha now, but when we release, it might be stable
- The status of the feature is defined in the code, in `featureset` package. The status changes over time.
- It is more important to know WHAT feature the code is linked to, rather than the STATUS_AT_PR_TIME.
- The status can then be calculated at ANY point in time.
- It is also much easier to explain when to use `feature_flag: foo` tag. 

category: misc 
ticket: none
