### PR TITLE
dkg: add aggregate lock hash signing skeleton

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -205,14 +205,14 @@ func aggSignLockHash(ctx context.Context, tcpNode host.Host, peerIdx int,
 
 	// Wire some core workflow components.
 	sigChan := make(chan *bls_sig.Signature, len(lock.Validators))
-	db := parsigdb.NewMemDB(lock.Threshold)
+	sigdb := parsigdb.NewMemDB(lock.Threshold)
 	exchange := parsigex.NewParSigEx(tcpNode, peerIdx, peers)
-	db.SubscribeInternal(exchange.Broadcast)
-	db.SubscribeThreshold(makeSigAgg(sigChan))
-	exchange.Subscribe(db.StoreExternal)
+	sigdb.SubscribeInternal(exchange.Broadcast)
+	sigdb.SubscribeThreshold(makeSigAgg(sigChan))
+	exchange.Subscribe(sigdb.StoreExternal)
 
 	// Start the process by inserting the partial signatures
-	err = db.StoreInternal(ctx, core.Duty{}, signedSet)
+	err = sigdb.StoreInternal(ctx, core.Duty{}, signedSet)
 	if err != nil {
 		return nil, err
 	}

--- a/tbls/tss.go
+++ b/tbls/tss.go
@@ -30,6 +30,11 @@ import (
 // see: https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-03#section-4.2.3
 var blsScheme = bls_sig.NewSigEth2()
 
+// Scheme returns the BLS12-381 ETH2 signature scheme.
+func Scheme() *bls_sig.SigEth2 {
+	return blsScheme
+}
+
 // Keygen returns a new BLS key pair.
 func Keygen() (*bls_sig.PublicKey, *bls_sig.SecretKey, error) {
 	pubkey, secret, err := blsScheme.Keygen()


### PR DESCRIPTION
Adds the general steps to create an aggregate signature of the lock hash by all validators.

category: feature 
ticket: #478
