### PR TITLE
core/scheduler: fix build

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -179,6 +179,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) {
 				return // context cancelled
 			}
 
+			instrumentDuty(duty, argSet)
 			ctx, span := core.StartDutyTrace(ctx, duty, "core/scheduler.scheduleSlot")
 			defer span.End()
 


### PR DESCRIPTION
Fixes the linter, previous PR removed `instrumentDuty`.

category: fixbuild
ticket: none
