### PR TITLE
testutil/genchangelog: handle invalid issue numbers

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
    - 2️⃣ PR body: Replace 'body...' with detailed description of the change.
    - 3️⃣ category: Pick one, delete the rest.
    - 4️⃣ ticket: Replace #000 with link to a GitHub issue (or 'none' if PR is trivial).
-   - 5️⃣ feature_flag: Feature as per `featureset` package (or delete completely if not applicable). (One of 'alpha', 'beta', or 'stable')
+   - 5️⃣ feature_flag: Feature as per `app/featureset.go` package (or delete completely if not applicable).
 🧑‍🎓 Please review our contribution guide https://github.com/ObolNetwork/charon/blob/main/docs/contributing.md
    - 📜 Sign the Contributor License Agreement (CLA) when prompted.
    - 🌱 Starting with an issue, outlining the problem and proposed solution, is highly encouraged.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
    - 2️⃣ PR body: Replace 'body...' with detailed description of the change.
    - 3️⃣ category: Pick one, delete the rest.
    - 4️⃣ ticket: Replace #000 with link to a GitHub issue (or 'none' if PR is trivial).
-   - 5️⃣ feature_flag: Feature as per `app/featureset.go` package (or delete completely if not applicable).
+   - 5️⃣ feature_flag: Feature as per `app/featureset/featureset.go` (or delete completely if not applicable).
 🧑‍🎓 Please review our contribution guide https://github.com/ObolNetwork/charon/blob/main/docs/contributing.md
    - 📜 Sign the Contributor License Agreement (CLA) when prompted.
    - 🌱 Starting with an issue, outlining the problem and proposed solution, is highly encouraged.

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -26,6 +26,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	_ "embed"
 	"encoding/json"
 	"flag"
@@ -42,6 +43,7 @@ import (
 	"time"
 
 	"github.com/obolnetwork/charon/app/errors"
+	applog "github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 )
 
@@ -133,7 +135,7 @@ func main() {
 
 	err := run(*rangeFlag, *outputFlag, token)
 	if err != nil {
-		fmt.Println(err.Error())
+		applog.Error(context.Background(), "Run error", err)
 		os.Exit(1)
 	}
 }
@@ -172,41 +174,55 @@ func run(gitRange string, output string, token string) error {
 	return nil
 }
 
-// makeIssueFunc returns a function that resolves closed issue titles via the github API.
-func makeIssueFunc(token string) func(int) (string, bool, error) {
-	return func(number int) (string, bool, error) {
+// makeIssueFunc returns a function that resolves an issue's title and status via the github API.
+func makeIssueFunc(token string) func(int) (issue string, status string, err error) {
+	return func(number int) (issue string, status string, err error) {
 		u := fmt.Sprintf("https://api.github.com/repos/obolnetwork/charon/issues/%d", number)
 		req, err := http.NewRequest("GET", u, nil)
 		if err != nil {
-			return "", false, errors.Wrap(err, "new request")
+			return "", "", errors.Wrap(err, "new request")
 		}
 		req.SetBasicAuth(token, "x-oauth-basic")
 
 		resp, err := new(http.Client).Do(req)
 		if err != nil {
-			return "", false, errors.Wrap(err, "query github issue")
+			return "", "", errors.Wrap(err, "query github issue")
 		}
 		defer resp.Body.Close()
 
 		b, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return "", false, errors.Wrap(err, "read body")
+			return "", "", errors.Wrap(err, "read body")
 		}
 
-		var issue struct {
+		opts := []z.Field{
+			z.Str("url", u),
+			z.Str("body", string(b)),
+			z.Int("issue", number),
+		}
+
+		var errResp struct {
+			Message string `json:"message"`
+			Docs    string `json:"documentation_url"`
+		}
+		if err = json.Unmarshal(b, &errResp); err != nil {
+			return "", "", errors.Wrap(err, "unmarshal issue", opts...)
+		} else if errResp.Message != "" && errResp.Docs != "" {
+			return "", errResp.Message, nil
+		}
+
+		var issueResp struct {
 			Title string `json:"title"`
 			State string `json:"state"`
 		}
-		err = json.Unmarshal(b, &issue)
+		err = json.Unmarshal(b, &issueResp)
 		if err != nil {
-			return "", false, errors.Wrap(err, "unmarshal issue")
-		} else if issue.Title == "" {
-			return "", false, errors.New("github api error: " + string(b))
-		} else if issue.State != "closed" {
-			return issue.Title, false, nil
+			return "", "", errors.Wrap(err, "unmarshal issue", opts...)
+		} else if issueResp.Title == "" {
+			return "", "", errors.New("invalid issue response, missing title", opts...)
 		}
 
-		return issue.Title, true, nil
+		return issueResp.Title, issueResp.State, nil
 	}
 }
 
@@ -225,7 +241,7 @@ func execTemplate(data tplData) ([]byte, error) {
 }
 
 // tplDataFromPRs builds the template data from the provides PRs, git range, issue title func.
-func tplDataFromPRs(prs []pullRequest, gitRange string, issueData func(int) (string, bool, error)) (tplData, error) {
+func tplDataFromPRs(prs []pullRequest, gitRange string, issueData func(int) (string, string, error)) (tplData, error) {
 	issues := make(map[int]tplIssue)
 	for _, pr := range prs {
 		issue := issues[pr.Issue]
@@ -238,11 +254,11 @@ func tplDataFromPRs(prs []pullRequest, gitRange string, issueData func(int) (str
 
 	cats := make(map[string]tplCategory)
 	for _, issue := range issues {
-		title, closed, err := issueData(issue.Number)
+		title, status, err := issueData(issue.Number)
 		if err != nil {
 			return tplData{}, err
-		} else if !closed {
-			fmt.Printf("Skipping non-closed issue #%d: %s (PRs=%d)\n", issue.Number, title, len(issue.PRs))
+		} else if status != "closed" {
+			fmt.Printf("Skipping '%s' issue #%d: %s (PRs=%d)\n", status, issue.Number, title, len(issue.PRs))
 			continue
 		}
 		issue.Title = title

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -195,12 +195,14 @@ func makeIssueFunc(token string) func(int) (issue string, status string, err err
 			return "", "", errors.Wrap(err, "read body")
 		}
 
+		// Common error fields
 		opts := []z.Field{
 			z.Str("url", u),
 			z.Str("body", string(b)),
 			z.Int("issue", number),
 		}
 
+		// Check if it is an error response
 		var errResp struct {
 			Message string `json:"message"`
 			Docs    string `json:"documentation_url"`
@@ -211,6 +213,7 @@ func makeIssueFunc(token string) func(int) (issue string, status string, err err
 			return "", errResp.Message, nil
 		}
 
+		// Else parse the issue response
 		var issueResp struct {
 			Title string `json:"title"`
 			State string `json:"state"`

--- a/testutil/genchangelog/main_internal_test.go
+++ b/testutil/genchangelog/main_internal_test.go
@@ -129,8 +129,8 @@ func TestParsePRs(t *testing.T) {
 	prs, err := parsePRs(gitRange)
 	require.NoError(t, err)
 
-	data, err := tplDataFromPRs(prs, gitRange, func(i int) (string, bool, error) {
-		return fmt.Sprintf("Issue#%d", i), true, nil
+	data, err := tplDataFromPRs(prs, gitRange, func(i int) (string, string, error) {
+		return fmt.Sprintf("Issue#%d", i), "closed", nil
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
Some commit point to invalid issues (#000). This handles that gracefully. Not that the `verify_pr` github action has been updated recently to block #000 tickets.

Also fix PR template issue.
 
category: bug
ticket: none
