### PR TITLE
testutil/genchangelog: remove api auth

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
       - main
     tags:
       - 'v*'
-name: Build docker image
+name: Build
 jobs:
   build-docker:
     runs-on: ubuntu-latest

--- a/docs/branching.md
+++ b/docs/branching.md
@@ -34,5 +34,5 @@ Charon is set up to create a release with Github Actions triggered by a tag. To 
 1. Identify the version of the release, e.g. `v0.1.2` (note the `v`).
 1. Push a PR that bumps charon version global variable, see example https://github.com/ObolNetwork/charon/pull/312
 1. Merge above PR, checkout latest main, and tag it: `git tag <version> && git push --tags`
-1. Generate changelog: `GITHUB_TOKEN=your-token-here go run testutil/genchangelog/main.go`.
+1. Generate changelog: `go run testutil/genchangelog/main.go`.
 1. Edit the auto-generated release on github: `https://github.com/ObolNetwork/charon/releases/tag/<version>`


### PR DESCRIPTION
Removes github token authentication from genchangelog since charon is now open source.

category: refactor
ticket: none
