### PR TITLE
core/qbft: do not buffer unjust messages

### DIFF
--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -226,8 +226,7 @@ func Run[I any, V comparable](ctx context.Context, d Definition[I, V], t Transpo
 				break
 			}
 
-			justified := isJustified(d, instance, msg)
-			if !justified {
+			if !isJustified(d, instance, msg) {
 				break
 			}
 
@@ -456,7 +455,7 @@ func isJustified[I any, V comparable](d Definition[I, V], instance I, msg Msg[I,
 	case MsgDecided:
 		return isJustifiedDecided(d, msg)
 	default:
-		return false
+		panic("invalid message type")
 	}
 }
 

--- a/core/qbft/uponrule_string.go
+++ b/core/qbft/uponrule_string.go
@@ -25,20 +25,17 @@ func _() {
 	var x [1]struct{}
 	_ = x[uponNothing-0]
 	_ = x[uponJustifiedPrePrepare-1]
-	_ = x[uponUnjustPrePrepare-2]
-	_ = x[uponQuorumPrepares-3]
-	_ = x[uponQuorumCommits-4]
-	_ = x[uponUnjustRoundChange-5]
-	_ = x[uponUnjustQuorumRoundChanges-6]
-	_ = x[uponFPlus1RoundChanges-7]
-	_ = x[uponQuorumRoundChanges-8]
-	_ = x[uponJustifiedDecided-9]
-	_ = x[uponUnjustDecided-10]
+	_ = x[uponQuorumPrepares-2]
+	_ = x[uponQuorumCommits-3]
+	_ = x[uponUnjustQuorumRoundChanges-4]
+	_ = x[uponFPlus1RoundChanges-5]
+	_ = x[uponQuorumRoundChanges-6]
+	_ = x[uponJustifiedDecided-7]
 }
 
-const _uponRule_name = "NothingJustifiedPrePrepareUnjustPrePrepareQuorumPreparesQuorumCommitsUnjustRoundChangeUnjustQuorumRoundChangesFPlus1RoundChangesQuorumRoundChangesJustifiedDecidedUnjustDecided"
+const _uponRule_name = "NothingJustifiedPrePrepareQuorumPreparesQuorumCommitsUnjustQuorumRoundChangesFPlus1RoundChangesQuorumRoundChangesJustifiedDecided"
 
-var _uponRule_index = [...]uint8{0, 7, 26, 42, 56, 69, 86, 110, 128, 146, 162, 175}
+var _uponRule_index = [...]uint8{0, 7, 26, 40, 53, 77, 95, 113, 129}
 
 func (i uponRule) String() string {
 	if i < 0 || i >= uponRule(len(_uponRule_index)-1) {


### PR DESCRIPTION
The current QBFT implementation is buffering ALL messages.
A valid message may however be unjust.
This is either due to a bug in the code, or due to Byzantine behaviour
To err on the side of caution, it should be assumed the be Byzantine, and those messages should not be buffered.

category: refactor
ticket: #525 
