### PR TITLE
core/qbft: fix justified preprepare issue

### DIFF
--- a/core/qbft/clock_internal_test.go
+++ b/core/qbft/clock_internal_test.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package qbft_test
+package qbft
 
 import (
 	"sync"

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -550,7 +550,7 @@ func containsJustifiedQrc[I any, V comparable](d Definition[I, V], justification
 		if rc.PreparedRound() > pr {
 			return zeroVal[V](), false
 		}
-		// Ensure one ROUND-CHANGE with pr and pv
+		// Ensure at least one ROUND-CHANGE with pr and pv
 		if rc.PreparedRound() == pr && rc.PreparedValue() == pv {
 			found = true
 		}

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -386,29 +386,6 @@ func classify[I any, V comparable](d Definition[I, V], instance I, round, proces
 	return uponNothing, nil
 }
 
-// highestPrepared implements algorithm 4:5 and returns
-// the highest prepared round (and pv) from the set of quorum
-// round change messages (Qrc).
-func highestPrepared[I any, V comparable](qrc []Msg[I, V]) (int64, V) {
-	if len(qrc) == 0 {
-		// Expect: len(Qrc) >= quorum
-		panic("bug: qrc empty")
-	}
-
-	var (
-		pr int64
-		pv V
-	)
-	for _, msg := range qrc {
-		if pr < msg.PreparedRound() {
-			pr = msg.PreparedRound()
-			pv = msg.PreparedValue()
-		}
-	}
-
-	return pr, pv
-}
-
 // nextMinRound implements algorithm 3:6 and returns the next minimum round
 // from received round change messages.
 func nextMinRound[I any, V comparable](d Definition[I, V], frc []Msg[I, V], round int64) int64 {


### PR DESCRIPTION
Fixes two related issues with justified preprepare messages:
 - it comes down to `highestPrepared` that didn't support multiple pvs at the highest round (see test message).
 - When getting pv to send with preprepare, we cannot just get it by only looking at qrc in the justification, since it might contain different pvs at the highest round. We should get it from the prepares included (or not) in the justification.
 - The same issue also triggered `unjust preprepare`, so refactored isJustifiedPreprepare to also use prepares to get pv to check, not qrc. 

This issue was triggered by running the test suite thousands of times.

category: bug
ticket: none
