### PR TITLE
refactor: remove dead code

### DIFF
--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -744,22 +744,6 @@ func filterMsgs[I any, V comparable](msgs []Msg[I, V], typ MsgType, round int64,
 	return resp
 }
 
-// key returns the message dedup key.
-func key[I any, V comparable](msg Msg[I, V]) dedupKey {
-	return dedupKey{
-		Source: msg.Source(),
-		Type:   msg.Type(),
-		Round:  msg.Round(),
-	}
-}
-
-// dedupKey provides the key to dedup received messages.
-type dedupKey struct {
-	Source int64
-	Type   MsgType
-	Round  int64
-}
-
 // zeroVal returns a zero value.
 func zeroVal[V comparable]() V {
 	var zero V


### PR DESCRIPTION
Delete deadcode in qbft. Fixes golangci-lint builds.

category: fixbuild
ticket: none
