### PR TITLE
docs: update contributing doc

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -119,7 +119,6 @@ To install githooks:
 To update githooks:
 ```sh
 pre-commit clean
-pre-commit autoupdate
 ```
 
 The **linter** used is [golangci-lint](https://golangci-lint.run/). It runs as part of the githooks and is configured in [.golangci.yml](../.golangci.yml)


### PR DESCRIPTION
`pre-commit autoupdate` updates all the hooks to the latest version. However, `golangci-lint` throws errors and there is an open issue [here](https://github.com/golangci/golangci-lint/issues/2649). So, until the linter is stable enough, it's best not to update it.

category: docs
ticket: none