### PR TITLE
cmd: write lock file in create cluster

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -79,7 +79,7 @@ func TestCmdFlags(t *testing.T) {
 					Enabled:   nil,
 					Disabled:  nil,
 				},
-				LockFile:         ".charon/cluster_lock.json",
+				LockFile:         ".charon/cluster-lock.json",
 				DataDir:          "from_env",
 				MonitoringAddr:   "127.0.0.1:16001",
 				ValidatorAPIAddr: "127.0.0.1:16002",

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -371,6 +371,7 @@ func writeDepositData(conf clusterConfig, secrets []*bls_sig.SecretKey) error {
 	return nil
 }
 
+// writeLock creates a cluster lock and writes it to disk.
 func writeLock(conf clusterConfig, dvs []tbls.TSS, peers []p2p.Peer) error {
 	lock, err := newLock(conf, dvs, peers)
 	if err != nil {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -425,9 +425,8 @@ func newLock(conf clusterConfig, dvs []tbls.TSS, peers []p2p.Peer) (cluster.Lock
 		}
 
 		vals = append(vals, cluster.DistValidator{
-			PubKey:              string(pk),
-			PubShares:           pubshares,
-			FeeRecipientAddress: "",
+			PubKey:    string(pk),
+			PubShares: pubshares,
 		})
 	}
 

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -35,12 +36,15 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util/deposit"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
+
+const clusterName = "local"
 
 const scriptTmpl = `#!/usr/bin/env bash
 
@@ -367,9 +371,71 @@ func writeDepositData(conf clusterConfig, secrets []*bls_sig.SecretKey) error {
 	return nil
 }
 
-func writeLock(_ clusterConfig, _ []tbls.TSS, _ []p2p.Peer) error {
-	// TODO(corver): Create lock file.
+func writeLock(conf clusterConfig, dvs []tbls.TSS, peers []p2p.Peer) error {
+	lock, err := newLock(conf, dvs, peers)
+	if err != nil {
+		return err
+	}
+
+	b, err := json.MarshalIndent(lock, "", " ")
+	if err != nil {
+		return errors.Wrap(err, "marshal cluster lock")
+	}
+
+	lockPath := path.Join(conf.ClusterDir, "cluster-lock.json")
+	err = os.WriteFile(lockPath, b, 0o400) // read-only
+	if err != nil {
+		return errors.Wrap(err, "write cluster lock")
+	}
+
 	return nil
+}
+
+// newLock returns a new unsigned cluster lock.
+func newLock(conf clusterConfig, dvs []tbls.TSS, peers []p2p.Peer) (cluster.Lock, error) {
+	var ops []cluster.Operator
+	for _, p := range peers {
+		enrStr, err := p2p.EncodeENR(p.ENR)
+		if err != nil {
+			return cluster.Lock{}, err
+		}
+
+		ops = append(ops, cluster.Operator{ENR: enrStr})
+	}
+
+	var vals []cluster.DistValidator
+	for _, dv := range dvs {
+		pk, err := tblsconv.KeyToCore(dv.PublicKey())
+		if err != nil {
+			return cluster.Lock{}, err
+		}
+
+		var pubshares [][]byte
+		for i := 0; i < dv.NumShares(); i++ {
+			share, err := dv.PublicShare(i + 1) // Shares are 1-indexed.
+			if err != nil {
+				return cluster.Lock{}, err
+			}
+			b, err := share.MarshalBinary()
+			if err != nil {
+				return cluster.Lock{}, errors.Wrap(err, "marshal pubshare")
+			}
+			pubshares = append(pubshares, b)
+		}
+
+		vals = append(vals, cluster.DistValidator{
+			PubKey:              string(pk),
+			PubShares:           pubshares,
+			FeeRecipientAddress: "",
+		})
+	}
+
+	def := cluster.NewDefinition(clusterName, len(dvs), conf.Threshold, "", "", "", ops, rand.Reader)
+
+	return cluster.Lock{
+		Definition: def,
+		Validators: vals,
+	}, nil
 }
 
 // newPeer returns a new peer, generating a p2pkey and ENR and node directory and run script in the process.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 }
 
 func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
-	flags.StringVar(&config.LockFile, "lock-file", ".charon/cluster_lock.json", "The path to the cluster lock file defining distributed validator cluster")
+	flags.StringVar(&config.LockFile, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster")
 	flags.StringVar(&config.BeaconNodeAddr, "beacon-node-endpoint", "http://localhost/", "Beacon node endpoint URL")
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:16002", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:16001", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")

--- a/cmd/testdata/TestCreateCluster_simnet_files.golden
+++ b/cmd/testdata/TestCreateCluster_simnet_files.golden
@@ -1,4 +1,5 @@
 [
+ "cluster-lock.json",
  "deposit-data.json",
  "node0",
  "node1",

--- a/cmd/testdata/TestCreateCluster_splitkeys_files.golden
+++ b/cmd/testdata/TestCreateCluster_splitkeys_files.golden
@@ -1,4 +1,5 @@
 [
+ "cluster-lock.json",
  "deposit-data.json",
  "node0",
  "node1",

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -74,7 +74,7 @@ func writeLock(datadir string, lock cluster.Lock) error {
 		return errors.Wrap(err, "marshal lock")
 	}
 
-	err = os.WriteFile(path.Join(datadir, "cluster_lock.json"), b, 0o444) // Read-only
+	err = os.WriteFile(path.Join(datadir, "cluster-lock.json"), b, 0o444) // Read-only
 	if err != nil {
 		return errors.Wrap(err, "write lock")
 	}

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -138,7 +138,7 @@ func testDKG(t *testing.T, def cluster.Definition, p2pKeys []*ecdsa.PrivateKey) 
 			secretShares[i] = append(secretShares[i], key)
 		}
 
-		lockFile, err := os.ReadFile(path.Join(dataDir, "cluster_lock.json"))
+		lockFile, err := os.ReadFile(path.Join(dataDir, "cluster-lock.json"))
 		require.NoError(t, err)
 
 		var lock cluster.Lock

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,7 +95,7 @@ Flags:
   -h, --help                           Help for run
       --jaeger-address string          Listening address for jaeger tracing
       --jaeger-service string          Service name used for jaeger tracing (default "charon")
-      --lock-file string               The path to the cluster lock file defining distributed validator cluster (default ".charon/cluster_lock.json")
+      --lock-file string               The path to the cluster lock file defining distributed validator cluster (default ".charon/cluster-lock.json")
       --log-format string              Log format; console, logfmt or json (default "console")
       --log-level string               Log level; debug, info, warn or error (default "info")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:16001")


### PR DESCRIPTION
Write a cluster lock file when running charon create cluster.

Rename cluster_lock.json to cluster-lock.json as per suggestion from Oisin.

category: feature
ticket: #528
