### PR TITLE
testutil/compose: add run command

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -42,8 +42,24 @@ func newRootCmd() *cobra.Command {
 
 	root.AddCommand(newDefineCmd())
 	root.AddCommand(newLockCmd())
+	root.AddCommand(newRunCmd())
 
 	return root
+}
+
+func newRunCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Create a docker-compose.yml from charon-compose.yml to run the cluster.",
+	}
+
+	dir := addDirFlag(cmd)
+
+	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
+		return compose.Run(cmd.Context(), *dir)
+	}
+
+	return cmd
 }
 
 func newLockCmd() *cobra.Command {
@@ -52,7 +68,7 @@ func newLockCmd() *cobra.Command {
 		Short: "Create a docker-compose.yml from charon-compose.yml for generating keys and a cluster lock file.",
 	}
 
-	dir := cmd.Flags().String("compose-dir", ".", "Directory to use for compose artifacts")
+	dir := addDirFlag(cmd)
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		return compose.Lock(cmd.Context(), *dir)
@@ -67,7 +83,7 @@ func newDefineCmd() *cobra.Command {
 		Short: "Create a charon-compose.yml definition; including both keygen and running definitions",
 	}
 
-	dir := cmd.Flags().String("compose-dir", ".", "Directory to use for compose artifacts")
+	dir := addDirFlag(cmd)
 	clean := cmd.Flags().Bool("clean", true, "Clean compose dir before defining a new cluster")
 	seed := cmd.Flags().Int("seed", int(time.Now().UnixNano()), "Randomness seed")
 
@@ -76,4 +92,8 @@ func newDefineCmd() *cobra.Command {
 	}
 
 	return cmd
+}
+
+func addDirFlag(cmd *cobra.Command) *string {
+	return cmd.Flags().String("compose-dir", ".", "Directory to use for compose artifacts")
 }

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 
 	"github.com/obolnetwork/charon/testutil/compose"
 )
@@ -53,7 +54,7 @@ func newRunCmd() *cobra.Command {
 		Short: "Create a docker-compose.yml from charon-compose.yml to run the cluster.",
 	}
 
-	dir := addDirFlag(cmd)
+	dir := addDirFlag(cmd.Flags())
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		return compose.Run(cmd.Context(), *dir)
@@ -68,7 +69,7 @@ func newLockCmd() *cobra.Command {
 		Short: "Create a docker-compose.yml from charon-compose.yml for generating keys and a cluster lock file.",
 	}
 
-	dir := addDirFlag(cmd)
+	dir := addDirFlag(cmd.Flags())
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		return compose.Lock(cmd.Context(), *dir)
@@ -83,7 +84,7 @@ func newDefineCmd() *cobra.Command {
 		Short: "Create a charon-compose.yml definition; including both keygen and running definitions",
 	}
 
-	dir := addDirFlag(cmd)
+	dir := addDirFlag(cmd.Flags())
 	clean := cmd.Flags().Bool("clean", true, "Clean compose dir before defining a new cluster")
 	seed := cmd.Flags().Int("seed", int(time.Now().UnixNano()), "Randomness seed")
 
@@ -94,6 +95,6 @@ func newDefineCmd() *cobra.Command {
 	return cmd
 }
 
-func addDirFlag(cmd *cobra.Command) *string {
-	return cmd.Flags().String("compose-dir", ".", "Directory to use for compose artifacts")
+func addDirFlag(flags *pflag.FlagSet) *string {
+	return flags.String("compose-dir", ".", "Directory to use for compose artifacts")
 }

--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -47,7 +47,8 @@ services:
     volumes:
       - .:/compose
   {{end}}
-
+  {{end}}
+  {{if .Monitoring}}
   prometheus:
     image: prom/prometheus:latest
     ports:

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -27,6 +27,7 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 )
 
+// Lock creates a docker-compose.yml from a charon-compose.yml for generating keys and a cluster lock file.
 func Lock(ctx context.Context, dir string) error {
 	ctx = log.WithTopic(ctx, "lock")
 
@@ -61,18 +62,23 @@ func Lock(ctx context.Context, dir string) error {
 	return writeDockerCompose(dir, data)
 }
 
-//nolint:deadcode // Busy implementing.
-func newNodeEnvs(mockValidator bool) []kv {
+// newNodeEnvs returns the default node environment variable to run a charon docker container.
+
+func newNodeEnvs(index int, validatorMock, beaconMock bool) []kv {
 	return []kv{
+		{"data_dir", fmt.Sprintf("/compose/node%d", index)},
+		{"jaeger_service", fmt.Sprintf("node%d", index)},
 		{"jaeger_address", "jaeger:6831"},
 		{"definition_file", "/compose/cluster-definition.json"},
 		{"lock_file", "/compose/cluster-lock.json"},
 		{"monitoring_address", "0.0.0.0:16001"},
 		{"validator_api_address", "0.0.0.0:16002"},
+		{"p2p_external_hostname", fmt.Sprintf("node%d", index)},
 		{"p2p_tcp_address", "0.0.0.0:16003"},
 		{"p2p_udp_address", "0.0.0.0:16004"},
 		{"p2p_bootnodes", "http://bootnode:16000/enr"},
-		{"simnet_validator_mock", fmt.Sprint(mockValidator)},
+		{"simnet_validator_mock", fmt.Sprintf(`"%v"`, validatorMock)},
+		{"simnet_beacon_mock", fmt.Sprintf(`"%v"`, beaconMock)},
 		{"log_level", "info"},
 	}
 }

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -21,6 +21,7 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 )
 
+// Run creates a docker-compose.yml from charon-compose.yml to run the cluster.
 func Run(ctx context.Context, dir string) error {
 	ctx = log.WithTopic(ctx, "run")
 

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -1,0 +1,50 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package compose
+
+import (
+	"context"
+
+	"github.com/obolnetwork/charon/app/log"
+)
+
+func Run(ctx context.Context, dir string) error {
+	ctx = log.WithTopic(ctx, "run")
+
+	conf, err := loadConfig(dir)
+	if err != nil {
+		return err
+	}
+
+	var nodes []node
+	for i := 0; i < len(conf.Def.Operators); i++ {
+		n := node{EnvVars: newNodeEnvs(i, true, true)}
+		nodes = append(nodes, n)
+	}
+
+	data := tmplData{
+		ComposeDir:       dir,
+		CharonImageTag:   conf.ImageTag,
+		CharonEntrypoint: containerBinary,
+		CharonCommand:    cmdRun,
+		Nodes:            nodes,
+	}
+
+	log.Info(ctx, "Created docker-compose.yml")
+	log.Info(ctx, "Run the cluster with: docker-compose up")
+
+	return writeDockerCompose(dir, data)
+}

--- a/testutil/compose/run_internal_test.go
+++ b/testutil/compose/run_internal_test.go
@@ -1,0 +1,47 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package compose
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestRunCompose(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	conf, _ := newDefaultConfig(1)
+
+	err = writeConfig(dir, conf)
+	require.NoError(t, err)
+
+	err = Run(context.Background(), dir)
+	require.NoError(t, err)
+
+	compose, err := os.ReadFile(path.Join(dir, "docker-compose.yml"))
+	require.NoError(t, err)
+	compose = bytes.ReplaceAll(compose, []byte(dir), []byte("testdir"))
+
+	testutil.RequireGoldenBytes(t, compose)
+}

--- a/testutil/compose/template.go
+++ b/testutil/compose/template.go
@@ -40,7 +40,8 @@ type tmplData struct {
 	Nodes []node
 	VCs   []vc
 
-	NodeOnly bool
+	NodeOnly   bool
+	Monitoring bool
 }
 
 // vc represents a validator client service in a docker-compose.yml.

--- a/testutil/compose/testdata/TestLockCompose.golden
+++ b/testutil/compose/testdata/TestLockCompose.golden
@@ -18,5 +18,6 @@ services:
       CHARON_CLUSTER_DIR: /compose
     
   
+  
 networks:
   compose:

--- a/testutil/compose/testdata/TestRunCompose.golden
+++ b/testutil/compose/testdata/TestRunCompose.golden
@@ -1,0 +1,101 @@
+version: "3.8"
+
+x-node-base: &node-base
+  image: ghcr.io/obolnetwork/charon:latest
+  entrypoint: /usr/local/bin/charon
+  command: run
+  networks: [compose]
+  volumes: [testdir:/compose]
+  depends_on: [bootnode] 
+
+services:
+  
+  node0:
+    <<: *node-base
+    environment:
+      CHARON_DATA_DIR: /compose/node0
+      CHARON_JAEGER_SERVICE: node0
+      CHARON_JAEGER_ADDRESS: jaeger:6831
+      CHARON_DEFINITION_FILE: /compose/cluster-definition.json
+      CHARON_LOCK_FILE: /compose/cluster-lock.json
+      CHARON_MONITORING_ADDRESS: 0.0.0.0:16001
+      CHARON_VALIDATOR_API_ADDRESS: 0.0.0.0:16002
+      CHARON_P2P_EXTERNAL_HOSTNAME: node0
+      CHARON_P2P_TCP_ADDRESS: 0.0.0.0:16003
+      CHARON_P2P_UDP_ADDRESS: 0.0.0.0:16004
+      CHARON_P2P_BOOTNODES: http://bootnode:16000/enr
+      CHARON_SIMNET_VALIDATOR_MOCK: "true"
+      CHARON_SIMNET_BEACON_MOCK: "true"
+      CHARON_LOG_LEVEL: info
+    
+  
+  node1:
+    <<: *node-base
+    environment:
+      CHARON_DATA_DIR: /compose/node1
+      CHARON_JAEGER_SERVICE: node1
+      CHARON_JAEGER_ADDRESS: jaeger:6831
+      CHARON_DEFINITION_FILE: /compose/cluster-definition.json
+      CHARON_LOCK_FILE: /compose/cluster-lock.json
+      CHARON_MONITORING_ADDRESS: 0.0.0.0:16001
+      CHARON_VALIDATOR_API_ADDRESS: 0.0.0.0:16002
+      CHARON_P2P_EXTERNAL_HOSTNAME: node1
+      CHARON_P2P_TCP_ADDRESS: 0.0.0.0:16003
+      CHARON_P2P_UDP_ADDRESS: 0.0.0.0:16004
+      CHARON_P2P_BOOTNODES: http://bootnode:16000/enr
+      CHARON_SIMNET_VALIDATOR_MOCK: "true"
+      CHARON_SIMNET_BEACON_MOCK: "true"
+      CHARON_LOG_LEVEL: info
+    
+  
+  node2:
+    <<: *node-base
+    environment:
+      CHARON_DATA_DIR: /compose/node2
+      CHARON_JAEGER_SERVICE: node2
+      CHARON_JAEGER_ADDRESS: jaeger:6831
+      CHARON_DEFINITION_FILE: /compose/cluster-definition.json
+      CHARON_LOCK_FILE: /compose/cluster-lock.json
+      CHARON_MONITORING_ADDRESS: 0.0.0.0:16001
+      CHARON_VALIDATOR_API_ADDRESS: 0.0.0.0:16002
+      CHARON_P2P_EXTERNAL_HOSTNAME: node2
+      CHARON_P2P_TCP_ADDRESS: 0.0.0.0:16003
+      CHARON_P2P_UDP_ADDRESS: 0.0.0.0:16004
+      CHARON_P2P_BOOTNODES: http://bootnode:16000/enr
+      CHARON_SIMNET_VALIDATOR_MOCK: "true"
+      CHARON_SIMNET_BEACON_MOCK: "true"
+      CHARON_LOG_LEVEL: info
+    
+  
+  node3:
+    <<: *node-base
+    environment:
+      CHARON_DATA_DIR: /compose/node3
+      CHARON_JAEGER_SERVICE: node3
+      CHARON_JAEGER_ADDRESS: jaeger:6831
+      CHARON_DEFINITION_FILE: /compose/cluster-definition.json
+      CHARON_LOCK_FILE: /compose/cluster-lock.json
+      CHARON_MONITORING_ADDRESS: 0.0.0.0:16001
+      CHARON_VALIDATOR_API_ADDRESS: 0.0.0.0:16002
+      CHARON_P2P_EXTERNAL_HOSTNAME: node3
+      CHARON_P2P_TCP_ADDRESS: 0.0.0.0:16003
+      CHARON_P2P_UDP_ADDRESS: 0.0.0.0:16004
+      CHARON_P2P_BOOTNODES: http://bootnode:16000/enr
+      CHARON_SIMNET_VALIDATOR_MOCK: "true"
+      CHARON_SIMNET_BEACON_MOCK: "true"
+      CHARON_LOG_LEVEL: info
+    
+  
+  bootnode:
+    <<: *node-base
+    command: bootnode
+    depends_on: []
+    environment:
+      CHARON_BOOTNODE_HTTP_ADDRESS: 0.0.0.0:16000
+      CHARON_DATA_DIR: /compose/bootnode
+      CHARON_P2P_BOOTNODES: ""
+      CHARON_P2P_EXTERNAL_HOSTNAME: bootnode
+  
+  
+networks:
+  compose:


### PR DESCRIPTION
Implements the `compose run` command that generates a docker-compose.yml for running a cluster.

category: feature
ticket: #568 

