### PR TITLE
testutil/compose: add dkg lock

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -87,9 +87,10 @@ func newDefineCmd() *cobra.Command {
 	dir := addDirFlag(cmd.Flags())
 	clean := cmd.Flags().Bool("clean", true, "Clean compose dir before defining a new cluster")
 	seed := cmd.Flags().Int("seed", int(time.Now().UnixNano()), "Randomness seed")
+	keygen := cmd.Flags().String("keygen", "", "Key generation process: create, split, dkg")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
-		return compose.Define(cmd.Context(), *dir, *clean, *seed)
+		return compose.Define(cmd.Context(), *dir, *clean, *seed, *keygen)
 	}
 
 	return cmd

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -35,7 +35,7 @@ import (
 )
 
 // Define defines a compose cluster; including both keygen and running definitions.
-func Define(ctx context.Context, dir string, clean bool, seed int) error {
+func Define(ctx context.Context, dir string, clean bool, seed int, keygen string) error {
 	ctx = log.WithTopic(ctx, "define")
 
 	if clean {
@@ -52,6 +52,10 @@ func Define(ctx context.Context, dir string, clean bool, seed int) error {
 	}
 
 	conf, p2pkeys := newDefaultConfig(seed)
+
+	if keygen != "" {
+		conf.KeyGen = keyGen(keygen)
+	}
 
 	// TODO(corver): Serve a web UI to allow configuration of default values.
 

--- a/testutil/compose/define_test.go
+++ b/testutil/compose/define_test.go
@@ -31,7 +31,7 @@ func TestDefine(t *testing.T) {
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	err = compose.Define(context.Background(), dir, false, 1)
+	err = compose.Define(context.Background(), dir, false, 1, "")
 	require.NoError(t, err)
 
 	conf, err := os.ReadFile(path.Join(dir, "charon-compose.yml"))


### PR DESCRIPTION
Adds support for DKG key generation to compose lock command.

category: feature
ticket: #568 
