### PR TITLE
testutil/compose: add auto up

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -146,7 +146,7 @@ func addUpFlag(flags *pflag.FlagSet) *bool {
 	return flags.Bool("up", true, "Execute `docker-compose up` when compose command completes")
 }
 
-// maybeExecUp executes `docker-compose up`.
+// execUp executes `docker-compose up`.
 func execUp(ctx context.Context, dir string) error {
 	ctx = log.WithTopic(ctx, "cmd")
 	log.Info(ctx, "Executing docker-compose up")

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -68,9 +68,7 @@ func newRunCmd() *cobra.Command {
 		}
 
 		if *up {
-			if err := execUp(cmd.Context(), *dir); err != nil {
-				return err
-			}
+			return execUp(cmd.Context(), *dir)
 		}
 
 		return nil
@@ -94,9 +92,7 @@ func newLockCmd() *cobra.Command {
 		}
 
 		if *up {
-			if err := execUp(cmd.Context(), *dir); err != nil {
-				return err
-			}
+			return execUp(cmd.Context(), *dir)
 		}
 
 		return nil
@@ -127,9 +123,7 @@ func newDefineCmd() *cobra.Command {
 		}
 
 		if *up {
-			if err := execUp(cmd.Context(), *dir); err != nil {
-				return err
-			}
+			return execUp(cmd.Context(), *dir)
 		}
 
 		return nil

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -164,7 +164,7 @@ func nodeFile(dir string, i int, file string) string {
 func writeConfig(dir string, conf Config) error {
 	b, err := json.MarshalIndent(conf, "", " ")
 	if err != nil {
-		return errors.Wrap(err, "marshal Config")
+		return errors.Wrap(err, "marshal config")
 	}
 
 	b, err = yaml.JSONToYAML(b)


### PR DESCRIPTION
Add automatically calling of docker-compose up after each command. Adding support for chaining commands: `compose define && compose lock && compose run`

category: feature
ticket: #568 

