### PR TITLE
docs: add pronunciation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://goreportcard.com/report/github.com/obolnetwork/charon"><img src="https://goreportcard.com/badge/github.com/obolnetwork/charon"></a>
 <a href="https://github.com/ObolNetwork/charon/actions/workflows/golangci-lint.yml"><img src="https://github.com/obolnetwork/charon/workflows/golangci-lint/badge.svg"></a></p>
 
-This repo contains the source code for the distributed validator client _Charon_; a HTTP middleware client for Ethereum Staking that enables you to safely run a single validator across a group of independent nodes.
+This repo contains the source code for the distributed validator client _Charon_ (pronounced 'kharon'); a HTTP middleware client for Ethereum Staking that enables you to safely run a single validator across a group of independent nodes.
 
 Charon is accompanied by a webapp called the [Distributed Validator Launchpad](https://github.com/obolnetwork/dv-launchpad) for distributed validator key creation.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Charon docs
 
-This page acts as an index for the charon markdown documentation.
+This page acts as an index for the charon (pronounced 'kharon') markdown documentation.
 
 - [Configuration](configuration.md): Configuring a charon node
 - [Architecture](architecture.md): Overview of charon cluster and node architecture


### PR DESCRIPTION
Adds the pronunciation of charon to the two READMEs. Got `kharon` from https://en.wikipedia.org/wiki/Charon and the idea from https://github.com/google/guice: `Guice (pronounced 'juice') is a ...`.

category: docs 
ticket: none
