### PR TITLE
testutil/compose: rename compose config

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -17,7 +17,7 @@
 // using docker-compose.
 //
 //  It consists of three steps:
-//   - compose define: Creates charon-compose.yml (and p2pkeys) that defines a desired cluster including keygen.
+//   - compose define: Creates config.json (and p2pkeys) and a docker-compose.yml to create a cluster definition file.
 //   - compose lock: Creates docker-compose.yml to generates keys and cluster lock file.
 //   - compose run: Creates docker-compose.yml that runs the cluster.
 package main
@@ -57,7 +57,7 @@ func newRootCmd() *cobra.Command {
 func newRunCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "run",
-		Short: "Create a docker-compose.yml from charon-compose.yml to run the cluster.",
+		Short: "Creates docker-compose.yml that runs the cluster.",
 	}
 
 	up := addUpFlag(cmd.Flags())
@@ -81,7 +81,7 @@ func newRunCmd() *cobra.Command {
 func newLockCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "lock",
-		Short: "Create a docker-compose.yml for generating keys and a cluster lock file.",
+		Short: "Creates docker-compose.yml to generates keys and cluster lock file.",
 	}
 
 	up := addUpFlag(cmd.Flags())
@@ -105,7 +105,7 @@ func newLockCmd() *cobra.Command {
 func newDefineCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "define",
-		Short: "Create a charon-compose.yml definition and a docker-compose.yml for generating a cluster definition file",
+		Short: "Creates config.json (and p2pkeys) and a docker-compose.yml to create a cluster definition file",
 	}
 
 	conf := compose.NewDefaultConfig()

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -18,7 +18,7 @@ package compose
 
 const (
 	version           = "obol/charon/compose/1.0.0"
-	composeFile       = "charon-compose.yml"
+	configFile        = "config.json"
 	defaultImageTag   = "latest"
 	defaultBeaconNode = "mock"
 	defaultKeyGen     = keyGenCreate

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -29,8 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
-	"github.com/goccy/go-yaml"
-
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
@@ -125,7 +123,7 @@ func Define(ctx context.Context, dir string, seed int, conf Config) error {
 		}
 	}
 
-	log.Info(ctx, "Creating charon-compose.yml")
+	log.Info(ctx, "Creating config.json")
 
 	if err := writeConfig(dir, conf); err != nil {
 		return err
@@ -225,12 +223,7 @@ func writeConfig(dir string, conf Config) error {
 		return errors.Wrap(err, "marshal config")
 	}
 
-	b, err = yaml.JSONToYAML(b)
-	if err != nil {
-		return errors.Wrap(err, "yaml config")
-	}
-
-	err = os.WriteFile(path.Join(dir, composeFile), b, 0o755) //nolint:gosec
+	err = os.WriteFile(path.Join(dir, configFile), b, 0o755) //nolint:gosec
 	if err != nil {
 		return errors.Wrap(err, "write config")
 	}

--- a/testutil/compose/define_test.go
+++ b/testutil/compose/define_test.go
@@ -35,7 +35,7 @@ func TestDefineCompose(t *testing.T) {
 	err = compose.Define(context.Background(), dir, 1, compose.NewDefaultConfig())
 	require.NoError(t, err)
 
-	conf, err := os.ReadFile(path.Join(dir, "charon-compose.yml"))
+	conf, err := os.ReadFile(path.Join(dir, "config.json"))
 	require.NoError(t, err)
 
 	testutil.RequireGoldenBytes(t, conf)

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -23,8 +23,6 @@ import (
 	"os"
 	"path"
 
-	"github.com/goccy/go-yaml"
-
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 )
@@ -112,14 +110,9 @@ func newNodeEnvs(index int, validatorMock, beaconMock bool) []kv {
 
 // loadConfig returns the config loaded from disk.
 func loadConfig(dir string) (Config, error) {
-	b, err := os.ReadFile(path.Join(dir, composeFile))
+	b, err := os.ReadFile(path.Join(dir, configFile))
 	if err != nil {
 		return Config{}, errors.Wrap(err, "load config")
-	}
-
-	b, err = yaml.YAMLToJSON(b)
-	if err != nil {
-		return Config{}, errors.Wrap(err, "yaml config")
 	}
 
 	var resp Config

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -23,7 +23,7 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 )
 
-// Run creates a docker-compose.yml from charon-compose.yml to run the cluster.
+// Run creates a docker-compose.yml from config.json to run the cluster.
 func Run(ctx context.Context, dir string) error {
 	ctx = log.WithTopic(ctx, "run")
 


### PR DESCRIPTION
Renames `charon-compose.yml` to `config.json` in order to differentiate and distinguish it from `docker-compose.yml`. 

category: refactor
ticket: #568 
