### PR TITLE
testutil/compose: add support for locally built binaries

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -114,9 +114,11 @@ func newDefineCmd() *cobra.Command {
 	dir := addDirFlag(cmd.Flags())
 	seed := cmd.Flags().Int("seed", int(time.Now().UnixNano()), "Randomness seed")
 	keygen := cmd.Flags().String("keygen", string(conf.KeyGen), "Key generation process: create, split, dkg")
+	buildLocal := cmd.Flags().Bool("build-local", conf.BuildLocal, "Enables building a local charon binary from source. Note this requires the CHARON_REPO env var.")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		conf.KeyGen = compose.KeyGen(*keygen)
+		conf.BuildLocal = *buildLocal
 
 		if err := compose.Define(cmd.Context(), *dir, *seed, conf); err != nil {
 			return err

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -81,7 +81,7 @@ type Config struct {
 	ImageTag string `json:"image_tag"`
 
 	// BuildLocal enables building a local charon binary from source and using that in the containers.
-	BuildLocal bool
+	BuildLocal bool `json:"build_local"`
 
 	// KeyGen defines the key generation process.
 	KeyGen KeyGen `json:"key_gen"`

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -26,6 +26,7 @@ const (
 	defaultNumNodes   = 4
 	defaultThreshold  = 3
 
+	localBinary      = "/compose/charon"
 	containerBinary  = "/usr/local/bin/charon"
 	cmdRun           = "run"
 	cmdDKG           = "dkg"
@@ -79,6 +80,9 @@ type Config struct {
 	// ImageTag defines the charon docker image tag: ghcr.io/obolnetwork/charon:{ImageTag}.
 	ImageTag string `json:"image_tag"`
 
+	// BuildLocal enables building a local charon binary from source and using that in the containers.
+	BuildLocal bool
+
 	// KeyGen defines the key generation process.
 	KeyGen KeyGen `json:"key_gen"`
 
@@ -87,6 +91,15 @@ type Config struct {
 
 	// VCs define the types of validator clients to use.
 	VCs []vcType `json:"validator_clients"`
+}
+
+// entrypoint returns the path to the charon binary based on the BuildLocal field.
+func (c Config) entrypoint() string {
+	if c.BuildLocal {
+		return localBinary
+	}
+
+	return containerBinary
 }
 
 // NewDefaultConfig returns a new default config.

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -154,6 +154,11 @@ func buildLocal(ctx context.Context, dir string) error {
 		return errors.New("cannot build local charon binary; CHARON_REPO env var, the path to the charon repo, is not set")
 	}
 
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return errors.Wrap(err, "abs dir")
+	}
+
 	target := path.Join(dir, "charon")
 
 	log.Info(ctx, "Building local charon binary", z.Str("repo", repo), z.Str("target", target))

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -53,7 +53,7 @@ func Lock(ctx context.Context, dir string) error {
 		data = tmplData{
 			ComposeDir:       dir,
 			CharonImageTag:   conf.ImageTag,
-			CharonEntrypoint: containerBinary,
+			CharonEntrypoint: conf.entrypoint(),
 			CharonCommand:    cmdCreateCluster,
 			Nodes:            []node{n},
 		}
@@ -68,7 +68,7 @@ func Lock(ctx context.Context, dir string) error {
 		data = tmplData{
 			ComposeDir:       dir,
 			CharonImageTag:   conf.ImageTag,
-			CharonEntrypoint: containerBinary,
+			CharonEntrypoint: conf.entrypoint(),
 			CharonCommand:    cmdDKG,
 			Bootnode:         true,
 			Nodes:            nodes,

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -45,7 +45,7 @@ func Run(ctx context.Context, dir string) error {
 	data := tmplData{
 		ComposeDir:       dir,
 		CharonImageTag:   conf.ImageTag,
-		CharonEntrypoint: containerBinary,
+		CharonEntrypoint: conf.entrypoint(),
 		CharonCommand:    cmdRun,
 		Nodes:            nodes,
 		Bootnode:         true,

--- a/testutil/compose/testdata/TestDefineCompose.golden
+++ b/testutil/compose/testdata/TestDefineCompose.golden
@@ -5,7 +5,7 @@
  "threshold": 3,
  "num_validators": 1,
  "image_tag": "latest",
- "BuildLocal": false,
+ "build_local": false,
  "key_gen": "create",
  "beacon_node": "mock",
  "validator_clients": [

--- a/testutil/compose/testdata/TestDefineCompose.golden
+++ b/testutil/compose/testdata/TestDefineCompose.golden
@@ -5,6 +5,7 @@
  "threshold": 3,
  "num_validators": 1,
  "image_tag": "latest",
+ "BuildLocal": false,
  "key_gen": "create",
  "beacon_node": "mock",
  "validator_clients": [


### PR DESCRIPTION
Adds support for locally built binaries via `compose define --build-local`. Thereby adding support for changing the source code inside the container. This is required for proper debugging. 

Note this requires the `CHARON_REPO` env var to be set. Developers are advised to put this in their bash profile.

category: feature 
ticket: #568 
