### PR TITLE
replace underscores with dashes

### DIFF
--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -35,7 +35,7 @@ func TestLoadLock(t *testing.T) {
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	filename := path.Join(dir, "cluster_lock.json")
+	filename := path.Join(dir, "cluster-lock.json")
 
 	err = os.WriteFile(filename, b, 0o644)
 	require.NoError(t, err)

--- a/cluster/doc.go
+++ b/cluster/doc.go
@@ -20,7 +20,7 @@
 // to `charon run` command.
 //
 //  launchpad.obol.net ─┐
-//                      ├─► cluster_definition.json ──► charon dkg ─┐
-//   charon create dkg ─┘                                           ├─► cluster_lock.json ──► charon run
+//                      ├─► cluster-definition.json ──► charon dkg ─┐
+//   charon create dkg ─┘                                           ├─► cluster-lock.json ──► charon run
 //                                           charon create cluster ─┘
 package cluster

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -97,8 +97,7 @@ func runCreateCluster(w io.Writer, conf clusterConfig) error {
 		if err := os.RemoveAll(conf.ClusterDir); err != nil {
 			return errors.Wrap(err, "remove cluster dir")
 		}
-	} else if _, err := os.Stat(path.Join(conf.ClusterDir, "manifest.json")); err == nil {
-		// TODO(xenowits): replace "manifest.json" with "cluster_lock.json"
+	} else if _, err := os.Stat(path.Join(conf.ClusterDir, "cluster-lock.json")); err == nil {
 		return errors.New("existing cluster found. Try again with --clean")
 	}
 
@@ -393,7 +392,7 @@ func writeOutput(out io.Writer, conf clusterConfig) {
 	_, _ = sb.WriteString(fmt.Sprintf(" --split-existing-keys=%v\n", conf.SplitKeys))
 	_, _ = sb.WriteString("\n")
 	_, _ = sb.WriteString(strings.TrimSuffix(conf.ClusterDir, "/") + "/\n")
-	_, _ = sb.WriteString("├─ manifest.json\tCluster manifest defines the cluster; used by all nodes\n")
+	_, _ = sb.WriteString("├─ cluster-lock.json\tCluster lock defines the cluster lock file which is signed by all nodes\n")
 	_, _ = sb.WriteString("├─ deposit-data.json\tDeposit data file is used to activate a Distributed Validator on DV Launchpad\n")
 	_, _ = sb.WriteString(fmt.Sprintf("├─ node[0-%d]/\t\tDirectory for each node\n", conf.NumNodes-1))
 	_, _ = sb.WriteString("│  ├─ p2pkey\t\tP2P networking private key for node authentication\n")

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -61,7 +61,7 @@ func newCreateDKGCmd(runFunc func(context.Context, createDKGConfig) error) *cobr
 
 func bindCreateDKGFlags(flags *pflag.FlagSet, config *createDKGConfig) {
 	flags.StringVar(&config.Name, "name", "", "Optional cosmetic cluster name")
-	flags.StringVar(&config.OutputDir, "output-dir", ".", "The folder to write the output cluster_definition.json file to.")
+	flags.StringVar(&config.OutputDir, "output-dir", ".", "The folder to write the output cluster-definition.json file to.")
 	flags.IntVar(&config.NumValidators, "num-validators", 1, "The number of distributed validators the cluster will manage (32ETH staked for each).")
 	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
 	flags.StringVar(&config.FeeRecipient, "fee-recipient-address", "", "Optional Ethereum address of the fee recipient")
@@ -92,7 +92,7 @@ func runCreateDKG(_ context.Context, conf createDKGConfig) error {
 	// Best effort creation of output dir, but error when writing the file.
 	_ = os.MkdirAll(conf.OutputDir, 0o755)
 
-	if err := os.WriteFile(path.Join(conf.OutputDir, "cluster_definition.json"), b, 0o444); err != nil {
+	if err := os.WriteFile(path.Join(conf.OutputDir, "cluster-definition.json"), b, 0o444); err != nil {
 		return errors.Wrap(err, "write definition")
 	}
 

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -48,5 +48,5 @@ this command at the same time.`,
 }
 
 func bindDefDirFlag(flags *pflag.FlagSet, dataDir *string) {
-	flags.StringVar(dataDir, "definition-file", ".charon/cluster_definition.json", "The path to the cluster definition file.")
+	flags.StringVar(dataDir, "definition-file", ".charon/cluster-definition.json", "The path to the cluster definition file.")
 }

--- a/cmd/testdata/TestCreateCluster_simnet_output.golden
+++ b/cmd/testdata/TestCreateCluster_simnet_output.golden
@@ -2,7 +2,7 @@ Created charon cluster:
  --split-existing-keys=false
 
 charon/
-├─ manifest.json	Cluster manifest defines the cluster; used by all nodes
+├─ cluster-lock.json	Cluster lock defines the cluster lock file which is signed by all nodes
 ├─ deposit-data.json	Deposit data file is used to activate a Distributed Validator on DV Launchpad
 ├─ node[0-3]/		Directory for each node
 │  ├─ p2pkey		P2P networking private key for node authentication

--- a/cmd/testdata/TestCreateCluster_splitkeys_output.golden
+++ b/cmd/testdata/TestCreateCluster_splitkeys_output.golden
@@ -9,7 +9,7 @@ Created charon cluster:
  --split-existing-keys=true
 
 charon/
-├─ manifest.json	Cluster manifest defines the cluster; used by all nodes
+├─ cluster-lock.json	Cluster lock defines the cluster lock file which is signed by all nodes
 ├─ deposit-data.json	Deposit data file is used to activate a Distributed Validator on DV Launchpad
 ├─ node[0-3]/		Directory for each node
 │  ├─ p2pkey		P2P networking private key for node authentication

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,14 +7,14 @@ This document describes the configuration options for running a charon node and 
 > Note this is for Charon V1 and extends on [DKG](dkg.md) docs. Charon V0 still uses old manifest files.
 
 A charon cluster is configured in two steps:
-- `cluster_definition.json` which defines the intended cluster configuration without validator keys.
-- `cluster_lock.json` which includes and extends `cluster_definition.json` with distributed validator bls public key shares and verifiers.
+- `cluster-definition.json` which defines the intended cluster configuration without validator keys.
+- `cluster-lock.json` which includes and extends `cluster-definition.json` with distributed validator bls public key shares and verifiers.
 
-The `charon create dkg` command is used to create `cluster_definition.json` file which is used as input to `charon dkg`.
+The `charon create dkg` command is used to create `cluster-definition.json` file which is used as input to `charon dkg`.
 
-The `charon create cluster` command combines both steps into one and just outputs the final `cluster_lock.json` without a DKG step.
+The `charon create cluster` command combines both steps into one and just outputs the final `cluster-lock.json` without a DKG step.
 
-The schema of the `cluster_definition.json` is defined as:
+The schema of the `cluster-definition.json` is defined as:
 ```json
 {
   "version": "v1.0.0",                  // Schema version
@@ -42,9 +42,9 @@ The schema of the `cluster_definition.json` is defined as:
 }
 ```
 
-The above `cluster_definition.json` is provided as input to the DKG which generates keys and the `cluster_lock.json` file.
+The above `cluster-definition.json` is provided as input to the DKG which generates keys and the `cluster-lock.json` file.
 
-The `cluster_lock.json` has the following schema:
+The `cluster-lock.json` has the following schema:
 ```json
 {
   "cluster_definition": {...},                              // Cluster definiition json, identical schema to above,
@@ -60,11 +60,11 @@ The `cluster_lock.json` has the following schema:
 }
 ```
 
-`charon run` just requires a `cluster_lock.json` file to configure the cluster.
+`charon run` just requires a `cluster-lock.json` file to configure the cluster.
 
 Future work:
- - To add validators to an existing `cluster_lock.json`: look at adding migrations list to `cluster_lock.json`?
- - Unique operator identifiers: each cluster_lock has a path that derive ENRs from root `cluster_spec.json` ENRs.
+ - To add validators to an existing `cluster-lock.json`: look at adding migrations list to `cluster-lock.json`?
+ - Unique operator identifiers: each cluster-lock has a path that derive ENRs from root `cluster-spec.json` ENRs.
 
 ## Flag Precedence
 

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -80,8 +80,8 @@ charon/             # project root
     - `version`: Print charon version
   - Defines and parses [viper](https://github.com/spf13/viper) configuration parameters for required by each command.
 - `cluster/`: Cluster config definition and files formats
-  - `cluster_definition.json` defines the intended cluster including confutation including operators.
-  - `cluster_lock.json` extends cluster definition adding distributed validator public keys and threshold verifiers.
+  - `cluster-definition.json` defines the intended cluster including confutation including operators.
+  - `cluster-lock.json` extends cluster definition adding distributed validator public keys and threshold verifiers.
 - `dkg/`: Distributed Key Generation command
   - Runs the dkg command that takes a cluster definition as input and generates a cluster lock file and private shares as output.
 - `app/`: Application run entrypoint


### PR DESCRIPTION
* Replaces `cluster_lock.json` and `cluster_definition.json` with `cluster-lock.json` and `cluster-definition.json` respectively.
* Change output text of `charon create cluster` to indicate that `cluster-lock.json` files are generated instead of `manifest.json`.

category: refactor
ticket: #588 
