### PR TITLE
cmd: ensures valid network during create dkg

### DIFF
--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -123,7 +123,7 @@ func NewForT(t *testing.T, dv, k, n, seed int) (Lock, []*ecdsa.PrivateKey, [][]*
 		Definition: NewDefinition(
 			"test cluster", dv, k,
 			testutil.RandomETHAddress(), testutil.RandomETHAddress(),
-			"0x0000000", ops, random),
+			"0x00000000", ops, random),
 		Validators:         vals,
 		SignatureAggregate: nil,
 	}, p2pKeys, dvShares

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -26,6 +26,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 )
 
@@ -36,17 +37,17 @@ type createDKGConfig struct {
 	Threshold         int
 	FeeRecipient      string
 	WithdrawalAddress string
-	ForkVersion       string
+	Network           string
 	DKGAlgo           string
 	OperatorENRs      []string
 }
 
-var validForkVersions = map[string]bool{
-	"0x00001020": true, // prater
-	"0x60000069": true, // kintsugi
-	"0x70000069": true, // kiln
-	"0x00000064": true, // gnosis
-	"0x00000000": true, // mainnet
+var networkToForkVersion = map[string]string{
+	"prater":   "0x00001020",
+	"kintsugi": "0x60000069",
+	"kiln":     "0x70000069",
+	"gnosis":   "0x00000064",
+	"mainnet":  "0x00000000",
 }
 
 func newCreateDKGCmd(runFunc func(context.Context, createDKGConfig) error) *cobra.Command {
@@ -74,7 +75,7 @@ func bindCreateDKGFlags(flags *pflag.FlagSet, config *createDKGConfig) {
 	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
 	flags.StringVar(&config.FeeRecipient, "fee-recipient-address", "", "Optional Ethereum address of the fee recipient")
 	flags.StringVar(&config.WithdrawalAddress, "withdrawal-address", "", "Withdrawal Ethereum address")
-	flags.StringVar(&config.ForkVersion, "fork-version", "", "Hex fork version identifying the target network/chain")
+	flags.StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, prater, kintsugi, kiln, gnosis.")
 	flags.StringVar(&config.DKGAlgo, "dkg-algorithm", "default", "DKG algorithm to use; default, keycast, frost")
 	flags.StringSliceVar(&config.OperatorENRs, "operator-enrs", nil, "Comma-separated list of each operator's Charon ENR address")
 }
@@ -87,12 +88,14 @@ func runCreateDKG(_ context.Context, conf createDKGConfig) error {
 		})
 	}
 
-	if !validForkVersions[conf.ForkVersion] {
-		return errors.New("invalid fork version")
+	if !validNetworks[conf.Network] {
+		return errors.New("unsupported network", z.Str("network", conf.Network))
 	}
 
+	forkVersion := networkToForkVersion[conf.Network]
+
 	def := cluster.NewDefinition(conf.Name, conf.NumValidators, conf.Threshold, conf.FeeRecipient, conf.WithdrawalAddress,
-		conf.ForkVersion, operators, crand.Reader)
+		forkVersion, operators, crand.Reader)
 
 	def.DKGAlgorithm = conf.DKGAlgo
 

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -41,6 +41,14 @@ type createDKGConfig struct {
 	OperatorENRs      []string
 }
 
+var validForkVersions = map[string]bool{
+	"0x00001020": true, // prater
+	"0x60000069": true, // kintsugi
+	"0x70000069": true, // kiln
+	"0x00000064": true, // gnosis
+	"0x00000000": true, // mainnet
+}
+
 func newCreateDKGCmd(runFunc func(context.Context, createDKGConfig) error) *cobra.Command {
 	var config createDKGConfig
 
@@ -66,7 +74,7 @@ func bindCreateDKGFlags(flags *pflag.FlagSet, config *createDKGConfig) {
 	flags.IntVarP(&config.Threshold, "threshold", "t", 3, "The threshold required for signature reconstruction. Minimum is n-(ceil(n/3)-1).")
 	flags.StringVar(&config.FeeRecipient, "fee-recipient-address", "", "Optional Ethereum address of the fee recipient")
 	flags.StringVar(&config.WithdrawalAddress, "withdrawal-address", "", "Withdrawal Ethereum address")
-	flags.StringVar(&config.ForkVersion, "fork-version", "", "Optional hex fork version identifying the target network/chain")
+	flags.StringVar(&config.ForkVersion, "fork-version", "", "Hex fork version identifying the target network/chain")
 	flags.StringVar(&config.DKGAlgo, "dkg-algorithm", "default", "DKG algorithm to use; default, keycast, frost")
 	flags.StringSliceVar(&config.OperatorENRs, "operator-enrs", nil, "Comma-separated list of each operator's Charon ENR address")
 }
@@ -77,6 +85,10 @@ func runCreateDKG(_ context.Context, conf createDKGConfig) error {
 		operators = append(operators, cluster.Operator{
 			ENR: opENR,
 		})
+	}
+
+	if !validForkVersions[conf.ForkVersion] {
+		return errors.New("invalid fork version")
 	}
 
 	def := cluster.NewDefinition(conf.Name, conf.NumValidators, conf.Threshold, conf.FeeRecipient, conf.WithdrawalAddress,


### PR DESCRIPTION
Ensures valid network during create dkg using network flag which is then used to get fork version to create cluster definition.

category: bug
ticket: #583