### PR TITLE
testutil/compose: introduce new and auto commands

### DIFF
--- a/testutil/compose/README.md
+++ b/testutil/compose/README.md
@@ -7,22 +7,23 @@ Compose is a tool that generates `docker-compose.yml` files such that different 
 The aim is for developers to be able to debug features and check functionality of clusters on their local machines.
 
 The `compose` command should be executed in sequential steps:
- 1. `compose clean`: Cleans the compose directory of existing artifacts.
- 2. `compose define`: Defines the target cluster and how keys are to be created.
-    1. It outputs `config.json` which is the compose config
-    1. It also creates `docker-compose.yml` in order to create `cluster-definition.json` if `keygen==dkg`.
- 1. `compose lock`: Creates `docker-compose.yml` to create threshold key shares and the `cluster-lock.json` file.
- 1. `compose run`: Creates `docker-compose.yml` to run the cluster.
+ 1. `compose new`: Creates a new config.json that defines what will be composed.
+ 2. `compose define`: Creates a docker-compose.yml that executes `charon create dkg` if keygen==dkg.
+ 3. `compose lock`: Creates a docker-compose.yml that executes `charon create cluster` or `charon dkg`.
+ 4. `compose run`: Creates a docker-compose.yml that executes `charon run`.
+
+The `compose` command also includes some convenience functions.
+- `compose clean`: Cleans the compose directory of existing files.
+- `compose auto`: Runs `compose define && compose lock && compose run`.
 
 Note that compose automatically runs `docker-compose up` at the end of each command. This can be disabled via `--up=false`.
 
-The `compose define` step configures the target cluster and key generation process. It supports the following flags:
+The `compose new` step configures the target cluster and key generation process. It supports the following flags:
  - `--keygen`: Key generation process: `create` or `dkg`.
    - create` creates keys locally via `charon create cluster`
    - `dkg` creates keys via `charon create dkg` followed by `charon dkg`.
  - `--split-keys-dir`: Path to a folder containing keys to split. Only applicable to `--keygen=create`.
  - `--build-local`: Build a local charon binary from source. Note this requires the `CHARON_REPO` path env var. Devs are encouraged to put this in the bash profile.
- - `--seed`: Randomness seed, can be used to produce deterministic p2pkeys for dkg.
 
 ## Usage
 Install the `compose` binary:
@@ -45,7 +46,7 @@ cd charon-compose
 ```
 Create the default cluster:
 ```
-compose clean && compose define && compose lock && compose run
+compose clean && compose new && compose define && compose lock && compose run
 ```
 Monitor the cluster via `grafana` and `jaeger`:
 ```
@@ -54,8 +55,6 @@ open http://localhost:16686            # Open Jaeger dashboard
 ```
 Creating a DKG based cluster that uses locally built binary:
 ```
-compose clean
-compose define --keygen=dkg --build-local
-compose lock
-compose run
+compose new --keygen=dkg --build-local
+compose auto
 ```

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -56,6 +56,7 @@ const (
 type step string
 
 const (
+	stepNew     step = "new"
 	stepDefined step = "defined"
 	stepLocked  step = "locked"
 )

--- a/testutil/compose/define_internal_test.go
+++ b/testutil/compose/define_internal_test.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
-package compose_test
+package compose
 
 import (
 	"bytes"
@@ -25,30 +25,19 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/testutil"
-	"github.com/obolnetwork/charon/testutil/compose"
 )
-
-func TestDefineCompose(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-
-	err = compose.Define(context.Background(), dir, 1, compose.NewDefaultConfig())
-	require.NoError(t, err)
-
-	conf, err := os.ReadFile(path.Join(dir, "config.json"))
-	require.NoError(t, err)
-
-	testutil.RequireGoldenBytes(t, conf)
-}
 
 func TestDefineDKG(t *testing.T) {
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	conf := compose.NewDefaultConfig()
+	conf := NewDefaultConfig()
 	conf.KeyGen = "dkg"
+	conf.Step = stepNew
+	p2pSeed = 1
+	require.NoError(t, writeConfig(dir, conf))
 
-	err = compose.Define(context.Background(), dir, 1, conf)
+	err = Define(context.Background(), dir)
 	require.NoError(t, err)
 
 	dc, err := os.ReadFile(path.Join(dir, "docker-compose.yml"))
@@ -62,10 +51,12 @@ func TestDefineCreate(t *testing.T) {
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	conf := compose.NewDefaultConfig()
+	conf := NewDefaultConfig()
 	conf.KeyGen = "create"
+	conf.Step = stepNew
+	require.NoError(t, writeConfig(dir, conf))
 
-	err = compose.Define(context.Background(), dir, 1, conf)
+	err = Define(context.Background(), dir)
 	require.NoError(t, err)
 
 	dc, err := os.ReadFile(path.Join(dir, "docker-compose.yml"))

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 // Lock creates a docker-compose.yml from a charon-compose.yml for generating keys and a cluster lock file.
@@ -33,11 +34,11 @@ func Lock(ctx context.Context, dir string) error {
 
 	conf, err := loadConfig(dir)
 	if errors.Is(err, fs.ErrNotExist) {
-		return errors.New("compose config not found; maybe try `compose define` first")
+		return errors.New("compose config not found; maybe try `compose new` first")
 	} else if err != nil {
 		return err
-	} else if conf.Step == stepLocked {
-		return errors.New("compose config already locked; maybe try `compose clean` or `compose run`")
+	} else if conf.Step != stepDefined {
+		return errors.New("compose config not defined, so can't be locked", z.Any("step", conf.Step))
 	}
 
 	var data tmplData

--- a/testutil/compose/new.go
+++ b/testutil/compose/new.go
@@ -1,0 +1,36 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package compose
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+// New creates a new compose config file from flags.
+func New(ctx context.Context, dir string, conf Config) error {
+	conf.Step = stepNew
+
+	log.Info(ctx, "Writing config to compose dir",
+		z.Str("dir", dir),
+		z.Str("config", fmt.Sprintf("%#v", conf)),
+	)
+
+	return writeConfig(dir, conf)
+}

--- a/testutil/compose/new_test.go
+++ b/testutil/compose/new_test.go
@@ -1,0 +1,41 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package compose_test
+
+import (
+	"context"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/compose"
+)
+
+func TestNewDefaultConfig(t *testing.T) {
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	err = compose.New(context.Background(), dir, compose.NewDefaultConfig())
+	require.NoError(t, err)
+
+	conf, err := os.ReadFile(path.Join(dir, "config.json"))
+	require.NoError(t, err)
+
+	testutil.RequireGoldenBytes(t, conf)
+}

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 // Run creates a docker-compose.yml from config.json to run the cluster.
@@ -29,11 +30,11 @@ func Run(ctx context.Context, dir string) error {
 
 	conf, err := loadConfig(dir)
 	if errors.Is(err, fs.ErrNotExist) {
-		return errors.New("compose config not found; maybe try `compose define` first")
+		return errors.New("compose config not found; maybe try `compose new` first")
 	} else if err != nil {
 		return err
 	} else if conf.Step != stepLocked {
-		return errors.New("compose config not locked yet, maybe try `compose lock` first")
+		return errors.New("compose config not lock, so can't be run", z.Any("step", conf.Step))
 	}
 
 	var (

--- a/testutil/compose/testdata/TestNewDefaultConfig.golden
+++ b/testutil/compose/testdata/TestNewDefaultConfig.golden
@@ -1,6 +1,6 @@
 {
  "version": "obol/charon/compose/1.0.0",
- "step": "defined",
+ "step": "new",
  "num_nodes": 4,
  "threshold": 3,
  "num_validators": 1,


### PR DESCRIPTION
Refactors compose:
 - Decouple `new` from `define`: `new` only creates config.json file, `define` is not identical to `lock` and `run`; it only creates docker-compose files.
 - This adds support for using existing config files, and generating clusters from them
 - Add convenience function `compose auto` that runs `compose define && compose lock && compose run`, since this will be the most common use-case.
 
 Result:
 ```
 compose new --keygen==dkg && compose auto
 ``` 

category: refactor 
ticket: #568 

