### PR TITLE
testutil/compose: safe clean

### DIFF
--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -26,6 +26,7 @@ const (
 	defaultNumNodes   = 4
 	defaultThreshold  = 3
 
+	charonImage      = "ghcr.io/obolnetwork/charon"
 	localBinary      = "/compose/charon"
 	containerBinary  = "/usr/local/bin/charon"
 	cmdRun           = "run"

--- a/testutil/compose/new.go
+++ b/testutil/compose/new.go
@@ -25,6 +25,10 @@ import (
 
 // New creates a new compose config file from flags.
 func New(ctx context.Context, dir string, conf Config) error {
+	if err := Clean(ctx, dir); err != nil {
+		return err
+	}
+
 	conf.Step = stepNew
 
 	log.Info(ctx, "Writing config to compose dir",


### PR DESCRIPTION
Make `compose clean` safe, by checking if config.json is present (and double check that no go files are present).

Note: I deleted my whole charon repo by running `compose clean` in the wrong folder  🤦 

Also pull latest docker image in define step.

category: bug 
ticket: #568 

