### PR TITLE
tbls: replace verifier with pubshares

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -99,16 +99,8 @@ func TestEncode(t *testing.T) {
 		Validators: []cluster.DistValidator{
 			{
 				PubKey: testutil.RandomETHAddress(),
-				Verifiers: [][]byte{
-					testutil.RandomBytes32(),
-					testutil.RandomBytes32(),
-				},
 			}, {
 				PubKey: testutil.RandomETHAddress(),
-				Verifiers: [][]byte{
-					testutil.RandomBytes32(),
-					testutil.RandomBytes32(),
-				},
 			},
 		},
 	}

--- a/cluster/distvalidator.go
+++ b/cluster/distvalidator.go
@@ -32,10 +32,6 @@ type DistValidator struct {
 	// It can be used to verify a partial signature created by any node in the cluster.
 	PubShares [][]byte `json:"public_shares,omitempty"`
 
-	// Verifiers are the threshold verifier commitments.
-	// Deprecated: Use PubShares.
-	Verifiers [][]byte `json:"threshold_verifiers,omitempty"`
-
 	// FeeRecipientAddress Ethereum address override for this validator, defaults to definition withdrawal address.
 	FeeRecipientAddress string `json:"fee_recipient_address,omitempty"`
 }
@@ -52,9 +48,9 @@ func (v DistValidator) HashTreeRootWith(hh *ssz.Hasher) error {
 	// Field (0) 'PubKey'
 	hh.PutBytes([]byte(v.PubKey))
 
-	for _, verifier := range v.Verifiers {
-		// Field (1+i) 'Verifier'
-		hh.PutBytes(verifier)
+	for _, pubshare := range v.PubShares {
+		// Field (1+i) 'Pubshare'
+		hh.PutBytes(pubshare)
 	}
 
 	// Field (N) 'FeeRecipientAddress'

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -65,15 +65,9 @@ func NewForT(t *testing.T, dv, k, n, seed int) (Lock, []*ecdsa.PrivateKey, [][]*
 		pk, err := tss.PublicKey().MarshalBinary()
 		require.NoError(t, err)
 
-		var verifiers [][]byte
-		for _, commitment := range tss.Verifier().Commitments {
-			verifiers = append(verifiers, commitment.ToAffineCompressed())
-		}
-
 		var pubshares [][]byte
 		for i := 0; i < n; i++ {
-			share, err := tss.PublicShare(i + 1) // Share indexes are 1-indexed.
-			require.NoError(t, err)
+			share := tss.PublicShare(i + 1) // Share indexes are 1-indexed.
 
 			b, err := share.MarshalBinary()
 			require.NoError(t, err)
@@ -84,7 +78,6 @@ func NewForT(t *testing.T, dv, k, n, seed int) (Lock, []*ecdsa.PrivateKey, [][]*
 		vals = append(vals, DistValidator{
 			PubKey:    fmt.Sprintf("%#x", pk),
 			PubShares: pubshares,
-			Verifiers: verifiers,
 		})
 		dvShares = append(dvShares, shares)
 	}

--- a/cluster/testdata/TestEncode_lock_json.golden
+++ b/cluster/testdata/TestEncode_lock_json.golden
@@ -31,20 +31,12 @@
  },
  "distributed_validators": [
   {
-   "distributed_public_key": "0x7b182e046410f44bc4b0f3f03a0d06820a30f257",
-   "threshold_verifiers": [
-    "NCyLgFXEZtiGRB0lmQbWms2JS5aK6fDrnZZc5qRpPE4=",
-    "vogVAbfZhGtm6wK1flzae2y6aJHWFr1obDe4NGE6yLo="
-   ]
+   "distributed_public_key": "0x7b182e046410f44bc4b0f3f03a0d06820a30f257"
   },
   {
-   "distributed_public_key": "0xa22c008ffe688352734ae4e3f1217acd5f832708",
-   "threshold_verifiers": [
-    "eVeydxnOPzGI3+V97r9vgllaEPe7ViygTVw9J5QpWMY=",
-    "2zJiZwZJ87yX2aIxZzXt5oKl3+bxoBH7yYrQ++eQADw="
-   ]
+   "distributed_public_key": "0x342c8b8055c466d886441d259906d69acd894b96"
   }
  ],
  "signature_aggregate": "bbXBREw6NNMqXEp/++jRgfftO4z+kE+T+PBtKbzZ7YQ=",
- "lock_hash": "wcS2qPDhSo0jvYr6tM+7pk4H+nsglA/cf8+baqBnuK0="
+ "lock_hash": "c1GjLXPvkrYyXHyyATXvQ64yEjCcc/YmXl4PrK5MeDQ="
 }

--- a/cluster/testdata/TestEncode_lock_yaml.golden
+++ b/cluster/testdata/TestEncode_lock_yaml.golden
@@ -23,12 +23,6 @@ cluster_definition:
   - otcjnEC0WsOVDZQfxP4cDLlq0yLWIoIpX7/hHiakMwc=
 distributed_validators:
 - distributed_public_key: "0x7b182e046410f44bc4b0f3f03a0d06820a30f257"
-  threshold_verifiers:
-  - NCyLgFXEZtiGRB0lmQbWms2JS5aK6fDrnZZc5qRpPE4=
-  - vogVAbfZhGtm6wK1flzae2y6aJHWFr1obDe4NGE6yLo=
-- distributed_public_key: "0xa22c008ffe688352734ae4e3f1217acd5f832708"
-  threshold_verifiers:
-  - eVeydxnOPzGI3+V97r9vgllaEPe7ViygTVw9J5QpWMY=
-  - 2zJiZwZJ87yX2aIxZzXt5oKl3+bxoBH7yYrQ++eQADw=
+- distributed_public_key: "0x342c8b8055c466d886441d259906d69acd894b96"
 signature_aggregate: bbXBREw6NNMqXEp/++jRgfftO4z+kE+T+PBtKbzZ7YQ=
-lock_hash: wcS2qPDhSo0jvYr6tM+7pk4H+nsglA/cf8+baqBnuK0=
+lock_hash: c1GjLXPvkrYyXHyyATXvQ64yEjCcc/YmXl4PrK5MeDQ=

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -337,10 +337,7 @@ func newLock(conf clusterConfig, dvs []tbls.TSS, peers []p2p.Peer) (cluster.Lock
 
 		var pubshares [][]byte
 		for i := 0; i < dv.NumShares(); i++ {
-			share, err := dv.PublicShare(i + 1) // Shares are 1-indexed.
-			if err != nil {
-				return cluster.Lock{}, err
-			}
+			share := dv.PublicShare(i + 1) // Shares are 1-indexed.
 			b, err := share.MarshalBinary()
 			if err != nil {
 				return cluster.Lock{}, errors.Wrap(err, "marshal pubshare")

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -626,8 +626,7 @@ func TestComponent_ProposerDuties(t *testing.T) {
 
 	// Create keys (just use normal keys, not split tbls)
 	pubkey := tss.PublicKey()
-	pubshare, err := tss.PublicShare(vIdx)
-	require.NoError(t, err)
+	pubshare := tss.PublicShare(vIdx)
 
 	eth2Share, err := tblsconv.KeyToETH2(pubshare)
 	require.NoError(t, err)

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -328,12 +328,9 @@ func aggLockHashSig(data map[core.PubKey][]core.ParSignedData, shares map[core.P
 			var pubshare *bls_sig.PublicKey
 			switch dkgAlgo {
 			case "keycast":
-				pubshare, err = tbls.GetPubShare(s.ShareIdx, shares[pk].Verifier)
-				if err != nil {
-					return nil, nil, errors.Wrap(err, "get pubshare from verifier")
-				}
+				pubshare = shares[pk].PublicShares[s.ShareIdx]
 			case "frost":
-				pubshare = shares[pk].PublicShares[uint32(s.ShareIdx)]
+				pubshare = shares[pk].PublicShares[s.ShareIdx]
 			default:
 				return nil, nil, errors.New("invalid dkg algo")
 			}
@@ -493,7 +490,6 @@ func dvsFromShares(shares []share) ([]cluster.DistValidator, error) {
 
 		dvs = append(dvs, cluster.DistValidator{
 			PubKey:    fmt.Sprintf("%#x", msg.PubKey),
-			Verifiers: msg.Verifiers,
 			PubShares: msg.PubShares,
 		})
 	}

--- a/dkg/frost.go
+++ b/dkg/frost.go
@@ -219,7 +219,7 @@ func makeShares(
 	targetID uint32,
 ) ([]share, error) {
 	// Get set of public shares for each validator.
-	pubShares := make(map[uint32]map[uint32]*bls_sig.PublicKey) // map[ValIdx]map[SourceID]*bls_sig.PublicKey
+	pubShares := make(map[uint32]map[int]*bls_sig.PublicKey) // map[ValIdx]map[SourceID]*bls_sig.PublicKey
 	for key, result := range r2Result {
 		if key.TargetID != targetID {
 			// Not for us.
@@ -232,10 +232,10 @@ func makeShares(
 
 		m, ok := pubShares[key.ValIdx]
 		if !ok {
-			m = make(map[uint32]*bls_sig.PublicKey)
+			m = make(map[int]*bls_sig.PublicKey)
 			pubShares[key.ValIdx] = m
 		}
-		m[key.SourceID] = pubShare
+		m[int(key.SourceID)] = pubShare
 	}
 
 	// Sort shares by vIdx

--- a/tbls/tss_test.go
+++ b/tbls/tss_test.go
@@ -53,8 +53,7 @@ func TestAggregateSignatures(t *testing.T) {
 
 		partialSigs[i] = psig
 
-		pubshare, err := tss.PublicShare(int(psig.Identifier))
-		require.NoError(t, err)
+		pubshare := tss.PublicShare(int(psig.Identifier))
 
 		ok, err := tbls.Verify(pubshare, msg, &bls_sig.Signature{Value: psig.Signature})
 		require.NoError(t, err)


### PR DESCRIPTION
Refactors tbls to use pubshares from start and remove verifier from the workflow.

category: refactor
ticket: #596
