### PR TITLE
tbls: cleanup to remove verifiers

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -99,8 +99,16 @@ func TestEncode(t *testing.T) {
 		Validators: []cluster.DistValidator{
 			{
 				PubKey: testutil.RandomETHAddress(),
+				PubShares: [][]byte{
+					testutil.RandomBytes32(),
+					testutil.RandomBytes32(),
+				},
 			}, {
 				PubKey: testutil.RandomETHAddress(),
+				PubShares: [][]byte{
+					testutil.RandomBytes32(),
+					testutil.RandomBytes32(),
+				},
 			},
 		},
 	}

--- a/cluster/distvalidator.go
+++ b/cluster/distvalidator.go
@@ -49,7 +49,6 @@ func (v DistValidator) HashTreeRootWith(hh *ssz.Hasher) error {
 	hh.PutBytes([]byte(v.PubKey))
 
 	for _, pubshare := range v.PubShares {
-		// Field (1+i) 'Pubshare'
 		hh.PutBytes(pubshare)
 	}
 

--- a/cluster/testdata/TestEncode_lock_json.golden
+++ b/cluster/testdata/TestEncode_lock_json.golden
@@ -31,12 +31,20 @@
  },
  "distributed_validators": [
   {
-   "distributed_public_key": "0x7b182e046410f44bc4b0f3f03a0d06820a30f257"
+   "distributed_public_key": "0x7b182e046410f44bc4b0f3f03a0d06820a30f257",
+   "public_shares": [
+    "NCyLgFXEZtiGRB0lmQbWms2JS5aK6fDrnZZc5qRpPE4=",
+    "vogVAbfZhGtm6wK1flzae2y6aJHWFr1obDe4NGE6yLo="
+   ]
   },
   {
-   "distributed_public_key": "0x342c8b8055c466d886441d259906d69acd894b96"
+   "distributed_public_key": "0xa22c008ffe688352734ae4e3f1217acd5f832708",
+   "public_shares": [
+    "eVeydxnOPzGI3+V97r9vgllaEPe7ViygTVw9J5QpWMY=",
+    "2zJiZwZJ87yX2aIxZzXt5oKl3+bxoBH7yYrQ++eQADw="
+   ]
   }
  ],
  "signature_aggregate": "bbXBREw6NNMqXEp/++jRgfftO4z+kE+T+PBtKbzZ7YQ=",
- "lock_hash": "c1GjLXPvkrYyXHyyATXvQ64yEjCcc/YmXl4PrK5MeDQ="
+ "lock_hash": "wcS2qPDhSo0jvYr6tM+7pk4H+nsglA/cf8+baqBnuK0="
 }

--- a/cluster/testdata/TestEncode_lock_yaml.golden
+++ b/cluster/testdata/TestEncode_lock_yaml.golden
@@ -23,6 +23,12 @@ cluster_definition:
   - otcjnEC0WsOVDZQfxP4cDLlq0yLWIoIpX7/hHiakMwc=
 distributed_validators:
 - distributed_public_key: "0x7b182e046410f44bc4b0f3f03a0d06820a30f257"
-- distributed_public_key: "0x342c8b8055c466d886441d259906d69acd894b96"
+  public_shares:
+  - NCyLgFXEZtiGRB0lmQbWms2JS5aK6fDrnZZc5qRpPE4=
+  - vogVAbfZhGtm6wK1flzae2y6aJHWFr1obDe4NGE6yLo=
+- distributed_public_key: "0xa22c008ffe688352734ae4e3f1217acd5f832708"
+  public_shares:
+  - eVeydxnOPzGI3+V97r9vgllaEPe7ViygTVw9J5QpWMY=
+  - 2zJiZwZJ87yX2aIxZzXt5oKl3+bxoBH7yYrQ++eQADw=
 signature_aggregate: bbXBREw6NNMqXEp/++jRgfftO4z+kE+T+PBtKbzZ7YQ=
-lock_hash: c1GjLXPvkrYyXHyyATXvQ64yEjCcc/YmXl4PrK5MeDQ=
+lock_hash: wcS2qPDhSo0jvYr6tM+7pk4H+nsglA/cf8+baqBnuK0=

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -173,7 +173,6 @@ func testDKG(t *testing.T, def cluster.Definition, p2pKeys []*ecdsa.PrivateKey) 
 			// Ensure all public shares can verify the partial signature
 			for _, lock := range locks {
 				if len(lock.Validators[i].PubShares) == 0 {
-					// TODO(corver): convert keycast to use public shares, not verifiers.
 					continue
 				}
 				pk, err := tblsconv.KeyFromBytes(lock.Validators[i].PubShares[j])

--- a/dkg/keycast.go
+++ b/dkg/keycast.go
@@ -38,7 +38,7 @@ type kcTransport interface {
 	GetShares(ctx context.Context, nodeIdx int) ([]byte, error)
 }
 
-// share is the co-validator public key, tbls verifiers or tbls publis shares, and private key share.
+// share is the co-validator public key, tbls public shares, and private key share.
 // Each node in the cluster will receive one for each distributed validator.
 type share struct {
 	PubKey      *bls_sig.PublicKey
@@ -173,11 +173,11 @@ func createShares(numValidators, numNodes, threshold int, random io.Reader) ([][
 			return nil, errors.New("bug: sanity check length of shares")
 		}
 
-		for ni := 0; ni < numNodes; ni++ {
-			resp[ni] = append(resp[ni], share{
+		for nodeIdx := 0; nodeIdx < numNodes; nodeIdx++ {
+			resp[nodeIdx] = append(resp[nodeIdx], share{
 				PubKey:       tss.PublicKey(),
 				PublicShares: tss.PublicShares(),
-				SecretShare:  shares[ni],
+				SecretShare:  shares[nodeIdx],
 			})
 		}
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ This document describes the configuration options for running a charon node and 
 
 A charon cluster is configured in two steps:
 - `cluster-definition.json` which defines the intended cluster configuration without validator keys.
-- `cluster-lock.json` which includes and extends `cluster-definition.json` with distributed validator bls public key shares and verifiers.
+- `cluster-lock.json` which includes and extends `cluster-definition.json` with distributed validator bls public key shares.
 
 The `charon create dkg` command is used to create `cluster-definition.json` file which is used as input to `charon dkg`.
 
@@ -51,7 +51,7 @@ The `cluster-lock.json` has the following schema:
   "distributed_validators": [                               // Length equaled to num_validators.
     {
       "distributed_public_key":  "0x123..abfc",             // DV root pubkey
-      "threshold_verifiers": [ "oA8Z...2XyT", "g1q...icu"], // length of threshold
+      "public_shares": [ "oA8Z...2XyT", "g1q...icu"], // length of threshold
       "fee_recipient": "0x123..abfc"                        // Defaults to withdrawal address if not set, can be edited manually
     }
   ],

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,10 +48,10 @@ The `cluster-lock.json` has the following schema:
 ```json
 {
   "cluster_definition": {...},                              // Cluster definiition json, identical schema to above,
-  "distributed_validators": [                               // Length equaled to num_validators.
+  "distributed_validators": [                               // Length equal to num_validators.
     {
       "distributed_public_key":  "0x123..abfc",             // DV root pubkey
-      "public_shares": [ "oA8Z...2XyT", "g1q...icu"], // length of threshold
+      "public_shares": [ "oA8Z...2XyT", "g1q...icu"],       // length of num_operators
       "fee_recipient": "0x123..abfc"                        // Defaults to withdrawal address if not set, can be edited manually
     }
   ],

--- a/docs/dkg.md
+++ b/docs/dkg.md
@@ -61,8 +61,8 @@ Once all clients in the cluster can establish a connection with one another and 
 No user input is required, charon does the work and outputs the following files to each machine and then exits.
 
 ```sh
-./cluster_manifest.yaml     # The original manifest file from the DV Launchpad
-./cluster_manifest.lock     # New lockfile based on cluster_manifest.yaml with validator group public keys and threshold BLS verifiers included with the initial cluster config
+./cluster-definition.json   # The original cluster definition file from the DV Launchpad
+./cluster-lock.json         # New lockfile based on cluster-definition.json with validator group public keys and public shares included with the initial cluster config
 ./charon/enr_private_key    # Created before the ceremony took place [Back this up]
 ./charon/validator_keys/    # Folder of key shares to be backed up and moved to validator client [Back this up]
 ./charon/deposit_data       # JSON file of deposit data for the distributed validators

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -81,7 +81,7 @@ charon/             # project root
   - Defines and parses [viper](https://github.com/spf13/viper) configuration parameters for required by each command.
 - `cluster/`: Cluster config definition and files formats
   - `cluster-definition.json` defines the intended cluster including confutation including operators.
-  - `cluster-lock.json` extends cluster definition adding distributed validator public keys and threshold verifiers.
+  - `cluster-lock.json` extends cluster definition adding distributed validator public keys and public shares.
 - `dkg/`: Distributed Key Generation command
   - Runs the dkg command that takes a cluster definition as input and generates a cluster lock file and private shares as output.
 - `app/`: Application run entrypoint

--- a/tbls/tss.go
+++ b/tbls/tss.go
@@ -57,7 +57,7 @@ func KeygenWithSeed(reader io.Reader) (*bls_sig.PublicKey, *bls_sig.SecretKey, e
 	return pubkey, secret, nil
 }
 
-// TSS (threshold signing scheme) wraps PubKey (PublicKey), Verifiers (the coefficients of the public polynomial)
+// TSS (threshold signing scheme) wraps PubKey (PublicKey), Pubshares (the public shares corresponding to each secret key share)
 // and threshold (number of shares).
 type TSS struct {
 	pubshares map[int]*bls_sig.PublicKey


### PR DESCRIPTION
Remaining cleanup to replace verifiers with public shares based on the comments on https://github.com/ObolNetwork/charon/pull/604 

category: refactor
ticket: none
