### PR TITLE
testutil/compose: support alerts and timeout

### DIFF
--- a/testutil/compose/compose/alert.go
+++ b/testutil/compose/compose/alert.go
@@ -1,0 +1,73 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+// startAlertCollector starts a server that accepts alert webhooks until the context is closed and returns
+// a channel on which the received webhooks will be sent.
+func startAlertCollector(ctx context.Context, port int) (chan []byte, error) {
+	l, err := net.Listen("tcp", fmt.Sprintf("0.0.0.0:%d", port))
+	if err != nil {
+		return nil, errors.Wrap(err, "new listener")
+	}
+
+	bodies := make(chan []byte)
+	server := http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer r.Body.Close()
+
+			b, err := io.ReadAll(r.Body)
+			if err != nil {
+				log.Error(ctx, "Read request body", err)
+				return
+			}
+
+			log.Info(ctx, "Received webhook", z.Str("body", string(b)))
+
+			bodies <- b
+		}),
+	}
+
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return server.Serve(l) //nolint:wrapcheck
+	})
+	eg.Go(func() error {
+		<-ctx.Done()
+		return server.Close() //nolint:wrapcheck
+	})
+	go func() {
+		if err := eg.Wait(); !errors.Is(err, context.Canceled) && !errors.Is(err, http.ErrServerClosed) {
+			log.Error(ctx, "Alert collector", err)
+		}
+		close(bodies)
+	}()
+
+	return bodies, nil
+}

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -256,12 +256,11 @@ func execUp(ctx context.Context, dir string) error {
 		err = ctx.Err()
 		return errors.Wrap(err, "run up")
 	}
-	// TODO(corver): parse and return any non-zero exit codes
 
 	return nil
 }
 
-// execUp executes `docker-compose up`.
+// execDown executes `docker-compose down`.
 func execDown(ctx context.Context, dir string) error {
 	log.Info(ctx, "Executing docker-compose down")
 
@@ -275,7 +274,6 @@ func execDown(ctx context.Context, dir string) error {
 	if err := cmd.Run(); err != nil {
 		return errors.Wrap(err, "run down")
 	}
-	// TODO(corver): parse and return any non-zero exit codes
 
 	return nil
 }

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -130,20 +130,51 @@ func newAutoCmd() *cobra.Command {
 	}
 
 	dir := addDirFlag(cmd.Flags())
-	up := true
+	alertTimeout := cmd.Flags().Duration("alert-timeout", 0, "Timeout to collect alerts before shutdown. Zero disables timeout.")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) (err error) {
 		runFuncs := []func(context.Context) (compose.TmplData, error){
-			newRunnerFunc("define", *dir, up, compose.Define),
-			newRunnerFunc("lock", *dir, up, compose.Lock),
-			newRunnerFunc("run", *dir, up, compose.Run),
+			newRunnerFunc("define", *dir, true, compose.Define),
+			newRunnerFunc("lock", *dir, true, compose.Lock),
+			newRunnerFunc("run", *dir, false, compose.Run),
 		}
 
+		rootCtx := log.WithTopic(cmd.Context(), "auto")
+
 		for _, runFunc := range runFuncs {
-			_, err := runFunc(cmd.Context())
+			_, err := runFunc(rootCtx)
 			if err != nil {
 				return err
 			}
+		}
+
+		ctx := rootCtx
+		if *alertTimeout != 0 {
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(rootCtx, *alertTimeout)
+			defer cancel()
+		}
+
+		alerts, err := startAlertCollector(ctx, 26354)
+		if err != nil {
+			return err
+		}
+
+		if err := execUp(ctx, *dir); !errors.Is(err, context.DeadlineExceeded) {
+			return err
+		}
+
+		if err := execDown(rootCtx, *dir); err != nil {
+			return err
+		}
+
+		var fail bool
+		for alert := range alerts {
+			log.Error(rootCtx, "Received alert", nil, z.Str("alert", string(alert)))
+			fail = true
+		}
+		if fail {
+			return errors.New("Alerts detected")
 		}
 
 		return nil
@@ -222,7 +253,27 @@ func execUp(ctx context.Context, dir string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
+		err = ctx.Err()
 		return errors.Wrap(err, "run up")
+	}
+	// TODO(corver): parse and return any non-zero exit codes
+
+	return nil
+}
+
+// execUp executes `docker-compose up`.
+func execDown(ctx context.Context, dir string) error {
+	log.Info(ctx, "Executing docker-compose down")
+
+	cmd := exec.CommandContext(ctx, "docker-compose", "down",
+		"--remove-orphans",
+		"--timeout=2",
+	)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return errors.Wrap(err, "run down")
 	}
 	// TODO(corver): parse and return any non-zero exit codes
 


### PR DESCRIPTION
Add support for `--alert-timeout` to `compose auto` that starts a webhook server that collects alerts and stops docker-compose after the timeout and reports any received alerts.

This add supports for grafana alerts based smoke test evaluators.

category: feature 
ticket: #609 
