### PR TITLE
app/retryer: remove error on expected timeout

### DIFF
--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -162,7 +162,7 @@ func (r *Retryer) DoAsync(parent context.Context, slot int64, name string, fn fu
 			span.AddEvent("retry.backoff.done")
 		}
 
-		if ctx.Err() != nil {
+		if i != 0 && ctx.Err() != nil { // Do not log an error if we haven't actually re-tried.
 			log.Error(ctx, "Timeout retrying "+name, ctx.Err())
 			return
 		}


### PR DESCRIPTION
QBFT blocks until the context is cancelled and therefore always returns a `context.DeadlineExceeded` error. This is expected, so should not result in errors. So only log "Timeout retrying" on second to third attempts.

category: bug
ticket: none
