### PR TITLE
app/retryer: refactor context error log

### DIFF
--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -162,7 +162,7 @@ func (r *Retryer) DoAsync(parent context.Context, slot int64, name string, fn fu
 			span.AddEvent("retry.backoff.done")
 		}
 
-		if i != 0 && ctx.Err() != nil { // Do not log an error if we haven't actually re-tried.
+		if ctx.Err() != nil {
 			log.Error(ctx, "Timeout retrying "+name, ctx.Err())
 			return
 		}

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -170,8 +170,8 @@ func (c *Component) Propose(ctx context.Context, duty core.Duty, data core.Unsig
 
 	// Run the algo, blocking until the context is cancelled.
 	err = qbft.Run[core.Duty, [32]byte](ctx, c.def, qt, duty, peerIdx, hash)
-	if err != nil && ctx.Err() == nil {
-		return err // Do not return context errors, as they are expected behaviour.
+	if err != nil && !isContextErr(err) {
+		return err // Only return non-context errors.
 	}
 
 	return nil
@@ -269,4 +269,8 @@ func (c *Component) getPeerIdx() (int64, error) {
 	}
 
 	return peerIdx, nil
+}
+
+func isContextErr(err error) bool {
+	return errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)
 }

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -131,7 +131,7 @@ func (c *Component) Start(ctx context.Context) {
 }
 
 // Propose participants in a consensus instance proposing the provided data.
-// It returns on error or when the context is cancelled.
+// It returns on error or nil when the context is cancelled.
 func (c *Component) Propose(ctx context.Context, duty core.Duty, data core.UnsignedDataSet) error {
 	ctx = log.WithTopic(ctx, "qbft")
 	ctx, cancel := context.WithCancel(ctx)
@@ -169,7 +169,12 @@ func (c *Component) Propose(ctx context.Context, duty core.Duty, data core.Unsig
 	}
 
 	// Run the algo, blocking until the context is cancelled.
-	return qbft.Run[core.Duty, [32]byte](ctx, c.def, qt, duty, peerIdx, hash)
+	err = qbft.Run[core.Duty, [32]byte](ctx, c.def, qt, duty, peerIdx, hash)
+	if err != nil && ctx.Err() == nil {
+		return err // Do not return context errors, as they are expected behaviour.
+	}
+
+	return nil
 }
 
 // makeHandler returns a consensus libp2p handler.


### PR DESCRIPTION
Refactors how context deadline errors are handled in retryer:
 - The previous change #625 removed error logs on context timeout during first attempt.
 - But this isn't correct since other blocking use-cases SHOULD error if they block and then timeout (like fetcher DutyPropser).
 - Revert that change, logging all timeout errors.
 - Instead refactor qbft consensus to not return an error on timeout, since that is expected behaviour.

category: refactor
ticket: none

