### PR TITLE
cluster: add backwards compatability test

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -19,6 +19,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/goccy/go-yaml"
@@ -143,4 +145,34 @@ func TestEncode(t *testing.T) {
 
 	require.Equal(t, b1, b2)
 	require.Equal(t, lock, lock2)
+}
+
+// TestBackwardsCompatability ensures that the current code is backwards compatible
+// with previous versions stored in testdata.
+func TestBackwardsCompatability(t *testing.T) {
+	tests := []struct {
+		version string
+	}{
+		{
+			version: "v1.0.0",
+		},
+		// Note: Add testdata files for newer versions when bumped.
+	}
+	for _, test := range tests {
+		t.Run(test.version, func(t *testing.T) {
+			suffix := strings.ReplaceAll(test.version, ".", "_")
+
+			b, err := os.ReadFile(fmt.Sprintf("testdata/definition_%s.json", suffix))
+			require.NoError(t, err)
+
+			var def cluster.Definition
+			require.NoError(t, json.Unmarshal(b, &def))
+
+			b, err = os.ReadFile(fmt.Sprintf("testdata/lock_%s.json", suffix))
+			require.NoError(t, err)
+
+			var lock cluster.Lock
+			require.NoError(t, json.Unmarshal(b, &lock))
+		})
+	}
 }

--- a/cluster/testdata/definition_v1_0_0.json
+++ b/cluster/testdata/definition_v1_0_0.json
@@ -1,0 +1,30 @@
+{
+ "name": "test definition",
+ "operators": [
+  {
+   "address": "0xe2d3d0d0de6bf8f9b44ce85ff044c6b1f83b8e88",
+   "enr": "enr://32f3a8aeb79ef856f659c18f0dcecc77c75e7a81bfde275f67cfe242cf3cc354",
+   "nonce": 0,
+   "enr_signature": "8+3i1r7MTqOuXohSap9KV4vLnvLUplMUdo1tKZdh6p4="
+  },
+  {
+   "address": "0x4f5aa6aec3fc78c6aae081ac8120c720efcd6cea",
+   "enr": "enr://cdd01d75045c3f000f8a796bce6c512c3801aacaeedfad5b506664e8c0e4a771",
+   "nonce": 1,
+   "enr_signature": "7OC4t8GWXZGBJRt8nJylIFr8FqI2ou/N0tEtKnnQdKg="
+  }
+ ],
+ "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
+ "version": "v1.0.0",
+ "num_validators": 2,
+ "threshold": 3,
+ "fee_recipient_address": "0x0194fdc2fa2ffcc041d3ff12045b73c86e4ff95f",
+ "withdrawal_address": "0xfb180daf48a79ee0b10d394651850fd4a178892e",
+ "dkg_algorithm": "default",
+ "fork_version": "0x00000002",
+ "definition_hash": "7EEI29e0I9C2ZfqIPXlHf1swxE5mmPTHHVykeuZ5q50=",
+ "operator_signatures": [
+  "KArpQ56w1q7KCCOuAtZ9hmrCxP5KclBT2hGbnU9RUUA=",
+  "otcjnEC0WsOVDZQfxP4cDLlq0yLWIoIpX7/hHiakMwc="
+ ]
+}

--- a/cluster/testdata/lock_v1_0_0.json
+++ b/cluster/testdata/lock_v1_0_0.json
@@ -1,0 +1,50 @@
+{
+ "cluster_definition": {
+  "name": "test definition",
+  "operators": [
+   {
+    "address": "0xe2d3d0d0de6bf8f9b44ce85ff044c6b1f83b8e88",
+    "enr": "enr://32f3a8aeb79ef856f659c18f0dcecc77c75e7a81bfde275f67cfe242cf3cc354",
+    "nonce": 0,
+    "enr_signature": "8+3i1r7MTqOuXohSap9KV4vLnvLUplMUdo1tKZdh6p4="
+   },
+   {
+    "address": "0x4f5aa6aec3fc78c6aae081ac8120c720efcd6cea",
+    "enr": "enr://cdd01d75045c3f000f8a796bce6c512c3801aacaeedfad5b506664e8c0e4a771",
+    "nonce": 1,
+    "enr_signature": "7OC4t8GWXZGBJRt8nJylIFr8FqI2ou/N0tEtKnnQdKg="
+   }
+  ],
+  "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
+  "version": "v1.0.0",
+  "num_validators": 2,
+  "threshold": 3,
+  "fee_recipient_address": "0x0194fdc2fa2ffcc041d3ff12045b73c86e4ff95f",
+  "withdrawal_address": "0xfb180daf48a79ee0b10d394651850fd4a178892e",
+  "dkg_algorithm": "default",
+  "fork_version": "0x00000002",
+  "definition_hash": "7EEI29e0I9C2ZfqIPXlHf1swxE5mmPTHHVykeuZ5q50=",
+  "operator_signatures": [
+   "KArpQ56w1q7KCCOuAtZ9hmrCxP5KclBT2hGbnU9RUUA=",
+   "otcjnEC0WsOVDZQfxP4cDLlq0yLWIoIpX7/hHiakMwc="
+  ]
+ },
+ "distributed_validators": [
+  {
+   "distributed_public_key": "0x7b182e046410f44bc4b0f3f03a0d06820a30f257",
+   "public_shares": [
+    "NCyLgFXEZtiGRB0lmQbWms2JS5aK6fDrnZZc5qRpPE4=",
+    "vogVAbfZhGtm6wK1flzae2y6aJHWFr1obDe4NGE6yLo="
+   ]
+  },
+  {
+   "distributed_public_key": "0xa22c008ffe688352734ae4e3f1217acd5f832708",
+   "public_shares": [
+    "eVeydxnOPzGI3+V97r9vgllaEPe7ViygTVw9J5QpWMY=",
+    "2zJiZwZJ87yX2aIxZzXt5oKl3+bxoBH7yYrQ++eQADw="
+   ]
+  }
+ ],
+ "signature_aggregate": "bbXBREw6NNMqXEp/++jRgfftO4z+kE+T+PBtKbzZ7YQ=",
+ "lock_hash": "wcS2qPDhSo0jvYr6tM+7pk4H+nsglA/cf8+baqBnuK0="
+}


### PR DESCRIPTION
Adds a backwards compatability test for cluster definition and lock versions.

category: test
ticket: none
