### PR TITLE
cmd/bootnode: fixes circuit reservation resource issues

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -253,8 +253,10 @@ func startBootnode(ctx context.Context, t *testing.T) (string, <-chan error) {
 				Level:  "error",
 				Format: "console",
 			},
-			AutoP2PKey: true,
-			P2PRelay:   true,
+			AutoP2PKey:    true,
+			P2PRelay:      true,
+			MaxResPerPeer: 8,
+			ResTTL:        2,
 		})
 	}()
 

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -41,7 +41,7 @@ type BootnodeConfig struct {
 	AutoP2PKey    bool
 	P2PRelay      bool
 	MaxResPerPeer int
-	RelayTimeout  int
+	ResTTL        int
 }
 
 func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.Command {
@@ -69,8 +69,8 @@ func bindBootnodeFlag(flags *pflag.FlagSet, config *BootnodeConfig) {
 	flags.StringVar(&config.HTTPAddr, "bootnode-http-address", "127.0.0.1:16005", "Listening address (ip and port) for the bootnode http server serving runtime ENR")
 	flags.BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
 	flags.BoolVar(&config.P2PRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
-	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 8, "Updates max reservations per peer")
-	flags.IntVar(&config.RelayTimeout, "relay-timeout", 2, "Updates default timout of a relay circuit reservation. (in minutes)")
+	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 8, "Updates max circuit reservations per peer")
+	flags.IntVar(&config.ResTTL, "reservation-ttl", 2, "Updates Reservation Time To Live of a connection between peer and bootnode.")
 }
 
 // RunBootnode starts a p2p-udp discv5 bootnode.
@@ -125,7 +125,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 
 			relayResources := relay.DefaultResources()
 			relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
-			relayResources.Limit.Duration = time.Duration(config.RelayTimeout) * time.Minute
+			relayResources.ReservationTTL = time.Duration(config.ResTTL) * time.Minute
 			relayService, err := relay.New(tcpNode, relay.WithResources(relayResources))
 			if err != nil {
 				p2pErr <- err

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -70,7 +70,7 @@ func bindBootnodeFlag(flags *pflag.FlagSet, config *BootnodeConfig) {
 	flags.BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
 	flags.BoolVar(&config.P2PRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
 	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 8, "Updates max circuit reservations per peer")
-	flags.IntVar(&config.ResTTL, "reservation-ttl", 2, "Updates Reservation Time To Live of a connection between peer and bootnode.")
+	flags.IntVar(&config.ResTTL, "reservation-ttl", 2, "Updates Reservation Time To Live (in minutes) of a connection between peer and bootnode.")
 }
 
 // RunBootnode starts a p2p-udp discv5 bootnode.

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -34,12 +34,14 @@ import (
 
 // BootnodeConfig defines the config of the bootnode.
 type BootnodeConfig struct {
-	DataDir    string
-	HTTPAddr   string
-	P2PConfig  p2p.Config
-	LogConfig  log.Config
-	AutoP2PKey bool
-	P2PRelay   bool
+	DataDir       string
+	HTTPAddr      string
+	P2PConfig     p2p.Config
+	LogConfig     log.Config
+	AutoP2PKey    bool
+	P2PRelay      bool
+	MaxResPerPeer int
+	RelayTimeout  int
 }
 
 func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.Command {
@@ -56,17 +58,19 @@ func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.
 	}
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
-	bindBootnodeFlag(cmd.Flags(), &config.HTTPAddr, &config.AutoP2PKey, &config.P2PRelay)
+	bindBootnodeFlag(cmd.Flags(), &config)
 	bindP2PFlags(cmd.Flags(), &config.P2PConfig)
 	bindLogFlags(cmd.Flags(), &config.LogConfig)
 
 	return cmd
 }
 
-func bindBootnodeFlag(flags *pflag.FlagSet, httpAddr *string, autoP2PKey, p2pRelay *bool) {
-	flags.StringVar(httpAddr, "bootnode-http-address", "127.0.0.1:16005", "Listening address (ip and port) for the bootnode http server serving runtime ENR")
-	flags.BoolVar(autoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
-	flags.BoolVar(p2pRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
+func bindBootnodeFlag(flags *pflag.FlagSet, config *BootnodeConfig) {
+	flags.StringVar(&config.HTTPAddr, "bootnode-http-address", "127.0.0.1:16005", "Listening address (ip and port) for the bootnode http server serving runtime ENR")
+	flags.BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
+	flags.BoolVar(&config.P2PRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
+	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 8, "Updates max reservations per peer")
+	flags.IntVar(&config.RelayTimeout, "relay-timeout", 2, "Updates default timout of a relay circuit reservation. (in minutes)")
 }
 
 // RunBootnode starts a p2p-udp discv5 bootnode.
@@ -119,7 +123,10 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 				return
 			}
 
-			relayService, err := relay.New(tcpNode)
+			relayResources := relay.DefaultResources()
+			relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
+			relayResources.Limit.Duration = time.Duration(config.RelayTimeout) * time.Minute
+			relayService, err := relay.New(tcpNode, relay.WithResources(relayResources))
 			if err != nil {
 				p2pErr <- err
 				return


### PR DESCRIPTION
Adds flags to modify max reservations per peer and relay timeout.

category: bug
ticket: #580
