### PR TITLE
github/workflows: notify main branch failures

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,3 +15,17 @@ jobs:
         with:
           version: v1.45.2
           only-new-issues: true
+
+      - name: notify failure
+        if: failure() && github.ref == 'refs/heads/main'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub
+          DISCORD_AVATAR: https://avatars.githubusercontent.com/u/583231
+          DISCORD_EMBEDS: |
+            [{
+              "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
+              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "color": 10038562
+            }]
+        uses: Ilshidur/action-discord@0.3.2

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -18,3 +18,17 @@ jobs:
         with:
           go-version: '^1.18.0'
       - uses: pre-commit/action@v2.0.3
+
+      - name: notify failure
+        if: failure() && github.ref == 'refs/heads/main'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub
+          DISCORD_AVATAR: https://avatars.githubusercontent.com/u/583231
+          DISCORD_EMBEDS: |
+            [{
+              "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
+              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "color": 10038562
+            }]
+        uses: Ilshidur/action-discord@0.3.2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,16 +63,3 @@ jobs:
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/compose # Pre-build current SHA charon binary
       - run: go test -v github.com/obolnetwork/charon/testutil/compose/compose -integration -sudo-perms -prebuilt-binary=charon
-
-  test_fail:
-    runs-on: ubuntu-latest
-    steps:
-      - run: exit 1
-      - name: notify failure
-        if: always()
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          DISCORD_EMBEDS: ${{ toJson(EVENT_PAYLOAD) }}
-        uses: Ilshidur/action-discord@0.3.2
-        with:
-          args: 'Testing failure notifications: {{ toJson(github) }}'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,3 +63,16 @@ jobs:
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/compose # Pre-build current SHA charon binary
       - run: go test -v github.com/obolnetwork/charon/testutil/compose/compose -integration -sudo-perms -prebuilt-binary=charon
+
+  test_fail:
+    runs-on: ubuntu-latest
+    steps:
+      - run: exit 1
+      - name: notify failure
+        if: always()
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_EMBEDS: ${{ toJson(EVENT_PAYLOAD) }}
+        uses: Ilshidur/action-discord@0.3.2
+        with:
+          args: 'Testing failure notifications: {{ toJson(github) }}'


### PR DESCRIPTION
Add discord notifications when main branch actions fail. Only do this for `pre-commit` and `golangci` for now since they fail the most.

category: misc
ticket: none
