### PR TITLE
tools: install compose

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -35,3 +35,6 @@ import (
 //go:generate go install github.com/bufbuild/buf/cmd/protoc-gen-buf-breaking
 //go:generate go install github.com/bufbuild/buf/cmd/protoc-gen-buf-lint
 //go:generate go install google.golang.org/protobuf/cmd/protoc-gen-go
+
+//go:generate echo Installing tools: compose
+//go:generate go install github.com/obolnetwork/charon/testutil/compose/compose


### PR DESCRIPTION
Installs latest version of `compose` when running `go generate tools.go`.

category: misc
ticket: none
