### PR TITLE
flags: remove peerdb flag

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -72,7 +72,6 @@ func TestCmdFlags(t *testing.T) {
 					TCPAddrs:  []string{"127.0.0.1:16003"},
 					Allowlist: "",
 					Denylist:  "",
-					DBPath:    "",
 				},
 				Feature: featureset.Config{
 					MinStatus: "stable",
@@ -97,7 +96,6 @@ func TestCmdFlags(t *testing.T) {
 				TCPAddrs:  []string{"127.0.0.1:16003"},
 				Allowlist: "",
 				Denylist:  "",
-				DBPath:    "",
 			},
 		},
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,7 +74,6 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
-	flags.StringVar(&config.DBPath, "p2p-peerdb", "", "Path to store a discv5 peer database. Empty default results in in-memory database.")
 	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", nil, "Comma-separated list of discv5 bootnode URLs or ENRs. Example: enode://<hex node id>@10.3.58.6:30303?discport=30301.")
 	flags.BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", false, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.")
 	flags.BoolVar(&config.UDPBootManifest, "p2p-bootmanifest", false, "Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,6 @@ Flags:
       --p2p-denylist string            Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-external-hostname string   The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string         The IP address advertised by libp2p. This may be used to advertise an external IP.
-      --p2p-peerdb string              Path to store a discv5 peer database. Empty default results in in-memory database.
       --p2p-tcp-address strings        Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. (default [127.0.0.1:16003])
       --p2p-udp-address string         Listening UDP address (ip and port) for discv5 discovery. (default "127.0.0.1:16004")
       --simnet-beacon-mock             Enables an internal mock beacon node for running a simnet.

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -25,8 +25,6 @@ import (
 )
 
 type Config struct {
-	// DBPath defines the discv5 peer database file path.
-	DBPath string
 	// UDPBootnodes defines the discv5 boot node URLs.
 	UDPBootnodes []string
 	// UDPBootManifest enables using manifest ENRS as discv5 boot nodes.

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -67,7 +67,8 @@ func NewUDPNode(config Config, ln *enode.LocalNode,
 
 // NewLocalEnode returns a local enode and a peer DB or an error.
 func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *enode.DB, error) {
-	db, err := enode.OpenDB(config.DBPath)
+	// Empty DB Path creates a new in-memory node database without a persistent backend
+	db, err := enode.OpenDB("")
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "open peer db")
 	}


### PR DESCRIPTION
Remove `--p2p-peerdb` flag, so `peerDB` now defaults to a new in-memory database.

category: refactor
ticket: #644 
