### PR TITLE
dkg: fixbuild

### DIFF
--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -37,6 +37,7 @@ import (
 )
 
 // newFrostP2P returns a p2p frost transport implementation.
+//nolint:dupl
 func newFrostP2P(ctx context.Context, tcpNode host.Host, peers map[uint32]peer.ID, clusterID string) *frostP2P {
 	var (
 		round1Recv  = make(chan *pb.FrostRound1Msg, len(peers))


### PR DESCRIPTION
Disables dupl lint for newFrostP2P.

category: fixbuild
ticket: none
