### PR TITLE
flags: rename bootmanifest to bootlock

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -180,11 +180,11 @@ func pingCluster(t *testing.T, test pingTest) {
 				DisablePromWrap: true,
 			},
 			P2P: p2p.Config{
-				UDPBootnodes:    bootnodes,
-				UDPBootManifest: test.BootLock,
-				ExternalHost:    test.ExternalHost,
-				ExternalIP:      test.ExternalIP,
-				BootnodeRelay:   test.BootnodeRelay,
+				UDPBootnodes:  bootnodes,
+				UDPBootLock:   test.BootLock,
+				ExternalHost:  test.ExternalHost,
+				ExternalIP:    test.ExternalIP,
+				BootnodeRelay: test.BootnodeRelay,
 			},
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -76,7 +76,7 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
 	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", nil, "Comma-separated list of discv5 bootnode URLs or ENRs. Example: enode://<hex node id>@10.3.58.6:30303?discport=30301.")
 	flags.BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", false, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.")
-	flags.BoolVar(&config.UDPBootManifest, "p2p-bootmanifest", false, "Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
+	flags.BoolVar(&config.UDPBootLock, "p2p-bootlock", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
 	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "127.0.0.1:16004", "Listening UDP address (ip and port) for discv5 discovery.")
 	flags.StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	flags.StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,7 +100,7 @@ Flags:
       --log-level string               Log level; debug, info, warn or error (default "info")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:16001")
       --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-bootmanifest               Enables using manifest ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
+      --p2p-bootlock                   Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
       --p2p-bootnode-relay             Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
       --p2p-bootnodes strings          Comma-separated list of discv5 bootnode URLs or ENRs. Example: enode://<hex node id>@10.3.58.6:30303?discport=30301.
       --p2p-denylist string            Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -55,7 +55,7 @@ func NewUDPBootnodes(ctx context.Context, config Config, peers []Peer,
 		resp = append(resp, node)
 	}
 
-	if config.UDPBootManifest {
+	if config.UDPBootLock {
 		for _, p := range peers {
 			if p.Enode.ID() == localEnode {
 				// Do not include ourselves as bootnode.

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -27,8 +27,8 @@ import (
 type Config struct {
 	// UDPBootnodes defines the discv5 boot node URLs.
 	UDPBootnodes []string
-	// UDPBootManifest enables using manifest ENRS as discv5 boot nodes.
-	UDPBootManifest bool
+	// UDPBootLock enables using cluster-lock ENRs as discv5 boot nodes.
+	UDPBootLock bool
 	// UDPAddr defines the discv5 udp listen address.
 	UDPAddr string
 	// ExternalIP is the IP advertised by libp2p.

--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -35,7 +35,7 @@ import (
 func NewRelays(conf Config, bootnodes []*enode.Node) ([]Peer, error) {
 	if !conf.BootnodeRelay {
 		return nil, nil
-	} else if conf.UDPBootManifest {
+	} else if conf.UDPBootLock {
 		// Relays not supported via manifest bootnodes yet.
 		return nil, nil
 	}


### PR DESCRIPTION
Rename `--p2p-bootmanifest` flag to `--p2p-bootlock`.

category: refactor
ticket: #642 
