### PR TITLE
core: refactor parsigneddata into an interface

### DIFF
--- a/core/encode.go
+++ b/core/encode.go
@@ -88,56 +88,6 @@ func EncodeAttesterUnsignedData(attData *AttestationData) (UnsignedData, error) 
 	return b, nil
 }
 
-// EncodeAttestationParSignedData returns the attestation as an encoded ParSignedData.
-func EncodeAttestationParSignedData(att *eth2p0.Attestation, shareIdx int) (ParSignedData, error) {
-	data, err := json.Marshal(att)
-	if err != nil {
-		return ParSignedData{}, errors.Wrap(err, "marshal attestation")
-	}
-
-	return ParSignedData{
-		Data:      data,
-		Signature: SigFromETH2(att.Signature), // Copy the signature
-		ShareIdx:  shareIdx,
-	}, nil
-}
-
-// EncodeExitParSignedData returns the signed voluntary exit as an encoded ParSignedData.
-func EncodeExitParSignedData(exit *eth2p0.SignedVoluntaryExit, shareIdx int) (ParSignedData, error) {
-	data, err := json.Marshal(exit)
-	if err != nil {
-		return ParSignedData{}, errors.Wrap(err, "marshal signed voluntary exit")
-	}
-
-	return ParSignedData{
-		Data:      data,
-		Signature: SigFromETH2(exit.Signature),
-		ShareIdx:  shareIdx,
-	}, nil
-}
-
-// DecodeAttestationParSignedData returns the attestation from the encoded ParSignedData.
-func DecodeAttestationParSignedData(data ParSignedData) (*eth2p0.Attestation, error) {
-	att := new(eth2p0.Attestation)
-	err := json.Unmarshal(data.Data, att)
-	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal attestation")
-	}
-
-	return att, nil
-}
-
-// DecodeExitParSignedData returns the signed voluntary exit from the encoded ParSignedData.
-func DecodeExitParSignedData(data ParSignedData) (*eth2p0.SignedVoluntaryExit, error) {
-	exit := new(eth2p0.SignedVoluntaryExit)
-	err := json.Unmarshal(data.Data, exit)
-	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal signed voluntary exit")
-	}
-
-	return exit, nil
-}
-
 // EncodeAttestationAggSignedData returns the attestation as an encoded AggSignedData.
 func EncodeAttestationAggSignedData(att *eth2p0.Attestation) (AggSignedData, error) {
 	data, err := json.Marshal(att)
@@ -160,20 +110,6 @@ func DecodeAttestationAggSignedData(data AggSignedData) (*eth2p0.Attestation, er
 	}
 
 	return att, nil
-}
-
-// EncodeRandaoParSignedData returns the RANDAO reveal as an encoded ParSignedData.
-func EncodeRandaoParSignedData(randao eth2p0.BLSSignature, shareIdx int) ParSignedData {
-	return ParSignedData{
-		Data:      nil, // Randao is just a signature, so keeping data nil.
-		Signature: SigFromETH2(randao),
-		ShareIdx:  shareIdx,
-	}
-}
-
-// DecodeRandaoParSignedData returns the RANDAO reveal from the encoded ParSignedData as BLS signature.
-func DecodeRandaoParSignedData(data ParSignedData) eth2p0.BLSSignature {
-	return data.Signature.ToETH2()
 }
 
 // EncodeRandaoAggSignedData returns the RANDAO reveal as an encoded AggSignedData.
@@ -210,53 +146,7 @@ func DecodeProposerUnsignedData(unsignedData UnsignedData) (*spec.VersionedBeaco
 	return proData, nil
 }
 
-// EncodeBlockParSignedData returns the partially signed block data as an encoded ParSignedData.
-func EncodeBlockParSignedData(block *spec.VersionedSignedBeaconBlock, shareIdx int) (ParSignedData, error) {
-	data, err := json.Marshal(block)
-	if err != nil {
-		return ParSignedData{}, errors.Wrap(err, "marshal block")
-	}
-
-	var sig Signature
-	switch block.Version {
-	case spec.DataVersionPhase0:
-		if block.Phase0 == nil {
-			return ParSignedData{}, errors.New("no phase0 block")
-		}
-		sig = SigFromETH2(block.Phase0.Signature)
-	case spec.DataVersionAltair:
-		if block.Altair == nil {
-			return ParSignedData{}, errors.New("no altair block")
-		}
-		sig = SigFromETH2(block.Altair.Signature)
-	case spec.DataVersionBellatrix:
-		if block.Bellatrix == nil {
-			return ParSignedData{}, errors.New("no bellatrix block")
-		}
-		sig = SigFromETH2(block.Bellatrix.Signature)
-	default:
-		return ParSignedData{}, errors.New("invalid block")
-	}
-
-	return ParSignedData{
-		Data:      data,
-		Signature: sig,
-		ShareIdx:  shareIdx,
-	}, nil
-}
-
-// DecodeBlockParSignedData returns the partially signed block data from the encoded ParSignedData.
-func DecodeBlockParSignedData(data ParSignedData) (*spec.VersionedSignedBeaconBlock, error) {
-	block := new(spec.VersionedSignedBeaconBlock)
-	err := json.Unmarshal(data.Data, block)
-	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal block")
-	}
-
-	return block, nil
-}
-
-// EncodeBlockAggSignedData returns the aggregated signed block data as an encoded AggSignedData.
+// EncodeBlockAggSignedData returns the partially signed block data as an encoded AggSignedData.
 func EncodeBlockAggSignedData(block *spec.VersionedSignedBeaconBlock) (AggSignedData, error) {
 	data, err := json.Marshal(block)
 	if err != nil {

--- a/core/encode_test.go
+++ b/core/encode_test.go
@@ -61,22 +61,6 @@ func TestEncodeAttesterUnsignedData(t *testing.T) {
 	require.Equal(t, data1, data2)
 }
 
-func TestEncodeAttesterParSignedData(t *testing.T) {
-	att1 := testutil.RandomAttestation()
-
-	data1, err := core.EncodeAttestationParSignedData(att1, 1)
-	require.NoError(t, err)
-
-	att2, err := core.DecodeAttestationParSignedData(data1)
-	require.NoError(t, err)
-
-	data2, err := core.EncodeAttestationParSignedData(att2, 1)
-	require.NoError(t, err)
-
-	require.Equal(t, att1, att2)
-	require.Equal(t, data1, data2)
-}
-
 func TestEncodeAttesterAggSignedData(t *testing.T) {
 	att1 := testutil.RandomAttestation()
 
@@ -90,47 +74,6 @@ func TestEncodeAttesterAggSignedData(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, att1, att2)
-	require.Equal(t, data1, data2)
-}
-
-func TestEncodExitAggSignedData(t *testing.T) {
-	exit1 := testutil.RandomExit()
-
-	data1, err := core.EncodeExitAggSignedData(exit1)
-	require.NoError(t, err)
-
-	exit2, err := core.DecodeExitAggSignedData(data1)
-	require.NoError(t, err)
-
-	data2, err := core.EncodeExitAggSignedData(exit2)
-	require.NoError(t, err)
-
-	require.Equal(t, exit1, exit2)
-	require.Equal(t, data1, data2)
-}
-
-func TestEncodeRandaoParSignedData(t *testing.T) {
-	randao1 := testutil.RandomEth2Signature()
-
-	data1 := core.EncodeRandaoParSignedData(randao1, 1)
-	randao2 := core.DecodeRandaoParSignedData(data1)
-	data2 := core.EncodeRandaoParSignedData(randao2, 1)
-
-	require.Equal(t, randao1, randao2)
-	require.Equal(t, data1, data2)
-}
-
-func TestEncodeExitParSignedData(t *testing.T) {
-	exit1 := testutil.RandomExit()
-
-	data1, err := core.EncodeExitParSignedData(exit1, 1)
-	require.NoError(t, err)
-	exit2, err := core.DecodeExitParSignedData(data1)
-	require.NoError(t, err)
-	data2, err := core.EncodeExitParSignedData(exit2, 1)
-	require.NoError(t, err)
-
-	require.Equal(t, exit1, exit2)
 	require.Equal(t, data1, data2)
 }
 
@@ -177,28 +120,6 @@ func TestEncodeProposerUnsignedData(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, proData1, proData2)
-	require.Equal(t, data1, data2)
-}
-
-func TestEncodeBlockParSignedData(t *testing.T) {
-	block1 := &spec.VersionedSignedBeaconBlock{
-		Version: spec.DataVersionPhase0,
-		Phase0: &eth2p0.SignedBeaconBlock{
-			Message:   testutil.RandomPhase0BeaconBlock(),
-			Signature: testutil.RandomEth2Signature(),
-		},
-	}
-
-	data1, err := core.EncodeBlockParSignedData(block1, 0)
-	require.NoError(t, err)
-
-	block2, err := core.DecodeBlockParSignedData(data1)
-	require.NoError(t, err)
-
-	data2, err := core.EncodeBlockParSignedData(block2, 0)
-	require.NoError(t, err)
-
-	require.Equal(t, block1, block2)
 	require.Equal(t, data1, data2)
 }
 

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -87,7 +87,7 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 
 		var exists bool
 		for _, s := range sigs {
-			if s.ShareIdx == sig.ShareIdx {
+			if s.ShareIdx() == sig.ShareIdx() {
 				exists = true
 				break
 			}

--- a/core/parsigex/memory_test.go
+++ b/core/parsigex/memory_test.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 	"testing"
 
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/core"
@@ -44,11 +45,11 @@ func TestMemEx(t *testing.T) {
 		i := i
 		ex := memExFunc()
 		ex.Subscribe(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
-			require.NotEqual(t, i, set[pubkey].ShareIdx, "received from self")
+			require.NotEqual(t, i, set[pubkey].ShareIdx(), "received from self")
 
 			received = append(received, tuple{
 				Target: i,
-				Source: set[pubkey].ShareIdx,
+				Source: set[pubkey].ShareIdx(),
 			})
 
 			return nil
@@ -58,7 +59,7 @@ func TestMemEx(t *testing.T) {
 
 	for i := 0; i < n; i++ {
 		set := make(core.ParSignedDataSet)
-		set[pubkey] = core.ParSignedData{ShareIdx: i}
+		set[pubkey] = core.NewParSig(eth2p0.BLSSignature{}, i)
 
 		err := exes[i].Broadcast(ctx, core.Duty{}, set)
 		require.NoError(t, err)

--- a/core/parsigneddata.go
+++ b/core/parsigneddata.go
@@ -17,7 +17,6 @@ package core
 
 import (
 	"encoding/json"
-	"github.com/obolnetwork/charon/eth2util"
 
 	"github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -30,39 +29,7 @@ var (
 	_ ParSignedData = Attestation{}
 	_ ParSignedData = ParSig{}
 	_ ParSignedData = SignedExit{}
-	_ ParSignedData = SignedEpoch{}
 )
-
-func NewSignedEpoch(epoch eth2p0.Epoch, sig eth2p0.BLSSignature, shareIdx int) SignedEpoch {
-	return SignedEpoch{Epoch: epoch, signature: sig, shareIdx: shareIdx}
-}
-
-// SignedEpoch is a signed epoch that implements ParSignedData.
-type SignedEpoch struct {
-	eth2p0.Epoch
-	signature eth2p0.BLSSignature
-	shareIdx  int
-}
-
-func (r SignedEpoch) DataRoot() (eth2p0.Root, error) {
-	return eth2util.MerkleEpoch(r.Epoch).HashTreeRoot()
-}
-
-func (r SignedEpoch) Signature() Signature {
-	return SigFromETH2(r.signature)
-}
-
-func (r SignedEpoch) ShareIdx() int {
-	return r.shareIdx
-}
-
-func (r SignedEpoch) MarshalData() ([]byte, error) {
-	return json.Marshal(r.Epoch)
-}
-
-func (SignedEpoch) AggSign(sig Signature) (AggSignedData, error) {
-	return EncodeRandaoAggSignedData(sig.ToETH2()), nil
-}
 
 func NewParSig(sig eth2p0.BLSSignature, shareIdx int) ParSig {
 	return ParSig{BLSSignature: sig, shareIdx: shareIdx}

--- a/core/parsigneddata.go
+++ b/core/parsigneddata.go
@@ -1,0 +1,271 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"encoding/json"
+	"github.com/obolnetwork/charon/eth2util"
+
+	"github.com/attestantio/go-eth2-client/spec"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+var (
+	_ ParSignedData = VersionedSignedBeaconBlock{}
+	_ ParSignedData = Attestation{}
+	_ ParSignedData = ParSig{}
+	_ ParSignedData = SignedExit{}
+	_ ParSignedData = SignedEpoch{}
+)
+
+func NewSignedEpoch(epoch eth2p0.Epoch, sig eth2p0.BLSSignature, shareIdx int) SignedEpoch {
+	return SignedEpoch{Epoch: epoch, signature: sig, shareIdx: shareIdx}
+}
+
+// SignedEpoch is a signed epoch that implements ParSignedData.
+type SignedEpoch struct {
+	eth2p0.Epoch
+	signature eth2p0.BLSSignature
+	shareIdx  int
+}
+
+func (r SignedEpoch) DataRoot() (eth2p0.Root, error) {
+	return eth2util.MerkleEpoch(r.Epoch).HashTreeRoot()
+}
+
+func (r SignedEpoch) Signature() Signature {
+	return SigFromETH2(r.signature)
+}
+
+func (r SignedEpoch) ShareIdx() int {
+	return r.shareIdx
+}
+
+func (r SignedEpoch) MarshalData() ([]byte, error) {
+	return json.Marshal(r.Epoch)
+}
+
+func (SignedEpoch) AggSign(sig Signature) (AggSignedData, error) {
+	return EncodeRandaoAggSignedData(sig.ToETH2()), nil
+}
+
+func NewParSig(sig eth2p0.BLSSignature, shareIdx int) ParSig {
+	return ParSig{BLSSignature: sig, shareIdx: shareIdx}
+}
+
+// ParSig is a partial signature that implements ParSignedData without additional data.
+type ParSig struct {
+	eth2p0.BLSSignature
+	shareIdx int
+}
+
+func (ParSig) DataRoot() (eth2p0.Root, error) {
+	// parsig (and randao) is just a signature, it doesn't have other data.
+	return eth2p0.Root{}, nil
+}
+
+func (r ParSig) Signature() Signature {
+	return SigFromETH2(r.BLSSignature)
+}
+
+func (r ParSig) ShareIdx() int {
+	return r.shareIdx
+}
+
+func (ParSig) MarshalData() ([]byte, error) {
+	return nil, nil
+}
+
+func (ParSig) AggSign(sig Signature) (AggSignedData, error) {
+	return EncodeRandaoAggSignedData(sig.ToETH2()), nil
+}
+
+func NewVersionedSignedBeaconBlock(block *spec.VersionedSignedBeaconBlock, shareIdx int) (VersionedSignedBeaconBlock, error) {
+	var sig Signature
+	switch block.Version {
+	case spec.DataVersionPhase0:
+		if block.Phase0 == nil {
+			return VersionedSignedBeaconBlock{}, errors.New("no phase0 block")
+		}
+		sig = SigFromETH2(block.Phase0.Signature)
+	case spec.DataVersionAltair:
+		if block.Altair == nil {
+			return VersionedSignedBeaconBlock{}, errors.New("no altair block")
+		}
+		sig = SigFromETH2(block.Altair.Signature)
+	case spec.DataVersionBellatrix:
+		if block.Bellatrix == nil {
+			return VersionedSignedBeaconBlock{}, errors.New("no bellatrix block")
+		}
+		sig = SigFromETH2(block.Bellatrix.Signature)
+	default:
+		return VersionedSignedBeaconBlock{}, errors.New("invalid block")
+	}
+
+	return VersionedSignedBeaconBlock{
+		VersionedSignedBeaconBlock: *block,
+		signature:                  sig,
+		shareIdx:                   shareIdx,
+	}, nil
+}
+
+// VersionedSignedBeaconBlock is a partially signed versioned beacon block and implements ParSignedData.
+type VersionedSignedBeaconBlock struct {
+	spec.VersionedSignedBeaconBlock
+	signature Signature
+	shareIdx  int
+}
+
+func (b VersionedSignedBeaconBlock) DataRoot() (eth2p0.Root, error) {
+	return b.Root()
+}
+
+func (b VersionedSignedBeaconBlock) Signature() Signature {
+	return b.signature
+}
+
+func (b VersionedSignedBeaconBlock) ShareIdx() int {
+	return b.shareIdx
+}
+
+func (b VersionedSignedBeaconBlock) AggSign(sig Signature) (AggSignedData, error) {
+	switch b.Version {
+	case spec.DataVersionPhase0:
+		if b.Phase0 == nil {
+			return AggSignedData{}, errors.New("no phase0 block")
+		}
+		b.Phase0.Signature = sig.ToETH2()
+	case spec.DataVersionAltair:
+		if b.Altair == nil {
+			return AggSignedData{}, errors.New("no altair block")
+		}
+		b.Altair.Signature = sig.ToETH2()
+	case spec.DataVersionBellatrix:
+		if b.Bellatrix == nil {
+			return AggSignedData{}, errors.New("no bellatrix block")
+		}
+		b.Bellatrix.Signature = sig.ToETH2()
+	default:
+		return AggSignedData{}, errors.New("invalid block")
+	}
+
+	return EncodeBlockAggSignedData(&b.VersionedSignedBeaconBlock)
+}
+
+func (b VersionedSignedBeaconBlock) MarshalData() ([]byte, error) {
+	var (
+		resp []byte
+		err  error
+	)
+	switch b.Version {
+	case spec.DataVersionPhase0:
+		if b.Phase0 == nil {
+			return nil, errors.New("no phase0 block")
+		}
+
+		resp, err = json.Marshal(b.Phase0)
+	case spec.DataVersionAltair:
+		if b.Altair == nil {
+			return nil, errors.New("no altair block")
+		}
+
+		resp, err = json.Marshal(b.Altair)
+	case spec.DataVersionBellatrix:
+		if b.Bellatrix == nil {
+			return nil, errors.New("no bellatrix block")
+		}
+
+		resp, err = json.Marshal(b.Bellatrix)
+	default:
+		return nil, errors.New("invalid block")
+	}
+
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal block")
+	}
+
+	return resp, nil
+}
+
+func NewAttestation(a *eth2p0.Attestation, shareIdx int) Attestation {
+	return Attestation{
+		Attestation: *a,
+		shareIdx:    shareIdx,
+	}
+}
+
+// Attestation is a partially signed attestation and implements ParSignedData.
+type Attestation struct {
+	eth2p0.Attestation
+
+	shareIdx int
+}
+
+func (a Attestation) DataRoot() (eth2p0.Root, error) {
+	return a.Data.HashTreeRoot()
+}
+
+func (a Attestation) Signature() Signature {
+	return SigFromETH2(a.Attestation.Signature)
+}
+
+func (a Attestation) ShareIdx() int {
+	return a.shareIdx
+}
+
+func (a Attestation) AggSign(sig Signature) (AggSignedData, error) {
+	a.Attestation.Signature = sig.ToETH2()
+	return EncodeAttestationAggSignedData(&a.Attestation)
+}
+
+func (a Attestation) MarshalData() ([]byte, error) {
+	return a.Attestation.MarshalJSON()
+}
+
+func NewSignedExit(a *eth2p0.SignedVoluntaryExit, shareIdx int) SignedExit {
+	return SignedExit{
+		SignedVoluntaryExit: *a,
+		shareIdx:            shareIdx,
+	}
+}
+
+type SignedExit struct {
+	eth2p0.SignedVoluntaryExit
+	shareIdx int
+}
+
+func (a SignedExit) DataRoot() (eth2p0.Root, error) {
+	return a.Message.HashTreeRoot()
+}
+
+func (a SignedExit) Signature() Signature {
+	return SigFromETH2(a.SignedVoluntaryExit.Signature)
+}
+
+func (a SignedExit) ShareIdx() int {
+	return a.shareIdx
+}
+
+func (a SignedExit) AggSign(sig Signature) (AggSignedData, error) {
+	a.SignedVoluntaryExit.Signature = sig.ToETH2()
+	return EncodeExitAggSignedData(&a.SignedVoluntaryExit)
+}
+
+func (a SignedExit) MarshalData() ([]byte, error) {
+	return a.SignedVoluntaryExit.MarshalJSON()
+}

--- a/core/proto.go
+++ b/core/proto.go
@@ -81,18 +81,11 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (ParSignedDa
 		}
 
 		return NewSignedExit(&a, int(data.ShareIdx)), nil
-	case DutySignature:
+	case DutySignature, DutyRandao:
 		return ParSig{
 			BLSSignature: Signature(data.Signature).ToETH2(),
 			shareIdx:     int(data.ShareIdx),
 		}, nil
-	case DutyRandao:
-		var a eth2p0.Epoch
-		if err := json.Unmarshal(data.Data, &a); err != nil {
-			return nil, errors.Wrap(err, "unmarshal attestation")
-		}
-
-		return NewSignedEpoch(a, Signature(data.Signature).ToETH2(), int(data.ShareIdx)), nil
 	default:
 		return nil, errors.New("unsupported duty type")
 	}

--- a/core/proto_test.go
+++ b/core/proto_test.go
@@ -16,13 +16,13 @@
 package core_test
 
 import (
-	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
-	"google.golang.org/protobuf/proto"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/obolnetwork/charon/core"
+	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -59,13 +59,6 @@ func TestParSignedDataSetProto(t *testing.T) {
 			Set: core.ParSignedDataSet{
 				testutil.RandomCorePubKey(t): core.NewSignedExit(testutil.RandomExit(), 998),
 				testutil.RandomCorePubKey(t): core.NewSignedExit(testutil.RandomExit(), 998),
-			},
-		},
-		{
-			Type: core.DutyRandao,
-			Set: core.ParSignedDataSet{
-				testutil.RandomCorePubKey(t): core.NewSignedEpoch(testutil.RandomEpoch(), testutil.RandomEth2Signature(), 998),
-				testutil.RandomCorePubKey(t): core.NewSignedEpoch(testutil.RandomEpoch(), testutil.RandomEth2Signature(), 998),
 			},
 		},
 	}

--- a/core/sigagg/sigagg.go
+++ b/core/sigagg/sigagg.go
@@ -22,7 +22,6 @@ package sigagg
 import (
 	"context"
 
-	"github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
@@ -67,7 +66,7 @@ func (a *Aggregator) Aggregate(ctx context.Context, duty core.Duty, pubkey core.
 		firstRoot   eth2p0.Root
 	)
 	for i, parSig := range parSigs {
-		root, err := getSignedRoot(duty.Type, parSig)
+		root, err := parSig.DataRoot()
 		if err != nil {
 			return err
 		}
@@ -78,13 +77,13 @@ func (a *Aggregator) Aggregate(ctx context.Context, duty core.Duty, pubkey core.
 			return errors.New("mismatching signed root")
 		}
 
-		s, err := tblsconv.SigFromCore(parSig.Signature)
+		s, err := tblsconv.SigFromCore(parSig.Signature())
 		if err != nil {
 			return errors.Wrap(err, "convert signature")
 		}
 
 		blsSigs = append(blsSigs, &bls_sig.PartialSignature{
-			Identifier: byte(parSig.ShareIdx),
+			Identifier: byte(parSig.ShareIdx()),
 			Signature:  s.Value,
 		})
 	}
@@ -98,7 +97,7 @@ func (a *Aggregator) Aggregate(ctx context.Context, duty core.Duty, pubkey core.
 	}
 
 	// Inject signature into resulting aggregate signed data.
-	aggSig, err := getAggSignedData(duty.Type, firstParSig, sig)
+	aggSig, err := firstParSig.AggSign(tblsconv.SigToCore(sig))
 	if err != nil {
 		return err
 	}
@@ -114,87 +113,4 @@ func (a *Aggregator) Aggregate(ctx context.Context, duty core.Duty, pubkey core.
 	}
 
 	return nil
-}
-
-// getAggSignedData returns the encoded aggregated signed data by injecting the aggregated signature.
-func getAggSignedData(typ core.DutyType, data core.ParSignedData, aggSig *bls_sig.Signature) (core.AggSignedData, error) {
-	eth2Sig := tblsconv.SigToETH2(aggSig)
-
-	switch typ {
-	case core.DutyAttester:
-		att, err := core.DecodeAttestationParSignedData(data)
-		if err != nil {
-			return core.AggSignedData{}, err
-		}
-		att.Signature = eth2Sig
-
-		return core.EncodeAttestationAggSignedData(att)
-	case core.DutyRandao:
-		return core.EncodeRandaoAggSignedData(eth2Sig), nil
-	case core.DutyProposer:
-		block, err := core.DecodeBlockParSignedData(data)
-		if err != nil {
-			return core.AggSignedData{}, err
-		}
-		switch block.Version {
-		case spec.DataVersionPhase0:
-			block.Phase0.Signature = eth2Sig
-		case spec.DataVersionAltair:
-			block.Altair.Signature = eth2Sig
-		case spec.DataVersionBellatrix:
-			block.Bellatrix.Signature = eth2Sig
-		default:
-			return core.AggSignedData{}, errors.New("invalid block version")
-		}
-
-		return core.EncodeBlockAggSignedData(block)
-	case core.DutyExit:
-		exit, err := core.DecodeExitParSignedData(data)
-		if err != nil {
-			return core.AggSignedData{}, err
-		}
-
-		exit.Signature = eth2Sig
-
-		return core.EncodeExitAggSignedData(exit)
-	default:
-		return core.AggSignedData{}, errors.New("unsupported duty type")
-	}
-}
-
-// getSignedRoot returns the signed object root from the partial signed data.
-func getSignedRoot(typ core.DutyType, data core.ParSignedData) (eth2p0.Root, error) {
-	switch typ {
-	case core.DutyAttester:
-		att, err := core.DecodeAttestationParSignedData(data)
-		if err != nil {
-			return eth2p0.Root{}, err
-		}
-
-		b, err := att.Data.HashTreeRoot()
-		if err != nil {
-			return eth2p0.Root{}, errors.Wrap(err, "hash attestion data")
-		}
-
-		return b, nil
-	case core.DutyRandao:
-		// randao is just a signature, it doesn't have other data to check
-		return eth2p0.Root{}, nil
-	case core.DutyProposer:
-		block, err := core.DecodeBlockParSignedData(data)
-		if err != nil {
-			return eth2p0.Root{}, err
-		}
-
-		return block.Root()
-	case core.DutyExit:
-		ve, err := core.DecodeExitParSignedData(data)
-		if err != nil {
-			return eth2p0.Root{}, err
-		}
-
-		return ve.Message.HashTreeRoot()
-	default:
-		return eth2p0.Root{}, errors.New("unsupported duty type")
-	}
 }

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -18,7 +18,6 @@ package sigagg_test
 import (
 	"context"
 	"crypto/rand"
-	"encoding/json"
 	"testing"
 
 	"github.com/attestantio/go-eth2-client/spec"
@@ -63,9 +62,7 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 		require.NoError(t, err)
 
 		att.Signature = tblsconv.SigToETH2(tblsconv.SigFromPartial(psig))
-
-		parsig, err := core.EncodeAttestationParSignedData(att, int(psig.Identifier))
-		require.NoError(t, err)
+		parsig := core.NewAttestation(att, int(psig.Identifier))
 
 		psigs = append(psigs, psig)
 		parsigs = append(parsigs, parsig)
@@ -120,8 +117,7 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 		require.NoError(t, err)
 
 		sig := tblsconv.SigToETH2(tblsconv.SigFromPartial(psig))
-
-		parsig := core.EncodeRandaoParSignedData(sig, int(psig.Identifier))
+		parsig := core.NewParSig(sig, int(psig.Identifier))
 
 		psigs = append(psigs, psig)
 		parsigs = append(parsigs, parsig)
@@ -179,17 +175,10 @@ func TestSigAgg_DutyExit(t *testing.T) {
 		require.NoError(t, err)
 
 		sig := tblsconv.SigToETH2(tblsconv.SigFromPartial(psig))
-		data, err := json.Marshal(&eth2p0.SignedVoluntaryExit{
+		parsig := core.NewSignedExit(&eth2p0.SignedVoluntaryExit{
 			Message:   exit.Message,
 			Signature: sig,
-		})
-		require.NoError(t, err)
-
-		parsig := core.ParSignedData{
-			Data:      data,
-			Signature: core.SigFromETH2(sig),
-			ShareIdx:  int(psig.Identifier),
-		}
+		}, int(psig.Identifier))
 
 		psigs = append(psigs, psig)
 		parsigs = append(parsigs, parsig)
@@ -284,7 +273,7 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 
 				setSigToSignedBlock(test.block, tblsconv.SigToETH2(tblsconv.SigFromPartial(psig)))
 
-				parsig, err := core.EncodeBlockParSignedData(test.block, int(psig.Identifier))
+				parsig, err := core.NewVersionedSignedBeaconBlock(test.block, int(psig.Identifier))
 				require.NoError(t, err)
 
 				psigs = append(psigs, psig)

--- a/core/types.go
+++ b/core/types.go
@@ -32,14 +32,15 @@ type DutyType int
 const (
 	// DutyType enums MUST not change, it will break backwards compatibility.
 
-	DutyUnknown  DutyType = 0
-	DutyProposer DutyType = 1
-	DutyAttester DutyType = 2
-	DutyRandao   DutyType = 3
-	DutyExit     DutyType = 4
+	DutyUnknown   DutyType = 0
+	DutyProposer  DutyType = 1
+	DutyAttester  DutyType = 2
+	DutyRandao    DutyType = 3
+	DutyExit      DutyType = 4
+	DutySignature DutyType = 5
 	// Only ever append new types here...
 
-	dutySentinel DutyType = 5 // Must always be last
+	dutySentinel DutyType = 6 // Must always be last
 )
 
 func (d DutyType) Valid() bool {
@@ -48,11 +49,12 @@ func (d DutyType) Valid() bool {
 
 func (d DutyType) String() string {
 	return map[DutyType]string{
-		DutyUnknown:  "unknown",
-		DutyAttester: "attester",
-		DutyProposer: "proposer",
-		DutyRandao:   "randao",
-		DutyExit:     "exit",
+		DutyUnknown:   "unknown",
+		DutyAttester:  "attester",
+		DutyProposer:  "proposer",
+		DutyRandao:    "randao",
+		DutyExit:      "exit",
+		DutySignature: "signature",
 	}[d]
 }
 
@@ -211,13 +213,12 @@ type AttestationData struct {
 
 // ParSignedData is a partially signed duty data.
 // Partial refers to it being signed by a single share of the BLS threshold signing scheme.
-type ParSignedData struct {
-	// Data is the partially signed duty data received from VC.
-	Data []byte
-	// Signature of tbls share extracted from data.
-	Signature Signature
-	// ShareIdx of the tbls share.
-	ShareIdx int
+type ParSignedData interface {
+	Signature() Signature
+	DataRoot() (eth2p0.Root, error)
+	ShareIdx() int
+	MarshalData() ([]byte, error)
+	AggSign(Signature) (AggSignedData, error)
 }
 
 // ParSignedDataSet is a set of partially signed duty data objects, one per validator.

--- a/core/types.go
+++ b/core/types.go
@@ -214,11 +214,17 @@ type AttestationData struct {
 // ParSignedData is a partially signed duty data.
 // Partial refers to it being signed by a single share of the BLS threshold signing scheme.
 type ParSignedData interface {
+	// Signature returns the partial signature.
 	Signature() Signature
+	// DataRoot returns the eth2 data root of te duty data used to create the signature.
 	DataRoot() (eth2p0.Root, error)
+	// ShareIdx returns the threshold BLS share index of the partial signature.
 	ShareIdx() int
+	// MarshalData return json marshalled duty data associated with the signature.
 	MarshalData() ([]byte, error)
-	AggSign(Signature) (AggSignedData, error)
+	// AggSign returns the aggregated signed duty data by replacing the partial signature
+	// with the provided aggregated signature.
+	AggSign(aggregate Signature) (AggSignedData, error)
 }
 
 // ParSignedDataSet is a set of partially signed duty data objects, one per validator.

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -33,9 +33,10 @@ func TestBackwardsCompatability(t *testing.T) {
 	require.EqualValues(t, 2, core.DutyAttester)
 	require.EqualValues(t, 3, core.DutyRandao)
 	require.EqualValues(t, 4, core.DutyExit)
+	require.EqualValues(t, 5, core.DutySignature)
 	// Add more types here.
 
-	const sentinel = core.DutyType(5)
+	const sentinel = core.DutyType(6)
 	for i := core.DutyUnknown; i <= sentinel; i++ {
 		if i == core.DutyUnknown {
 			require.False(t, i.Valid())

--- a/core/validatorapi/eth2types.go
+++ b/core/validatorapi/eth2types.go
@@ -25,8 +25,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
-
 	"github.com/obolnetwork/charon/app/errors"
 )
 
@@ -125,27 +123,4 @@ func (v v1Validator) MarshalJSON() ([]byte, error) {
 	}
 
 	return bytes.ToLower(b), nil // ValidatorState must be lower case.
-}
-
-// MerkleEpoch wraps epoch to implement ssz.HashRoot.
-type MerkleEpoch eth2p0.Epoch
-
-func (m MerkleEpoch) HashTreeRoot() ([32]byte, error) {
-	b, err := ssz.HashWithDefaultHasher(m)
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "hash default epoch")
-	}
-
-	return b, nil
-}
-
-func (m MerkleEpoch) HashTreeRootWith(hh *ssz.Hasher) error {
-	indx := hh.Index()
-
-	// Field (1) 'Epoch'
-	hh.PutUint64(uint64(m))
-
-	hh.Merkleize(indx)
-
-	return nil
 }

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -329,10 +329,6 @@ func TestComponent_BeaconBlockProposal(t *testing.T) {
 		vIdx = 1
 	)
 
-	slotsPerEpoch, err := eth2Svc.SlotsPerEpoch(ctx)
-	require.NoError(t, err)
-	epoch := slot / slotsPerEpoch
-
 	component, err := validatorapi.NewComponentInsecure(eth2Svc, vIdx)
 	require.NoError(t, err)
 
@@ -365,7 +361,7 @@ func TestComponent_BeaconBlockProposal(t *testing.T) {
 
 	component.RegisterParSigDB(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
 		require.Equal(t, set, core.ParSignedDataSet{
-			pubkey: core.NewSignedEpoch(eth2p0.Epoch(epoch), randao, vIdx),
+			pubkey: core.NewParSig(randao, vIdx),
 		})
 		require.Equal(t, duty, core.NewRandaoDuty(slot))
 

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -30,18 +30,20 @@ import (
 // to get support from parsigex and parsigdb core components. This may subject to change when DKG
 // package has its own networking and database components.
 // Values of following constants should not change as it can break backwards compatibility.
+type sigType int
+
 const (
 	// dutyLock is responsible for lock hash signed partial signatures exchange and aggregation.
-	dutyLock core.DutyType = 101
+	sigLock sigType = 101
 	// dutyDepositData is responsible for deposit data signed partial signatures exchange and aggregation.
-	dutyDepositData core.DutyType = 102
+	sigDepositData sigType = 102
 )
 
 // sigData includes the fields obtained from sigdb when threshold is reached.
 type sigData struct {
-	duty   core.DutyType
-	pubkey core.PubKey
-	psigs  []core.ParSignedData
+	sigType sigType
+	pubkey  core.PubKey
+	psigs   []core.ParSignedData
 }
 
 // exchanger is responsible for exchanging partial signatures between peers on libp2p.
@@ -71,9 +73,10 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 
 // exchange exhanges partial signatures of lockhash/deposit-data among dkg participants and returns all the partial
 // signatures of the group according to public key of each DV.
-func (e *exchanger) exchange(ctx context.Context, duty core.DutyType, set core.ParSignedDataSet) (map[core.PubKey][]core.ParSignedData, error) {
+func (e *exchanger) exchange(ctx context.Context, sigType sigType, set core.ParSignedDataSet) (map[core.PubKey][]core.ParSignedData, error) {
 	// Start the process by storing current peer's ParSignedDataSet
-	err := e.sigdb.StoreInternal(ctx, core.Duty{Type: duty}, set)
+	duty := core.Duty{Type: core.DutySignature, Slot: int64(sigType)}
+	err := e.sigdb.StoreInternal(ctx, duty, set)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +87,7 @@ func (e *exchanger) exchange(ctx context.Context, duty core.DutyType, set core.P
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		case peerSet := <-e.sigChan:
-			if duty != peerSet.duty {
+			if sigType != peerSet.sigType {
 				// Do nothing if duty doesn't match
 				continue
 			}
@@ -103,9 +106,9 @@ func (e *exchanger) exchange(ctx context.Context, duty core.DutyType, set core.P
 // pushPsigs is responsible for writing partial signature data to sigChan obtained from other peers.
 func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, pk core.PubKey, psigs []core.ParSignedData) error {
 	e.sigChan <- sigData{
-		duty:   duty.Type,
-		pubkey: pk,
-		psigs:  psigs,
+		sigType: sigType(duty.Slot),
+		pubkey:  pk,
+		psigs:   psigs,
 	}
 
 	return nil

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -50,10 +50,7 @@ func TestExchanger(t *testing.T) {
 	for i := 0; i < dvs; i++ {
 		set := make([]core.ParSignedData, nodes)
 		for j := 0; j < nodes; j++ {
-			set[j] = core.ParSignedData{
-				Signature: testutil.RandomCoreSignature(),
-				ShareIdx:  j + 1,
-			}
+			set[j] = core.NewParSig(testutil.RandomEth2Signature(), j+1)
 		}
 		expectedData[pubkeys[i]] = set
 	}
@@ -61,11 +58,11 @@ func TestExchanger(t *testing.T) {
 	dataToBeSent := make(map[int]core.ParSignedDataSet)
 	for pk, psigs := range expectedData {
 		for _, psig := range psigs {
-			_, ok := dataToBeSent[psig.ShareIdx-1]
+			_, ok := dataToBeSent[psig.ShareIdx()-1]
 			if !ok {
-				dataToBeSent[psig.ShareIdx-1] = make(core.ParSignedDataSet)
+				dataToBeSent[psig.ShareIdx()-1] = make(core.ParSignedDataSet)
 			}
-			dataToBeSent[psig.ShareIdx-1][pk] = psig
+			dataToBeSent[psig.ShareIdx()-1][pk] = psig
 		}
 	}
 
@@ -110,7 +107,7 @@ func TestExchanger(t *testing.T) {
 		go func(node int) {
 			defer wg.Done()
 
-			data, err := exchangers[node].exchange(ctx, dutyLock, dataToBeSent[node])
+			data, err := exchangers[node].exchange(ctx, sigLock, dataToBeSent[node])
 			require.NoError(t, err)
 
 			actual = append(actual, data)

--- a/eth2util/epoch.go
+++ b/eth2util/epoch.go
@@ -1,0 +1,30 @@
+package eth2util
+
+import (
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+// MerkleEpoch wraps epoch to implement ssz.HashRoot.
+type MerkleEpoch eth2p0.Epoch
+
+func (m MerkleEpoch) HashTreeRoot() ([32]byte, error) {
+	b, err := ssz.HashWithDefaultHasher(m)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash default epoch")
+	}
+
+	return b, nil
+}
+
+func (m MerkleEpoch) HashTreeRootWith(hh *ssz.Hasher) error {
+	indx := hh.Index()
+
+	// Field (1) 'Epoch'
+	hh.PutUint64(uint64(m))
+
+	hh.Merkleize(indx)
+
+	return nil
+}

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -17,7 +17,6 @@ package p2p
 
 import (
 	"context"
-
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -17,6 +17,7 @@ package p2p
 
 import (
 	"context"
+
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/obolnetwork/charon/eth2util"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -37,7 +38,6 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
-	"github.com/obolnetwork/charon/core/validatorapi"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -165,7 +165,7 @@ func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc, s
 		pubkey = duty.PubKey
 
 		// create randao reveal to propose block
-		sigRoot, err := validatorapi.MerkleEpoch(epoch).HashTreeRoot()
+		sigRoot, err := eth2util.MerkleEpoch(epoch).HashTreeRoot()
 		if err != nil {
 			return err
 		}

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/obolnetwork/charon/eth2util"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -38,6 +37,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"


### PR DESCRIPTION
Refactors `core.ParSignedData` into an interface as experiment to see if this makes the code more robust and readable.

WIP
NO NOT MERGE

category: refactor
ticket: none