### PR TITLE
p2p: implement naive p2p sender

### DIFF
--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -1,0 +1,62 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"context"
+
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/network"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/protocol"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+)
+
+// SendAsync sends a libp2p message and logs a warning on error.
+//   Usage: go p2p.SendAsync(ctx, tcpNode, protoId, peerId, msg)
+func SendAsync(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) {
+	err := sendMsg(ctx, tcpNode, protoID, peerID, msg)
+	if err != nil {
+		log.Warn(ctx, "Failed sending p2p message", err)
+	}
+}
+
+func sendMsg(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) error {
+	b, err := proto.Marshal(msg)
+	if err != nil {
+		return errors.Wrap(err, "marshal proto")
+	}
+
+	// Circuit relay connections are transient
+	s, err := tcpNode.NewStream(network.WithUseTransient(ctx, ""), peerID, protoID)
+	if err != nil {
+		return errors.Wrap(err, "tcpNode stream")
+	}
+
+	_, err = s.Write(b)
+	if err != nil {
+		return errors.Wrap(err, "tcpNode write")
+	}
+
+	if err := s.Close(); err != nil {
+		return errors.Wrap(err, "tcpNode close")
+	}
+
+	return nil
+}

--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -115,18 +116,17 @@ func TestSmoke(t *testing.T) {
 				data.VCs[3].Image = "consensys/teku:22.3"
 			},
 		},
-		// TODO(corver): Enable after https://github.com/ObolNetwork/charon/issues/635
-		//{
-		//	Name: "1 of 4 down",
-		//	TmplFunc: func(data *compose.TmplData) {
-		//		node0 := data.Nodes[0]
-		//		for i := 0; i < len(node0.EnvVars); i++ {
-		//			if strings.HasPrefix(node0.EnvVars[i].Key, "p2p") {
-		//				data.Nodes[0].EnvVars[i].Key = "unset" // Zero p2p flags to it cannot communicate
-		//			}
-		//		}
-		//	},
-		// },
+		{
+			Name: "1 of 4 down",
+			TmplFunc: func(data *compose.TmplData) {
+				node0 := data.Nodes[0]
+				for i := 0; i < len(node0.EnvVars); i++ {
+					if strings.HasPrefix(node0.EnvVars[i].Key, "p2p") {
+						data.Nodes[0].EnvVars[i].Key = "unset" // Zero p2p flags to it cannot communicate
+					}
+				}
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Implement v0 of the p2p sender. It doesn't do log filtering yet. This does however solve the issue of one node being down.

category: feature
ticket: #635 
