### PR TITLE
eth2util: move and refactor epoch hash root

### DIFF
--- a/core/consensus/msg.go
+++ b/core/consensus/msg.go
@@ -122,12 +122,16 @@ func hashProto(msg proto.Message) ([32]byte, error) {
 	hh := ssz.DefaultHasherPool.Get()
 	defer ssz.DefaultHasherPool.Put(hh)
 
+	index := hh.Index()
+
 	// Do deterministic marshalling.
 	b, err := proto.MarshalOptions{Deterministic: true}.Marshal(msg)
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "marshal proto")
 	}
 	hh.PutBytes(b)
+
+	hh.Merkleize(index)
 
 	hash, err := hh.HashRoot()
 	if err != nil {

--- a/core/validatorapi/eth2types.go
+++ b/core/validatorapi/eth2types.go
@@ -25,7 +25,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/obolnetwork/charon/app/errors"
 )
@@ -125,27 +124,4 @@ func (v v1Validator) MarshalJSON() ([]byte, error) {
 	}
 
 	return bytes.ToLower(b), nil // ValidatorState must be lower case.
-}
-
-// MerkleEpoch wraps epoch to implement ssz.HashRoot.
-type MerkleEpoch eth2p0.Epoch
-
-func (m MerkleEpoch) HashTreeRoot() ([32]byte, error) {
-	b, err := ssz.HashWithDefaultHasher(m)
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "hash default epoch")
-	}
-
-	return b, nil
-}
-
-func (m MerkleEpoch) HashTreeRootWith(hh *ssz.Hasher) error {
-	indx := hh.Index()
-
-	// Field (1) 'Epoch'
-	hh.PutUint64(uint64(m))
-
-	hh.Merkleize(indx)
-
-	return nil
 }

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -31,6 +31,7 @@ import (
 	"github.com/obolnetwork/charon/app/tracer"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -478,7 +479,7 @@ func (c Component) verifyRandaoParSig(ctx context.Context, pubKey core.PubKey, s
 	}
 
 	// Randao signing root is the epoch.
-	sigRoot, err := MerkleEpoch(epoch).HashTreeRoot()
+	sigRoot, err := eth2util.EpochHashRoot(epoch)
 	if err != nil {
 		return err
 	}

--- a/eth2util/hash.go
+++ b/eth2util/hash.go
@@ -1,0 +1,42 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2util
+
+import (
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+// EpochHashRoot returns the ssz hash root of the epoch.
+func EpochHashRoot(epoch eth2p0.Epoch) ([32]byte, error) {
+	hasher := ssz.DefaultHasherPool.Get()
+	defer ssz.DefaultHasherPool.Put(hasher)
+
+	indx := hasher.Index()
+
+	hasher.PutUint64(uint64(epoch))
+
+	hasher.Merkleize(indx)
+
+	hash, err := hasher.HashRoot()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash epoch")
+	}
+
+	return hash, nil
+}

--- a/eth2util/hash_test.go
+++ b/eth2util/hash_test.go
@@ -1,0 +1,34 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2util_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/eth2util"
+)
+
+func TestEpochHashRoot(t *testing.T) {
+	resp, err := eth2util.EpochHashRoot(2)
+	require.NoError(t, err)
+	require.Equal(t,
+		"0200000000000000000000000000000000000000000000000000000000000000",
+		hex.EncodeToString(resp[:]),
+	)
+}

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -37,7 +37,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
-	"github.com/obolnetwork/charon/core/validatorapi"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -165,7 +165,7 @@ func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc, s
 		pubkey = duty.PubKey
 
 		// create randao reveal to propose block
-		sigRoot, err := validatorapi.MerkleEpoch(epoch).HashTreeRoot()
+		sigRoot, err := eth2util.EpochHashRoot(epoch)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Move `EpochMerkle` to `eth2util` since it is used by different packages. Also simplify it to a function `EpochHashRoot`.

category: refactor
ticket: none
