### PR TITLE
core/parsigdb: fix mutex issue

### DIFF
--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -121,10 +121,7 @@ func (db *MemDB) store(k key, value core.ParSignedData) ([]core.ParSignedData, b
 
 	db.entries[k] = append(db.entries[k], value)
 
-	var clone []core.ParSignedData
-	copy(clone, db.entries[k])
-
-	return clone, true
+	return append([]core.ParSignedData(nil), db.entries[k]...), true
 }
 
 type key struct {

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -106,7 +106,7 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 	return nil
 }
 
-// store return true if the value was added to the list of signatures at the provided key
+// store returns true if the value was added to the list of signatures at the provided key
 // and returns a copy of the resulting list.
 func (db *MemDB) store(k key, value core.ParSignedData) ([]core.ParSignedData, bool) {
 	db.mu.Lock()


### PR DESCRIPTION
Fixes issue where parsigdb mutex was locked while calling downstream subscribers. 

This aligns with best practice of decreasing locking scope to absolute minimum. 

category: refactor
ticket: none

