### PR TITLE
dkg: move writing of files at the end

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -162,7 +162,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Aggregated deposit data signatures")
 
-	// Write keystores, deposit data and cluster lock files
+	// Write keystores, deposit data and cluster lock files after exchange of partial signatures in order
+	// to prevent partial data writes in case of peer connection lost
 
 	if err := writeKeystores(conf.DataDir, shares); err != nil {
 		return err

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -148,11 +148,6 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.New("unsupported dkg algorithm")
 	}
 
-	if err := writeKeystores(conf.DataDir, shares); err != nil {
-		return err
-	}
-	log.Debug(ctx, "Saved keyshares to disk")
-
 	// Sign, exchange and aggregate Lock Hash signatures
 	lock, err := signAndAggLockHash(ctx, shares, def, nodeIdx, ex)
 	if err != nil {
@@ -160,17 +155,22 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
-	if err = writeLock(conf.DataDir, lock); err != nil {
-		return err
-	}
-	log.Debug(ctx, "Saved lock file to disk")
-
 	// Sign, exchange and aggregate Deposit Data signatures
 	aggSigDepositData, err := signAndAggDepositData(ctx, ex, shares, def.WithdrawalAddress, network, nodeIdx)
 	if err != nil {
 		return err
 	}
 	log.Debug(ctx, "Aggregated deposit data signatures")
+
+	if err := writeKeystores(conf.DataDir, shares); err != nil {
+		return err
+	}
+	log.Debug(ctx, "Saved keyshares to disk")
+
+	if err = writeLock(conf.DataDir, lock); err != nil {
+		return err
+	}
+	log.Debug(ctx, "Saved lock file to disk")
 
 	if err := writeDepositData(aggSigDepositData, def.WithdrawalAddress, network, conf.DataDir); err != nil {
 		return err

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -162,6 +162,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Aggregated deposit data signatures")
 
+	// Write keystores, deposit data and cluster lock files
+
 	if err := writeKeystores(conf.DataDir, shares); err != nil {
 		return err
 	}


### PR DESCRIPTION
Moves writing of files like keystores, cluster-lock and deposit-data at the end of p2p exchange, so that we won't get files written to the disk if any peer drops in between

category: bug
ticket: none
