### PR TITLE
p2p: implement sender log filter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -312,6 +312,8 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
+	sender := new(p2p.Sender)
+
 	sched, err := scheduler.New(corePubkeys, eth2Cl)
 	if err != nil {
 		return err
@@ -339,7 +341,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	if conf.TestConfig.ParSigExFunc != nil {
 		parSigEx = conf.TestConfig.ParSigExFunc()
 	} else {
-		parSigEx = parsigex.NewParSigEx(tcpNode, nodeIdx.PeerIdx, peerIDs)
+		parSigEx = parsigex.NewParSigEx(tcpNode, sender, nodeIdx.PeerIdx, peerIDs)
 	}
 
 	sigAgg := sigagg.New(lock.Threshold)

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -43,7 +43,7 @@ const (
 )
 
 // New returns a new consensus QBFT component.
-func New(tcpNode host.Host, peers []p2p.Peer, p2pKey *ecdsa.PrivateKey) (*Component, error) {
+func New(tcpNode host.Host, sender *p2p.Sender, peers []p2p.Peer, p2pKey *ecdsa.PrivateKey) (*Component, error) {
 	// Extract peer pubkeys.
 	keys := make(map[int64]*ecdsa.PublicKey)
 	for i, p := range peers {
@@ -57,6 +57,7 @@ func New(tcpNode host.Host, peers []p2p.Peer, p2pKey *ecdsa.PrivateKey) (*Compon
 
 	c := &Component{
 		tcpNode:     tcpNode,
+		sender:      sender,
 		peers:       peers,
 		privkey:     p2pKey,
 		pubkeys:     keys,
@@ -108,6 +109,7 @@ func New(tcpNode host.Host, peers []p2p.Peer, p2pKey *ecdsa.PrivateKey) (*Compon
 type Component struct {
 	// Immutable state
 	tcpNode host.Host
+	sender  *p2p.Sender
 	peers   []p2p.Peer
 	pubkeys map[int64]*ecdsa.PublicKey
 	privkey *ecdsa.PrivateKey

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -87,7 +87,7 @@ func TestComponent(t *testing.T) {
 			hosts[i].Peerstore().AddAddrs(hostsInfo[j].ID, hostsInfo[j].Addrs, peerstore.PermanentAddrTTL)
 		}
 
-		c, err := consensus.New(hosts[i], peers, p2pkeys[i])
+		c, err := consensus.New(hosts[i], new(p2p.Sender), peers, p2pkeys[i])
 		require.NoError(t, err)
 		c.Subscribe(func(_ context.Context, _ core.Duty, set core.UnsignedDataSet) error {
 			results <- set

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -35,9 +35,10 @@ import (
 
 const protocol = "/charon/parsigex/1.0.0"
 
-func NewParSigEx(tcpNode host.Host, peerIdx int, peers []peer.ID) *ParSigEx {
+func NewParSigEx(tcpNode host.Host, sender *p2p.Sender, peerIdx int, peers []peer.ID) *ParSigEx {
 	parSigEx := &ParSigEx{
 		tcpNode: tcpNode,
+		sender:  sender,
 		peerIdx: peerIdx,
 		peers:   peers,
 	}
@@ -50,6 +51,7 @@ func NewParSigEx(tcpNode host.Host, peerIdx int, peers []peer.ID) *ParSigEx {
 // It ensures that all partial signatures are persisted by all peers.
 type ParSigEx struct {
 	tcpNode host.Host
+	sender  *p2p.Sender
 	peerIdx int
 	peers   []peer.ID
 	subs    []func(context.Context, core.Duty, core.ParSignedDataSet) error
@@ -104,7 +106,7 @@ func (m *ParSigEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSi
 			continue
 		}
 
-		go p2p.SendAsync(ctx, m.tcpNode, protocol, p, msg)
+		go m.sender.SendAsync(ctx, m.tcpNode, protocol, p, msg)
 	}
 
 	return nil

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -78,7 +78,7 @@ func TestParSigEx(t *testing.T) {
 
 	// create ParSigEx components for each host
 	for i := 0; i < n; i++ {
-		sigex := parsigex.NewParSigEx(hosts[i], new(p2p.Sender), i, peers)
+		sigex := parsigex.NewParSigEx(hosts[i], new(p2p.Sender).Send, i, peers)
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
 			require.Equal(t, duty, d)
 			require.Equal(t, data, set)

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/parsigex"
+	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -77,7 +78,7 @@ func TestParSigEx(t *testing.T) {
 
 	// create ParSigEx components for each host
 	for i := 0; i < n; i++ {
-		sigex := parsigex.NewParSigEx(hosts[i], i, peers)
+		sigex := parsigex.NewParSigEx(hosts[i], new(p2p.Sender), i, peers)
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
 			require.Equal(t, duty, d)
 			require.Equal(t, data, set)

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -57,7 +57,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
 		sigdb:   parsigdb.NewMemDB(len(peers)),
-		sigex:   parsigex.NewParSigEx(tcpNode, new(p2p.Sender), peerIdx, peers),
+		sigex:   parsigex.NewParSigEx(tcpNode, new(p2p.Sender).Send, peerIdx, peers),
 		sigChan: make(chan sigData, len(peers)),
 		numVals: vals,
 	}

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -24,6 +24,7 @@ import (
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/parsigdb"
 	"github.com/obolnetwork/charon/core/parsigex"
+	"github.com/obolnetwork/charon/p2p"
 )
 
 // Note: Following duty types shouldn't be confused with the duty types in core workflow. This was
@@ -56,7 +57,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
 		sigdb:   parsigdb.NewMemDB(len(peers)),
-		sigex:   parsigex.NewParSigEx(tcpNode, peerIdx, peers),
+		sigex:   parsigex.NewParSigEx(tcpNode, new(p2p.Sender), peerIdx, peers),
 		sigChan: make(chan sigData, len(peers)),
 		numVals: vals,
 	}

--- a/p2p/sender_internal_test.go
+++ b/p2p/sender_internal_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package p2p
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+func TestSenderAddResult(t *testing.T) {
+	sender := new(Sender)
+	peerID := peer.ID("test")
+	failure := errors.New("failure")
+	success := error(nil)
+
+	assertFailing := func(t *testing.T, expect bool) {
+		t.Helper()
+		var state peerState
+		if val, ok := sender.states.Load(peerID); ok {
+			state = val.(peerState)
+		}
+		require.Equal(t, expect, state.failing)
+	}
+
+	add := func(result error) {
+		sender.addResult(context.Background(), peerID, result)
+	}
+
+	assertFailing(t, false) // Start not failing
+	add(failure)
+	assertFailing(t, true) // Single failure changes state to failing.
+	add(failure)
+	assertFailing(t, true) // Still failing.
+	add(success)
+	assertFailing(t, true) // Still failing.
+	add(success)
+	assertFailing(t, true) // Still failing.
+	add(success)
+	assertFailing(t, false) // Hysteresis success changes state to success.
+	add(success)
+	assertFailing(t, false) // Still success
+	add(success)
+	assertFailing(t, false) // Still success
+	add(failure)
+	assertFailing(t, true) // Single failure changes state to failing.
+
+	// TODO(corver): Assert logs
+	// INFO P2P sending failing {"peer": "better-week"}
+	// INFO P2P sending recovered {"peer": "better-week"}
+	// INFO P2P sending failing {"peer": "better-week"}
+}


### PR DESCRIPTION
Implement `p2p.Sender` that filters p2p sending logs per peer based on state changes.

Still need to wire and refactor other components to also use `p2p.Sender.`

category: feature
ticket: #635
