### PR TITLE
github/workflows: fix release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
     name: Publish Release
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+        with:
+          go-version: '^1.18.0'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Add go 1.18 so go commands do not fail.

category: misc
ticket: #320 
