### PR TITLE
p2p: refactor send function interface

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -23,7 +23,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"github.com/libp2p/go-libp2p-core/protocol"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 
@@ -36,10 +35,7 @@ import (
 
 const protocolID = "/charon/parsigex/1.0.0"
 
-// SendFunc is the function responsible for sending libp2p messages.
-type SendFunc func(context.Context, host.Host, protocol.ID, peer.ID, proto.Message) error
-
-func NewParSigEx(tcpNode host.Host, sendFunc SendFunc, peerIdx int, peers []peer.ID) *ParSigEx {
+func NewParSigEx(tcpNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []peer.ID) *ParSigEx {
 	parSigEx := &ParSigEx{
 		tcpNode:  tcpNode,
 		sendFunc: sendFunc,
@@ -55,7 +51,7 @@ func NewParSigEx(tcpNode host.Host, sendFunc SendFunc, peerIdx int, peers []peer
 // It ensures that all partial signatures are persisted by all peers.
 type ParSigEx struct {
 	tcpNode  host.Host
-	sendFunc SendFunc
+	sendFunc p2p.SendFunc
 	peerIdx  int
 	peers    []peer.ID
 	subs     []func(context.Context, core.Duty, core.ParSignedDataSet) error

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -78,7 +78,7 @@ func TestParSigEx(t *testing.T) {
 
 	// create ParSigEx components for each host
 	for i := 0; i < n; i++ {
-		sigex := parsigex.NewParSigEx(hosts[i], new(p2p.Sender).Send, i, peers)
+		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers)
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
 			require.Equal(t, duty, d)
 			require.Equal(t, data, set)

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -57,7 +57,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
 		sigdb:   parsigdb.NewMemDB(len(peers)),
-		sigex:   parsigex.NewParSigEx(tcpNode, new(p2p.Sender).Send, peerIdx, peers),
+		sigex:   parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers),
 		sigChan: make(chan sigData, len(peers)),
 		numVals: vals,
 	}

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -39,7 +39,7 @@ const (
 type SendFunc func(context.Context, host.Host, protocol.ID, peer.ID, proto.Message) error
 
 var (
-	_ SendFunc = new(Sender).Send
+	_ SendFunc = Send
 	_ SendFunc = new(Sender).SendAsync
 )
 
@@ -99,7 +99,7 @@ func (s *Sender) addResult(ctx context.Context, peerID peer.ID, err error) {
 // It implements SendFunc.
 func (s *Sender) SendAsync(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) error {
 	go func() {
-		err := s.Send(ctx, tcpNode, protoID, peerID, msg)
+		err := Send(ctx, tcpNode, protoID, peerID, msg)
 		s.addResult(ctx, peerID, err)
 	}()
 
@@ -107,7 +107,7 @@ func (s *Sender) SendAsync(ctx context.Context, tcpNode host.Host, protoID proto
 }
 
 // Send sends a libp2p message synchronously. It implements SendFunc.
-func (*Sender) Send(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) error {
+func Send(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) error {
 	b, err := proto.Marshal(msg)
 	if err != nil {
 		return errors.Wrap(err, "marshal proto")

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -96,6 +96,7 @@ func (s *Sender) addResult(ctx context.Context, peerID peer.ID, err error) {
 }
 
 // SendAsync returns nil sends a libp2p message asynchronously. It logs results on state change (success to/from failure).
+// It implements SendFunc.
 func (s *Sender) SendAsync(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) error {
 	go func() {
 		err := s.Send(ctx, tcpNode, protoID, peerID, msg)
@@ -105,7 +106,7 @@ func (s *Sender) SendAsync(ctx context.Context, tcpNode host.Host, protoID proto
 	return nil
 }
 
-// Send sends a libp2p message synchronously.
+// Send sends a libp2p message synchronously. It implements SendFunc.
 func (*Sender) Send(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message) error {
 	b, err := proto.Marshal(msg)
 	if err != nil {

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -35,6 +35,14 @@ const (
 	senderBuffer     = senderHysteresis + 1
 )
 
+// SendFunc is an abstract function responsible for sending libp2p messages.
+type SendFunc func(context.Context, host.Host, protocol.ID, peer.ID, proto.Message) error
+
+var (
+	_ SendFunc = new(Sender).Send
+	_ SendFunc = new(Sender).SendAsync
+)
+
 type peerState struct {
 	failing bool
 	buffer  []error


### PR DESCRIPTION
Make the interface `p2p.SendFunc` and the implementations `p2p.Sender.Send` and `p2p.Sender.SendAsync` more explicit.

category: refactor
ticket: #635 
