### PR TITLE
testutil/combine: implement BLS secret share combine tool

### DIFF
--- a/tbls/tss.go
+++ b/tbls/tss.go
@@ -216,8 +216,8 @@ func Sign(sk *bls_sig.SecretKey, msg []byte) (*bls_sig.Signature, error) {
 	return sig, nil
 }
 
-// CombineSecrets returns the root/group secret by combining threshold secret shares.
-func CombineSecrets(shares []*bls_sig.SecretKeyShare, t, n int) (*bls_sig.SecretKey, error) {
+// CombineShares returns the root/group secret by combining threshold secret shares.
+func CombineShares(shares []*bls_sig.SecretKeyShare, t, n int) (*bls_sig.SecretKey, error) {
 	var shamirShares []*share.ShamirShare
 	for _, s := range shares {
 		b, err := s.MarshalBinary()

--- a/tbls/tss.go
+++ b/tbls/tss.go
@@ -216,6 +216,42 @@ func Sign(sk *bls_sig.SecretKey, msg []byte) (*bls_sig.Signature, error) {
 	return sig, nil
 }
 
+// CombineSecrets returns the root/group secret by combining threshold secret shares.
+func CombineSecrets(shares []*bls_sig.SecretKeyShare, t, n int) (*bls_sig.SecretKey, error) {
+	var shamirShares []*share.ShamirShare
+	for _, s := range shares {
+		b, err := s.MarshalBinary()
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal key share")
+		}
+
+		lenMin1 := len(b) - 1
+		shamirShare := share.ShamirShare{
+			Id:    uint32(b[lenMin1]),
+			Value: b[:lenMin1],
+		}
+
+		shamirShares = append(shamirShares, &shamirShare)
+	}
+
+	scheme, err := share.NewFeldman(uint32(t), uint32(n), curves.BLS12381G1())
+	if err != nil {
+		return nil, errors.Wrap(err, "new Feldman VSS")
+	}
+
+	secretScaler, err := scheme.Combine(shamirShares...)
+	if err != nil {
+		return nil, errors.Wrap(err, "combine shares")
+	}
+
+	resp := new(bls_sig.SecretKey)
+	if err := resp.UnmarshalBinary(secretScaler.Bytes()); err != nil {
+		return nil, errors.Wrap(err, "unmarshal secret")
+	}
+
+	return resp, nil
+}
+
 // SplitSecret splits the secret and returns n secret shares and t verifiers.
 func SplitSecret(secret *bls_sig.SecretKey, t, n int, reader io.Reader) ([]*bls_sig.SecretKeyShare, *share.FeldmanVerifier, error) {
 	scheme, err := share.NewFeldman(uint32(t), uint32(n), curves.BLS12381G1())

--- a/tbls/tss_test.go
+++ b/tbls/tss_test.go
@@ -38,7 +38,7 @@ func TestGenerateTSS(t *testing.T) {
 	require.Equal(t, shares, tss.NumShares())
 }
 
-func TestCombineSecrets(t *testing.T) {
+func TestCombineShares(t *testing.T) {
 	const (
 		threshold = 3
 		total     = 5
@@ -50,7 +50,7 @@ func TestCombineSecrets(t *testing.T) {
 	shares, _, err := tbls.SplitSecret(secret, threshold, total, rand.Reader)
 	require.NoError(t, err)
 
-	result, err := tbls.CombineSecrets(shares, threshold, total)
+	result, err := tbls.CombineShares(shares, threshold, total)
 	require.NoError(t, err)
 
 	expect, err := secret.MarshalBinary()

--- a/tbls/tss_test.go
+++ b/tbls/tss_test.go
@@ -38,6 +38,29 @@ func TestGenerateTSS(t *testing.T) {
 	require.Equal(t, shares, tss.NumShares())
 }
 
+func TestCombineSecrets(t *testing.T) {
+	const (
+		threshold = 3
+		total     = 5
+	)
+
+	_, secret, err := tbls.Keygen()
+	require.NoError(t, err)
+
+	shares, _, err := tbls.SplitSecret(secret, threshold, total, rand.Reader)
+	require.NoError(t, err)
+
+	result, err := tbls.CombineSecrets(shares, threshold, total)
+	require.NoError(t, err)
+
+	expect, err := secret.MarshalBinary()
+	require.NoError(t, err)
+	actual, err := result.MarshalBinary()
+	require.NoError(t, err)
+
+	require.Equal(t, expect, actual)
+}
+
 func TestAggregateSignatures(t *testing.T) {
 	threshold := 3
 	shares := 5

--- a/testutil/combine/main.go
+++ b/testutil/combine/main.go
@@ -14,6 +14,7 @@
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Command combine combines threshold BLS secret shares into the group/root BLS secret.
+// Note this only combines a single secret at a time.
 package main
 
 import (
@@ -51,7 +52,7 @@ func main() {
 func run(ctx context.Context, lockfile, inputDir, outputDir string) error {
 	log.Info(ctx, "Resharing key shares",
 		z.Str("lockfile", lockfile),
-		z.Str("output_dir", outputDir),
+		z.Str("input_dir", inputDir),
 		z.Str("output_dir", outputDir),
 	)
 

--- a/testutil/combine/main.go
+++ b/testutil/combine/main.go
@@ -34,9 +34,9 @@ import (
 )
 
 var (
-	inputDir  = flag.String("input-dir", ".", "Directory containing the input keyshare to reshare")
-	outputDir = flag.String("output-dir", "output", "Directory to write the reshared output keyshare")
-	lockfile  = flag.String("lock-file", "cluster-lock.json", "Cluster lock file")
+	inputDir  = flag.String("input-dir", ".", "Directory containing the input keyshare to combine")
+	outputDir = flag.String("output-dir", "output", "Directory to write the output combined keyshare")
+	lockfile  = flag.String("lock-file", "cluster-lock.json", "Cluster lock file (required to infer share indexes)")
 )
 
 func main() {

--- a/testutil/combine/main.go
+++ b/testutil/combine/main.go
@@ -1,0 +1,150 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Command combine combines threshold BLS secret shares into the group/root BLS secret.
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"os"
+
+	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/eth2util/keystore"
+	"github.com/obolnetwork/charon/tbls"
+)
+
+var (
+	inputDir  = flag.String("input-dir", ".", "Directory containing the input keyshare to reshare")
+	outputDir = flag.String("output-dir", "output", "Directory to write the reshared output keyshare")
+	lockfile  = flag.String("lock-file", "cluster-lock.json", "Cluster lock file")
+)
+
+func main() {
+	ctx := context.Background()
+	err := run(ctx, *lockfile, *inputDir, *outputDir)
+	if err != nil {
+		log.Error(ctx, "Fatal run error", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, lockfile, inputDir, outputDir string) error {
+	log.Info(ctx, "Resharing key shares",
+		z.Str("lockfile", lockfile),
+		z.Str("output_dir", outputDir),
+		z.Str("output_dir", outputDir),
+	)
+
+	b, err := os.ReadFile(lockfile)
+	if err != nil {
+		return errors.Wrap(err, "read lock file")
+	}
+	var lock cluster.Lock
+	if err := json.Unmarshal(b, &lock); err != nil {
+		return errors.Wrap(err, "unmarshal lock file")
+	}
+
+	secrets, err := keystore.LoadKeys(inputDir)
+	if err != nil {
+		return err
+	}
+
+	shares, err := secretsToShares(lock, secrets)
+	if err != nil {
+		return err
+	}
+
+	if len(shares) < lock.Threshold {
+		return errors.New("insufficient number of keys")
+	}
+
+	secret, err := tbls.CombineSecrets(shares, lock.Threshold, len(lock.Operators))
+	if err != nil {
+		return err
+	}
+
+	return keystore.StoreKeys([]*bls_sig.SecretKey{secret}, outputDir)
+}
+
+//nolint:gocognit // It is just nested loops searching through all DVs to find the index of each share.
+func secretsToShares(lock cluster.Lock, secrets []*bls_sig.SecretKey) ([]*bls_sig.SecretKeyShare, error) {
+	n := len(lock.Operators)
+
+	var resp []*bls_sig.SecretKeyShare
+	for _, secret := range secrets {
+		pubkey, err := secret.GetPublicKey()
+		if err != nil {
+			return nil, errors.Wrap(err, "pubkey from share")
+		}
+
+		expect, err := pubkey.MarshalBinary()
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal pubkey")
+		}
+
+		var found bool
+		for _, val := range lock.Validators {
+			for i := 0; i < n; i++ {
+				pubShare, err := val.PublicShare(i)
+				if err != nil {
+					return nil, errors.Wrap(err, "pubshare from lock")
+				}
+
+				actual, err := pubShare.MarshalBinary()
+				if err != nil {
+					return nil, errors.Wrap(err, "marshal pubshare")
+				}
+
+				if !bytes.Equal(expect, actual) {
+					continue
+				}
+
+				secretBin, err := secret.MarshalBinary()
+				if err != nil {
+					return nil, errors.Wrap(err, "marshalling secret")
+				}
+
+				// ref: https://github.com/coinbase/kryptology/blob/71ffd4cbf01951cd0ee056fc7b45b13ffb178330/pkg/signatures/bls/bls_sig/lib.go#L26
+				share := new(bls_sig.SecretKeyShare)
+				if err := share.UnmarshalBinary(append(secretBin, byte(i+1))); err != nil {
+					return nil, errors.Wrap(err, "unmarshalling share")
+				}
+
+				resp = append(resp, share)
+				found = true
+
+				break
+			}
+
+			if found {
+				break
+			}
+		}
+
+		if !found {
+			return nil, errors.New("share not found in lock")
+		}
+	}
+
+	return resp, nil
+}

--- a/testutil/combine/main.go
+++ b/testutil/combine/main.go
@@ -80,7 +80,7 @@ func run(ctx context.Context, lockfile, inputDir, outputDir string) error {
 		return errors.New("insufficient number of keys")
 	}
 
-	secret, err := tbls.CombineSecrets(shares, lock.Threshold, len(lock.Operators))
+	secret, err := tbls.CombineShares(shares, lock.Threshold, len(lock.Operators))
 	if err != nil {
 		return err
 	}

--- a/testutil/combine/main.go
+++ b/testutil/combine/main.go
@@ -35,12 +35,13 @@ import (
 )
 
 var (
-	inputDir  = flag.String("input-dir", ".", "Directory containing the input keyshare to combine")
+	inputDir  = flag.String("input-dir", ".", "Directory containing the input keyshares to combine")
 	outputDir = flag.String("output-dir", "output", "Directory to write the output combined keyshare")
 	lockfile  = flag.String("lock-file", "cluster-lock.json", "Cluster lock file (required to infer share indexes)")
 )
 
 func main() {
+	flag.Parse()
 	ctx := context.Background()
 	err := run(ctx, *lockfile, *inputDir, *outputDir)
 	if err != nil {

--- a/testutil/combine/main_internal_test.go
+++ b/testutil/combine/main_internal_test.go
@@ -1,0 +1,85 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/eth2util/keystore"
+	"github.com/obolnetwork/charon/tbls/tblsconv"
+)
+
+func TestCombine(t *testing.T) {
+	lock, _, shares := cluster.NewForT(t, 1, 3, 4, 0)
+
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	lockfile := storeLock(t, dir, lock)
+
+	var secrets []*bls_sig.SecretKey
+	for _, share := range shares[0] {
+		secret, err := tblsconv.ShareToSecret(share)
+		require.NoError(t, err)
+		secrets = append(secrets, secret)
+	}
+	err = keystore.StoreKeys(secrets, dir)
+	require.NoError(t, err)
+
+	out, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	err = run(context.Background(), lockfile, dir, out)
+	require.NoError(t, err)
+
+	result, err := keystore.LoadKeys(out)
+	require.NoError(t, err)
+	require.Len(t, result, 1)
+
+	pubkey, err := result[0].GetPublicKey()
+	require.NoError(t, err)
+	actualBytes, err := pubkey.MarshalBinary()
+	require.NoError(t, err)
+
+	pubkey, err = lock.Validators[0].PublicKey()
+	require.NoError(t, err)
+	expectBytes, err := pubkey.MarshalBinary()
+	require.NoError(t, err)
+
+	require.Equal(t, expectBytes, actualBytes)
+}
+
+func storeLock(t *testing.T, dir string, lock cluster.Lock) string {
+	t.Helper()
+
+	b, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	file := path.Join(dir, "lock.json")
+
+	err = os.WriteFile(file, b, 0o755)
+	require.NoError(t, err)
+
+	return file
+}


### PR DESCRIPTION
Simple CLI tool to combine secret shares into a root secret. That can then be used by `create cluster -split-keys` to "reshare" a cluster. 

Note this is only for local dev testing purposes.

category: test
ticket: none
