### PR TITLE
core/qbft: improve logging and slowly increase round timeouts

### DIFF
--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -84,6 +84,7 @@ func New(tcpNode host.Host, sender *p2p.Sender, peers []p2p.Peer, p2pKey *ecdsa.
 		},
 
 		// NewTimer returns a 750ms+(round*250ms) period timer.
+		// TODO(corver): Round timeout is a tradeoff between fast consensus if nodes are down and lifeness in slow networks.
 		NewTimer: func(round int64) (<-chan time.Time, func()) {
 			timer := time.NewTimer(roundStart + (time.Duration(round) * roundIncrease))
 			return timer.C, func() { timer.Stop() }

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -308,6 +308,8 @@ func Run[I any, V comparable](ctx context.Context, d Definition[I, V], t Transpo
 			stopTimer()
 			timerChan, stopTimer = d.NewTimer(round)
 
+			d.LogUponRule(ctx, instance, process, round, nil, "RoundTimeout")
+
 			err = broadcastRoundChange()
 
 		case <-ctx.Done(): // Cancelled

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -238,6 +238,10 @@ func testQBFT(t *testing.T, test test) {
 			resultChan <- qcommit
 		},
 		LogUponRule: func(_ context.Context, instance int64, process, round int64, msg Msg[int64, int64], rule string) {
+			if msg == nil {
+				t.Logf("%s %v@%d ~= %v", clock.NowStr(), process, round, rule)
+				return
+			}
 			t.Logf("%s %d => %v@%d -> %v@%d ~= %v", clock.NowStr(), msg.Source(), msg.Type(), msg.Round(), process, round, rule)
 			if round > maxRound {
 				cancel()


### PR DESCRIPTION
Incremental improvements after testnet dry run. 
 - Add round to upon rule debug logging
 - Add round timeout debug logging
 - Increase round timeout by 250ms per round to support slow networks.  

category: refactor
ticket: none
feature_flag: qbft_consensus