### PR TITLE
core/validatorapi: fix proxy response flushing

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -654,7 +654,7 @@ type writeFlusher interface {
 	http.Flusher
 }
 
-// proxyResponseWriter wraps a http response writer and instruments errors.
+// proxyResponseWriter wraps the writeFlusher interface and instruments errors.
 type proxyResponseWriter struct {
 	writeFlusher
 }


### PR DESCRIPTION
Fix event stream proxy issue. Since we wrapped the response writer in our own type, it didn't implement http.Flusher, so streaming responses were not proxied/flushed to the client.

category: bug
ticket: #688 
