### PR TITLE
cmd: fix bootnode reservation issue

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -256,7 +256,6 @@ func startBootnode(ctx context.Context, t *testing.T) (string, <-chan error) {
 			AutoP2PKey:    true,
 			P2PRelay:      true,
 			MaxResPerPeer: 8,
-			ResTTL:        2,
 		})
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/ferranbt/fastssz v0.0.0-20220103083642-bc5fefefa28b
 	github.com/goccy/go-yaml v1.9.5
 	github.com/gorilla/mux v1.8.0
+	github.com/ipfs/go-log/v2 v2.5.1
 	github.com/jonboulle/clockwork v0.3.0
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/libp2p/go-libp2p v0.20.0
@@ -82,7 +83,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/ipfs/go-cid v0.1.0 // indirect
 	github.com/ipfs/go-ipfs-util v0.0.2 // indirect
-	github.com/ipfs/go-log/v2 v2.5.1 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jdxcode/netrc v0.0.0-20210204082910-926c7f70242a // indirect


### PR DESCRIPTION
Fixes bootnode "reservation refused" issue. Turns out, `ReservationTTL` doesn't control how long reservations are valid for, instead `validity = 30min` is hardcoded in `github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay/constraints.go:14`.

So remove `reservation-ttl` flag and increase the default `max-reservations` to 30 (1/min). 

Also add default info relay logs for more visibility.

category: bug
ticket: none
