### PR TITLE
core: rename fetch args and update docs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -575,7 +575,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 	signer := validatormock.NewSigner(secrets...)
 
 	// Trigger validatormock when scheduler triggers new slot.
-	sched.Subscribe(func(ctx context.Context, duty core.Duty, _ core.FetchArgSet) error {
+	sched.Subscribe(func(ctx context.Context, duty core.Duty, _ core.DutyDefinitionSet) error {
 		ctx = log.WithTopic(ctx, "vmock")
 		go func() {
 			addr := "http://" + conf.ValidatorAPIAddr

--- a/core/dutydefinition.go
+++ b/core/dutydefinition.go
@@ -22,8 +22,8 @@ import (
 )
 
 var (
-	_ FetchArg = AttesterDefinition{}
-	_ FetchArg = ProposerDefinition{}
+	_ DutyDefinition = AttesterDefinition{}
+	_ DutyDefinition = ProposerDefinition{}
 )
 
 // NewAttesterDefinition is a convenience function that returns a new attester definition.
@@ -31,13 +31,13 @@ func NewAttesterDefinition(duty *eth2v1.AttesterDuty) AttesterDefinition {
 	return AttesterDefinition{AttesterDuty: *duty}
 }
 
-// AttesterDefinition defines an attester duty. It implements FetchArg.
+// AttesterDefinition defines an attester duty. It implements DutyDefinition.
 // Note the slight rename from Duty to Definition to avoid overloading the term Duty.
 type AttesterDefinition struct {
 	eth2v1.AttesterDuty
 }
 
-func (d AttesterDefinition) Clone() (FetchArg, error) {
+func (d AttesterDefinition) Clone() (DutyDefinition, error) {
 	duty := new(eth2v1.AttesterDuty)
 	err := cloneJSONMarshaler(&d.AttesterDuty, duty)
 	if err != nil {
@@ -56,13 +56,13 @@ func NewProposerDefinition(duty *eth2v1.ProposerDuty) ProposerDefinition {
 	return ProposerDefinition{ProposerDuty: *duty}
 }
 
-// ProposerDefinition defines a block proposer duty. It implements FetchArg.
+// ProposerDefinition defines a block proposer duty. It implements DutyDefinition.
 // Note the slight rename from Duty to Definition to avoid overloading the term Duty.
 type ProposerDefinition struct {
 	eth2v1.ProposerDuty
 }
 
-func (d ProposerDefinition) Clone() (FetchArg, error) {
+func (d ProposerDefinition) Clone() (DutyDefinition, error) {
 	duty := new(eth2v1.ProposerDuty)
 	err := cloneJSONMarshaler(&d.ProposerDuty, duty)
 	if err != nil {

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -106,8 +106,8 @@ func (f *Fetcher) fetchAttesterData(ctx context.Context, slot int64, defSet core
 	dataByCommIdx := make(map[eth2p0.CommitteeIndex]*eth2p0.AttestationData)
 
 	resp := make(core.UnsignedDataSet)
-	for pubkey, DutyDefinition := range defSet {
-		attDuty, ok := DutyDefinition.(core.AttesterDefinition)
+	for pubkey, def := range defSet {
+		attDuty, ok := def.(core.AttesterDefinition)
 		if !ok {
 			return nil, errors.New("invalid attester definition")
 		}

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -61,7 +61,7 @@ func TestFetchAttester(t *testing.T) {
 		CommitteesAtSlot: notZero,
 	}
 
-	argSet := core.FetchArgSet{
+	defSet := core.DutyDefinitionSet{
 		pubkeysByIdx[vIdxA]: core.NewAttesterDefinition(&dutyA),
 		pubkeysByIdx[vIdxB]: core.NewAttesterDefinition(&dutyB),
 	}
@@ -89,7 +89,7 @@ func TestFetchAttester(t *testing.T) {
 		return nil
 	})
 
-	err = fetch.Fetch(ctx, duty, argSet)
+	err = fetch.Fetch(ctx, duty, defSet)
 	require.NoError(t, err)
 }
 
@@ -115,7 +115,7 @@ func TestFetchProposer(t *testing.T) {
 		Slot:           slot,
 		ValidatorIndex: vIdxB,
 	}
-	argSet := core.FetchArgSet{
+	defSet := core.DutyDefinitionSet{
 		pubkeysByIdx[vIdxA]: core.NewProposerDefinition(&dutyA),
 		pubkeysByIdx[vIdxB]: core.NewProposerDefinition(&dutyB),
 	}
@@ -156,7 +156,7 @@ func TestFetchProposer(t *testing.T) {
 		return nil
 	})
 
-	err = fetch.Fetch(ctx, duty, argSet)
+	err = fetch.Fetch(ctx, duty, defSet)
 	require.NoError(t, err)
 }
 

--- a/core/retry.go
+++ b/core/retry.go
@@ -25,7 +25,7 @@ import (
 func WithAsyncRetry(retryer *retry.Retryer[Duty]) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
-		w.FetcherFetch = func(ctx context.Context, duty Duty, set FetchArgSet) error {
+		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
 			go retryer.DoAsync(ctx, duty, "fetcher fetch", func(ctx context.Context) error {
 				return clone.FetcherFetch(ctx, duty, set)
 			})

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -52,8 +52,8 @@ func instrumentSlot(slot slot) {
 }
 
 // instrumentDuty increments the duty counter.
-func instrumentDuty(duty core.Duty, argSet core.FetchArgSet) {
-	for pubkey := range argSet {
+func instrumentDuty(duty core.Duty, defSet core.DutyDefinitionSet) {
+	for pubkey := range defSet {
 		dutyCounter.WithLabelValues(duty.Type.String(), pubkey.String()).Inc()
 	}
 }

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -132,7 +132,7 @@ func (s *Scheduler) Run() error {
 	}
 }
 
-// GetDuty returns the defSet for a duty if resolved already, otherwise an error.
+// GetDutyDefinition returns the definition for a duty if resolved already, otherwise an error.
 func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
 	slotsPerEpoch, err := s.eth2Cl.SlotsPerEpoch(ctx)
 	if err != nil {

--- a/core/scheduler/testdata/TestSchedulerDuties_grouped.golden
+++ b/core/scheduler/testdata/TestSchedulerDuties_grouped.golden
@@ -2,14 +2,14 @@
  {
   "Time": "00:00.000",
   "duty": "0/proposer",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\"}"
   }
  },
  {
   "Time": "00:04.000",
   "duty": "0/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"0\",\"validator_index\":\"2\",\"committee_index\":\"0\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"2\"}",
    "0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"0\",\"validator_index\":\"3\",\"committee_index\":\"0\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"3\"}",
    "0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"1\"}"

--- a/core/scheduler/testdata/TestSchedulerDuties_spread.golden
+++ b/core/scheduler/testdata/TestSchedulerDuties_spread.golden
@@ -2,42 +2,42 @@
  {
   "Time": "00:00.000",
   "duty": "0/proposer",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\"}"
   }
  },
  {
   "Time": "00:04.000",
   "duty": "0/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"1\"}"
   }
  },
  {
   "Time": "00:00.000",
   "duty": "1/proposer",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"1\",\"validator_index\":\"2\"}"
   }
  },
  {
   "Time": "00:16.000",
   "duty": "1/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"1\",\"validator_index\":\"2\",\"committee_index\":\"1\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"2\"}"
   }
  },
  {
   "Time": "00:00.000",
   "duty": "2/proposer",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"2\",\"validator_index\":\"3\"}"
   }
  },
  {
   "Time": "00:28.000",
   "duty": "2/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"2\",\"validator_index\":\"3\",\"committee_index\":\"2\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"3\"}"
   }
  }

--- a/core/scheduler/testdata/TestSchedulerDuties_spread_errors.golden
+++ b/core/scheduler/testdata/TestSchedulerDuties_spread_errors.golden
@@ -2,35 +2,35 @@
  {
   "Time": "00:04.000",
   "duty": "0/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490": "{\"pubkey\":\"0x914cff835a769156ba43ad50b931083c2dadd94e8359ce394bc7a3e06424d0214922ddf15f81640530b9c25c0bc0d490\",\"slot\":\"0\",\"validator_index\":\"1\",\"committee_index\":\"0\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"1\"}"
   }
  },
  {
   "Time": "00:00.000",
   "duty": "1/proposer",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"1\",\"validator_index\":\"2\"}"
   }
  },
  {
   "Time": "00:16.000",
   "duty": "1/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea": "{\"pubkey\":\"0x8dae41352b69f2b3a1c0b05330c1bf65f03730c520273028864b11fcb94d8ce8f26d64f979a0ee3025467f45fd2241ea\",\"slot\":\"1\",\"validator_index\":\"2\",\"committee_index\":\"1\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"2\"}"
   }
  },
  {
   "Time": "00:00.000",
   "duty": "2/proposer",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"2\",\"validator_index\":\"3\"}"
   }
  },
  {
   "Time": "00:28.000",
   "duty": "2/attester",
-  "DutyArgSet": {
+  "DutyDefSet": {
    "0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76": "{\"pubkey\":\"0x8ee91545183c8c2db86633626f5074fd8ef93c4c9b7a2879ad1768f600c5b5906c3af20d47de42c3b032956fa8db1a76\",\"slot\":\"2\",\"validator_index\":\"3\",\"committee_index\":\"2\",\"committee_length\":\"16\",\"committees_at_slot\":\"16\",\"validator_committee_index\":\"3\"}"
   }
  }

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -66,7 +66,7 @@ func WithTracing() WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
 
-		w.FetcherFetch = func(parent context.Context, duty Duty, set FetchArgSet) error {
+		w.FetcherFetch = func(parent context.Context, duty Duty, set DutyDefinitionSet) error {
 			ctx, span := tracer.Start(parent, "core/fetcher.Fetch")
 			defer span.End()
 

--- a/core/types.go
+++ b/core/types.go
@@ -168,14 +168,13 @@ func (k PubKey) ToETH2() (eth2p0.BLSPubKey, error) {
 	return resp, nil
 }
 
-// DutyDefinition defines a duty containing the parameters required
+// DutyDefinition defines the duty including parameters required
 // to fetch the duty data, it is the result of resolving duties
 // at the start of an epoch.
 type DutyDefinition interface {
-	// Clone returns a cloned copy of the DutyDefinition. For an immutable core workflow architecture,
-	// remember to clone data when it leaves the current scope (sharing, storing, returning, etc).
+	// Clone returns a cloned copy of the DutyDefinition.
 	Clone() (DutyDefinition, error)
-	// Marshaler returns the json serialised unsigned duty data.
+	// Marshaler returns the json serialised duty definition.
 	json.Marshaler
 }
 

--- a/core/types.go
+++ b/core/types.go
@@ -168,26 +168,24 @@ func (k PubKey) ToETH2() (eth2p0.BLSPubKey, error) {
 	return resp, nil
 }
 
-// FetchArg defines a duty containing the parameters required
+// DutyDefinition defines a duty containing the parameters required
 // to fetch the duty data, it is the result of resolving duties
 // at the start of an epoch.
-// TODO(corver): Rename to DutyDefinition.
-type FetchArg interface {
-	// Clone returns a cloned copy of the FetchArg. For an immutable core workflow architecture,
+type DutyDefinition interface {
+	// Clone returns a cloned copy of the DutyDefinition. For an immutable core workflow architecture,
 	// remember to clone data when it leaves the current scope (sharing, storing, returning, etc).
-	Clone() (FetchArg, error)
+	Clone() (DutyDefinition, error)
 	// Marshaler returns the json serialised unsigned duty data.
 	json.Marshaler
 }
 
-// FetchArgSet is a set of fetch args, one per validator.
-// TODO(corver): Rename to DutyDefinitionSet.
-type FetchArgSet map[PubKey]FetchArg
+// DutyDefinitionSet is a set of duty definitions, one per validator.
+type DutyDefinitionSet map[PubKey]DutyDefinition
 
-// Clone returns a cloned copy of the FetchArgSet. For an immutable core workflow architecture,
+// Clone returns a cloned copy of the DutyDefinitionSet. For an immutable core workflow architecture,
 // remember to clone data when it leaves the current scope (sharing, storing, returning, etc).
-func (s FetchArgSet) Clone() (FetchArgSet, error) {
-	resp := make(FetchArgSet, len(s))
+func (s DutyDefinitionSet) Clone() (DutyDefinitionSet, error) {
+	resp := make(DutyDefinitionSet, len(s))
 	for key, data := range s {
 		var err error
 		resp[key], err = data.Clone()

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -351,8 +351,8 @@ func TestComponent_BeaconBlockProposal(t *testing.T) {
 	block1.Phase0.ProposerIndex = vIdx
 	block1.Phase0.Body.RANDAOReveal = randao
 
-	component.RegisterGetDutyFunc(func(ctx context.Context, duty core.Duty) (core.FetchArgSet, error) {
-		return core.FetchArgSet{pubkey: nil}, nil
+	component.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+		return core.DutyDefinitionSet{pubkey: nil}, nil
 	})
 
 	component.RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error) {
@@ -413,8 +413,8 @@ func TestComponent_SubmitBeaconBlock(t *testing.T) {
 	unsignedBlock.Phase0.Slot = slot
 	unsignedBlock.Phase0.ProposerIndex = vIdx
 
-	vapi.RegisterGetDutyFunc(func(ctx context.Context, duty core.Duty) (core.FetchArgSet, error) {
-		return core.FetchArgSet{corePubKey: nil}, nil
+	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+		return core.DutyDefinitionSet{corePubKey: nil}, nil
 	})
 
 	// Sign beacon block
@@ -491,8 +491,8 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	unsignedBlock.Phase0.Slot = slot
 	unsignedBlock.Phase0.ProposerIndex = vIdx
 
-	vapi.RegisterGetDutyFunc(func(ctx context.Context, duty core.Duty) (core.FetchArgSet, error) {
-		return core.FetchArgSet{corePubKey: nil}, nil
+	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+		return core.DutyDefinitionSet{corePubKey: nil}, nil
 	})
 
 	// Add invalid Signature to beacon block
@@ -541,8 +541,8 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
 	require.NoError(t, err)
 
-	vapi.RegisterGetDutyFunc(func(ctx context.Context, duty core.Duty) (core.FetchArgSet, error) {
-		return core.FetchArgSet{pubkey: nil}, nil
+	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+		return core.DutyDefinitionSet{pubkey: nil}, nil
 	})
 
 	// invalid block scenarios

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -361,7 +361,7 @@ type ParSignedData struct {
 
 ```
 
-The following `SignedData` implementations are provided: `Attestation`, `VersionedSignedBeaconBlock`, `SignedVoluntaryExit`, and `Signature` which just a signature without any data used for `DutyRandao`.
+The following `SignedData` implementations are provided: `Attestation`, `VersionedSignedBeaconBlock`, `SignedVoluntaryExit`, and `Signature` which is just a signature without any data used for `DutyRandao`.
 
 Multiple `ParSignedData` are combined into a single `ParSignedDataSet` defines as follows:
 ```go
@@ -436,7 +436,7 @@ Duties originating in the `scheduler` (`DutyAttester`, `DutyProposer`) are not s
 Instead of waiting for the `validatorapi` to submit signatures, these duties directly request
 signatures from the remote signer instance. The flow is otherwise unaffected.
 
-Duties originating in the `validatorapi` (`DutyRandao`, `DutyAggregator`) has to refactored to
+Duties originating in the `validatorapi` (`DutyRandao`, `DutyExit`) has to refactored to
 originate in the `scheduler`, since charon is in full control of the duties in this architecture.
 
 The overall core workflow remains the same, `scheduler` just schedules all the duties.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,13 +149,13 @@ An abstract `DutyDefinition` type is defined that represents the json formatted 
 Note the ETH2 spec refers to these as "duties", but we use a slightly different term to avoid overloading
 the term "duty" which we defined above.
 ```go
-// DutyDefinition defines a duty containing the parameters required
+// DutyDefinition defines a duty including parameters required
 // to fetch the duty data, it is the result of resolving duties
 // at the start of an epoch.
 type DutyDefinition interface {
   // Clone returns a cloned copy of the DutyDefinition.
   Clone() (DutyDefinition, error)
-  // Marshaler returns the json serialised unsigned duty data.
+  // Marshaler returns the json serialised duty definition.
   json.Marshaler
 }
 ```
@@ -360,6 +360,8 @@ type ParSignedData struct {
 }
 
 ```
+
+The following `SignedData` implementations are provided: `Attestation`, `VersionedSignedBeaconBlock`, `SignedVoluntaryExit`, and `Signature` which just a signature without any data used for `DutyRandao`.
 
 Multiple `ParSignedData` are combined into a single `ParSignedDataSet` defines as follows:
 ```go

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -146,6 +146,8 @@ at the end of each epoch for the next epoch. It then caches the results returned
 when the associated slot starts.
 
 An abstract `DutyDefinition` type is defined that represents the json formatted responses returned by the beacon node above.
+Note the ETH2 spec refers to these as "duties", but we use a slightly different term to avoid overloading
+the term "duty" which we defined above.
 ```go
 // DutyDefinition defines a duty containing the parameters required
 // to fetch the duty data, it is the result of resolving duties

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -27,7 +27,7 @@ charon/             # project root
 │
 ├─ core/            # core workflow; charon business logic (see architecture doc for details)
 │  ├─ interfaces.go # component interfaces: Scheduler, Fetcher, Consensus, etc.
-│  ├─ types.go      # core workflow types: Duty, PubKey, FetchArg, UnsignedData, etc.
+│  ├─ types.go      # core workflow types: Duty, PubKey, DutyDefinition, UnsignedData, etc.
 │  ├─ encode.go     # encode/decode the abstract types with type safe API
 │  │
 │  │                # core workflow component implementations


### PR DESCRIPTION
Renames `FetchArgs` to `DutyDefinition` and update docs.

category: refactor
ticket: #698 
