### PR TITLE
testutil/compose: run smoke tests in parallel

### DIFF
--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -132,6 +132,8 @@ func TestSmoke(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			t.Parallel()
+
 			dir, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 


### PR DESCRIPTION
Runs smoke tests in parallel for faster feedback.

category: test
ticket: #631 
