### PR TITLE
build: charon cluster deployment workflow

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -41,3 +41,11 @@ jobs:
         push: true
         build-args: GITHUB_SHA=${{ github.sha }}
         tags: ${{ steps.meta.outputs.tags }}
+        
+    - name: Deploy charon
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.CHARON_K8S_REPO_ACCESS_TOKEN }}
+        repository: ObolNetwork/charon-k8s
+        event-type: charon-package-published
+        client-payload: '{"sha": "${{ github.sha }}"}'

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -41,7 +41,7 @@ jobs:
         push: true
         build-args: GITHUB_SHA=${{ github.sha }}
         tags: ${{ steps.meta.outputs.tags }}
-        
+
     - name: Deploy charon
       uses: peter-evans/repository-dispatch@v2
       with:


### PR DESCRIPTION
Add a step to the build workflow to trigger/dispatch the Charon cluster deployment workflow in the Charon-k8s repository. This will deploy/update the long-lived Charon clusters running on the GKE dev env.

This step dispatches a package published event each time a new Charon image is pushed to the Github registry. The actual deployment workflow is in the charon-k8s repo.


category: misc
ticket: none
