### PR TITLE
refactor: change cluster-lock default dir

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -79,7 +79,7 @@ func TestCmdFlags(t *testing.T) {
 					Enabled:   nil,
 					Disabled:  nil,
 				},
-				LockFile:         ".charon/cluster-lock.json",
+				LockFile:         ".charon/cluster/cluster-lock.json",
 				DataDir:          "from_env",
 				MonitoringAddr:   "127.0.0.1:3620",
 				ValidatorAPIAddr: "127.0.0.1:3600",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 }
 
 func bindRunFlags(flags *pflag.FlagSet, config *app.Config) {
-	flags.StringVar(&config.LockFile, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster")
+	flags.StringVar(&config.LockFile, "lock-file", ".charon/cluster/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster")
 	flags.StringVar(&config.BeaconNodeAddr, "beacon-node-endpoint", "http://localhost/", "Beacon node endpoint URL")
 	flags.StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API")
 	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the monitoring API (prometheus, pprof)")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,7 +91,7 @@ Flags:
   -h, --help                           Help for run
       --jaeger-address string          Listening address for jaeger tracing
       --jaeger-service string          Service name used for jaeger tracing (default "charon")
-      --lock-file string               The path to the cluster lock file defining distributed validator cluster (default ".charon/cluster-lock.json")
+      --lock-file string               The path to the cluster lock file defining distributed validator cluster (default ".charon/cluster/cluster-lock.json")
       --log-format string              Log format; console, logfmt or json (default "console")
       --log-level string               Log level; debug, info, warn or error (default "info")
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:3620")


### PR DESCRIPTION
Change `cluster-lock` default dir to `.charon/cluster/cluster-lock.json`

category: refactor
ticket: none
