### PR TITLE
refactor: update default bootnode ports

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -68,7 +68,7 @@ func TestCmdFlags(t *testing.T) {
 					Format: "console",
 				},
 				P2P: p2p.Config{
-					UDPBootnodes: []string{"http://bootnode.gcp.obol.tech:16000/enr"},
+					UDPBootnodes: []string{"http://bootnode.gcp.obol.tech:3640/enr"},
 					UDPAddr:      "127.0.0.1:3630",
 					TCPAddrs:     []string{"127.0.0.1:3610"},
 					Allowlist:    "",
@@ -93,7 +93,7 @@ func TestCmdFlags(t *testing.T) {
 			Args:    slice("create", "enr"),
 			Datadir: ".charon",
 			P2PConfig: &p2p.Config{
-				UDPBootnodes: []string{"http://bootnode.gcp.obol.tech:16000/enr"},
+				UDPBootnodes: []string{"http://bootnode.gcp.obol.tech:3640/enr"},
 				UDPAddr:      "127.0.0.1:3630",
 				TCPAddrs:     []string{"127.0.0.1:3610"},
 				Allowlist:    "",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,7 +74,7 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 }
 
 func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
-	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.gcp.obol.tech:16000/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
+	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.gcp.obol.tech:3640/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
 	flags.BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", false, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.")
 	flags.BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
 	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "127.0.0.1:3630", "Listening UDP address (ip and port) for discv5 discovery.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -97,7 +97,7 @@ Flags:
       --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:3620")
       --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
       --p2p-bootnode-relay             Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
-      --p2p-bootnodes strings          Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.gcp.obol.tech:16000/enr])
+      --p2p-bootnodes strings          Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.gcp.obol.tech:3640/enr])
       --p2p-bootnodes-from-lockfile    Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
       --p2p-denylist string            Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-external-hostname string   The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.


### PR DESCRIPTION
Change default bootnode from `http://bootnode.gcp.obol.tech:16000` to `http://bootnode.gcp.obol.tech:3640`

category: refactor
ticket: none
