### PR TITLE
dkg: integrate sync service to dkg

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -51,6 +51,8 @@ type Config struct {
 }
 
 // Run executes a dkg ceremony and writes secret share keystore and cluster lock files as output to disk.
+// TODO(dhruv): remove this nolint
+//nolint: gocognit,gocyclo
 func Run(ctx context.Context, conf Config) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/dkg/sync/client.go
+++ b/dkg/sync/client.go
@@ -59,7 +59,7 @@ func (c *Client) AwaitConnected() error {
 		}
 	}
 
-	log.Info(c.ctx, "Client connected to Server 🎉", z.Any("client", p2p.PeerName(c.tcpNode.ID())))
+	log.Info(c.ctx, "Client connected to Server 🎉", z.Any("client", p2p.PeerName(c.tcpNode.ID())), z.Any("server", p2p.PeerName(c.server.ID)))
 
 	return nil
 }

--- a/dkg/sync/sync_test.go
+++ b/dkg/sync/sync_test.go
@@ -20,7 +20,11 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 	"math/rand"
+	"net/http"
+	"os"
+	"path"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/libp2p/go-libp2p"
@@ -29,8 +33,14 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"golang.org/x/sync/errgroup"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/cmd"
+	"github.com/obolnetwork/charon/dkg"
 	"github.com/obolnetwork/charon/dkg/sync"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
@@ -96,6 +106,142 @@ func TestAwaitAllShutdown(t *testing.T) {
 	require.NoError(t, server.AwaitAllShutdown())
 }
 
+func TestSyncWithBootnode(t *testing.T) {
+	const nodes = 4
+	lock, keys, _ := cluster.NewForT(t, 1, nodes, nodes, 0)
+	def := lock.Definition
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start bootnode
+	bootnode, errChan := startBootnode(ctx, t)
+
+	// Setup
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	conf := dkg.Config{
+		DataDir: dir,
+		P2P: p2p.Config{
+			UDPBootnodes: []string{bootnode},
+		},
+		Log:     log.DefaultConfig(),
+		TestDef: &def,
+	}
+
+	var eg errgroup.Group
+	for i := 0; i < len(def.Operators); i++ {
+		conf := conf
+		conf.DataDir = path.Join(dir, fmt.Sprintf("node%d", i))
+		conf.P2P.TCPAddrs = []string{testutil.AvailableAddr(t).String()}
+		conf.P2P.UDPAddr = testutil.AvailableAddr(t).String()
+
+		require.NoError(t, os.MkdirAll(conf.DataDir, 0o755))
+		err := crypto.SaveECDSA(p2p.KeyPath(conf.DataDir), keys[i])
+		require.NoError(t, err)
+
+		eg.Go(func() error {
+			return syncRun(ctx, conf)
+		})
+		if i == 0 {
+			// Allow node0 some time to startup, this just mitigates startup races and backoffs but isn't required.
+			time.Sleep(time.Millisecond * 100)
+		}
+	}
+
+	// Wait until complete
+	runChan := make(chan error, 1)
+	go func() {
+		runChan <- eg.Wait()
+	}()
+
+	select {
+	case err := <-errChan:
+		// If this returns first, something went wrong with the bootnode and the test will fail.
+		cancel()
+		testutil.SkipIfBindErr(t, err)
+		require.Fail(t, "bootnode error: %v", err)
+	case err := <-runChan:
+		cancel()
+		testutil.SkipIfBindErr(t, err)
+		require.NoError(t, err)
+	}
+}
+
+func syncRun(ctx context.Context, conf dkg.Config) error {
+	conf.Log.Level = zapcore.InfoLevel.String()
+	if err := log.InitLogger(conf.Log); err != nil {
+		return err
+	}
+
+	def := *conf.TestDef
+	peers, err := def.Peers()
+	if err != nil {
+		return err
+	}
+
+	key, err := p2p.LoadPrivKey(conf.DataDir)
+	if err != nil {
+		return err
+	}
+
+	priv, err := libp2pcrypto.UnmarshalSecp256k1PrivateKey(crypto.FromECDSA(key))
+	if err != nil {
+		return errors.Wrap(err, "libp2p k1 key")
+	}
+
+	tcpNode, shutdown, err := setupP2P(ctx, key, conf.P2P, peers)
+	if err != nil {
+		return err
+	}
+	defer shutdown()
+
+	defHash, err := def.HashTreeRoot()
+	if err != nil {
+		return errors.Wrap(err, "hash definition")
+	}
+
+	// Sign definition hash with charon-enr-private-key
+	hashSig, err := priv.Sign(defHash[:])
+	if err != nil {
+		return errors.Wrap(err, "sign definition hash")
+	}
+
+	server := sync.NewServer(ctx, tcpNode, peers, defHash[:], nil)
+	var clients []*sync.Client
+	for _, peer := range peers {
+		if peer.ID == tcpNode.ID() {
+			continue
+		}
+		c := sync.NewClient(ctx, tcpNode, peer, hashSig, nil)
+		clients = append(clients, c)
+	}
+
+	for _, c := range clients {
+		if err = c.AwaitConnected(); err != nil {
+			return errors.Wrap(err, "client await connected")
+		}
+	}
+
+	if err = server.AwaitAllConnected(); err != nil {
+		return errors.Wrap(err, "server await all connected")
+	}
+
+	// Shutdown all clients and server
+	for _, c := range clients {
+		if err = c.Shutdown(); err != nil {
+			return errors.Wrap(err, "client shutdown")
+		}
+	}
+
+	if err = server.AwaitAllShutdown(); err != nil {
+		return errors.Wrap(err, "await all shutdown")
+	}
+
+	return nil
+}
+
 func testGetServerAndClients(t *testing.T, ctx context.Context, num int) (*sync.Server, []*sync.Client) {
 	t.Helper()
 
@@ -154,4 +300,88 @@ func newSyncHost(t *testing.T, seed int64) (host.Host, libp2pcrypto.PrivKey) {
 	require.NoError(t, err)
 
 	return host, priv
+}
+
+// startBootnode starts a charon bootnode and returns its http ENR endpoint.
+func startBootnode(ctx context.Context, t *testing.T) (string, <-chan error) {
+	t.Helper()
+
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	addr := testutil.AvailableAddr(t).String()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- cmd.RunBootnode(ctx, cmd.BootnodeConfig{
+			DataDir:  dir,
+			HTTPAddr: addr,
+			P2PConfig: p2p.Config{
+				UDPAddr:  testutil.AvailableAddr(t).String(),
+				TCPAddrs: []string{testutil.AvailableAddr(t).String()},
+			},
+			LogConfig: log.Config{
+				Level:  "error",
+				Format: "console",
+			},
+			AutoP2PKey: true,
+			P2PRelay:   true,
+		})
+	}()
+
+	endpoint := "http://" + addr + "/enr"
+
+	// Wait for bootnode to become available.
+	for ctx.Err() == nil {
+		_, err := http.Get(endpoint)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	return endpoint, errChan
+}
+
+// setupP2P returns a started libp2p tcp node and a shutdown function.
+func setupP2P(ctx context.Context, key *ecdsa.PrivateKey, p2pConf p2p.Config, peers []p2p.Peer) (host.Host, func(), error) {
+	localEnode, db, err := p2p.NewLocalEnode(p2pConf, key)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to open enode")
+	}
+
+	bootnodes, err := p2p.NewUDPBootnodes(ctx, p2pConf, peers, localEnode.ID())
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "new bootnodes")
+	}
+
+	udpNode, err := p2p.NewUDPNode(p2pConf, localEnode, key, bootnodes)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "")
+	}
+
+	relays, err := p2p.NewRelays(p2pConf, bootnodes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	tcpNode, err := p2p.NewTCPNode(p2pConf, key, p2p.NewOpenGater(), udpNode, peers, relays)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "")
+	}
+
+	for _, relay := range relays {
+		go func(relay p2p.Peer) {
+			err := p2p.NewRelayReserver(tcpNode, relay)(ctx)
+			if err != nil {
+				log.Error(ctx, "Reserve relay error", err)
+			}
+		}(relay)
+	}
+
+	return tcpNode, func() {
+		db.Close()
+		udpNode.Close()
+		_ = tcpNode.Close()
+	}, nil
 }


### PR DESCRIPTION
Integrates sync service to dkg which replaces waitConnect function and adds test.

category: feature
ticket: #684 
