### PR TITLE
cmd/createdkg: verify enr in create dkg

### DIFF
--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/p2p"
 )
 
 type createDKGConfig struct {
@@ -90,7 +92,11 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 	}()
 
 	var operators []cluster.Operator
-	for _, opENR := range conf.OperatorENRs {
+	for i, opENR := range conf.OperatorENRs {
+		_, err := p2p.DecodeENR(opENR)
+		if err != nil {
+			return errors.Wrap(err, fmt.Sprintf("invalid ENR of operator %d", i))
+		}
 		operators = append(operators, cluster.Operator{
 			ENR: opENR,
 		})

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/json"
-	"fmt"
 	"os"
 	"path"
 
@@ -95,7 +94,7 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 	for i, opENR := range conf.OperatorENRs {
 		_, err := p2p.DecodeENR(opENR)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("invalid ENR of operator %d", i))
+			return errors.Wrap(err, "invalid ENR", z.Int("operator", i))
 		}
 		operators = append(operators, cluster.Operator{
 			ENR: opENR,

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -1,0 +1,74 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cmd
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDkgValid(t *testing.T) {
+	temp, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	conf := createDKGConfig{
+		OutputDir:         temp,
+		NumValidators:     1,
+		Threshold:         3,
+		FeeRecipient:      "",
+		WithdrawalAddress: defaultWithdrawalAddr,
+		Network:           defaultNetwork,
+		DKGAlgo:           "default",
+		OperatorENRs: []string{
+			"enr:-JG4QFI0llFYxSoTAHm24OrbgoVx77dL6Ehl1Ydys39JYoWcBhiHrRhtGXDTaygWNsEWFb1cL7a1Bk0klIdaNuXplKWGAYGv0Gt7gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL6bcis0tFXnbqG4KuywxT5BLhtmijPFApKCDJNl3mXFYN0Y3CCDhqDdWRwgg4u",
+			"enr:-JG4QPnqHa7FU3PBqGxpV5L0hjJrTUqv8Wl6_UTHt-rELeICWjvCfcVfwmax8xI_eJ0ntI3ly9fgxAsmABud6-yBQiuGAYGv0iYPgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMLLCMZ5Oqi_sdnBfdyhmysZMfFm78PgF7Y9jitTJPSroN0Y3CCPoODdWRwgj6E",
+			"enr:-JG4QDKNYm_JK-w6NuRcUFKvJAlq2L4CwkECelzyCVrMWji4YnVRn8AqQEL5fTQotPL2MKxiKNmn2k6XEINtq-6O3Z2GAYGvzr_LgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKlO7fSaBa3h48CdM-qb_Xb2_hSrJOy6nNjR0mapAqMboN0Y3CCDhqDdWRwgg4u",
+			"enr:-JG4QKu734_MXQklKrNHe9beXIsIV5bqv58OOmsjWmp6CF5vJSHNinYReykn7-IIkc5-YsoF8Hva1Q3pl7_gUj5P9cOGAYGv0jBLgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMM3AvPhXGCUIzBl9VFOw7VQ6_m8dGifVfJ1YXrvZsaZoN0Y3CCDhqDdWRwgg4u",
+		},
+	}
+
+	err = runCreateDKG(context.Background(), conf)
+	require.NoError(t, err)
+}
+
+func TestCreateDkgInvalid(t *testing.T) {
+	tests := []struct {
+		conf createDKGConfig
+	}{
+		{
+			conf: createDKGConfig{OperatorENRs: []string{"-JG4QDKNYm_JK-w6NuRcUFKvJAlq2L4CwkECelzyCVrMWji4YnVRn8AqQEL5fTQotPL2MKxiKNmn2k6XEINtq-6O3Z2GAYGvzr_LgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKlO7fSaBa3h48CdM-qb_Xb2_hSrJOy6nNjR0mapAqMboN0Y3CCDhqDdWRwgg4u"}},
+		},
+		{
+			conf: createDKGConfig{OperatorENRs: []string{"enr:JG4QDKNYm_JK-w6NuRcUFKvJAlq2L4CwkECelzyCVrMWji4YnVRn8AqQEL5fTQotPL2MKxiKNmn2k6XEINtq-6O3Z2GAYGvzr_LgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKlO7fSaBa3h48CdM-qb_Xb2_hSrJOy6nNjR0mapAqMboN0Y3CCDhqDdWRwgg4u"}},
+		},
+		{
+			conf: createDKGConfig{OperatorENRs: []string{"enrJG4QDKNYm_JK-w6NuRcUFKvJAlq2L4CwkECelzyCVrMWji4YnVRn8AqQEL5fTQotPL2MKxiKNmn2k6XEINtq-6O3Z2GAYGvzr_LgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKlO7fSaBa3h48CdM-qb_Xb2_hSrJOy6nNjR0mapAqMboN0Y3CCDhqDdWRwgg4u"}},
+		},
+		{
+			conf: createDKGConfig{OperatorENRs: []string{"JG4QDKNYm_JK-w6NuRcUFKvJAlq2L4CwkECelzyCVrMWji4YnVRn8AqQEL5fTQotPL2MKxiKNmn2k6XEINtq-6O3Z2GAYGvzr_LgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKlO7fSaBa3h48CdM-qb_Xb2_hSrJOy6nNjR0mapAqMboN0Y3CCDhqDdWRwgg4u"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("create dkg", func(t *testing.T) {
+			err := runCreateDKG(context.Background(), test.conf)
+			require.Error(t, err)
+		})
+	}
+}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -137,7 +137,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	var shares []share
 	switch def.DKGAlgorithm {
-	case "default", "keycast":
+	case "keycast":
 		tp := keycastP2P{
 			tcpNode:   tcpNode,
 			peers:     peers,
@@ -148,7 +148,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		if err != nil {
 			return err
 		}
-	case "frost":
+	case "default", "frost":
 		shares, err = runFrostParallel(ctx, tp, uint32(def.NumValidators), uint32(len(peerMap)),
 			uint32(def.Threshold), uint32(nodeIdx.ShareIdx), clusterID)
 		if err != nil {

--- a/p2p/enr.go
+++ b/p2p/enr.go
@@ -39,6 +39,11 @@ func EncodeENR(record enr.Record) (string, error) {
 // DecodeENR returns a enr record decoded from the string.
 // See reference github.com/ethereum/go-ethereum@v1.10.10/p2p/dnsdisc/tree.go:378.
 func DecodeENR(enrStr string) (enr.Record, error) {
+	ok := strings.HasPrefix(enrStr, "enr:")
+	if !ok {
+		return enr.Record{}, errors.New("invalid ENR with no prefix (enr:)")
+	}
+
 	enrStr = strings.TrimPrefix(enrStr, "enr:")
 	enrBytes, err := base64.URLEncoding.DecodeString(enrStr)
 	if err != nil {


### PR DESCRIPTION
Verifies operator ENRs to be in standard form at the start of create dkg. Also make frost dkg as the default one.

category: refactor
ticket: #752 
