### PR TITLE
core/scheduler: workaround clock skew issue

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -17,7 +17,6 @@ package scheduler
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"sync"
 	"testing"
@@ -480,12 +479,8 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2Provider,
 		e2pks = append(e2pks, e2pk)
 	}
 
-	state := fmt.Sprint(slot)
-	if slot == 0 {
-		state = "head"
-	}
-
-	vals, err := eth2Cl.ValidatorsByPubKey(ctx, state, e2pks)
+	// Use "head" instead of slot to mitigate clock skew timing issues.
+	vals, err := eth2Cl.ValidatorsByPubKey(ctx, "head", e2pks)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a workaround for sporadic clock skew wrt beacon node. Instead of querying for what we think is the current slot, just query the "head". 

Note this does introduce a small risk of off-by-one issues in the "active validator logic". But this is only applicable to when validators become active or inactive and has insignificant impact.  

category: bug 
ticket: #764
