### PR TITLE
core/schedule: implement beacon node clock sync

### DIFF
--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -38,12 +38,16 @@ type Feature string
 const (
 	// QBFTConsensus introduces qbft consensus, see https://github.com/ObolNetwork/charon/issues/445.
 	QBFTConsensus Feature = "qbft_consensus"
+
+	// BeaconClockSync offsets slot start time by syncing with beacon node events.
+	BeaconClockSync Feature = "beacon_clock_sync"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		QBFTConsensus: statusStable,
+		QBFTConsensus:   statusStable,
+		BeaconClockSync: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/core/scheduler/clocksync.go
+++ b/core/scheduler/clocksync.go
@@ -1,0 +1,97 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+// newClockSyncer returns a function that returns the current median beacon node clock sync offset.
+// TODO(corver): Improve accuracy by subtracting half ping rtt.
+func newClockSyncer(ctx context.Context, eventsProvider eth2client.EventsProvider, clock clockwork.Clock,
+	genesis time.Time, slotDuration time.Duration,
+) (func() time.Duration, error) {
+	const (
+		maxOffset   = time.Second
+		offsetCount = 10
+	)
+	var (
+		mu           sync.Mutex
+		medianOffset time.Duration
+		offsets      []time.Duration
+	)
+
+	// Subscribe to head events to sync beacon node clock
+	err := eventsProvider.Events(ctx, []string{"head"}, func(event *eth2v1.Event) {
+		if event.Topic != "head" {
+			return
+		}
+		head, ok := event.Data.(*eth2v1.HeadEvent)
+		if !ok {
+			log.Error(ctx, "Invalid head event data type", nil, z.Str("type", fmt.Sprintf("%T", head)))
+			return
+		}
+
+		startTime := genesis.Add(time.Duration(head.Slot) * slotDuration)
+		newOffset := clock.Since(startTime)
+
+		offsets = append(offsets, newOffset)
+		if len(offsets) < offsetCount {
+			return
+		}
+
+		offsets = offsets[len(offsets)-offsetCount:]
+
+		clone := append([]time.Duration(nil), offsets...)
+		sort.Slice(clone, func(i, j int) bool {
+			return clone[i] < clone[j]
+		})
+
+		median := clone[len(clone)/2]
+		syncMedianGauge.Set(medianOffset.Seconds())
+		if median < -maxOffset || median > maxOffset {
+			log.Warn(ctx, "Ignoring too big beacon node clock sync offset", nil,
+				z.Any("offset", newOffset), z.U64("slot", uint64(head.Slot)))
+
+			return
+		}
+
+		mu.Lock()
+		medianOffset = median
+		mu.Unlock()
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return func() time.Duration {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return medianOffset
+	}, nil
+}

--- a/core/scheduler/clocksync.go
+++ b/core/scheduler/clocksync.go
@@ -31,6 +31,7 @@ import (
 )
 
 // newClockSyncer returns a function that returns the current median beacon node clock sync offset.
+// The clock sync offset is the duration we need to add to our clock to sync with the beacon node's clock.
 // TODO(corver): Improve accuracy by subtracting half ping rtt.
 func newClockSyncer(ctx context.Context, eventsProvider eth2client.EventsProvider, clock clockwork.Clock,
 	genesis time.Time, slotDuration time.Duration,
@@ -64,7 +65,7 @@ func newClockSyncer(ctx context.Context, eventsProvider eth2client.EventsProvide
 			return
 		}
 
-		offsets = offsets[len(offsets)-offsetCount:]
+		offsets = offsets[len(offsets)-offsetCount:] // Trim buffer to max offsetCount items.
 
 		clone := append([]time.Duration(nil), offsets...)
 		sort.Slice(clone, func(i, j int) bool {

--- a/core/scheduler/clocksync_internal_test.go
+++ b/core/scheduler/clocksync_internal_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClockSync(t *testing.T) {
+	clock := clockwork.NewFakeClock()
+	slotDuration := time.Second
+	provider := &testEventsProvider{t: t}
+	syncOffset, err := newClockSyncer(context.Background(), provider, clock, clock.Now(), slotDuration)
+	require.NoError(t, err)
+
+	require.Zero(t, syncOffset())
+
+	// 100ms offset
+	clock.Advance(time.Millisecond * 100)
+
+	var slot int
+
+	// Offset is zero until min 10 events
+	for i := 0; i < 9; i++ {
+		clock.Advance(slotDuration)
+		slot++
+		provider.Push(slot)
+		require.Zero(t, syncOffset())
+	}
+
+	clock.Advance(slotDuration)
+	slot++
+	provider.Push(slot)
+
+	require.Equal(t, time.Millisecond*100, syncOffset())
+
+	// Increase offset to 200ms
+	clock.Advance(time.Millisecond * 100)
+
+	// First 4 slots will still be previous median
+	for i := 0; i < 4; i++ {
+		clock.Advance(slotDuration)
+		slot++
+		provider.Push(slot)
+		require.Equal(t, time.Millisecond*100, syncOffset())
+	}
+
+	// Next slot has new expected offset
+	clock.Advance(slotDuration)
+	slot++
+	provider.Push(slot)
+	require.Equal(t, time.Millisecond*200, syncOffset())
+
+	// Increase offset to 1.2s
+	clock.Advance(time.Second)
+
+	// Median never updated since new offset too big.
+	for i := 0; i < 10; i++ {
+		clock.Advance(slotDuration)
+		slot++
+		provider.Push(slot)
+		require.Equal(t, time.Millisecond*200, syncOffset())
+	}
+}
+
+type testEventsProvider struct {
+	t       *testing.T
+	handler eth2client.EventHandlerFunc
+}
+
+func (p *testEventsProvider) Events(_ context.Context, topics []string, handler eth2client.EventHandlerFunc) error {
+	require.Equal(p.t, []string{"head"}, topics)
+	p.handler = handler
+
+	return nil
+}
+
+func (p *testEventsProvider) Push(slot int) {
+	p.handler(&eth2v1.Event{
+		Topic: "head",
+		Data:  &eth2v1.HeadEvent{Slot: eth2p0.Slot(slot)},
+	})
+}

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -43,6 +43,13 @@ var (
 		Name:      "duty_total",
 		Help:      "The total count of duties scheduled by pubkey and type",
 	}, []string{"type", "pubkey"})
+
+	syncMedianGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "clock_sync_median_seconds",
+		Help:      "The beacon node clock sync median offset in seconds",
+	})
 )
 
 // instrumentSlot sets the current slot and epoch metrics.

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -63,6 +63,7 @@ var (
 	_ eth2client.Service                     = (*Mock)(nil)
 	_ eth2client.ValidatorsProvider          = (*Mock)(nil)
 	_ eth2client.VoluntaryExitSubmitter      = (*Mock)(nil)
+	_ eth2client.EventsProvider              = (*Mock)(nil)
 )
 
 // New returns a new beacon client mock configured with the default and provided options.
@@ -136,6 +137,7 @@ type Mock struct {
 	ValidatorsFunc          func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
 	GenesisTimeFunc         func(context.Context) (time.Time, error)
 	NodeSyncingFunc         func(context.Context) (*eth2v1.SyncState, error)
+	EventsFunc              func(context.Context, []string, eth2client.EventHandlerFunc) error
 }
 
 func (m Mock) SubmitAttestations(ctx context.Context, attestations []*eth2p0.Attestation) error {
@@ -180,6 +182,10 @@ func (m Mock) GenesisTime(ctx context.Context) (time.Time, error) {
 
 func (m Mock) NodeSyncing(ctx context.Context) (*eth2v1.SyncState, error) {
 	return m.NodeSyncingFunc(ctx)
+}
+
+func (m Mock) Events(ctx context.Context, topics []string, handler eth2client.EventHandlerFunc) error {
+	return m.EventsFunc(ctx, topics, handler)
 }
 
 func (Mock) Name() string {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	eth2client "github.com/attestantio/go-eth2-client"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -411,6 +412,9 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		},
 		NodeSyncingFunc: func(ctx context.Context) (*eth2v1.SyncState, error) {
 			return httpMock.NodeSyncing(ctx)
+		},
+		EventsFunc: func(context.Context, []string, eth2client.EventHandlerFunc) error {
+			return nil
 		},
 	}
 }


### PR DESCRIPTION
Implements a beacon node clock sync feature in alpha. It uses median offset of 10 last head events slots. 

category: feature 
ticket: #764 
feature_flag: beacon_clock_sync
