### PR TITLE
testutil/compose: fix default external bootnode flag

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -268,7 +268,7 @@ func newNewCmd() *cobra.Command {
 	keygen := cmd.Flags().String("keygen", string(conf.KeyGen), "Key generation process: create, split, dkg")
 	buildLocal := cmd.Flags().Bool("build-local", conf.BuildBinary, "Enables building a local charon binary from source. Note this requires the CHARON_REPO env var.")
 	beaconNode := cmd.Flags().String("beacon-node", conf.BeaconNode, "Beacon node URL endpoint or 'mock' for simnet.")
-	extBootnode := cmd.Flags().String("external-bootnode", conf.BeaconNode, "Optional external bootnode HTTP url.")
+	extBootnode := cmd.Flags().String("external-bootnode", "", "Optional external bootnode HTTP url.")
 	splitKeys := cmd.Flags().String("split-keys-dir", conf.SplitKeysDir, "Directory containing keys to split for keygen==create, or empty not to split.")
 	featureSet := cmd.Flags().String("feature-set", conf.FeatureSet, "Minimum feature set to enable: alpha, beta, stable")
 


### PR DESCRIPTION
Fixes default external bootnode flag, it should be empty.

category: test
ticket: none
