### PR TITLE
core/scheduler: log clock sync offset

### DIFF
--- a/core/scheduler/clocksync.go
+++ b/core/scheduler/clocksync.go
@@ -37,7 +37,7 @@ func newClockSyncer(ctx context.Context, eventsProvider eth2client.EventsProvide
 	genesis time.Time, slotDuration time.Duration,
 ) (func() time.Duration, error) {
 	const (
-		maxOffset   = time.Second
+		maxOffset   = time.Second * 2
 		offsetCount = 10
 	)
 	var (
@@ -75,8 +75,8 @@ func newClockSyncer(ctx context.Context, eventsProvider eth2client.EventsProvide
 		median := clone[len(clone)/2]
 		syncMedianGauge.Set(medianOffset.Seconds())
 		if median < -maxOffset || median > maxOffset {
-			log.Warn(ctx, "Ignoring too big beacon node clock sync offset", nil,
-				z.Any("offset", newOffset), z.U64("slot", uint64(head.Slot)))
+			log.Warn(ctx, "Ignoring too big beacon node clock sync median offset", nil,
+				z.Any("offset", median), z.U64("slot", uint64(head.Slot)))
 
 			return
 		}

--- a/core/scheduler/clocksync_internal_test.go
+++ b/core/scheduler/clocksync_internal_test.go
@@ -72,8 +72,8 @@ func TestClockSync(t *testing.T) {
 	provider.Push(slot)
 	require.Equal(t, time.Millisecond*200, syncOffset())
 
-	// Increase offset to 1.2s
-	clock.Advance(time.Second)
+	// Increase offset to 2.2s
+	clock.Advance(2 * time.Second)
 
 	// Median never updated since new offset too big.
 	for i := 0; i < 10; i++ {

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -124,7 +124,7 @@ func (s *Scheduler) Run() error {
 			return nil
 		case slot := <-slotTicker:
 			slotCtx := log.WithCtx(ctx, z.I64("slot", slot.Slot))
-			log.Debug(slotCtx, "Slot ticked")
+			log.Debug(slotCtx, "Slot ticked", z.Any("beacon_clock_offset", slot.SyncOffset))
 
 			instrumentSlot(slot)
 
@@ -402,6 +402,7 @@ type slot struct {
 	Time          time.Time
 	SlotsPerEpoch int64
 	SlotDuration  time.Duration
+	SyncOffset    time.Duration
 }
 
 func (s slot) Next() slot {
@@ -451,12 +452,14 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clo
 	resp := make(chan slot)
 
 	go func() {
+		var prevSyncOffset time.Duration
 		for {
 			resp <- slot{
 				Slot:          height,
 				Time:          startTime,
 				SlotsPerEpoch: int64(slotsPerEpoch),
 				SlotDuration:  slotDuration,
+				SyncOffset:    prevSyncOffset,
 			}
 			height++
 
@@ -465,7 +468,8 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clo
 			delay := startTime.Sub(clock.Now())
 			if featureset.Enabled(featureset.BeaconClockSync) {
 				// Add offset to start time to account for beacon node clock skew.
-				delay += syncOffset()
+				prevSyncOffset = syncOffset()
+				delay += prevSyncOffset
 			}
 
 			select {


### PR DESCRIPTION
Add beacon clock offset to debug logs and bump max offset to 2s since 1s is too common it seems.

category: misc
ticket: #764 
feature_flag: beacon_clock_sync
