### PR TITLE
dkg/sync: move connected logs to server

### DIFF
--- a/dkg/sync/client.go
+++ b/dkg/sync/client.go
@@ -72,7 +72,6 @@ func (c *Client) Run(ctx context.Context) error {
 			return err
 		}
 
-		log.Info(ctx, "Connected to peer (outbound)")
 		c.setConnected()
 
 		reconnect, err := c.sendMsgs(ctx, stream)


### PR DESCRIPTION
Moves connected logs to server and removes inbound and outbound logs from client and server.

category: bug
ticket: #762 
