### PR TITLE
cluster: improve error when p2pkey doesn't match definition

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -167,7 +167,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	nodeIdx, err := lock.NodeIdx(tcpNode.ID())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "private key not matching lock file")
 	}
 
 	log.Info(ctx, "Lock file loaded",

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -118,7 +118,7 @@ func (d Definition) NodeIdx(pID peer.ID) (NodeIdx, error) {
 		}, nil
 	}
 
-	return NodeIdx{}, errors.New("unknown peer id")
+	return NodeIdx{}, errors.New("peer not in definition")
 }
 
 // Sealed returns true if all config signatures are fully populated and valid. A "sealed" definition is ready for use in DKG.

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -99,7 +99,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	nodeIdx, err := def.NodeIdx(tcpNode.ID())
 	if err != nil {
-		return err
+		return errors.Wrap(err, "private key not matching definition file")
 	}
 
 	defHash, err := def.HashTreeRoot()


### PR DESCRIPTION
Improves the error if the provided p2pkey isn't included in the cluster definition.

category: misc
ticket: none
