### PR TITLE
core/scheduler: improve clock sync logging

### DIFF
--- a/core/scheduler/clocksync.go
+++ b/core/scheduler/clocksync.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	maxOffset   = time.Second * 2
+	maxOffset   = time.Second * 6 // Half a slot
 	offsetCount = 10
 )
 
@@ -76,9 +76,9 @@ func newClockSyncer(ctx context.Context, eventsProvider eth2client.EventsProvide
 		median := clone[len(clone)/2]
 		syncMedianGauge.Set(medianOffset.Seconds())
 		if median < -maxOffset || median > maxOffset {
-			log.Warn(ctx, "Ignoring too big beacon node clock sync median offset", nil,
+			// This will spam logs, but probably ok since this is bad.
+			log.Warn(ctx, "Ignoring too big beacon node clock sync offset", nil,
 				z.Any("offset", median), z.U64("slot", uint64(head.Slot)))
-
 			return
 		}
 


### PR DESCRIPTION
Rather than including offsets in every slot tick log. Split it to its own periodic (+-1m) debug logs that makes it clear what it means and also includes if the feature is enabled.

category: misc
ticket: #764 
feature_flag: beacon_clock_sync
