### PR TITLE
core/scheduler: subtract half rtt from sync offset

### DIFF
--- a/core/scheduler/clocksync_internal_test.go
+++ b/core/scheduler/clocksync_internal_test.go
@@ -31,7 +31,8 @@ func TestClockSync(t *testing.T) {
 	clock := clockwork.NewFakeClock()
 	slotDuration := time.Second
 	provider := &testEventsProvider{t: t}
-	syncOffset, err := newClockSyncer(context.Background(), provider, clock, clock.Now(), slotDuration)
+	pinger := func() time.Duration { return 0 }
+	syncOffset, err := newClockSyncer(context.Background(), provider, pinger, clock, clock.Now(), slotDuration)
 	require.NoError(t, err)
 
 	require.Zero(t, syncOffset())

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -50,6 +50,13 @@ var (
 		Name:      "beacon_node_offset_seconds",
 		Help:      "The beacon node clock sync median offset in seconds",
 	})
+
+	syncRTTGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "beacon_node_rtt_seconds",
+		Help:      "The beacon node clock sync ping rtt in seconds",
+	})
 )
 
 // instrumentSlot sets the current slot and epoch metrics.

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -36,14 +36,15 @@ import (
 
 // eth2Provider defines the eth2 provider subset used by this package.
 type eth2Provider interface {
-	eth2client.NodeSyncingProvider
-	eth2client.GenesisTimeProvider
-	eth2client.ValidatorsProvider
-	eth2client.SlotsPerEpochProvider
-	eth2client.SlotDurationProvider
 	eth2client.AttesterDutiesProvider
-	eth2client.ProposerDutiesProvider
 	eth2client.EventsProvider
+	eth2client.GenesisTimeProvider
+	eth2client.NodeSyncingProvider
+	eth2client.ProposerDutiesProvider
+	eth2client.SlotDurationProvider
+	eth2client.SlotsPerEpochProvider
+	eth2client.ValidatorsProvider
+	// Above sorted alphabetically.
 }
 
 // delayFunc abstracts slot offset delaying/sleeping for deterministic tests.
@@ -439,7 +440,9 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clo
 		return nil, err
 	}
 
-	syncOffset, err := newClockSyncer(ctx, eth2Cl, clock, genesis, slotDuration)
+	pingFunc := newBeaconPinger(ctx, eth2Cl)
+
+	syncOffset, err := newClockSyncer(ctx, eth2Cl, pingFunc, clock, genesis, slotDuration)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Improve sync offset by subtracting the time it takes to send messages over the wire (rtt/2).

category: misc
ticket: #764 
feature_flag: beacon_clock_sync
