### PR TITLE
dockerfile: try and collide docker uid+gid with host uid+gid to reduce permission denied errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ ENV GITHUB_SHA=${GITHUB_SHA}
 COPY --from=builder /app/charon /usr/local/bin/
 # Don't run container as root
 ENV USER=charon
-ENV UID=12345
-ENV GID=23456
+ENV UID=1000
+ENV GID=1000
 RUN addgroup -g "$GID" "$USER"
 RUN adduser \
     --disabled-password \


### PR DESCRIPTION
Right now charon's user ID is 12345 and group ID is 23456, neither of which are ever present on a host. Instead, defaulting to 1000:1000 seems to be what unix defaults its first user account to. That way, although charon still not running as root, it should have the ability to write to the host folder without it, provided the linux user is using the first user on their machine (ids start at 1000 and work up)

category: bug
ticket: none