### PR TITLE
github: push charon to official docker hub registry

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -4,7 +4,7 @@ on:
       - main
     tags:
       - 'v*'
-name: Build and publish Docker Image
+name: Build and Publish Docker Image
 jobs:
   build-docker:
     runs-on: ubuntu-latest
@@ -14,7 +14,7 @@ jobs:
 
     - uses: docker/setup-buildx-action@v1
 
-    - id: meta
+    - name: Define docker image meta data tags
       uses: docker/metadata-action@v3
       with:
         images: ghcr.io/obolnetwork/charon
@@ -28,32 +28,15 @@ jobs:
           # Tag "tag ref" on tag push events
           type=ref,event=tag
 
-    # Login and push to github container registry
-    - uses: docker/login-action@v1
+    - name: Login to Github container registry
+      uses: docker/login-action@v2
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - uses: docker/build-push-action@v2
-      with:
-        context: .
-        platforms: linux/amd64,linux/arm64
-        push: true
-        build-args: GITHUB_SHA=${{ github.sha }}
-        tags: ${{ steps.meta.outputs.tags }}
-
-    # Trigger the charon-k8s deploy job
-    - name: Deploy charon
-      uses: peter-evans/repository-dispatch@v2
-      with:
-        token: ${{ secrets.CHARON_K8S_REPO_ACCESS_TOKEN }}
-        repository: ObolNetwork/charon-k8s
-        event-type: charon-package-published
-        client-payload: '{"sha": "${{ github.sha }}"}'
-
-    # Deploy to dockerhub as well as GHCR
-    - uses: docker/login-action@v2
+    - name: Login to Dockerhub container registry
+      uses: docker/login-action@v2
       with:
         username: obolnetwork
         password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -65,3 +48,11 @@ jobs:
         push: true
         build-args: GITHUB_SHA=${{ github.sha }}
         tags: ${{ steps.meta.outputs.tags }}
+
+    - name: Trigger charon-K8S deploy job
+      uses: peter-evans/repository-dispatch@v2
+      with:
+        token: ${{ secrets.CHARON_K8S_REPO_ACCESS_TOKEN }}
+        repository: ObolNetwork/charon-k8s
+        event-type: charon-package-published
+        client-payload: '{"sha": "${{ github.sha }}"}'

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -53,7 +53,7 @@ jobs:
         client-payload: '{"sha": "${{ github.sha }}"}'
 
     # Deploy to dockerhub as well as GHCR
-    - uses: docker/login-action@v1
+    - uses: docker/login-action@v2
       with:
         username: obolnetwork
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -4,7 +4,7 @@ on:
       - main
     tags:
       - 'v*'
-name: Build
+name: Build and publish Docker Image
 jobs:
   build-docker:
     runs-on: ubuntu-latest
@@ -28,6 +28,7 @@ jobs:
           # Tag "tag ref" on tag push events
           type=ref,event=tag
 
+    # Login and push to github container registry
     - uses: docker/login-action@v1
       with:
         registry: ghcr.io
@@ -42,6 +43,7 @@ jobs:
         build-args: GITHUB_SHA=${{ github.sha }}
         tags: ${{ steps.meta.outputs.tags }}
 
+    # Trigger the charon-k8s deploy job
     - name: Deploy charon
       uses: peter-evans/repository-dispatch@v2
       with:
@@ -49,3 +51,17 @@ jobs:
         repository: ObolNetwork/charon-k8s
         event-type: charon-package-published
         client-payload: '{"sha": "${{ github.sha }}"}'
+
+    # Deploy to dockerhub as well as GHCR
+    - uses: docker/login-action@v1
+      with:
+        username: obolnetwork
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - uses: docker/build-push-action@v2
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        build-args: GITHUB_SHA=${{ github.sha }}
+        tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Pushes the charon image to docker hub after ghcr. Needs to be tested by being merged. Potentially we don't want to send dev builds here too and might want to split this to only run on tags not commits to main. 

category: misc
ticket: #781 

