### PR TITLE
enr: add warning to create enr command

### DIFF
--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -59,8 +59,11 @@ func runCreateEnrCmd(w io.Writer, config p2p.Config, dataDir string) error {
 	}
 	defer db.Close()
 
-	_, _ = fmt.Fprintf(w, "Created ENR private key: %s/charon-enr-private-key\n", dataDir)
+	keyPath := fmt.Sprintf("%s/%s", dataDir, "charon-enr-private-key")
+
+	_, _ = fmt.Fprintf(w, "Created ENR private key: %s\n", keyPath)
 	_, _ = fmt.Fprintln(w, localEnode.Node().String())
+	_, _ = fmt.Fprintf(w, "\nPLEASE BACKUP YOUR KEY IMMEDIATELY! IF YOU LOSE YOUR KEY, YOU WON'T BE ABLE TO PARTICIPATE IN RUNNING A CLUSTER. YOU CAN FIND YOUR KEY IN **%s**.\n", keyPath)
 
 	return nil
 }

--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -59,11 +60,26 @@ func runCreateEnrCmd(w io.Writer, config p2p.Config, dataDir string) error {
 	}
 	defer db.Close()
 
-	keyPath := fmt.Sprintf("%s/%s", dataDir, "charon-enr-private-key")
+	keyPath := fmt.Sprintf("%s", p2p.KeyPath(dataDir))
 
 	_, _ = fmt.Fprintf(w, "Created ENR private key: %s\n", keyPath)
 	_, _ = fmt.Fprintln(w, localEnode.Node().String())
-	_, _ = fmt.Fprintf(w, "\nPLEASE BACKUP YOUR KEY IMMEDIATELY! IF YOU LOSE YOUR KEY, YOU WON'T BE ABLE TO PARTICIPATE IN RUNNING A CLUSTER. YOU CAN FIND YOUR KEY IN **%s**.\n", keyPath)
+
+	writeEnrWarning(w, keyPath)
 
 	return nil
+}
+
+// writeEnrWarning writes backup key warning to the terminal.
+func writeEnrWarning(w io.Writer, keyPath string) {
+	var sb strings.Builder
+	_, _ = sb.WriteString("\n")
+	_, _ = sb.WriteString("***************** WARNING: Backup key **********************\n")
+	_, _ = sb.WriteString(" PLEASE BACKUP YOUR KEY IMMEDIATELY! IF YOU LOSE YOUR KEY,\n")
+	_, _ = sb.WriteString(" YOU WON'T BE ABLE TO PARTICIPATE IN RUNNING A CHARON CLUSTER.\n\n")
+	_, _ = sb.WriteString(fmt.Sprintf(" YOU CAN FIND YOUR KEY IN %s\n", keyPath))
+	_, _ = sb.WriteString("****************************************************************\n")
+	_, _ = sb.WriteString("\n")
+
+	_, _ = w.Write([]byte(sb.String()))
 }


### PR DESCRIPTION
Add backup key warning in `create enr` command.

category: misc
ticket: #785 