### PR TITLE
core/fetcher: add hardcoded graffiti

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -149,9 +149,10 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot int64, defSet core
 
 		randao := randaoData.Signature().ToETH2()
 
-		// TODO(dhruv): what to do with graffiti?
-		// passing empty graffiti since it is not required in API
+		// TODO(dhruv): replace hardcoded graffiti with the one from cluster-lock.json
 		var graffiti [32]byte
+		s := []byte("Obol Distributed Validator")
+		copy(graffiti[:], s)
 		block, err := f.eth2Cl.BeaconBlockProposal(ctx, eth2p0.Slot(uint64(slot)), randao, graffiti[:])
 		if err != nil {
 			return nil, err

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -352,19 +352,7 @@ func proposeBlock(p eth2client.BeaconBlockProposalProvider) handlerFunc {
 		}
 		copy(randao[:], b)
 
-		var graffiti []byte
-		if query.Has("graffiti") {
-			graffiti, err = hexQuery(query, "graffiti")
-			if err != nil {
-				return nil, errors.Wrap(err, "hexadecimal encoding")
-			}
-			// TODO(leo): where should we put this constant?
-			if len(graffiti) > 32 {
-				return nil, errors.New("above graffiti length max of 32")
-			}
-		}
-
-		block, err := p.BeaconBlockProposal(ctx, eth2p0.Slot(slot), randao, graffiti)
+		block, err := p.BeaconBlockProposal(ctx, eth2p0.Slot(slot), randao, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -352,7 +352,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 							DepositCount: 0,
 							BlockHash:    testutil.RandomBytes32(),
 						},
-						Graffiti:          testutil.RandomBytes32(),
+						Graffiti:          graffiti,
 						ProposerSlashings: []*eth2p0.ProposerSlashing{},
 						AttesterSlashings: []*eth2p0.AttesterSlashing{},
 						Attestations:      []*eth2p0.Attestation{testutil.RandomAttestation(), testutil.RandomAttestation()},


### PR DESCRIPTION
Adds "Obol Distributed Validator" as graffiti in every beacon block by charon which would be replaced with graffiti obtained from cluster-lock.json

category: misc
ticket: none
