### PR TITLE
core/tracker: add tests for tracker component

### DIFF
--- a/core/deadline.go
+++ b/core/deadline.go
@@ -81,7 +81,7 @@ func NewDeadliner(ctx context.Context, deadlineFunc func(Duty) time.Time) *Deadl
 		}
 
 		// TODO(dhruv): optimise getCurrDuty and updating current state if earlier deadline detected,
-		// using min heap or ordered map
+		//  using a min heap or an ordered map.
 		for {
 			select {
 			case <-ctx.Done():

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -102,6 +102,7 @@ func NewDeadliner(ctx context.Context, deadlineFunc func(Duty) time.Time) *Deadl
 }
 
 // Add adds a duty to be notified of the deadline.
+// TODO(xenowits): Ignore expired duties.
 func (d *Deadline) Add(duty Duty) {
 	select {
 	case <-d.quit:

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -33,7 +33,7 @@ func TestDeadliner(t *testing.T) {
 	startTime := time.Now()
 
 	deadlineFunc := func(duty core.Duty) time.Time {
-		duration := time.Second
+		duration := time.Millisecond
 		if duty.Type == core.DutyExit {
 			// Do not timeout exit duties.
 			return time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -63,9 +63,8 @@ type Tracker struct {
 	reportDutyFunc func(core.Duty, bool, string, string)
 }
 
-// NewTracker returns a new Tracker.
-// TODO(xenowits): implement reportDutyFunc to emit metrics.
-func NewTracker(deadliner core.Deadliner, reportDutyFunc func(failedDuty core.Duty, isFailed bool, component string, msg string)) *Tracker {
+// New returns a new Tracker.
+func New(deadliner core.Deadliner) *Tracker {
 	t := &Tracker{
 		input:          make(chan event),
 		events:         make(map[core.Duty][]event),
@@ -73,6 +72,14 @@ func NewTracker(deadliner core.Deadliner, reportDutyFunc func(failedDuty core.Du
 		deadliner:      deadliner,
 		reportDutyFunc: reportDutyFunc,
 	}
+
+	return t
+}
+
+// NewForT returns a new Tracker for use in tests.
+func NewForT(deadliner core.Deadliner, reportDutyFunc func(failedDuty core.Duty, isFailed bool, component string, msg string)) *Tracker {
+	t := New(deadliner)
+	t.reportDutyFunc = reportDutyFunc
 
 	return t
 }
@@ -125,6 +132,11 @@ func analyseDutyFailed(duty core.Duty, es []event) (bool, component, string) {
 	// TODO(xenowits): Improve message to have more specific details.
 	//  Ex: If the duty got stuck during validatorAPI, we can say "the VC didn't successfully submit a signed duty").
 	return true, events[0].component + 1, fmt.Sprintf("%s failed in %s component", duty.String(), (events[0].component + 1).String())
+}
+
+// reportDutyFunc instruments the duty. It ignores non-failed duties.
+func reportDutyFunc(core.Duty, bool, string, string) {
+	// TODO(xenowits): Implement logic for reporting duties.
 }
 
 // SchedulerEvent inputs event from core.Scheduler component.

--- a/core/tracker/tracker_test.go
+++ b/core/tracker/tracker_test.go
@@ -34,7 +34,7 @@ func TestNewTracker(t *testing.T) {
 
 	deadlineFunc := func(startTime time.Time) func(core.Duty) time.Time {
 		return func(duty core.Duty) time.Time {
-			duration := time.Second
+			duration := time.Millisecond
 			lateFactor := 1
 
 			if duty.Type == core.DutyExit {

--- a/core/tracker/tracker_test.go
+++ b/core/tracker/tracker_test.go
@@ -49,7 +49,8 @@ func TestTracker(t *testing.T) {
 		go func() {
 			require.NoError(t, tr.SchedulerEvent(ctx, duty, defSet))
 			require.NoError(t, tr.FetcherEvent(ctx, duty, unsignedDataSet))
-			// Send duty to tracker via deadline channel
+
+			// Explicitly mark the current duty as deadlined.
 			deadliner.deadlineChan <- duty
 		}()
 
@@ -81,7 +82,7 @@ func TestTracker(t *testing.T) {
 			require.NoError(t, tr.ParSigDBThresholdEvent(ctx, duty, pubkey, nil))
 			require.NoError(t, tr.SigAggEvent(ctx, duty, pubkey, nil))
 
-			// Send duty to tracker via deadline channel
+			// Explicitly mark the current duty as deadlined.
 			deadliner.deadlineChan <- duty
 		}()
 

--- a/core/tracker/tracker_test.go
+++ b/core/tracker/tracker_test.go
@@ -1,0 +1,154 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/tracker"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestNewTracker(t *testing.T) {
+	duty, defSet := trackerHelper(t)
+
+	deadlineFunc := func(startTime time.Time) func(core.Duty) time.Time {
+		return func(duty core.Duty) time.Time {
+			duration := time.Second
+			lateFactor := 1
+
+			if duty.Type == core.DutyExit {
+				// Do not timeout exit duties.
+				return time.Date(9999, 1, 1, 0, 0, 0, 0, time.UTC)
+			}
+
+			start := startTime.Add(duration * time.Duration(duty.Slot))
+			end := start.Add(duration * time.Duration(lateFactor))
+
+			return end
+		}
+	}
+
+	pubkey := testutil.RandomCorePubKey(t)
+	unsignedDataSet := make(core.UnsignedDataSet)
+	for pubkey := range defSet {
+		unsignedDataSet[pubkey] = testutil.RandomCoreAttestationData(t)
+	}
+
+	parSignedDataSet := make(core.ParSignedDataSet)
+	for pubkey := range defSet {
+		parSignedDataSet[pubkey] = core.ParSignedData{
+			SignedData: nil,
+			ShareIdx:   0,
+		}
+	}
+
+	t.Run("FailAtConsensus", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		deadliner := core.NewDeadliner(ctx, deadlineFunc(time.Now()))
+
+		reportDutyFunc := func(failedDuty core.Duty, isFailed bool, component string, msg string) {
+			require.Equal(t, duty, failedDuty)
+			require.True(t, isFailed)
+			require.Equal(t, component, "consensus")
+			cancel()
+		}
+
+		tr := tracker.NewTracker(deadliner, reportDutyFunc)
+
+		go func() {
+			require.NoError(t, tr.SchedulerEvent(ctx, duty, defSet))
+			require.NoError(t, tr.FetcherEvent(ctx, duty, unsignedDataSet))
+		}()
+
+		require.ErrorIs(t, tr.Run(ctx), context.Canceled)
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		deadliner := core.NewDeadliner(ctx, deadlineFunc(time.Now()))
+
+		reportDutyFunc := func(failedDuty core.Duty, isFailed bool, component string, msg string) {
+			require.Equal(t, duty, failedDuty)
+			require.False(t, isFailed)
+			require.Equal(t, "sigAgg", component)
+			cancel()
+		}
+
+		tr := tracker.NewTracker(deadliner, reportDutyFunc)
+
+		go func() {
+			require.NoError(t, tr.SchedulerEvent(ctx, duty, defSet))
+			require.NoError(t, tr.FetcherEvent(ctx, duty, unsignedDataSet))
+			require.NoError(t, tr.ConsensusEvent(ctx, duty, unsignedDataSet))
+			require.NoError(t, tr.ValidatorAPIEvent(ctx, duty, parSignedDataSet))
+			require.NoError(t, tr.ParSigDBInternalEvent(ctx, duty, parSignedDataSet))
+			require.NoError(t, tr.ParSigExEvent(ctx, duty, parSignedDataSet))
+			require.NoError(t, tr.ParSigDBThresholdEvent(ctx, duty, pubkey, nil))
+			require.NoError(t, tr.SigAggEvent(ctx, duty, pubkey, nil))
+		}()
+
+		require.ErrorIs(t, tr.Run(ctx), context.Canceled)
+	})
+}
+
+func trackerHelper(t *testing.T) (core.Duty, core.DutyDefinitionSet) {
+	t.Helper()
+
+	const (
+		slot    = 1
+		vIdxA   = 2
+		vIdxB   = 3
+		notZero = 99 // Validation require non-zero values
+	)
+
+	pubkeysByIdx := map[eth2p0.ValidatorIndex]core.PubKey{
+		vIdxA: testutil.RandomCorePubKey(t),
+		vIdxB: testutil.RandomCorePubKey(t),
+	}
+
+	dutyA := eth2v1.AttesterDuty{
+		Slot:             slot,
+		ValidatorIndex:   vIdxA,
+		CommitteeIndex:   vIdxA,
+		CommitteeLength:  notZero,
+		CommitteesAtSlot: notZero,
+	}
+
+	dutyB := eth2v1.AttesterDuty{
+		Slot:             slot,
+		ValidatorIndex:   vIdxB,
+		CommitteeIndex:   vIdxB,
+		CommitteeLength:  notZero,
+		CommitteesAtSlot: notZero,
+	}
+
+	defSet := core.DutyDefinitionSet{
+		pubkeysByIdx[vIdxA]: core.NewAttesterDefinition(&dutyA),
+		pubkeysByIdx[vIdxB]: core.NewAttesterDefinition(&dutyB),
+	}
+
+	duty := core.Duty{Type: core.DutyAttester, Slot: slot}
+
+	return duty, defSet
+}


### PR DESCRIPTION
- Add unit tests for tracker component.
- Add `reportDutyFunc` to `NewTracker`.

It will be followed by a PR for wiring tracker along with the integration tests.

category: test
ticket: #768 
