### PR TITLE
github: add non-ghcr tags for dockerhub

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -18,7 +18,9 @@ jobs:
       id: meta
       uses: docker/metadata-action@v3
       with:
-        images: ghcr.io/obolnetwork/charon
+        images: |
+          obolnetwork/charon
+          ghcr.io/obolnetwork/charon
         tags: |
           # Tag "git short sha" on push to branch (main)
           type=sha,event=branch,prefix=


### PR DESCRIPTION
Fixes issue that dockerhub images are not pushed. Adds non-ghcr image prefix so dockerhub compatible tags are also produced. See https://github.com/docker/metadata-action#images-input for example. 

category: misc
ticket: #781
