### PR TITLE
core/bcast: make lighthouse submit attestations idempotent

### DIFF
--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -82,9 +82,8 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty,
 		}
 
 		err = b.eth2Cl.SubmitAttestations(ctx, []*eth2p0.Attestation{&att.Attestation})
-		if err != nil && (strings.Contains(err.Error(), "PriorAttestationKnown") ||
-			strings.Contains(err.Error(), "No peers on libp2p topic")) {
-			// Lighthouse and Nimbus aren't idempotent, so just swallow this non-issue.
+		if err != nil && strings.Contains(err.Error(), "PriorAttestationKnown") {
+			// Lighthouse isn't idempotent, so just swallow this non-issue.
 			// See reference github.com/attestantio/go-eth2-client@v0.11.7/multi/submitattestations.go:38
 			err = nil
 		}

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -82,8 +82,9 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty,
 		}
 
 		err = b.eth2Cl.SubmitAttestations(ctx, []*eth2p0.Attestation{&att.Attestation})
-		if err != nil && strings.Contains(err.Error(), "PriorAttestationKnown") {
-			// Lighthouse isn't idempotent, so just swallow this non-issue.
+		if err != nil && (strings.Contains(err.Error(), "PriorAttestationKnown") ||
+			strings.Contains(err.Error(), "No peers on libp2p topic")) {
+			// Lighthouse and Nimbus aren't idempotent, so just swallow this non-issue.
 			// See reference github.com/attestantio/go-eth2-client@v0.11.7/multi/submitattestations.go:38
 			err = nil
 		}

--- a/core/bcast/bcast_test.go
+++ b/core/bcast/bcast_test.go
@@ -39,16 +39,19 @@ func TestBroadcastAttestation(t *testing.T) {
 
 	aggData := core.Attestation{Attestation: *testutil.RandomAttestation()}
 
-	// Assert output and return lighthouse known error on duplicates
+	// Assert output and return lighthouse and nimbus known error on duplicates
 	var submitted int
 	mock.SubmitAttestationsFunc = func(ctx context.Context, attestations []*eth2p0.Attestation) error {
 		require.Len(t, attestations, 1)
 		require.Equal(t, aggData.Attestation, *attestations[0])
 
 		submitted++
-		if submitted > 1 {
+		if submitted > 2 {
 			// Non-idempotent error returned by lighthouse but swallowed by bcast.
 			return errors.New("Verification: PriorAttestationKnown")
+		} else if submitted > 1 {
+			// Non-idempotent error returned by nimbus but swallowed by bcast.
+			return errors.New(`"message":"No peers on libp2p topic"`)
 		}
 
 		return nil
@@ -57,6 +60,8 @@ func TestBroadcastAttestation(t *testing.T) {
 	bcaster, err := bcast.New(ctx, mock)
 	require.NoError(t, err)
 
+	err = bcaster.Broadcast(ctx, core.Duty{Type: core.DutyAttester}, "", aggData)
+	require.NoError(t, err)
 	err = bcaster.Broadcast(ctx, core.Duty{Type: core.DutyAttester}, "", aggData)
 	require.NoError(t, err)
 	err = bcaster.Broadcast(ctx, core.Duty{Type: core.DutyAttester}, "", aggData)


### PR DESCRIPTION
Catch and ignore lighthouse non-idempotent error. This follows the example set inside goeth2client (but only used for failover in multi-client setup).

category: bug 
ticket: #777 
