### PR TITLE
p2p: add charon cluster header when resolving bootnode enr

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -160,7 +160,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		}
 	}
 
-	tcpNode, localEnode, err := wireP2P(ctx, life, conf, lock, p2pKey)
+	tcpNode, localEnode, err := wireP2P(ctx, life, conf, lock, p2pKey, lockHashHex)
 	if err != nil {
 		return err
 	}
@@ -212,7 +212,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 }
 
 // wireP2P constructs the p2p tcp (libp2p) and udp (discv5) nodes and registers it with the life cycle manager.
-func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, lock cluster.Lock, p2pKey *ecdsa.PrivateKey,
+func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
+	lock cluster.Lock, p2pKey *ecdsa.PrivateKey, lockHashHex string,
 ) (host.Host, *enode.LocalNode, error) {
 	peers, err := lock.Peers()
 	if err != nil {
@@ -228,7 +229,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config, lock clu
 		return nil, nil, err
 	}
 
-	bootnodes, err := p2p.NewUDPBootnodes(ctx, conf.P2P, peers, localEnode.ID())
+	bootnodes, err := p2p.NewUDPBootnodes(ctx, conf.P2P, peers, localEnode.ID(), lockHashHex)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/p2p/discovery_internal_test.go
+++ b/p2p/discovery_internal_test.go
@@ -43,11 +43,13 @@ func TestQueryBootnodeENR(t *testing.T) {
 	record, err := EncodeENR(r)
 	require.NoError(t, err)
 
+	const header = "foo/bar"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, header, r.Header.Get("Charon-Cluster"))
 		_, _ = w.Write([]byte(record))
 	}))
 
-	resp, err := queryBootnodeENR(context.Background(), srv.URL, 0)
+	resp, err := queryBootnodeENR(context.Background(), srv.URL, 0, header)
 	require.NoError(t, err)
 	require.Equal(t, record, resp)
 }
@@ -56,7 +58,7 @@ func TestQueryBootnodeENR_DNS(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 	defer cancel()
 
-	_, err := queryBootnodeENR(ctx, "http://this.does.not.exist:123", 0)
+	_, err := queryBootnodeENR(ctx, "http://this.does.not.exist:123", 0, "")
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.DeadlineExceeded))
 }
@@ -65,12 +67,12 @@ func TestQueryBootnodeENR_Timeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*10)
 	defer cancel()
 
-	_, err := queryBootnodeENR(ctx, "http://127.0.0.1:1", 0)
+	_, err := queryBootnodeENR(ctx, "http://127.0.0.1:1", 0, "")
 	require.Error(t, err)
 	require.True(t, errors.Is(err, context.DeadlineExceeded))
 }
 
 func TestQueryBootnodeENR_Invalid(t *testing.T) {
-	_, err := queryBootnodeENR(context.Background(), "this is not a url", 0)
+	_, err := queryBootnodeENR(context.Background(), "this is not a url", 0, "")
 	require.Error(t, err)
 }


### PR DESCRIPTION
Add the "Charon-Cluster" header to the http request when resolving bootnode ENR on startup.

category: feature
ticket: #786 
