### PR TITLE
core: unsigned data implementation for duty builder proposer

### DIFF
--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -277,6 +277,13 @@ func UnmarshalUnsignedData(typ DutyType, data []byte) (UnsignedData, error) {
 		}
 
 		return resp, nil
+	case DutyBuilderProposer:
+		var resp VersionedBlindedBeaconBlock
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, errors.Wrap(err, "unmarshal block")
+		}
+
+		return resp, nil
 	default:
 		return nil, errors.New("unsupported unsigned data duty type")
 	}

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -18,6 +18,7 @@ package core
 import (
 	"encoding/json"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -30,6 +31,7 @@ import (
 var (
 	_ UnsignedData = AttestationData{}
 	_ UnsignedData = VersionedBeaconBlock{}
+	_ UnsignedData = VersionedBlindedBeaconBlock{}
 )
 
 // AttestationData wraps the eth2 attestation data and adds the original duty.
@@ -176,6 +178,83 @@ func (b *VersionedBeaconBlock) UnmarshalJSON(input []byte) error {
 	}
 
 	*b = VersionedBeaconBlock{VersionedBeaconBlock: resp}
+
+	return nil
+}
+
+type VersionedBlindedBeaconBlock struct {
+	eth2api.VersionedBlindedBeaconBlock
+}
+
+// NewVersionedBlindedBeaconBlock validates and returns a new wrapped VersionedBlindedBeaconBlock.
+func NewVersionedBlindedBeaconBlock(block *eth2api.VersionedBlindedBeaconBlock) (VersionedBlindedBeaconBlock, error) {
+	switch block.Version {
+	case spec.DataVersionBellatrix:
+		if block.Bellatrix == nil {
+			return VersionedBlindedBeaconBlock{}, errors.New("no bellatrix block")
+		}
+	default:
+		return VersionedBlindedBeaconBlock{}, errors.New("unknown version")
+	}
+
+	return VersionedBlindedBeaconBlock{VersionedBlindedBeaconBlock: *block}, nil
+}
+
+func (b VersionedBlindedBeaconBlock) Clone() (UnsignedData, error) {
+	var resp VersionedBlindedBeaconBlock
+	err := cloneJSONMarshaler(b, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "clone block")
+	}
+
+	return resp, nil
+}
+
+func (b VersionedBlindedBeaconBlock) MarshalJSON() ([]byte, error) {
+	var marshaller json.Marshaler
+	switch b.Version {
+	// No block nil checks since `NewVersionedSignedBlindedBeaconBlock` assumed.
+	case spec.DataVersionBellatrix:
+		marshaller = b.Bellatrix
+	default:
+		return nil, errors.New("unknown version")
+	}
+
+	block, err := marshaller.MarshalJSON()
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal block")
+	}
+
+	resp, err := json.Marshal(versionedRawBlockJSON{
+		Version: int(b.Version),
+		Block:   block,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal wrapper")
+	}
+
+	return resp, nil
+}
+
+func (b *VersionedBlindedBeaconBlock) UnmarshalJSON(input []byte) error {
+	var raw versionedRawBlockJSON
+	if err := json.Unmarshal(input, &raw); err != nil {
+		return errors.Wrap(err, "unmarshal block")
+	}
+
+	resp := eth2api.VersionedBlindedBeaconBlock{Version: spec.DataVersion(raw.Version)}
+	switch resp.Version {
+	case spec.DataVersionBellatrix:
+		block := new(eth2v1.BlindedBeaconBlock)
+		if err := json.Unmarshal(raw.Block, &block); err != nil {
+			return errors.Wrap(err, "unmarshal bellatrix")
+		}
+		resp.Bellatrix = block
+	default:
+		return errors.New("unknown version")
+	}
+
+	*b = VersionedBlindedBeaconBlock{VersionedBlindedBeaconBlock: resp}
 
 	return nil
 }

--- a/core/unsigneddata_test.go
+++ b/core/unsigneddata_test.go
@@ -37,3 +37,17 @@ func TestCloneVersionedBeaconBlock(t *testing.T) {
 
 	require.Equal(t, slot1, slot2)
 }
+
+func TestCloneVersionedBlindedBeaconBlock(t *testing.T) {
+	block := testutil.RandomCoreVersionBlindedBeaconBlock(t)
+	slot1, err := block.Slot()
+	require.NoError(t, err)
+
+	clone, err := block.Clone()
+	require.NoError(t, err)
+	block2 := clone.(core.VersionedBlindedBeaconBlock)
+	slot2, err := block2.Slot()
+	require.NoError(t, err)
+
+	require.Equal(t, slot1, slot2)
+}

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"testing"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -194,6 +195,50 @@ func RandomCoreVersionBeaconBlock(t *testing.T) core.VersionedBeaconBlock {
 	}
 }
 
+func RandomBellatrixBlindedBeaconBlock(t *testing.T) *eth2v1.BlindedBeaconBlock {
+	t.Helper()
+
+	return &eth2v1.BlindedBeaconBlock{
+		Slot:          RandomSlot(),
+		ProposerIndex: RandomVIdx(),
+		ParentRoot:    RandomRoot(),
+		StateRoot:     RandomRoot(),
+		Body:          RandomBellatrixBlindedBeaconBlockBody(t),
+	}
+}
+
+func RandomBellatrixBlindedBeaconBlockBody(t *testing.T) *eth2v1.BlindedBeaconBlockBody {
+	t.Helper()
+
+	return &eth2v1.BlindedBeaconBlockBody{
+		RANDAOReveal: RandomEth2Signature(),
+		ETH1Data: &eth2p0.ETH1Data{
+			DepositRoot:  RandomRoot(),
+			DepositCount: 0,
+			BlockHash:    RandomBytes32(),
+		},
+		Graffiti:               RandomBytes32(),
+		ProposerSlashings:      []*eth2p0.ProposerSlashing{},
+		AttesterSlashings:      []*eth2p0.AttesterSlashing{},
+		Attestations:           []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Deposits:               []*eth2p0.Deposit{},
+		VoluntaryExits:         []*eth2p0.SignedVoluntaryExit{},
+		SyncAggregate:          RandomSyncAggregate(t),
+		ExecutionPayloadHeader: RandomExecutionPayloadHeader(),
+	}
+}
+
+func RandomCoreVersionBlindedBeaconBlock(t *testing.T) core.VersionedBlindedBeaconBlock {
+	t.Helper()
+
+	return core.VersionedBlindedBeaconBlock{
+		VersionedBlindedBeaconBlock: eth2api.VersionedBlindedBeaconBlock{
+			Version:   spec.DataVersionBellatrix,
+			Bellatrix: RandomBellatrixBlindedBeaconBlock(t),
+		},
+	}
+}
+
 func RandomSyncAggregate(t *testing.T) *altair.SyncAggregate {
 	t.Helper()
 
@@ -222,6 +267,25 @@ func RandomExecutionPayLoad() *bellatrix.ExecutionPayload {
 		BaseFeePerGas: RandomArray32(),
 		BlockHash:     RandomArray32(),
 		Transactions:  []bellatrix.Transaction{},
+	}
+}
+
+func RandomExecutionPayloadHeader() *bellatrix.ExecutionPayloadHeader {
+	return &bellatrix.ExecutionPayloadHeader{
+		ParentHash:       RandomArray32(),
+		FeeRecipient:     bellatrix.ExecutionAddress{},
+		StateRoot:        RandomArray32(),
+		ReceiptsRoot:     RandomArray32(),
+		LogsBloom:        [256]byte{},
+		PrevRandao:       RandomArray32(),
+		BlockNumber:      0,
+		GasLimit:         0,
+		GasUsed:          0,
+		Timestamp:        0,
+		ExtraData:        RandomBytes32(),
+		BaseFeePerGas:    RandomArray32(),
+		BlockHash:        RandomArray32(),
+		TransactionsRoot: RandomArray32(),
 	}
 }
 

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -254,34 +254,21 @@ func RandomSyncAggregate(t *testing.T) *altair.SyncAggregate {
 func RandomExecutionPayLoad() *bellatrix.ExecutionPayload {
 	return &bellatrix.ExecutionPayload{
 		ParentHash:    RandomArray32(),
-		FeeRecipient:  bellatrix.ExecutionAddress{},
 		StateRoot:     RandomArray32(),
 		ReceiptsRoot:  RandomArray32(),
-		LogsBloom:     [256]byte{},
 		PrevRandao:    RandomArray32(),
-		BlockNumber:   0,
-		GasLimit:      0,
-		GasUsed:       0,
-		Timestamp:     0,
 		ExtraData:     RandomBytes32(),
 		BaseFeePerGas: RandomArray32(),
 		BlockHash:     RandomArray32(),
-		Transactions:  []bellatrix.Transaction{},
 	}
 }
 
 func RandomExecutionPayloadHeader() *bellatrix.ExecutionPayloadHeader {
 	return &bellatrix.ExecutionPayloadHeader{
 		ParentHash:       RandomArray32(),
-		FeeRecipient:     bellatrix.ExecutionAddress{},
 		StateRoot:        RandomArray32(),
 		ReceiptsRoot:     RandomArray32(),
-		LogsBloom:        [256]byte{},
 		PrevRandao:       RandomArray32(),
-		BlockNumber:      0,
-		GasLimit:         0,
-		GasUsed:          0,
-		Timestamp:        0,
 		ExtraData:        RandomBytes32(),
 		BaseFeePerGas:    RandomArray32(),
 		BlockHash:        RandomArray32(),

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -260,6 +260,7 @@ func RandomExecutionPayLoad() *bellatrix.ExecutionPayload {
 		ExtraData:     RandomBytes32(),
 		BaseFeePerGas: RandomArray32(),
 		BlockHash:     RandomArray32(),
+		Transactions:  []bellatrix.Transaction{},
 	}
 }
 


### PR DESCRIPTION
- unsigned data implementation of blinded blocker proposer
- implementation of clone test
- Addition to random.go to generate random blinded block body and blinded block (required for clone test)

This touches core & testutil not sure on convention for PR header when this is the case - have gone with core for now

category: feature
ticket: #809 