### PR TITLE
core/deadline: ignore deadlined duties

### DIFF
--- a/core/deadline.go
+++ b/core/deadline.go
@@ -65,10 +65,9 @@ type Deadline struct {
 }
 
 // NewForT returns a Deadline for use in tests.
-func NewForT(t *testing.T, deadlineFunc func(Duty) time.Time, clock clockwork.Clock) (*Deadline, context.CancelFunc) {
+func NewForT(ctx context.Context, t *testing.T, deadlineFunc func(Duty) time.Time, clock clockwork.Clock) *Deadline {
 	t.Helper()
 
-	ctx, cancel := context.WithCancel(context.Background())
 	d := &Deadline{
 		inputChan:    make(chan deadlineInput),
 		deadlineChan: make(chan Duty),
@@ -78,7 +77,7 @@ func NewForT(t *testing.T, deadlineFunc func(Duty) time.Time, clock clockwork.Cl
 
 	go d.run(ctx, deadlineFunc)
 
-	return d, cancel
+	return d
 }
 
 // NewDeadliner returns a new instance of Deadline.

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/jonboulle/clockwork"
 
 	"github.com/obolnetwork/charon/app/errors"
 )
@@ -38,20 +39,42 @@ type slotTimeProvider interface {
 // may only be used by a single goroutine. So, multiple instances are required
 // for different components and use cases.
 type Deadliner interface {
-	// Add adds a duty to be notified of the Deadline via C.
-	// Note that duties will be deduplicated and only a single duty will be provided via C.
-	Add(duty Duty)
+	// Add returns true if the duty was added for future deadline scheduling. It is idempotent
+	// and returns true if the duty was previously added and still awaits deadline scheduling. It
+	// returns false if the duty has already expired and cannot therefore be added for scheduling.
+	Add(duty Duty) bool
 
 	// C returns the same read channel every time and contains deadlined duties.
 	// It should only be called by a single goroutine.
 	C() <-chan Duty
 }
 
+// deadlinerInput represents the input to inputChan.
+type deadlineInput struct {
+	duty    Duty
+	success chan<- bool
+}
+
 // Deadline implements the Deadliner interface.
 type Deadline struct {
-	dutyChan     chan Duty
+	inputChan    chan deadlineInput
 	deadlineChan chan Duty
+	clock        clockwork.Clock
 	quit         chan struct{}
+}
+
+// NewForT returns a Deadline for use in tests.
+func NewForT(ctx context.Context, deadlineFunc func(Duty) time.Time, clock clockwork.Clock) *Deadline {
+	d := &Deadline{
+		inputChan:    make(chan deadlineInput),
+		deadlineChan: make(chan Duty),
+		clock:        clock,
+		quit:         make(chan struct{}),
+	}
+
+	go d.run(ctx, deadlineFunc)
+
+	return d
 }
 
 // NewDeadliner returns a new instance of Deadline.
@@ -59,56 +82,79 @@ type Deadline struct {
 // and sending the deadlined duty to receiver's deadlineChan.
 func NewDeadliner(ctx context.Context, deadlineFunc func(Duty) time.Time) *Deadline {
 	d := &Deadline{
-		dutyChan:     make(chan Duty),
+		inputChan:    make(chan deadlineInput),
 		deadlineChan: make(chan Duty),
+		clock:        clockwork.NewRealClock(),
 		quit:         make(chan struct{}),
 	}
 
-	go func() {
-		duties := make(map[Duty]bool)
-		currDuty, currDeadline := getCurrDuty(duties, deadlineFunc)
-		currTimer := time.NewTimer(time.Until(currDeadline))
-
-		defer func() {
-			close(d.quit)
-			currTimer.Stop()
-		}()
-
-		setCurrState := func() {
-			currTimer.Stop()
-			currDuty, currDeadline = getCurrDuty(duties, deadlineFunc)
-			currTimer = time.NewTimer(time.Until(currDeadline))
-		}
-
-		// TODO(dhruv): optimise getCurrDuty and updating current state if earlier deadline detected,
-		//  using a min heap or an ordered map.
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case duty := <-d.dutyChan:
-				duties[duty] = true
-				setCurrState()
-			case <-currTimer.C:
-				// Send deadlined duty to receiver
-				d.deadlineChan <- currDuty
-				delete(duties, currDuty)
-				setCurrState()
-			}
-		}
-	}()
+	go d.run(ctx, deadlineFunc)
 
 	return d
 }
 
-// Add adds a duty to be notified of the deadline.
-// TODO(xenowits): Ignore expired duties.
-func (d *Deadline) Add(duty Duty) {
+func (d *Deadline) run(ctx context.Context, deadlineFunc func(Duty) time.Time) {
+	duties := make(map[Duty]bool)
+	currDuty, currDeadline := getCurrDuty(duties, deadlineFunc)
+	currTimer := d.clock.NewTimer(currDeadline.Sub(d.clock.Now()))
+
+	defer func() {
+		close(d.quit)
+		currTimer.Stop()
+	}()
+
+	setCurrState := func() {
+		currTimer.Stop()
+		currDuty, currDeadline = getCurrDuty(duties, deadlineFunc)
+		currTimer = d.clock.NewTimer(currDeadline.Sub(d.clock.Now()))
+	}
+
+	// TODO(dhruv): optimise getCurrDuty and updating current state if earlier deadline detected,
+	//  using min heap or ordered map
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case input := <-d.inputChan:
+			deadline := deadlineFunc(input.duty)
+			expired := deadline.Before(d.clock.Now())
+
+			input.success <- !expired
+
+			// Ignore expired duties.
+			if expired {
+				continue
+			}
+
+			duties[input.duty] = true
+
+			if deadline.Before(currDeadline) {
+				setCurrState()
+			}
+		case <-currTimer.Chan():
+			// Send deadlined duty to receiver.
+			d.deadlineChan <- currDuty
+			delete(duties, currDuty)
+			setCurrState()
+		}
+	}
+}
+
+// Add adds a duty to be notified of the deadline. It returns true if the duty was added successfully.
+func (d *Deadline) Add(duty Duty) bool {
+	res := make(chan bool)
+
 	select {
 	case <-d.quit:
-		return
-	default:
-		d.dutyChan <- duty
+		return false
+	case d.inputChan <- deadlineInput{duty: duty, success: res}:
+	}
+
+	select {
+	case <-d.quit:
+		return false
+	case ok := <-res:
+		return ok
 	}
 }
 

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -16,7 +16,6 @@
 package core_test
 
 import (
-	"context"
 	"sort"
 	"sync"
 	"testing"
@@ -29,9 +28,6 @@ import (
 )
 
 func TestDeadliner(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	expiredDuties, nonExpiredDuties, voluntaryExits, dutyExpired := setupData(t)
 	clock := clockwork.NewFakeClock()
 
@@ -50,7 +46,8 @@ func TestDeadliner(t *testing.T) {
 		}
 	}
 
-	deadliner := core.NewForT(ctx, deadlineFuncProvider(), clock)
+	deadliner, cancel := core.NewForT(t, deadlineFuncProvider(), clock)
+	defer cancel()
 
 	wg := &sync.WaitGroup{}
 	wg.Add(3)

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -57,9 +57,10 @@ func TestDeadliner(t *testing.T) {
 	addDuties(t, wg, nonExpiredDuties, true, deadliner)
 	addDuties(t, wg, voluntaryExits, true, deadliner)
 
+	// Wait till all the duties are added to the deadliner.
 	wg.Wait()
 
-	clock.Advance(1 * time.Second)
+	clock.Advance(time.Second)
 
 	var actualDuties []core.Duty
 	for i := 0; i < len(nonExpiredDuties); i++ {

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -86,10 +86,12 @@ func (t *Tracker) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case e := <-t.input:
-			if t.deadliner.Add(e.duty) {
-				// Call to Add() succeeded which means that the duty has not timed out, so we can store it.
-				t.events[e.duty] = append(t.events[e.duty], e)
+			if !t.deadliner.Add(e.duty) {
+				// Ignore expired duties
+				continue
 			}
+
+			t.events[e.duty] = append(t.events[e.duty], e)
 		case duty := <-t.deadliner.C():
 			failed, failedComponent, failedMsg := analyseDutyFailed(duty, t.events[duty])
 

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -27,12 +27,12 @@ import (
 	"github.com/obolnetwork/charon/testutil"
 )
 
-func TestTracker1(t *testing.T) {
-	duty, defSet, pubkey, unsignedDataSet, parSignedDataSet := setupData1(t)
+func TestTracker(t *testing.T) {
+	duty, defSet, pubkey, unsignedDataSet, parSignedDataSet := setupData(t)
 
 	t.Run("FailAtConsensus", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		deadliner := testDeadliner1{
+		deadliner := testDeadliner{
 			deadlineChan: make(chan core.Duty),
 		}
 
@@ -59,7 +59,7 @@ func TestTracker1(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
-		deadliner := testDeadliner1{
+		deadliner := testDeadliner{
 			deadlineChan: make(chan core.Duty),
 		}
 
@@ -92,18 +92,20 @@ func TestTracker1(t *testing.T) {
 }
 
 // testDeadliner is a mock deadliner implementation.
-type testDeadliner1 struct {
+type testDeadliner struct {
 	deadlineChan chan core.Duty
 }
 
-func (testDeadliner1) Add(core.Duty) {}
+func (testDeadliner) Add(core.Duty) bool {
+	return true
+}
 
-func (t testDeadliner1) C() <-chan core.Duty {
+func (t testDeadliner) C() <-chan core.Duty {
 	return t.deadlineChan
 }
 
 // setupData returns the data required to test tracker.
-func setupData1(t *testing.T) (core.Duty, core.DutyDefinitionSet, core.PubKey, core.UnsignedDataSet, core.ParSignedDataSet) {
+func setupData(t *testing.T) (core.Duty, core.DutyDefinitionSet, core.PubKey, core.UnsignedDataSet, core.ParSignedDataSet) {
 	t.Helper()
 
 	const (


### PR DESCRIPTION
- Modify `Deadliner` to ignore deadlined duties.
- Modify `Add(duty)` to return true if a duty is added successfully.
- Fix deadline tests.

category: refactor
ticket: #814 