### PR TITLE
core: add changes for signed data for builder proposer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,9 @@ linters-settings:
   cyclop:
     max-complexity: 15
     skip-tests: true
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 350
   exhaustive:
     default-signifies-exhaustive: true
   forbidigo:


### PR DESCRIPTION
- signed data implementation of blinded blocker proposer
- implementation of sigagg test

An issue with pre commit check specifically golangci-lint "dupl", appeared to be giving a false positive

`core/sigagg/sigagg_test.go:346: 346-400 lines are duplicate of `core/sigagg/sigagg_test.go:261-315` (dupl)`

This issue https://github.com/golangci/golangci-lint/issues/1372 discussed updating the dupl threshold in the config which I've done. Not sure if I'm missing something and this is a legitimate dupl or if this has happened to you guys before and you have a better solution. 

category: feature
ticket: #809 
