### PR TITLE
cmd: support multiple beacon nodes

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -28,6 +28,7 @@ import (
 	eth2client "github.com/attestantio/go-eth2-client"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2http "github.com/attestantio/go-eth2-client/http"
+	eth2multi "github.com/attestantio/go-eth2-client/multi"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/ethereum/go-ethereum/p2p/enode"
@@ -73,7 +74,7 @@ type Config struct {
 	DataDir          string
 	MonitoringAddr   string
 	ValidatorAPIAddr string
-	BeaconNodeAddr   string
+	BeaconNodeAddrs  []string
 	JaegerAddr       string
 	JaegerService    string
 	SimnetBMock      bool
@@ -273,7 +274,8 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 // wireCoreWorkflow wires the core workflow components.
 func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
-	lock cluster.Lock, nodeIdx cluster.NodeIdx, tcpNode host.Host, p2pKey *ecdsa.PrivateKey, eth2Cl eth2client.Service, beaconAddr string, peerIDs []peer.ID,
+	lock cluster.Lock, nodeIdx cluster.NodeIdx, tcpNode host.Host, p2pKey *ecdsa.PrivateKey, eth2Cl eth2client.Service,
+	beaconAddrs []string, peerIDs []peer.ID,
 ) error {
 	// Convert and prep public keys and public shares
 	var (
@@ -333,7 +335,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	if err := wireVAPIRouter(life, conf.ValidatorAPIAddr, beaconAddr, vapi); err != nil {
+	if err := wireVAPIRouter(life, conf.ValidatorAPIAddr, beaconAddrs, vapi); err != nil {
 		return err
 	}
 
@@ -418,11 +420,13 @@ func eth2PubKeys(validators []cluster.DistValidator) ([]eth2p0.BLSPubKey, error)
 	return pubkeys, nil
 }
 
-// newETH2Client returns a new eth2client and a beacon node address; it is either a beaconmock for simnet or a http client to a real beacon node.
-func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager, validators []cluster.DistValidator) (eth2client.Service, string, error) {
+// newETH2Client returns a new eth2client and a beacon node addresses; it is either a beaconmock for simnet or a http client to a real beacon node.
+func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
+	validators []cluster.DistValidator,
+) (eth2client.Service, []string, error) {
 	pubkeys, err := eth2PubKeys(validators)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	if conf.SimnetBMock { // Configure the beacon mock.
@@ -436,23 +440,27 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager, va
 		opts = append(opts, conf.TestConfig.SimnetBMockOpts...)
 		bmock, err := beaconmock.New(opts...)
 		if err != nil {
-			return nil, "", err
+			return nil, nil, err
 		}
 
 		life.RegisterStop(lifecycle.StopBeaconMock, lifecycle.HookFuncErr(bmock.Close))
 
-		return bmock, bmock.HTTPAddr(), nil
+		return bmock, []string{bmock.HTTPAddr()}, nil
+	}
+
+	if len(conf.BeaconNodeAddrs) == 0 {
+		return nil, nil, errors.New("beacon node endpoints empty")
 	}
 
 	eth2Cl, err := eth2wrap.NewHTTPService(ctx,
-		eth2http.WithLogLevel(1),
-		eth2http.WithAddress(conf.BeaconNodeAddr),
+		eth2multi.WithLogLevel(1),
+		eth2multi.WithAddresses(conf.BeaconNodeAddrs),
 	)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "new eth2 http client")
+		return nil, nil, errors.Wrap(err, "new eth2 http client")
 	}
 
-	return eth2Cl, conf.BeaconNodeAddr, nil
+	return eth2Cl, conf.BeaconNodeAddrs, nil
 }
 
 // newConsensus returns a new consensus component and its start lifecycle hook.
@@ -510,8 +518,8 @@ func createMockValidators(pubkeys []eth2p0.BLSPubKey) beaconmock.ValidatorSet {
 }
 
 // wireVAPIRouter constructs the validator API router and registers it with the life cycle manager.
-func wireVAPIRouter(life *lifecycle.Manager, vapiAddr string, beaconAddr string, handler validatorapi.Handler) error {
-	vrouter, err := validatorapi.NewRouter(handler, beaconAddr)
+func wireVAPIRouter(life *lifecycle.Manager, vapiAddr string, beaconAddrs []string, handler validatorapi.Handler) error {
+	vrouter, err := validatorapi.NewRouter(handler, beaconAddrs)
 	if err != nil {
 		return errors.Wrap(err, "new monitoring server")
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -455,6 +455,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 	eth2Cl, err := eth2wrap.NewHTTPService(ctx,
 		eth2multi.WithLogLevel(1),
 		eth2multi.WithAddresses(conf.BeaconNodeAddrs),
+		eth2wrap.WithMultiMetrics(),
 	)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "new eth2 http client")

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	eth2http "github.com/attestantio/go-eth2-client/http"
+	eth2multi "github.com/attestantio/go-eth2-client/multi"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -46,23 +46,23 @@ var (
 )
 
 // NewHTTPService returns a new instrumented eth2 http service.
-func NewHTTPService(ctx context.Context, params ...eth2http.Parameter) (*Service, error) {
-	eth2Svc, err := eth2http.New(ctx, params...)
+func NewHTTPService(ctx context.Context, params ...eth2multi.Parameter) (*Service, error) {
+	eth2Svc, err := eth2multi.New(ctx, params...)
 	if err != nil {
-		return nil, errors.Wrap(err, "new eth2http")
+		return nil, errors.Wrap(err, "new eth2multi")
 	}
 
-	eth2Cl, ok := eth2Svc.(*eth2http.Service)
+	eth2Cl, ok := eth2Svc.(*eth2multi.Service)
 	if !ok {
-		return nil, errors.New("invalid eth2http service")
+		return nil, errors.New("invalid eth2multi service")
 	}
 
 	return &Service{Service: eth2Cl}, nil
 }
 
-// Service wraps an eth2http.Service adding prometheus metrics and error wrapping.
+// Service wraps an eth2multi.Service adding prometheus metrics and error wrapping.
 type Service struct {
-	*eth2http.Service
+	*eth2multi.Service
 }
 
 // latency measures endpoint latency.

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -79,3 +79,15 @@ func latency(endpoint string) func() {
 func incError(endpoint string) {
 	errorCount.WithLabelValues(endpoint).Inc()
 }
+
+// WithMultiMetrics returns a eth2multi functional option that enables prometheus metrics.
+func WithMultiMetrics() eth2multi.Parameter {
+	return eth2multi.WithMonitor(eth2Monitor{})
+}
+
+// eth2Monitor implements eth2metrics.Monitor enabling eth2multi prometheus metrics.
+type eth2Monitor struct{}
+
+func (eth2Monitor) Presenter() string {
+	return "prometheus"
+}

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -29,20 +29,6 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 )
 
-// EpochFromStateID converts a state ID to its epoch.
-func (s *Service) EpochFromStateID(ctx context.Context, stateID string) (phase0.Epoch, error) {
-	const label = "epoch_from_state_id"
-	defer latency(label)()
-
-	res0, err := s.Service.EpochFromStateID(ctx, stateID)
-	if err != nil {
-		incError(label)
-		err = errors.Wrap(err, "eth2http")
-	}
-
-	return res0, err
-}
-
 // SignedBeaconBlock fetches a signed beacon block given a block ID.
 func (s *Service) SignedBeaconBlock(ctx context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error) {
 	const label = "signed_beacon_block"

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -14,7 +14,7 @@
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
 // Command genwrap provides a code generator for eth2client provider
-// methods implemented by eth2http.Service.
+// methods implemented by eth2multi.Service.
 // It adds prometheus metrics and error wrapping.
 package main
 
@@ -68,11 +68,13 @@ import (
 
 	// skip some provider methods.
 	skip = map[string]bool{
-		// eth2http doesn't implement these
+		// eth2multi doesn't implement these
 		"GenesisValidatorsRoot": true,
 		"Index":                 true,
 		"PubKey":                true,
 		"SyncState":             true,
+		"EpochFromStateID":      true,
+		"NodeClient":            true,
 
 		// these are cached, so no need to instrument.
 		"GenesisTime":                   true,

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -51,7 +51,7 @@ func TestRouterIntegration(t *testing.T) {
 		t.Skip("Skipping integration test since BEACON_URL not found")
 	}
 
-	r, err := NewRouter(Handler(nil), []string{beaconURL})
+	r, err := NewRouter(Handler(nil), testBeaconAddr(beaconURL))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -484,7 +484,7 @@ func testRouter(t *testing.T, handler testHandler, callback func(context.Context
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, []string{proxy.URL})
+	r, err := NewRouter(handler, testBeaconAddr(proxy.URL))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -505,7 +505,7 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, []string{proxy.URL})
+	r, err := NewRouter(handler, testBeaconAddr(proxy.URL))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -616,4 +616,15 @@ func nest(data interface{}, nests ...string) interface{} {
 	}
 
 	return res
+}
+
+// testBeaconAddr implements eth2client.Service only returning an address.
+type testBeaconAddr string
+
+func (t testBeaconAddr) Name() string {
+	return string(t)
+}
+
+func (t testBeaconAddr) Address() string {
+	return string(t)
 }

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -51,7 +51,7 @@ func TestRouterIntegration(t *testing.T) {
 		t.Skip("Skipping integration test since BEACON_URL not found")
 	}
 
-	r, err := NewRouter(Handler(nil), beaconURL)
+	r, err := NewRouter(Handler(nil), []string{beaconURL})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -484,7 +484,7 @@ func testRouter(t *testing.T, handler testHandler, callback func(context.Context
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, proxy.URL)
+	r, err := NewRouter(handler, []string{proxy.URL})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -505,7 +505,7 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, proxy.URL)
+	r, err := NewRouter(handler, []string{proxy.URL})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,30 +83,31 @@ Usage:
   charon run [flags]
 
 Flags:
-      --beacon-node-endpoint string    Beacon node endpoint URL (default "http://localhost/")
-      --data-dir string                The directory where charon will store all its internal data (default ".charon")
-      --feature-set string             Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
-      --feature-set-disable strings    Comma-separated list of features to disable, overriding the default minimum feature set.
-      --feature-set-enable strings     Comma-separated list of features to enable, overriding the default minimum feature set.
-  -h, --help                           Help for run
-      --jaeger-address string          Listening address for jaeger tracing
-      --jaeger-service string          Service name used for jaeger tracing (default "charon")
-      --lock-file string               The path to the cluster lock file defining distributed validator cluster (default ".charon/cluster-lock.json")
-      --log-format string              Log format; console, logfmt or json (default "console")
-      --log-level string               Log level; debug, info, warn or error (default "info")
-      --monitoring-address string      Listening address (ip and port) for the monitoring API (prometheus, pprof) (default "127.0.0.1:3620")
-      --p2p-allowlist string           Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-bootnode-relay             Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
-      --p2p-bootnodes strings          Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.gcp.obol.tech:3640/enr])
-      --p2p-bootnodes-from-lockfile    Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
-      --p2p-denylist string            Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
-      --p2p-external-hostname string   The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
-      --p2p-external-ip string         The IP address advertised by libp2p. This may be used to advertise an external IP.
-      --p2p-tcp-address strings        Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. (default [127.0.0.1:3610])
-      --p2p-udp-address string         Listening UDP address (ip and port) for discv5 discovery. (default "127.0.0.1:3630")
-      --simnet-beacon-mock             Enables an internal mock beacon node for running a simnet.
-      --simnet-validator-mock          Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.
-      --validator-api-address string   Listening address (ip and port) for validator-facing traffic proxying the beacon-node API (default "127.0.0.1:3600")
+      --beacon-node-endpoint string     Beacon node endpoint URL. Deprecated, please use beacon-node-endpoints.
+      --beacon-node-endpoints strings   Comma separated list of one or more beacon node endpoint URLs.
+      --data-dir string                 The directory where charon will store all its internal data (default ".charon")
+      --feature-set string              Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
+      --feature-set-disable strings     Comma-separated list of features to disable, overriding the default minimum feature set.
+      --feature-set-enable strings      Comma-separated list of features to enable, overriding the default minimum feature set.
+  -h, --help                            Help for run
+      --jaeger-address string           Listening address for jaeger tracing.
+      --jaeger-service string           Service name used for jaeger tracing. (default "charon")
+      --lock-file string                The path to the cluster lock file defining distributed validator cluster. (default ".charon/cluster-lock.json")
+      --log-format string               Log format; console, logfmt or json (default "console")
+      --log-level string                Log level; debug, info, warn or error (default "info")
+      --monitoring-address string       Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
+      --p2p-allowlist string            Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
+      --p2p-bootnode-relay              Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
+      --p2p-bootnodes strings           Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.gcp.obol.tech:3640/enr])
+      --p2p-bootnodes-from-lockfile     Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
+      --p2p-denylist string             Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
+      --p2p-external-hostname string    The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
+      --p2p-external-ip string          The IP address advertised by libp2p. This may be used to advertise an external IP.
+      --p2p-tcp-address strings         Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. (default [127.0.0.1:3610])
+      --p2p-udp-address string          Listening UDP address (ip and port) for discv5 discovery. (default "127.0.0.1:3630")
+      --simnet-beacon-mock              Enables an internal mock beacon node for running a simnet.
+      --simnet-validator-mock           Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.
+      --validator-api-address string    Listening address (ip and port) for validator-facing traffic proxying the beacon-node API. (default "127.0.0.1:3600")
 
 ````
 <!-- Code above generated by cmd/cmd_internal_test.go#TestConfigReference. DO NOT EDIT -->

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -192,11 +192,7 @@ func (Mock) Name() string {
 	return "beacon-mock"
 }
 
-func (Mock) Address() string {
-	return "mock-address"
-}
-
-func (m Mock) HTTPAddr() string {
+func (m Mock) Address() string {
 	return "http://" + m.httpServer.Addr
 }
 


### PR DESCRIPTION
Adds support for multiple beacon nodes via eth2 multi client. Adds the `--beacon-node-endpoints` flags and deprecates `--beacon-node-endpoint` flag. Updates validatorapi proxy to use active eth2client address.

category: feature
ticket: #552 
