### PR TITLE
app/version: bump to v0.9.0

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -19,7 +19,7 @@ import "runtime/debug"
 
 // Version is the release version of the codebase.
 // Usually overridden by tag names when building binaries.
-const Version = "v0.8.0"
+const Version = "v0.9.0"
 
 // GitCommit returns the git commit hash and timestamp from build info.
 func GitCommit() (hash string, timestamp string) {


### PR DESCRIPTION
Bumps the version to v0.9.0 for release.

category: misc
ticket: none
