### PR TITLE
github: fix changelog generation

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -11,7 +11,8 @@ jobs:
     name: Build Docker Image
     steps:
     - uses: actions/checkout@v3
-
+      with:
+        fetch-depth: 0
     - uses: docker/setup-buildx-action@v1
 
     - name: Define docker image meta data tags


### PR DESCRIPTION
Fix automatic changelog generation by doing a deep checkout so full git history is available to `genchangelog`. 

category: misc
ticket: none
