### PR TITLE
app/eth2wrap: fix interface issue

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -47,6 +47,10 @@ var (
 		Name:      "errors_total",
 		Help:      "Total number of errors returned by eth2 beacon node requests",
 	}, []string{"endpoint"})
+
+	// Interface assertions.
+	_ eth2Provider = (*eth2http.Service)(nil)
+	_ eth2Provider = (*eth2multi.Service)(nil)
 )
 
 // NewHTTPService returns a new instrumented eth2 http service.

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -58,7 +58,6 @@ var (
 	_ eth2client.ProposerDutiesProvider                = (*Service)(nil)
 	_ eth2client.SignedBeaconBlockProvider             = (*Service)(nil)
 	_ eth2client.SlotDurationProvider                  = (*Service)(nil)
-	_ eth2client.SlotFromStateIDProvider               = (*Service)(nil)
 	_ eth2client.SlotsPerEpochProvider                 = (*Service)(nil)
 	_ eth2client.SpecProvider                          = (*Service)(nil)
 	_ eth2client.SyncCommitteeContributionProvider     = (*Service)(nil)
@@ -97,7 +96,6 @@ type eth2Provider interface {
 	eth2client.ProposerDutiesProvider
 	eth2client.SignedBeaconBlockProvider
 	eth2client.SlotDurationProvider
-	eth2client.SlotFromStateIDProvider
 	eth2client.SlotsPerEpochProvider
 	eth2client.SpecProvider
 	eth2client.SyncCommitteeContributionProvider

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -90,6 +90,7 @@ type eth2Provider interface {
 		"PubKey":                true,
 		"SyncState":             true,
 		"EpochFromStateID":      true,
+		"SlotFromStateID":       true,
 		"NodeClient":            true,
 	}
 


### PR DESCRIPTION
Fixes interface issue by removing `SlotFromStateID` which isn't supported by eth2multi. Also add interface assertions to avoid this in future.

category: bug
ticket: none

