### PR TITLE
app/eth2wrap: add Submitter interfaces to eth2wrap

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -34,16 +34,21 @@ var (
 	_ eth2client.Service = (*Service)(nil)
 
 	_ eth2client.AggregateAttestationProvider          = (*Service)(nil)
+	_ eth2client.AggregateAttestationsSubmitter        = (*Service)(nil)
 	_ eth2client.AttestationDataProvider               = (*Service)(nil)
 	_ eth2client.AttestationPoolProvider               = (*Service)(nil)
+	_ eth2client.AttestationsSubmitter                 = (*Service)(nil)
 	_ eth2client.AttesterDutiesProvider                = (*Service)(nil)
 	_ eth2client.BeaconBlockHeadersProvider            = (*Service)(nil)
 	_ eth2client.BeaconBlockProposalProvider           = (*Service)(nil)
 	_ eth2client.BeaconBlockRootProvider               = (*Service)(nil)
+	_ eth2client.BeaconBlockSubmitter                  = (*Service)(nil)
+	_ eth2client.BeaconCommitteeSubscriptionsSubmitter = (*Service)(nil)
 	_ eth2client.BeaconCommitteesProvider              = (*Service)(nil)
 	_ eth2client.BeaconStateProvider                   = (*Service)(nil)
 	_ eth2client.BeaconStateRootProvider               = (*Service)(nil)
 	_ eth2client.BlindedBeaconBlockProposalProvider    = (*Service)(nil)
+	_ eth2client.BlindedBeaconBlockSubmitter           = (*Service)(nil)
 	_ eth2client.DepositContractProvider               = (*Service)(nil)
 	_ eth2client.DomainProvider                        = (*Service)(nil)
 	_ eth2client.EventsProvider                        = (*Service)(nil)
@@ -55,6 +60,7 @@ var (
 	_ eth2client.GenesisTimeProvider                   = (*Service)(nil)
 	_ eth2client.NodeSyncingProvider                   = (*Service)(nil)
 	_ eth2client.NodeVersionProvider                   = (*Service)(nil)
+	_ eth2client.ProposalPreparationsSubmitter         = (*Service)(nil)
 	_ eth2client.ProposerDutiesProvider                = (*Service)(nil)
 	_ eth2client.SignedBeaconBlockProvider             = (*Service)(nil)
 	_ eth2client.SlotDurationProvider                  = (*Service)(nil)
@@ -62,27 +68,36 @@ var (
 	_ eth2client.SlotsPerEpochProvider                 = (*Service)(nil)
 	_ eth2client.SpecProvider                          = (*Service)(nil)
 	_ eth2client.SyncCommitteeContributionProvider     = (*Service)(nil)
+	_ eth2client.SyncCommitteeContributionsSubmitter   = (*Service)(nil)
 	_ eth2client.SyncCommitteeDutiesProvider           = (*Service)(nil)
+	_ eth2client.SyncCommitteeMessagesSubmitter        = (*Service)(nil)
+	_ eth2client.SyncCommitteeSubscriptionsSubmitter   = (*Service)(nil)
 	_ eth2client.SyncCommitteesProvider                = (*Service)(nil)
 	_ eth2client.TargetAggregatorsPerCommitteeProvider = (*Service)(nil)
 	_ eth2client.ValidatorBalancesProvider             = (*Service)(nil)
 	_ eth2client.ValidatorsProvider                    = (*Service)(nil)
+	_ eth2client.VoluntaryExitSubmitter                = (*Service)(nil)
 )
 
 type eth2Provider interface {
 	eth2client.Service
 
 	eth2client.AggregateAttestationProvider
+	eth2client.AggregateAttestationsSubmitter
 	eth2client.AttestationDataProvider
 	eth2client.AttestationPoolProvider
+	eth2client.AttestationsSubmitter
 	eth2client.AttesterDutiesProvider
 	eth2client.BeaconBlockHeadersProvider
 	eth2client.BeaconBlockProposalProvider
 	eth2client.BeaconBlockRootProvider
+	eth2client.BeaconBlockSubmitter
+	eth2client.BeaconCommitteeSubscriptionsSubmitter
 	eth2client.BeaconCommitteesProvider
 	eth2client.BeaconStateProvider
 	eth2client.BeaconStateRootProvider
 	eth2client.BlindedBeaconBlockProposalProvider
+	eth2client.BlindedBeaconBlockSubmitter
 	eth2client.DepositContractProvider
 	eth2client.DomainProvider
 	eth2client.EventsProvider
@@ -94,6 +109,7 @@ type eth2Provider interface {
 	eth2client.GenesisTimeProvider
 	eth2client.NodeSyncingProvider
 	eth2client.NodeVersionProvider
+	eth2client.ProposalPreparationsSubmitter
 	eth2client.ProposerDutiesProvider
 	eth2client.SignedBeaconBlockProvider
 	eth2client.SlotDurationProvider
@@ -101,11 +117,15 @@ type eth2Provider interface {
 	eth2client.SlotsPerEpochProvider
 	eth2client.SpecProvider
 	eth2client.SyncCommitteeContributionProvider
+	eth2client.SyncCommitteeContributionsSubmitter
 	eth2client.SyncCommitteeDutiesProvider
+	eth2client.SyncCommitteeMessagesSubmitter
+	eth2client.SyncCommitteeSubscriptionsSubmitter
 	eth2client.SyncCommitteesProvider
 	eth2client.TargetAggregatorsPerCommitteeProvider
 	eth2client.ValidatorBalancesProvider
 	eth2client.ValidatorsProvider
+	eth2client.VoluntaryExitSubmitter
 }
 
 // SignedBeaconBlock fetches a signed beacon block given a block ID.
@@ -192,6 +212,20 @@ func (s *Service) AggregateAttestation(ctx context.Context, slot phase0.Slot, at
 	return res0, err
 }
 
+// SubmitAggregateAttestations submits aggregate attestations.
+func (s *Service) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) error {
+	const label = "submit_aggregate_attestations"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitAggregateAttestations(ctx, aggregateAndProofs)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
+}
+
 // AttestationData fetches the attestation data for the given slot and committee index.
 func (s *Service) AttestationData(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (*phase0.AttestationData, error) {
 	const label = "attestation_data"
@@ -218,6 +252,20 @@ func (s *Service) AttestationPool(ctx context.Context, slot phase0.Slot) ([]*pha
 	}
 
 	return res0, err
+}
+
+// SubmitAttestations submits attestations.
+func (s *Service) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) error {
+	const label = "submit_attestations"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitAttestations(ctx, attestations)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
 }
 
 // AttesterDuties obtains attester duties.
@@ -250,6 +298,34 @@ func (s *Service) SyncCommitteeDuties(ctx context.Context, epoch phase0.Epoch, v
 	return res0, err
 }
 
+// SubmitSyncCommitteeMessages submits sync committee messages.
+func (s *Service) SubmitSyncCommitteeMessages(ctx context.Context, messages []*altair.SyncCommitteeMessage) error {
+	const label = "submit_sync_committee_messages"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitSyncCommitteeMessages(ctx, messages)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
+}
+
+// SubmitSyncCommitteeSubscriptions subscribes to sync committees.
+func (s *Service) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscriptions []*apiv1.SyncCommitteeSubscription) error {
+	const label = "submit_sync_committee_subscriptions"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitSyncCommitteeSubscriptions(ctx, subscriptions)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
+}
+
 // SyncCommitteeContribution provides a sync committee contribution.
 func (s *Service) SyncCommitteeContribution(ctx context.Context, slot phase0.Slot, subcommitteeIndex uint64, beaconBlockRoot phase0.Root) (*altair.SyncCommitteeContribution, error) {
 	const label = "sync_committee_contribution"
@@ -262,6 +338,20 @@ func (s *Service) SyncCommitteeContribution(ctx context.Context, slot phase0.Slo
 	}
 
 	return res0, err
+}
+
+// SubmitSyncCommitteeContributions submits sync committee contributions.
+func (s *Service) SubmitSyncCommitteeContributions(ctx context.Context, contributionAndProofs []*altair.SignedContributionAndProof) error {
+	const label = "submit_sync_committee_contributions"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitSyncCommitteeContributions(ctx, contributionAndProofs)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
 }
 
 // BeaconBlockHeader provides the block header of a given block ID.
@@ -306,6 +396,34 @@ func (s *Service) BeaconBlockRoot(ctx context.Context, blockID string) (*phase0.
 	return res0, err
 }
 
+// SubmitBeaconBlock submits a beacon block.
+func (s *Service) SubmitBeaconBlock(ctx context.Context, block *spec.VersionedSignedBeaconBlock) error {
+	const label = "submit_beacon_block"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitBeaconBlock(ctx, block)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
+}
+
+// SubmitBeaconCommitteeSubscriptions subscribes to beacon committees.
+func (s *Service) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*apiv1.BeaconCommitteeSubscription) error {
+	const label = "submit_beacon_committee_subscriptions"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
+}
+
 // BeaconState fetches a beacon state given a state ID.
 func (s *Service) BeaconState(ctx context.Context, stateID string) (*spec.VersionedBeaconState, error) {
 	const label = "beacon_state"
@@ -346,6 +464,20 @@ func (s *Service) BlindedBeaconBlockProposal(ctx context.Context, slot phase0.Sl
 	}
 
 	return res0, err
+}
+
+// SubmitBlindedBeaconBlock submits a beacon block.
+func (s *Service) SubmitBlindedBeaconBlock(ctx context.Context, block *api.VersionedSignedBlindedBeaconBlock) error {
+	const label = "submit_blinded_beacon_block"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitBlindedBeaconBlock(ctx, block)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
 }
 
 // Events feeds requested events with the given topics to the supplied handler.
@@ -402,6 +534,21 @@ func (s *Service) NodeSyncing(ctx context.Context) (*apiv1.SyncState, error) {
 	}
 
 	return res0, err
+}
+
+// SubmitProposalPreparations provides the beacon node with information required if a proposal for the given validators
+// shows up in the next epoch.
+func (s *Service) SubmitProposalPreparations(ctx context.Context, preparations []*apiv1.ProposalPreparation) error {
+	const label = "submit_proposal_preparations"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitProposalPreparations(ctx, preparations)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
 }
 
 // ProposerDuties obtains proposer duties for the given epoch.
@@ -468,4 +615,18 @@ func (s *Service) ValidatorsByPubKey(ctx context.Context, stateID string, valida
 	}
 
 	return res0, err
+}
+
+// SubmitVoluntaryExit submits a voluntary exit.
+func (s *Service) SubmitVoluntaryExit(ctx context.Context, voluntaryExit *phase0.SignedVoluntaryExit) error {
+	const label = "submit_voluntary_exit"
+	defer latency(label)()
+
+	err := s.eth2Provider.SubmitVoluntaryExit(ctx, voluntaryExit)
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2http")
+	}
+
+	return err
 }

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -306,7 +306,7 @@ func parseEth2Methods(pkg *packages.Package) ([]Method, []string, error) {
 					continue
 				}
 
-				if !strings.HasSuffix(typeSpec.Name.Name, "Provider") {
+				if !strings.HasSuffix(typeSpec.Name.Name, "Provider") && !strings.HasSuffix(typeSpec.Name.Name, "Submitter") {
 					continue
 				}
 


### PR DESCRIPTION
Adds Submitter suffixed interfaces to eth2Provider in eth2wrap.

category: bug
ticket: none
