### PR TITLE
testutil/beaconmock: wrap mock

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -449,9 +449,14 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 			return nil, "", err
 		}
 
+		wrap, err := eth2wrap.Wrap(bmock)
+		if err != nil {
+			return nil, "", err
+		}
+
 		life.RegisterStop(lifecycle.StopBeaconMock, lifecycle.HookFuncErr(bmock.Close))
 
-		return bmock, bmock.Address(), nil
+		return wrap, wrap.Address(), nil
 	}
 
 	if len(conf.BeaconNodeAddrs) == 0 {

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -53,6 +53,16 @@ var (
 	_ eth2Provider = (*eth2multi.Service)(nil)
 )
 
+// Wrap returns an instrumented wrapped eth2 service.
+func Wrap(eth2Svc eth2client.Service) (*Service, error) {
+	eth2Cl, ok := eth2Svc.(eth2Provider)
+	if !ok {
+		return nil, errors.New("invalid eth2 service")
+	}
+
+	return &Service{eth2Provider: eth2Cl}, nil
+}
+
 // NewHTTPService returns a new instrumented eth2 http service.
 func NewHTTPService(ctx context.Context, timeout time.Duration, addresses ...string) (*Service, error) {
 	var (

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -54,19 +54,19 @@ import (
 
 // Interface assertions.
 var (
-	_ HTTPMock                                      = (*Mock)(nil)
-	_ eth2client.AttestationDataProvider            = (*Mock)(nil)
-	_ eth2client.AttestationsSubmitter              = (*Mock)(nil)
-	_ eth2client.AttesterDutiesProvider             = (*Mock)(nil)
-	_ eth2client.BlindedBeaconBlockProposalProvider = (*Mock)(nil)
-	_ eth2client.BlindedBeaconBlockSubmitter        = (*Mock)(nil)
-	_ eth2client.BeaconBlockProposalProvider        = (*Mock)(nil)
-	_ eth2client.BeaconBlockSubmitter               = (*Mock)(nil)
-	_ eth2client.ProposerDutiesProvider             = (*Mock)(nil)
-	_ eth2client.Service                            = (*Mock)(nil)
-	_ eth2client.ValidatorsProvider                 = (*Mock)(nil)
-	_ eth2client.VoluntaryExitSubmitter             = (*Mock)(nil)
-	_ eth2client.EventsProvider                     = (*Mock)(nil)
+	_ HTTPMock                                      = Mock{}
+	_ eth2client.AttestationDataProvider            = Mock{}
+	_ eth2client.AttestationsSubmitter              = Mock{}
+	_ eth2client.AttesterDutiesProvider             = Mock{}
+	_ eth2client.BlindedBeaconBlockProposalProvider = Mock{}
+	_ eth2client.BlindedBeaconBlockSubmitter        = Mock{}
+	_ eth2client.BeaconBlockProposalProvider        = Mock{}
+	_ eth2client.BeaconBlockSubmitter               = Mock{}
+	_ eth2client.ProposerDutiesProvider             = Mock{}
+	_ eth2client.Service                            = Mock{}
+	_ eth2client.ValidatorsProvider                 = Mock{}
+	_ eth2client.VoluntaryExitSubmitter             = Mock{}
+	_ eth2client.EventsProvider                     = Mock{}
 )
 
 // New returns a new beacon client mock configured with the default and provided options.
@@ -125,6 +125,7 @@ func defaultHTTPMock() Mock {
 // Create a new instance with default behaviour via New and then override any function.
 type Mock struct {
 	HTTPMock
+	missingEth2Methods
 	httpServer *http.Server
 	overrides  []staticOverride
 	clock      clockwork.Clock

--- a/testutil/beaconmock/missing.go
+++ b/testutil/beaconmock/missing.go
@@ -1,0 +1,50 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package beaconmock
+
+import (
+	"context"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// missingEth2Methods defines the set of eth2 methods that are not implements by beaconmock but required by eth2wrap.
+// We are opting for runtime errors for beaconmock but compiletime errors for eth2http and eth2multi.
+type missingEth2Methods interface {
+	AggregateAttestation(ctx context.Context, slot eth2p0.Slot, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error)
+	SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*eth2p0.SignedAggregateAndProof) error
+	AttestationPool(ctx context.Context, slot eth2p0.Slot) ([]*eth2p0.Attestation, error)
+	BeaconBlockHeader(ctx context.Context, blockID string) (*eth2v1.BeaconBlockHeader, error)
+	BeaconBlockRoot(ctx context.Context, blockID string) (*eth2p0.Root, error)
+	SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2v1.BeaconCommitteeSubscription) error
+	BeaconState(ctx context.Context, stateID string) (*spec.VersionedBeaconState, error)
+	BeaconStateRoot(ctx context.Context, stateID string) (*eth2p0.Root, error)
+	FarFutureEpoch(ctx context.Context) (eth2p0.Epoch, error)
+	Finality(ctx context.Context, stateID string) (*eth2v1.Finality, error)
+	SubmitProposalPreparations(ctx context.Context, preparations []*eth2v1.ProposalPreparation) error
+	SignedBeaconBlock(ctx context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error)
+	SyncCommitteeContribution(ctx context.Context, slot eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
+	SubmitSyncCommitteeContributions(ctx context.Context, contributionAndProofs []*altair.SignedContributionAndProof) error
+	SubmitSyncCommitteeMessages(ctx context.Context, messages []*altair.SyncCommitteeMessage) error
+	SubmitSyncCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2v1.SyncCommitteeSubscription) error
+	SyncCommittee(ctx context.Context, stateID string) (*eth2v1.SyncCommittee, error)
+	SyncCommitteeAtEpoch(ctx context.Context, stateID string, epoch eth2p0.Epoch) (*eth2v1.SyncCommittee, error)
+	TargetAggregatorsPerCommittee(ctx context.Context) (uint64, error)
+	ValidatorBalances(ctx context.Context, stateID string, validatorIndices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]eth2p0.Gwei, error)
+}


### PR DESCRIPTION
Wraps beaconmock in eth2wrap to get better metrics and runtime safety.

category: misc
ticket: none
