### PR TITLE
core/tracker: implement analyse cluster participation

### DIFF
--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -22,6 +22,7 @@ import (
 
 var participationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "core",
-	Name:      "cluster_participation",
+	Subsystem: "tracker",
+	Name:      "participation",
 	Help:      "Set to 1 if peer participated successfully for the given duty and Distributed Validator public key or else 0",
-}, []string{"duty", "peer_name", "pubkeys"})
+}, []string{"duty", "peer"})

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -1,0 +1,27 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var participationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "core",
+	Name:      "cluster_participation",
+	Help:      "Set to 1 if peer participated successfully for the given duty and Distributed Validator public key or else 0",
+}, []string{"duty", "peer_name", "pubkey"})

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -24,5 +24,5 @@ var participationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "core",
 	Subsystem: "tracker",
 	Name:      "participation",
-	Help:      "Set to 1 if peer participated successfully for the given duty and Distributed Validator public key or else 0",
+	Help:      "Set to 1 if peer participated successfully for the given duty or else 0",
 }, []string{"duty", "peer"})

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -24,4 +24,4 @@ var participationGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Namespace: "core",
 	Name:      "cluster_participation",
 	Help:      "Set to 1 if peer participated successfully for the given duty and Distributed Validator public key or else 0",
-}, []string{"duty", "peer_name", "pubkey"})
+}, []string{"duty", "peer_name", "pubkeys"})

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -91,6 +91,7 @@ func New(deadliner core.Deadliner, peers []p2p.Peer) *Tracker {
 // Run blocks and registers events from each component in tracker's input channel.
 // It also analyses and reports the duties whose deadline gets crossed.
 func (t *Tracker) Run(ctx context.Context) error {
+	ctx = log.WithTopic(ctx, "tracker")
 	defer close(t.quit)
 
 	for {
@@ -159,7 +160,7 @@ func analyseParticipation(events []event) (map[int]bool, error) {
 		// If we get a parSigEx event, then the corresponding peer with e.shareIdx participated successfully.
 		if e.component == parSigEx || e.component == parSigDBInternal {
 			if e.shareIdx == 0 {
-				return nil, errors.New("invalid shareIdx", z.Any("component", e.component))
+				return nil, errors.New("shareIdx empty", z.Any("component", e.component))
 			}
 			resp[e.shareIdx] = true
 		}

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -174,7 +174,6 @@ func analyseParticipation(events []event) map[core.PubKey]map[shareIdx]bool {
 }
 
 // newParticipationReporter returns a new participation reporter function which logs and instruments peer participation
-
 func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty, map[core.PubKey]map[shareIdx]bool, map[core.PubKey]map[shareIdx]bool) {
 	return func(ctx context.Context, duty core.Duty, currentParticipation map[core.PubKey]map[shareIdx]bool, lastParticipation map[core.PubKey]map[shareIdx]bool) {
 		for pubKey, dvPeers := range currentParticipation {

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -192,7 +192,7 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 			// Avoid spamming from identical logs.
 			if len(absentPeers) > 0 && !reflect.DeepEqual(currentParticipation[pubKey], lastParticipation[pubKey]) {
 				log.Info(ctx, "Peers didn't participate",
-					z.Str("pubkey", pubKey.String()),
+					z.Str("pubkeys", pubKey.String()),
 					z.Str("duty", duty.String()),
 					z.Any("peers", absentPeers),
 				)

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -186,10 +186,11 @@ func TestTrackerParticipation(t *testing.T) {
 	deadliner := testDeadliner{deadlineChan: make(chan core.Duty)}
 	tr := New(deadliner, peers)
 
-	count := 0
+	var count int
 	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, lastParticipation map[core.PubKey]map[shareIdx]bool) {
 		require.Equal(t, testData[count].duty, actualDuty)
 		require.True(t, reflect.DeepEqual(actualParticipation, participationPerDuty[testData[count].duty]))
+
 		if count == 2 {
 			// For third duty, last Participation should be equal to that of second duty.
 			require.Equal(t, participationPerDuty[testData[count].duty], lastParticipation)

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -17,18 +17,25 @@ package tracker
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"math/rand"
+	"reflect"
 	"testing"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
 )
 
-func TestTracker(t *testing.T) {
-	duty, defSet, pubkey, unsignedDataSet, parSignedDataSet := setupData(t)
+func TestTrackerFailedDuty(t *testing.T) {
+	duty, pubkeys, defSet, unsignedDataSet, parSignedDataSet := setupData(t)
 
 	t.Run("FailAtConsensus", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
@@ -40,10 +47,12 @@ func TestTracker(t *testing.T) {
 			require.Equal(t, duty, failedDuty)
 			require.True(t, isFailed)
 			require.Equal(t, component, "consensus")
+
+			// Signal exit to central go routine.
 			cancel()
 		}
 
-		tr := New(deadliner)
+		tr := New(deadliner, []p2p.Peer{})
 		tr.failedDutyReporter = failedDutyReporter
 
 		go func() {
@@ -67,10 +76,12 @@ func TestTracker(t *testing.T) {
 			require.Equal(t, duty, failedDuty)
 			require.False(t, isFailed)
 			require.Equal(t, "sigAgg", component)
+
+			// Signal exit to central go routine.
 			cancel()
 		}
 
-		tr := New(deadliner)
+		tr := New(deadliner, []p2p.Peer{})
 		tr.failedDutyReporter = failedDutyReporter
 
 		go func() {
@@ -80,8 +91,10 @@ func TestTracker(t *testing.T) {
 			require.NoError(t, tr.ValidatorAPIEvent(ctx, duty, parSignedDataSet))
 			require.NoError(t, tr.ParSigDBInternalEvent(ctx, duty, parSignedDataSet))
 			require.NoError(t, tr.ParSigExEvent(ctx, duty, parSignedDataSet))
-			require.NoError(t, tr.ParSigDBThresholdEvent(ctx, duty, pubkey, nil))
-			require.NoError(t, tr.SigAggEvent(ctx, duty, pubkey, nil))
+			for _, pk := range pubkeys {
+				require.NoError(t, tr.ParSigDBThresholdEvent(ctx, duty, pk, nil))
+				require.NoError(t, tr.SigAggEvent(ctx, duty, pk, nil))
+			}
 
 			// Explicitly mark the current duty as deadlined.
 			deadliner.deadlineChan <- duty
@@ -89,6 +102,144 @@ func TestTracker(t *testing.T) {
 
 		require.ErrorIs(t, tr.Run(ctx), context.Canceled)
 	})
+}
+
+func TestTrackerAllParticipation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	expectedDuty, pubkeys, _, _, internalPSignedDataSet := setupData(t)
+
+	numPeers := 3
+	peers := testPeers(t, numPeers)
+	expectedParticipation := make(map[core.PubKey]map[shareIdx]bool)
+	for _, pk := range pubkeys {
+		expectedParticipation[pk] = make(map[shareIdx]bool)
+		expectedParticipation[pk][1] = true // Own participation
+
+		// Other peers participation.
+		for _, peer := range peers {
+			expectedParticipation[pk][shareIdx(peer.Index+1)] = true
+		}
+	}
+
+	// ParSignedDataSet to be sent by ParSigExEvent corresponding to each peer.
+	var pSigDataPerPeer []core.ParSignedDataSet
+	for _, p := range peers {
+		data := make(core.ParSignedDataSet)
+		for _, pk := range pubkeys {
+			data[pk] = core.ParSignedData{ShareIdx: p.Index + 1}
+		}
+		pSigDataPerPeer = append(pSigDataPerPeer, data)
+	}
+
+	deadliner := testDeadliner{deadlineChan: make(chan core.Duty)}
+	tr := New(deadliner, peers)
+	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, unique bool) {
+		require.Equal(t, expectedDuty, actualDuty)
+		require.True(t, reflect.DeepEqual(actualParticipation, expectedParticipation))
+		require.True(t, unique)
+
+		// Signal exit to central go routine.
+		cancel()
+	}
+	// Ignore failedDutyReporter part to isolate participation only
+	tr.failedDutyReporter = func(core.Duty, bool, string, string) {}
+
+	go func() {
+		require.NoError(t, tr.ParSigDBInternalEvent(ctx, expectedDuty, internalPSignedDataSet))
+		for _, data := range pSigDataPerPeer {
+			require.NoError(t, tr.ParSigExEvent(ctx, expectedDuty, data))
+		}
+		for _, pk := range pubkeys {
+			require.NoError(t, tr.ParSigDBThresholdEvent(ctx, expectedDuty, pk, nil))
+			require.NoError(t, tr.SigAggEvent(ctx, expectedDuty, pk, nil))
+		}
+
+		// Explicitly mark the current duty as deadlined.
+		deadliner.deadlineChan <- expectedDuty
+	}()
+
+	require.ErrorIs(t, tr.Run(ctx), context.Canceled)
+}
+
+func TestTrackerLessParticipation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	expectedDuty, pubkeys, _, _, internalPSignedDataSet := setupData(t)
+
+	numPeers := 3
+	peers := testPeers(t, numPeers)
+	expectedParticipation := make(map[core.PubKey]map[shareIdx]bool)
+	for _, pk := range pubkeys {
+		expectedParticipation[pk] = make(map[shareIdx]bool)
+		expectedParticipation[pk][1] = true // Own participation
+
+		// Other peers participation
+		for _, peer := range peers {
+			expectedParticipation[pk][shareIdx(peer.Index+1)] = true
+		}
+		// Drop one peer
+		delete(expectedParticipation[pk], shareIdx(peers[0].Index+1))
+	}
+
+	// ParSignedDataSet to be sent by ParSigExEvent corresponding to each peer.
+	var pSigDataPerPeer []core.ParSignedDataSet
+	for _, p := range peers {
+		data := make(core.ParSignedDataSet)
+		for _, pk := range pubkeys {
+			data[pk] = core.ParSignedData{ShareIdx: p.Index + 1}
+		}
+		pSigDataPerPeer = append(pSigDataPerPeer, data)
+	}
+
+	// Drop one peer
+	pSigDataPerPeer = pSigDataPerPeer[1:]
+
+	deadliner := testDeadliner{deadlineChan: make(chan core.Duty)}
+	tr := New(deadliner, peers)
+	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, unique bool) {
+		require.Equal(t, expectedDuty, actualDuty)
+		require.True(t, reflect.DeepEqual(actualParticipation, expectedParticipation))
+		require.True(t, unique)
+
+		// Signal exit to central go routine.
+		cancel()
+	}
+	// Ignore failedDutyReporter part to isolate participation only
+	tr.failedDutyReporter = func(core.Duty, bool, string, string) {}
+
+	go func() {
+		require.NoError(t, tr.ParSigDBInternalEvent(ctx, expectedDuty, internalPSignedDataSet))
+		for _, data := range pSigDataPerPeer {
+			require.NoError(t, tr.ParSigExEvent(ctx, expectedDuty, data))
+		}
+
+		// Explicitly mark the current duty as deadlined.
+		deadliner.deadlineChan <- expectedDuty
+	}()
+
+	require.ErrorIs(t, tr.Run(ctx), context.Canceled)
+}
+
+func testPeers(t *testing.T, n int) []p2p.Peer {
+	t.Helper()
+
+	var resp []p2p.Peer
+	for i := 1; i <= n; i++ {
+		p2pKey, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(int64(i))))
+		require.NoError(t, err)
+
+		var r enr.Record
+		r.SetSeq(0)
+
+		err = enode.SignV4(&r, p2pKey)
+		require.NoError(t, err)
+
+		p, err := p2p.NewPeer(r, i)
+		require.NoError(t, err)
+
+		resp = append(resp, p)
+	}
+
+	return resp
 }
 
 // testDeadliner is a mock deadliner implementation.
@@ -105,7 +256,7 @@ func (t testDeadliner) C() <-chan core.Duty {
 }
 
 // setupData returns the data required to test tracker.
-func setupData(t *testing.T) (core.Duty, core.DutyDefinitionSet, core.PubKey, core.UnsignedDataSet, core.ParSignedDataSet) {
+func setupData(t *testing.T) (core.Duty, map[eth2p0.ValidatorIndex]core.PubKey, core.DutyDefinitionSet, core.UnsignedDataSet, core.ParSignedDataSet) {
 	t.Helper()
 
 	const (
@@ -115,11 +266,9 @@ func setupData(t *testing.T) (core.Duty, core.DutyDefinitionSet, core.PubKey, co
 		notZero = 99 // Validation require non-zero values
 	)
 
-	pubkey := testutil.RandomCorePubKey(t)
-
 	pubkeysByIdx := map[eth2p0.ValidatorIndex]core.PubKey{
-		vIdxA: pubkey,
-		vIdxB: pubkey,
+		vIdxA: testutil.RandomCorePubKey(t),
+		vIdxB: testutil.RandomCorePubKey(t),
 	}
 
 	dutyA := eth2v1.AttesterDuty{
@@ -154,9 +303,9 @@ func setupData(t *testing.T) (core.Duty, core.DutyDefinitionSet, core.PubKey, co
 	for pubkey := range defSet {
 		parSignedDataSet[pubkey] = core.ParSignedData{
 			SignedData: nil,
-			ShareIdx:   0,
+			ShareIdx:   1,
 		}
 	}
 
-	return duty, defSet, pubkey, unsignedDataSet, parSignedDataSet
+	return duty, pubkeysByIdx, defSet, unsignedDataSet, parSignedDataSet
 }

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -133,10 +133,9 @@ func TestTrackerAllParticipation(t *testing.T) {
 
 	deadliner := testDeadliner{deadlineChan: make(chan core.Duty)}
 	tr := New(deadliner, peers)
-	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, unique bool) {
+	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, _ map[core.PubKey]map[shareIdx]bool) {
 		require.Equal(t, expectedDuty, actualDuty)
 		require.True(t, reflect.DeepEqual(actualParticipation, expectedParticipation))
-		require.True(t, unique)
 
 		// Signal exit to central go routine.
 		cancel()
@@ -195,10 +194,9 @@ func TestTrackerLessParticipation(t *testing.T) {
 
 	deadliner := testDeadliner{deadlineChan: make(chan core.Duty)}
 	tr := New(deadliner, peers)
-	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, unique bool) {
+	tr.participationReporter = func(_ context.Context, actualDuty core.Duty, actualParticipation map[core.PubKey]map[shareIdx]bool, _ map[core.PubKey]map[shareIdx]bool) {
 		require.Equal(t, expectedDuty, actualDuty)
 		require.True(t, reflect.DeepEqual(actualParticipation, expectedParticipation))
-		require.True(t, unique)
 
 		// Signal exit to central go routine.
 		cancel()

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -46,6 +46,11 @@ type Peer struct {
 	Name string
 }
 
+// ShareIdx returns share index of this Peer.
+func (p Peer) ShareIdx() int {
+	return p.Index + 1
+}
+
 // NewPeer returns a new charon peer.
 func NewPeer(record enr.Record, index int) (Peer, error) {
 	var enodePubkey enode.Secp256k1

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -46,7 +46,7 @@ type Peer struct {
 	Name string
 }
 
-// ShareIdx returns share index of this Peer.
+// ShareIdx returns share index of this Peer. ShareIdx is 1-indexed while peerIdx is 0-indexed.
 func (p Peer) ShareIdx() int {
 	return p.Index + 1
 }


### PR DESCRIPTION
Implements analyse cluster participation and participation reporter to calculate cluster participation based on partial signatures exchanged and instruments the results.

category: feature
ticket: #821
