### PR TITLE
cluster: refactor v1.2.0 to hex

### DIFF
--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -462,6 +462,6 @@ type definitionJSONv1x2 struct {
 	WithdrawalAddress   string             `json:"withdrawal_address,omitempty"`
 	DKGAlgorithm        string             `json:"dkg_algorithm"`
 	ForkVersion         string             `json:"fork_version"`
-	ConfigHash          base58             `json:"config_hash"`
-	DefinitionHash      base58             `json:"definition_hash"`
+	ConfigHash          ethHex             `json:"config_hash"`
+	DefinitionHash      ethHex             `json:"definition_hash"`
 }

--- a/cluster/distvalidator.go
+++ b/cluster/distvalidator.go
@@ -91,7 +91,7 @@ type distValidatorJSONv1x1 struct {
 // distValidatorJSONv1x2 is the json formatter of DistValidator for versions v1.2.0 and later.
 type distValidatorJSONv1x2 struct {
 	PubKey              ethHex   `json:"distributed_public_key"`
-	PubShares           []base58 `json:"public_shares,omitempty"`
+	PubShares           []ethHex `json:"public_shares,omitempty"`
 	FeeRecipientAddress string   `json:"fee_recipient_address,omitempty"`
 }
 
@@ -115,7 +115,7 @@ func distValidatorsFromV1x1(distValidators []distValidatorJSONv1x1) []DistValida
 func distValidatorsToV1x1(distValidators []DistValidator) ([]distValidatorJSONv1x1, error) {
 	var resp []distValidatorJSONv1x1
 	for _, dv := range distValidators {
-		var shares []base58
+		var shares []ethHex
 		for _, share := range dv.PubShares {
 			shares = append(shares, share)
 		}
@@ -149,7 +149,7 @@ func distValidatorsFromV1x2(distValidators []distValidatorJSONv1x2) []DistValida
 func distValidatorsToV1x2(distValidators []DistValidator) ([]distValidatorJSONv1x2, error) {
 	var resp []distValidatorJSONv1x2
 	for _, dv := range distValidators {
-		var shares []base58
+		var shares []ethHex
 		for _, share := range dv.PubShares {
 			shares = append(shares, share)
 		}

--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/signer/core/apitypes"
-	b58 "github.com/mr-tron/base58"
 
 	"github.com/obolnetwork/charon/app/errors"
 )
@@ -97,34 +96,6 @@ func digestEIP712(address string, message []byte, nonce int) ([32]byte, error) {
 	rawData := []byte(fmt.Sprintf("\x19\x01%s%s", string(domainSeparator), string(typedDataHash)))
 
 	return crypto.Keccak256Hash(rawData), nil
-}
-
-// base58 represents a byte slices that is json formatted as base58.
-type base58 []byte
-
-func (b *base58) UnmarshalJSON(data []byte) error {
-	var str58 string
-	if err := json.Unmarshal(data, &str58); err != nil {
-		return errors.Wrap(err, "unmarshal base58 string")
-	}
-
-	resp, err := b58.Decode(str58)
-	if err != nil {
-		return errors.Wrap(err, "unmarshal base58")
-	}
-
-	*b = resp
-
-	return nil
-}
-
-func (b base58) MarshalJSON() ([]byte, error) {
-	resp, err := json.Marshal(b58.Encode(b))
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal base58")
-	}
-
-	return resp, nil
 }
 
 // ethHex represents a byte slices that is json formatted as 0x prefixed hex.

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -215,6 +215,6 @@ type lockJSONv1x1 struct {
 type lockJSONv1x2 struct {
 	Definition         Definition              `json:"cluster_definition"`
 	Validators         []distValidatorJSONv1x2 `json:"distributed_validators"`
-	SignatureAggregate base58                  `json:"signature_aggregate"`
-	LockHash           base58                  `json:"lock_hash"`
+	SignatureAggregate ethHex                  `json:"signature_aggregate"`
+	LockHash           ethHex                  `json:"lock_hash"`
 }

--- a/cluster/testdata/definition_v1_2_0.json
+++ b/cluster/testdata/definition_v1_2_0.json
@@ -25,6 +25,6 @@
  "withdrawal_address": "0x81855ad8681d0d86d1e91e00167939cb6694d2c4",
  "dkg_algorithm": "default",
  "fork_version": "0x00000002",
- "config_hash": "DCpH5R1gjgM1f6LSb3AUiLytR9vtudRNupTYUXzsEZL7",
- "definition_hash": "HrZF9DRExsjfycAjxHivg7TyCs5jamdUTyCH6ew6Vsu"
+ "config_hash": "0xb55316a71b36def96de991157cae9e2d91bf36a9f183f9dc3fd6cec6fb28009c",
+ "definition_hash": "0x045153757e859572ed61b2fefd5fa9982a94de0029eb55dc35570596f9ed8200"
 }

--- a/cluster/testdata/lock_v1_2_0.json
+++ b/cluster/testdata/lock_v1_2_0.json
@@ -26,25 +26,25 @@
   "withdrawal_address": "0x81855ad8681d0d86d1e91e00167939cb6694d2c4",
   "dkg_algorithm": "default",
   "fork_version": "0x00000002",
-  "config_hash": "DCpH5R1gjgM1f6LSb3AUiLytR9vtudRNupTYUXzsEZL7",
-  "definition_hash": "HrZF9DRExsjfycAjxHivg7TyCs5jamdUTyCH6ew6Vsu"
+  "config_hash": "0xb55316a71b36def96de991157cae9e2d91bf36a9f183f9dc3fd6cec6fb28009c",
+  "definition_hash": "0x045153757e859572ed61b2fefd5fa9982a94de0029eb55dc35570596f9ed8200"
  },
  "distributed_validators": [
   {
    "distributed_public_key": "0x4c7215a3b539eb1e5849c6077dbb5722f5717a28",
    "public_shares": [
-    "m61LeNo64BuJXhkNEUksDsuLHrK72euehDZ9XArsRJN",
-    "3U9mUEP8CoVU6iNxWPcjTmnW9pyL8mv2CDDvYtQyQZQB"
+    "0x0b4b373970115e82ed6f4125c8fa7311e4d7defa922daae7786667f7e936cd4f",
+    "0x24abf7df866baa56038367ad6145de1ee8f4a8b0993ebdf8883a0ad8be9c3978"
    ]
   },
   {
    "distributed_public_key": "0xb04883e56a156a8de563afa467d49dec6a40e9a1",
    "public_shares": [
-    "BjqgJrKCMnQie8X6zwVNBSfoqR4TSPXyyAuFg9rtBD5o",
-    "7s1mP4MawgThd8Hcci2Q9MGVh8nsma8sXeXUyC1qf3qp"
+    "0x9f8e4da6430105220d0b29688b734b8ea0f3ca9936e8461f10d77c96ea80a7a6",
+    "0x65f606f6a63b7f3dfd2567c18979e4d60f26686d9bf2fb26c901ff354cde1607"
    ]
   }
  ],
- "signature_aggregate": "52tPbov2Pj8E77VLnATFiwweM6WnWX3SRTf3irCEsbeH",
- "lock_hash": "EBppsyQRmoZTm9kuG8JDYhcXbZjkEXGTDXaYfrqNVBG"
+ "signature_aggregate": "0x3bea6f5b3af6de0374366c4719e43a1b067d89bc7f01f1f573981659a44ff17a",
+ "lock_hash": "0x0360ca3755497e55d52ceb1a9f9435cfd2a9ef20e6565d610f3b3b447c3c3e2b"
 }

--- a/cluster/version.go
+++ b/cluster/version.go
@@ -19,8 +19,8 @@ const (
 	currentVersion = v1_1
 	dkgAlgo        = "default"
 
-	v1_2 = "v1.2.0" // WIP
-	v1_1 = "v1.1.0"
+	v1_2 = "v1.2.0" // Draft
+	v1_1 = "v1.1.0" // Default
 	v1_0 = "v1.0.0"
 )
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,8 +34,8 @@ The schema of the `cluster-definition.json` is defined as:
   "withdrawal_address": "0x123..abfc",          // ETH1 withdrawal address
   "dkg_algorithm": "foo_dkg_v1" ,               // Optional DKG algorithm for key generation
   "fork_version": "0x00112233",                 // Chain/Network identifier
-  "config_hash": "abcfde...acbfed",             // Base58 hash of the static (non-changing) fields
-  "definition_hash": "abcdef...abcedef"         // Final base58 hash of all fields
+  "config_hash": "abcfde...acbfed",             // Hash of the static (non-changing) fields
+  "definition_hash": "abcdef...abcedef"         // Final hash of all fields
 }
 ```
 
@@ -52,8 +52,8 @@ The `cluster-lock.json` has the following schema:
       "fee_recipient": "0x123..abfc"                        // Defaults to withdrawal address if not set, can be edited manually
     }
   ],
-  "lock_hash": "abcdef...abcedef",                          // Base58 config_hash plus distributed_validators
-  "signature_aggregate": "abcdef...abcedef"                 // Base58 BLS aggregate signature of the lock hash signed by each DV pubkey.
+  "lock_hash": "abcdef...abcedef",                          // Config_hash plus distributed_validators
+  "signature_aggregate": "abcdef...abcedef"                 // BLS aggregate signature of the lock hash signed by each DV pubkey.
 }
 ```
 
@@ -63,9 +63,8 @@ The `cluster-lock.json` has the following schema:
 
 The following is the historical change log of the cluster config:
 - `v1.2.0` **draft**:
-  - Refactored base64 EIP712 signatures to 0x prefixed hex.
+  - Refactored all base64 fields to Ethereum's standard 0x prefixed hex.
     - Refactored definition operator signatures: `config_signature` and `enr_signature`.
-  - Refactored base64 fields to base58.
     - Refactored definition fields: `config_hash` and `definition_hash`.
     - Refactored lock fields: `lock_hash`, `signature_aggregate` and `distributed_validators.public_shares`.
   - See example [definition.json](../cluster/testdata/definition_v1_2_0.json) and [lock.json](../cluster/testdata/lock_v1_2_0.json)

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/libp2p/go-libp2p v0.20.0
 	github.com/libp2p/go-libp2p-core v0.17.0
-	github.com/mr-tron/base58 v1.2.0
 	github.com/multiformats/go-multiaddr v0.6.0
 	github.com/prometheus/client_golang v1.12.2
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
@@ -122,6 +121,7 @@ require (
 	github.com/minio/blake2b-simd v0.0.0-20160723061019-3f5f724cb5b1 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
+	github.com/mr-tron/base58 v1.2.0 // indirect
 	github.com/multiformats/go-base32 v0.0.4 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-multiaddr-dns v0.3.1 // indirect


### PR DESCRIPTION
Refactors v1.2.0 to hex instead of base58 since that is standard ETH format for bytes.

category: refactor
ticket: #848 
