### PR TITLE
core/validator: leverage eth2multi refresh when no active peers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -194,8 +194,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	initStartupMetrics(lockHashHex)
 
-	// TODO(dhruv): Get rid of fallbackBeaconAddr when it is being handled by eth2client.
-	eth2Cl, fallbackBeaconAddr, err := newETH2Client(ctx, conf, life, lock.Validators)
+	eth2Cl, err := newETH2Client(ctx, conf, life, lock.Validators)
 	if err != nil {
 		return err
 	}
@@ -209,7 +208,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 
-	if err := wireCoreWorkflow(ctx, life, conf, lock, nodeIdx, tcpNode, p2pKey, eth2Cl, fallbackBeaconAddr, peerIDs); err != nil {
+	if err := wireCoreWorkflow(ctx, life, conf, lock, nodeIdx, tcpNode, p2pKey, eth2Cl, peerIDs); err != nil {
 		return err
 	}
 
@@ -279,8 +278,8 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 // wireCoreWorkflow wires the core workflow components.
 func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
-	lock cluster.Lock, nodeIdx cluster.NodeIdx, tcpNode host.Host, p2pKey *ecdsa.PrivateKey, eth2Cl eth2client.Service,
-	fallbackBeaconAddr string, peerIDs []peer.ID,
+	lock cluster.Lock, nodeIdx cluster.NodeIdx, tcpNode host.Host, p2pKey *ecdsa.PrivateKey,
+	eth2Cl eth2client.Service, peerIDs []peer.ID,
 ) error {
 	// Convert and prep public keys and public shares
 	var (
@@ -340,7 +339,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	if err := wireVAPIRouter(life, conf.ValidatorAPIAddr, eth2Cl, fallbackBeaconAddr, vapi); err != nil {
+	if err := wireVAPIRouter(life, conf.ValidatorAPIAddr, eth2Cl, vapi); err != nil {
 		return err
 	}
 
@@ -429,10 +428,10 @@ func eth2PubKeys(validators []cluster.DistValidator) ([]eth2p0.BLSPubKey, error)
 // simnet or a multi http client to a real beacon node.
 func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 	validators []cluster.DistValidator,
-) (eth2client.Service, string, error) {
+) (eth2client.Service, error) {
 	pubkeys, err := eth2PubKeys(validators)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
 	if conf.SimnetBMock { // Configure the beacon mock.
@@ -446,29 +445,29 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		opts = append(opts, conf.TestConfig.SimnetBMockOpts...)
 		bmock, err := beaconmock.New(opts...)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 
 		wrap, err := eth2wrap.Wrap(bmock)
 		if err != nil {
-			return nil, "", err
+			return nil, err
 		}
 
 		life.RegisterStop(lifecycle.StopBeaconMock, lifecycle.HookFuncErr(bmock.Close))
 
-		return wrap, wrap.Address(), nil
+		return wrap, nil
 	}
 
 	if len(conf.BeaconNodeAddrs) == 0 {
-		return nil, "", errors.New("beacon node endpoints empty")
+		return nil, errors.New("beacon node endpoints empty")
 	}
 
 	eth2Cl, err := eth2wrap.NewHTTPService(ctx, eth2ClientTimeout, conf.BeaconNodeAddrs...)
 	if err != nil {
-		return nil, "", errors.Wrap(err, "new eth2 http client")
+		return nil, errors.Wrap(err, "new eth2 http client")
 	}
 
-	return eth2Cl, conf.BeaconNodeAddrs[0], nil
+	return eth2Cl, nil
 }
 
 // newConsensus returns a new consensus component and its start lifecycle hook.
@@ -526,8 +525,8 @@ func createMockValidators(pubkeys []eth2p0.BLSPubKey) beaconmock.ValidatorSet {
 }
 
 // wireVAPIRouter constructs the validator API router and registers it with the life cycle manager.
-func wireVAPIRouter(life *lifecycle.Manager, vapiAddr string, eth2Cl eth2client.Service, fallbackBeaconAddr string, handler validatorapi.Handler) error {
-	vrouter, err := validatorapi.NewRouter(handler, eth2Cl, fallbackBeaconAddr)
+func wireVAPIRouter(life *lifecycle.Manager, vapiAddr string, eth2Cl eth2client.Service, handler validatorapi.Handler) error {
+	vrouter, err := validatorapi.NewRouter(handler, eth2Cl)
 	if err != nil {
 		return errors.Wrap(err, "new monitoring server")
 	}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -69,7 +69,7 @@ type Handler interface {
 // NewRouter returns a new validator http server router. The http router
 // translates http requests related to the distributed validator to the validatorapi.Handler.
 // All other requests are reserve-proxied to the beacon-node address.
-func NewRouter(h Handler, eth2Cl eth2client.Service, fallbackBeaconAddr string) (*mux.Router, error) {
+func NewRouter(h Handler, eth2Cl eth2client.Service) (*mux.Router, error) {
 	// Register subset of distributed validator related endpoints
 	endpoints := []struct {
 		Name    string
@@ -140,7 +140,7 @@ func NewRouter(h Handler, eth2Cl eth2client.Service, fallbackBeaconAddr string) 
 	}
 
 	// Everything else is proxied
-	proxy, err := proxyHandler(eth2Cl, fallbackBeaconAddr)
+	proxy, err := proxyHandler(eth2Cl)
 	if err != nil {
 		return nil, err
 	}
@@ -512,10 +512,10 @@ func submitExit(p eth2client.VoluntaryExitSubmitter) handlerFunc {
 }
 
 // proxyHandler returns a reverse proxy handler.
-func proxyHandler(eth2Cl eth2client.Service, fallbackBeaconAddr string) (http.HandlerFunc, error) {
+func proxyHandler(eth2Cl eth2client.Service) (http.HandlerFunc, error) {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Get active beacon node address.
-		targetURL, err := getBeaconNodeAddress(eth2Cl, fallbackBeaconAddr)
+		targetURL, err := getBeaconNodeAddress(r.Context(), eth2Cl)
 		if err != nil {
 			ctx := log.WithTopic(r.Context(), "vapi")
 			log.Error(ctx, "Proxy target beacon node address", err)
@@ -544,10 +544,23 @@ func proxyHandler(eth2Cl eth2client.Service, fallbackBeaconAddr string) (http.Ha
 }
 
 // getBeaconNodeAddress returns an active beacon node proxy target address.
-func getBeaconNodeAddress(eth2Cl eth2client.Service, fallbackBeaconAddr string) (*url.URL, error) {
+func getBeaconNodeAddress(ctx context.Context, eth2Cl eth2client.Service) (*url.URL, error) {
 	addr := eth2Cl.Address()
 	if addr == "none" {
-		addr = fallbackBeaconAddr
+		// Trigger refresh of inactive clients to hopefully resolve any active clients.
+		syncProvider, ok := eth2Cl.(eth2client.NodeSyncingProvider)
+		if !ok {
+			return nil, errors.New("invalid eth2 client")
+		}
+		_, err := syncProvider.NodeSyncing(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "ping inactive beacon nodes")
+		}
+
+		addr = eth2Cl.Address()
+		if addr == "none" {
+			return nil, errors.Wrap(err, "no active beacon nodes")
+		}
 	}
 
 	targetURL, err := url.Parse(addr)

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -554,12 +554,12 @@ func getBeaconNodeAddress(ctx context.Context, eth2Cl eth2client.Service) (*url.
 		}
 		_, err := syncProvider.NodeSyncing(ctx)
 		if err != nil {
-			return nil, errors.Wrap(err, "ping inactive beacon nodes")
+			return nil, errors.New("no active beacon nodes") // Not wrapping since error will be confusing.
 		}
 
 		addr = eth2Cl.Address()
 		if addr == "none" {
-			return nil, errors.Wrap(err, "no active beacon nodes")
+			return nil, errors.New("no active beacon nodes")
 		}
 	}
 

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -52,7 +52,7 @@ func TestRouterIntegration(t *testing.T) {
 		t.Skip("Skipping integration test since BEACON_URL not found")
 	}
 
-	r, err := NewRouter(Handler(nil), testBeaconAddr(beaconURL), beaconURL)
+	r, err := NewRouter(Handler(nil), testBeaconAddr(beaconURL))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -528,7 +528,7 @@ func testRouter(t *testing.T, handler testHandler, callback func(context.Context
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, testBeaconAddr(proxy.URL), proxy.URL)
+	r, err := NewRouter(handler, testBeaconAddr(proxy.URL))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -549,7 +549,7 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, testBeaconAddr(proxy.URL), proxy.URL)
+	r, err := NewRouter(handler, testBeaconAddr(proxy.URL))
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)


### PR DESCRIPTION
Remove fallback workaround for eth2multi and trigger newly added refresh logic when no clients are active.

category: refactor
ticket: none
