### PR TITLE
p2p: improve external hostname error message

### DIFF
--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -56,7 +56,7 @@ func runCreateEnrCmd(w io.Writer, config p2p.Config, dataDir string) error {
 
 	localEnode, db, err := p2p.NewLocalEnode(config, key)
 	if err != nil {
-		return errors.Wrap(err, "failed to open peer DB")
+		return errors.Wrap(err, "failed to open enode")
 	}
 	defer db.Close()
 

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/netutil"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 // UDPNode wraps a discv5 udp node and adds the bootnodes relays.
@@ -113,7 +114,8 @@ func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *eno
 	if config.ExternalHost != "" {
 		ips, err := net.LookupIP(config.ExternalHost)
 		if err != nil || len(ips) == 0 {
-			return nil, nil, errors.Wrap(err, "could not resolve p2p external host")
+			return nil, nil, errors.Wrap(err, "resolve IP of p2p external host flag",
+				z.Str("p2p_external_hostname", config.ExternalHost))
 		}
 
 		// Use first IPv4 returned from the resolver.


### PR DESCRIPTION
Improve error message when `p2p_external_hostname` flag cannot be resolved to an IP.

Previous: `failed to open peer DB: could not resolve p2p external host: lookup charon on 192.168.65.5:53: no such host
`
New: `failed to open enode: resolve IP of p2p external host flag: lookup charon on 192.168.65.5:53: no such host {"p2p_external_hostname":"charon"}
 `

category: misc
ticket: none

