### PR TITLE
core: fix deadliner constructor bug

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -79,6 +79,7 @@ issues:
     - "defer: prefer not to defer chains of function calls" # Relax revive
     - "avoid control coupling" # Relax revive
     - "shadows an import name" # Relax revive
+    - "confusing-naming" # Relax revive
     - "shadow: declaration of \"err\" shadows declaration" # Relax govet
 
 linters:

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -50,7 +50,7 @@ func TestDeadliner(t *testing.T) {
 		}
 	}
 
-	deadliner := core.NewForT(ctx, t, deadlineFuncProvider(), clock)
+	deadliner := core.NewDeadlinerForT(ctx, t, deadlineFuncProvider(), clock)
 
 	wg := &sync.WaitGroup{}
 

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -201,6 +201,8 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 		if fmt.Sprint(prevAbsent) != fmt.Sprint(absentPeers) {
 			if len(absentPeers) == 0 {
 				log.Info(ctx, "All peers participated in duty")
+			} else if len(absentPeers) == len(peers) {
+				log.Info(ctx, "No peers participated in duty")
 			} else {
 				log.Info(ctx, "Not all peers participated in duty", z.Any("absent", absentPeers))
 			}


### PR DESCRIPTION
Fix deadliner constructor issue which was due to having multiple different constructors.

category: bug
ticket: none
