### PR TITLE
app: push readyz in background

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -205,7 +205,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 
-	if err := wireMonitoringAPI(life, conf.MonitoringAddr, localEnode, tcpNode, eth2Cl, peerIDs); err != nil {
+	if err := wireMonitoringAPI(ctx, life, conf.MonitoringAddr, localEnode, tcpNode, eth2Cl, peerIDs); err != nil {
 		return err
 	}
 

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -35,6 +35,12 @@ import (
 	"github.com/obolnetwork/charon/app/lifecycle"
 )
 
+var (
+	errReadyPingFailing      = errors.New("couldn't ping all peers")
+	errReadySyncing          = errors.New("beacon node not synced")
+	errReadyBeaconNodeFailed = errors.New("failed to get beacon sync state")
+)
+
 // wireMonitoringAPI constructs the monitoring API and registers it with the life cycle manager.
 // It serves prometheus metrics, pprof profiling and the runtime enr.
 func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, addr string, localNode *enode.LocalNode, tcpNode host.Host, eth2Svc eth2client.Service, peerIDs []peer.ID) error {
@@ -101,23 +107,32 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2client
 			case <-ctx.Done():
 				return
 			case <-ticker.Chan():
-				mu.Lock()
 				syncing, err := beaconNodeSyncing(ctx, eth2Cl)
 				if err != nil {
-					readyErr = errors.New("failed to get beacon sync state")
+					mu.Lock()
+					readyErr = errReadyBeaconNodeFailed
+					mu.Unlock()
+
 					readyzGauge.Set(0)
 				} else if syncing {
-					readyErr = errors.New("beacon node not synced")
+					mu.Lock()
+					readyErr = errReadySyncing
+					mu.Unlock()
+
 					readyzGauge.Set(0)
 				} else if peersReady(ctx, peerIDs, tcpNode) != nil {
-					readyErr = errors.New("couldn't ping all peers")
+					mu.Lock()
+					readyErr = errReadyPingFailing
+					mu.Unlock()
+
 					readyzGauge.Set(0)
 				} else {
+					mu.Lock()
 					readyErr = nil
+					mu.Unlock()
+
 					readyzGauge.Set(1)
 				}
-
-				mu.Unlock()
 			}
 		}
 	}()
@@ -159,7 +174,7 @@ func peersReady(ctx context.Context, peerIDs []peer.ID, tcpNode host.Host) error
 	var (
 		// Require quorum successes (excluding self). Formula from IBFT 2.0 paper https://arxiv.org/pdf/1909.10194.pdf
 		require  = int(math.Ceil(float64(len(peerIDs)*2)/3)) - 1
-		actual   int
+		okCount  int
 		errCount int
 	)
 	for {
@@ -170,7 +185,7 @@ func peersReady(ctx context.Context, peerIDs []peer.ID, tcpNode host.Host) error
 			if res.Error != nil {
 				errCount++
 			} else {
-				actual++
+				okCount++
 			}
 
 			// Return error if we cannot reach quorum peers.
@@ -178,7 +193,7 @@ func peersReady(ctx context.Context, peerIDs []peer.ID, tcpNode host.Host) error
 				return errors.New("not enough peers")
 			}
 
-			if actual == require {
+			if okCount == require {
 				return nil
 			}
 		}

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -126,6 +126,7 @@ func TestStartCheckerSyncing(t *testing.T) {
 	clock.Advance(15 * time.Second)
 	clock.BlockUntil(1)
 
+	// Infinite loop required since mutexes are non-deterministic.
 	for {
 		err := readyErrFunc()
 		if err != nil {
@@ -183,6 +184,7 @@ func TestStartCheckerPingFail(t *testing.T) {
 	clock.Advance(15 * time.Second)
 	clock.BlockUntil(1)
 
+	// Infinite loop required since mutexes are non-deterministic.
 	for {
 		err := readyErrFunc()
 		if err != nil {

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -118,7 +118,7 @@ func TestStartChecker(t *testing.T) {
 					}
 
 					return false
-				}, 10*time.Millisecond, time.Millisecond)
+				}, 100*time.Millisecond, time.Millisecond)
 			} else {
 				require.Eventually(t, func() bool {
 					err = readyErrFunc()
@@ -127,7 +127,7 @@ func TestStartChecker(t *testing.T) {
 					}
 
 					return false
-				}, 10*time.Millisecond, time.Millisecond)
+				}, 100*time.Millisecond, time.Millisecond)
 			}
 		})
 	}

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -120,7 +120,14 @@ func TestStartChecker(t *testing.T) {
 					return false
 				}, 10*time.Millisecond, time.Millisecond)
 			} else {
-				require.NoError(t, readyErrFunc())
+				require.Eventually(t, func() bool {
+					err = readyErrFunc()
+					if err == nil {
+						return true
+					}
+
+					return false
+				}, 10*time.Millisecond, time.Millisecond)
 			}
 		})
 	}

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -1,0 +1,203 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/jonboulle/clockwork"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+func TestStartCheckerSuccess(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	const numNodes = 3
+	var (
+		peers     []peer.ID
+		hosts     []host.Host
+		hostsInfo []peer.AddrInfo
+	)
+
+	for i := 0; i < numNodes; i++ {
+		h := testutil.CreateHost(t, testutil.AvailableAddr(t))
+		info := peer.AddrInfo{
+			ID:    h.ID(),
+			Addrs: h.Addrs(),
+		}
+		hostsInfo = append(hostsInfo, info)
+		peers = append(peers, h.ID())
+		hosts = append(hosts, h)
+	}
+
+	// connect each host with its peers
+	for i := 0; i < numNodes; i++ {
+		for k := 0; k < numNodes; k++ {
+			if i == k {
+				continue
+			}
+			hosts[i].Peerstore().AddAddrs(hostsInfo[k].ID, hostsInfo[k].Addrs, peerstore.PermanentAddrTTL)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(nodeIdx int) {
+			defer wg.Done()
+			clock := clockwork.NewFakeClock()
+			readyErrFunc := startReadyChecker(ctx, hosts[nodeIdx], bmock, peers, clock)
+
+			// We wrap the Advance() calls with blockers to make sure that the ticker
+			// can go to sleep and produce ticks without time passing in parallel.
+			clock.BlockUntil(1)
+			clock.Advance(15 * time.Second)
+			clock.BlockUntil(1)
+
+			require.NoError(t, readyErrFunc(), nodeIdx)
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestStartCheckerSyncing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	bmock.NodeSyncingFunc = func(ctx context.Context) (*eth2v1.SyncState, error) {
+		return &eth2v1.SyncState{IsSyncing: true}, nil
+	}
+
+	const numNodes = 3
+	var (
+		peers     []peer.ID
+		hosts     []host.Host
+		hostsInfo []peer.AddrInfo
+	)
+
+	for i := 0; i < numNodes; i++ {
+		h := testutil.CreateHost(t, testutil.AvailableAddr(t))
+		info := peer.AddrInfo{
+			ID:    h.ID(),
+			Addrs: h.Addrs(),
+		}
+		hostsInfo = append(hostsInfo, info)
+		peers = append(peers, h.ID())
+		hosts = append(hosts, h)
+	}
+
+	// connect each host with its peers
+	for i := 0; i < numNodes; i++ {
+		for k := 0; k < numNodes; k++ {
+			if i == k {
+				continue
+			}
+			hosts[i].Peerstore().AddAddrs(hostsInfo[k].ID, hostsInfo[k].Addrs, peerstore.PermanentAddrTTL)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(nodeIdx int) {
+			defer wg.Done()
+			clock := clockwork.NewFakeClock()
+			readyErrFunc := startReadyChecker(ctx, hosts[nodeIdx], bmock, peers, clock)
+
+			// We wrap the Advance() calls with blockers to make sure that the ticker
+			// can go to sleep and produce ticks without time passing in parallel.
+			clock.BlockUntil(1)
+			clock.Advance(15 * time.Second)
+			clock.BlockUntil(1)
+
+			require.EqualError(t, readyErrFunc(), "beacon node not synced")
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestStartCheckerPingFail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	const numNodes = 3
+	var (
+		peers     []peer.ID
+		hosts     []host.Host
+		hostsInfo []peer.AddrInfo
+	)
+
+	for i := 0; i < numNodes; i++ {
+		h := testutil.CreateHost(t, testutil.AvailableAddr(t))
+		info := peer.AddrInfo{
+			ID:    h.ID(),
+			Addrs: h.Addrs(),
+		}
+		hostsInfo = append(hostsInfo, info)
+		peers = append(peers, h.ID())
+		hosts = append(hosts, h)
+	}
+
+	// Connect each host with its peers except last one
+	for i := 0; i < numNodes-1; i++ {
+		for k := 0; k < numNodes-1; k++ {
+			if i == k {
+				continue
+			}
+			hosts[i].Peerstore().AddAddrs(hostsInfo[k].ID, hostsInfo[k].Addrs, peerstore.PermanentAddrTTL)
+		}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numNodes; i++ {
+		wg.Add(1)
+		go func(nodeIdx int) {
+			defer wg.Done()
+
+			clock := clockwork.NewFakeClock()
+			readyErrFunc := startReadyChecker(ctx, hosts[nodeIdx], bmock, peers, clock)
+
+			// We wrap the Advance() calls with blockers to make sure that the ticker
+			// can go to sleep and produce ticks without time passing in parallel.
+			clock.BlockUntil(1)
+			clock.Advance(15 * time.Second)
+			clock.BlockUntil(1)
+
+			require.EqualError(t, readyErrFunc(), "couldn't ping all peers")
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
This change pushed readyz metrics every 1 second. Earlier we were pushing this metric only when someone calls readyz endpoint. If no-one calls that endpoint it will show inactive on readyz grafana panel.

category: bug
ticket: #880 
