### PR TITLE
p2p: fix empty allow list

### DIFF
--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -49,14 +49,17 @@ func NewUDPNode(config Config, ln *enode.LocalNode,
 		return nil, errors.Wrap(err, "parse udp address")
 	}
 
-	netlist, err := netutil.ParseNetlist(config.Allowlist)
-	if err != nil {
-		return nil, errors.Wrap(err, "parse allow list")
+	var allowList *netutil.Netlist
+	if config.Allowlist != "" {
+		allowList, err = netutil.ParseNetlist(config.Allowlist) // Note empty string results in "none allowed".
+		if err != nil {
+			return nil, errors.Wrap(err, "parse allow list")
+		}
 	}
 
 	node, err := discover.ListenV5(conn, ln, discover.Config{
 		PrivateKey:  key,
-		NetRestrict: netlist,
+		NetRestrict: allowList,
 		Bootnodes:   bootnodes,
 	})
 	if err != nil {

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -51,7 +51,7 @@ func NewUDPNode(config Config, ln *enode.LocalNode,
 
 	var allowList *netutil.Netlist
 	if config.Allowlist != "" {
-		allowList, err = netutil.ParseNetlist(config.Allowlist) // Note empty string results in "none allowed".
+		allowList, err = netutil.ParseNetlist(config.Allowlist) // Note empty string would result in "none allowed".
 		if err != nil {
 			return nil, errors.Wrap(err, "parse allow list")
 		}


### PR DESCRIPTION
When `--p2p-allowlist` is not defined, it should default to "allow all". But an empty string results in a empty netlist which results in "allow none". This is only now a problem since geth's discv5 previously ignored `NetRestrict`. 

category: bug
ticket: none
