### PR TITLE
docs: add more examples and details to tradeoffs

### DIFF
--- a/docs/goguidelines.md
+++ b/docs/goguidelines.md
@@ -36,7 +36,7 @@ Instead, it follows a more procedural style for a focus on *functions and values
 
 > Note that we do use types and interfaces and methods and mutable state when required, we just prefer immutable values and functions where applicable.
 
-The following are examples of *functions and values over types 
+The following are examples of *functions and values over types*: 
 ### Prefer functions returning functions over new types with methods #1
 ```go
 // startReadyChecker returns a function that returns true if the app is ready.

--- a/docs/goguidelines.md
+++ b/docs/goguidelines.md
@@ -25,14 +25,71 @@ We take inspiration and guidance from these top-quality go projects.
 
 ## Tradeoffs
 Go is a high-level imperative “getting s@&!t done” language but there are always a
-thousand ways to approach a problem. Keeping the following priorities in mind should
-drive to what the go community refers to as “canonical go”.
+thousand ways to approach a problem. The Charon codebase doesn't follow the common OOP-like style which emphasises *types and interfaces*. 
+Instead, it follows a more procedural style for a focus on *functions and values*, [#AlgorthimsAndDataStructuresOverTypes](https://en.wikipedia.org/wiki/Object-oriented_programming#cite_note-48). This style can be summarized by the following tradeoffs:
 
 - Prefer **unexported over exported** types and functions. [#WriteShyCode](https://dave.cheney.net/practical-go/presentations/qcon-china.html#_package_design)
 - Prefer **functions over methods** as methods lends itself to stateful code while functions are stateless. [#FunctionsOverMethods](https://kellysutton.com/2018/07/13/simple-made-easy-methods-vs-functions.html)
 - Prefer **structs over objects** as structs tend to be more on the immutable data side while “objects” tend to be mutable and combine data with logic. [#TheValueOfValues](https://www.youtube.com/watch?v=-I-VpPMzG7c)
 - Prefer **explicit over implement** as explicit code doesn’t hide anything while implicit code does.
 - Prefer **immutability over mutability** as that results in code that is easier to reason about and debug and compose.
+
+> Note that we do use types and interfaces and methods and mutable state when required, we just prefer immutable values and functions where applicable.
+
+The following are examples of *functions and values over types 
+### Prefer functions returning functions over new types with methods #1
+```go
+// startReadyChecker returns a function that returns true if the app is ready.
+isReady := startReadyChecker(foo, bar)
+// Use the isReady function
+for isReady() { ... }
+```
+vs
+```go
+// newReadyChecker returns a checker instance that has a IsReady method that returns true if the app is ready.
+checker := newReadyChecker(foo, bar)
+// Use the checker instance
+for checker.IsReady() { ... }
+```
+Reasoning: The startReadyChecker contains all state and logic in one function and the resulting isReady function cannot be misused. The checker instance introduces a new type with fields that are accesible and can therefore be misused, it is also at risk of being extended with more logic and coupling.
+ 
+### Prefer functions returning functions over new types with methods #2
+```go
+// newFooHandler returns a http.HandlerFunc for handling foo requests.
+mux.Handle("/foo", newFooHandler(dependencies))
+``` 
+vs 
+```go
+// newServer returns a server instance with http.HandlerFunc methods handling all requests (including foo requests).
+server := newServer(dependencies)
+mux.Handle("/foo", server.handleFoo)
+``` 
+Reasoning: The newFooHandler is completely decoupled from other handlers, except via explicit dependencies. The server struct will grow and grow and will attract shared state and coupling.
+
+### Prefer function local variables and anonumous mutation functions over fields and methods
+```go
+func foo() {
+   var x,y,z int
+   updateState := func(x2,y2,z2 int) {
+     // Update x,y,z in one place
+   }
+
+   // Call updateState when required
+}
+``` 
+vs
+```go
+type fooer struct {
+  x,y,z int
+}
+func (f fooer) foo() {
+  // Call f.updateState when required
+}
+func (f fooer) updateState(x2,y2,z2 int) {
+  // Update x,y,z in one place
+}
+```
+Reasoning: Function local variables cannot be leaked and misuse is much harder than struct fields which are accessible from anywhere.
 
 ## Style
 We follow [go fumpt](https://pkg.go.dev/mvdan.cc/gofumpt) , `go vet` and [golangci-lint](https://golangci-lint.run/) for automated formatting and vetting and linting,

--- a/docs/goguidelines.md
+++ b/docs/goguidelines.md
@@ -25,7 +25,7 @@ We take inspiration and guidance from these top-quality go projects.
 
 ## Tradeoffs
 Go is a high-level imperative “getting s@&!t done” language but there are always a
-thousand ways to approach a problem. The Charon codebase doesn't follow the common OOP-like style which emphasises *types and interfaces*. 
+thousand ways to approach a problem. The Charon codebase doesn't follow the common OOP-like style which emphasises *types and interfaces*.
 Instead, it follows a more procedural style for a focus on *functions and values*, [#AlgorthimsAndDataStructuresOverTypes](https://en.wikipedia.org/wiki/Object-oriented_programming#cite_note-48). This style can be summarized by the following tradeoffs:
 
 - Prefer **unexported over exported** types and functions. [#WriteShyCode](https://dave.cheney.net/practical-go/presentations/qcon-china.html#_package_design)
@@ -36,7 +36,7 @@ Instead, it follows a more procedural style for a focus on *functions and values
 
 > Note that we do use types and interfaces and methods and mutable state when required, we just prefer immutable values and functions where applicable.
 
-The following are examples of *functions and values over types*: 
+The following are examples of *functions and values over types*:
 ### Prefer functions returning functions over new types with methods #1
 ```go
 // startReadyChecker returns a function that returns true if the app is ready.
@@ -52,18 +52,18 @@ checker := newReadyChecker(foo, bar)
 for checker.IsReady() { ... }
 ```
 Reasoning: The startReadyChecker contains all state and logic in one function and the resulting isReady function cannot be misused. The checker instance introduces a new type with fields that are accesible and can therefore be misused, it is also at risk of being extended with more logic and coupling.
- 
+
 ### Prefer functions returning functions over new types with methods #2
 ```go
 // newFooHandler returns a http.HandlerFunc for handling foo requests.
 mux.Handle("/foo", newFooHandler(dependencies))
-``` 
-vs 
+```
+vs
 ```go
 // newServer returns a server instance with http.HandlerFunc methods handling all requests (including foo requests).
 server := newServer(dependencies)
 mux.Handle("/foo", server.handleFoo)
-``` 
+```
 Reasoning: The newFooHandler is completely decoupled from other handlers, except via explicit dependencies. The server struct will grow and grow and will attract shared state and coupling.
 
 ### Prefer function local variables and anonumous mutation functions over fields and methods
@@ -76,7 +76,7 @@ func foo() {
 
    // Call updateState when required
 }
-``` 
+```
 vs
 ```go
 type fooer struct {


### PR DESCRIPTION
Make our style more explicit and add examples.

category: docs 
ticket: none
