### PR TITLE
dkg/sync: only shutdown server once response written

### DIFF
--- a/dkg/sync/server.go
+++ b/dkg/sync/server.go
@@ -183,10 +183,6 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 			return err
 		}
 
-		if msg.Shutdown {
-			s.setShutdown(pID)
-		}
-
 		// Prep response
 		resp := &pb.MsgSyncResponse{
 			SyncTimestamp: msg.Timestamp,
@@ -215,6 +211,7 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 		}
 
 		if msg.Shutdown {
+			s.setShutdown(pID)
 			return nil
 		}
 	}


### PR DESCRIPTION
Mitigate against broken connections during DKG sync protocol shutdown. Only mark client as shutdown after successfully sending the response from the server. Note this still doesn't guarantee that the client will always receive it (the connection can break en-route), but this does reduce the scope of the race condition.

category: bug
ticket: none
