### PR TITLE
p2p: enable autonat

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -61,7 +61,8 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater,
 		libp2p.UserAgent("obolnetwork-charon/" + version.Version),
 		// Limit connections to DV peers.
 		libp2p.ConnectionGater(connGater),
-
+		// Enable Autonat (required for hole punching)
+		libp2p.EnableNATService(),
 		// Define p2pcfg.AddrsFactory that does not advertise
 		// addresses via libp2p, since we use discv5 for peer discovery.
 		libp2p.AddrsFactory(func([]ma.Multiaddr) []ma.Multiaddr { return nil }),


### PR DESCRIPTION
Enables libp2p.Autonat feature by default on both Charon and BootNodes. This is required for holepunching but should not affect current networking in any negative way.

category: feature
ticket: none
