### PR TITLE
github: add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,11 +1,11 @@
 ---
-name: "\U0001F41EBug report"
-about: Report a bug or problem with running charon-distributed-validator-node
+name: "\U0001F41E Bug report"
+about: Report a bug or problem with running charon
 labels: Bug
 ---
 <!--
 
-Hellooo! 😄
+Hey there!
 
 To help us tend to your issue faster, please search our currently open issues before submitting a new one.
 Existing issues often contain information about workarounds, resolution, or progress updates.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,59 @@
+---
+name: "\U0001F41EBug report"
+about: Report a bug or problem with running charon-distributed-validator-node
+labels: Bug
+---
+<!--
+
+Hellooo! 😄
+
+To help us tend to your issue faster, please search our currently open issues before submitting a new one.
+Existing issues often contain information about workarounds, resolution, or progress updates.
+
+]-->
+
+# 🐞 Bug Report
+
+### Description
+
+<!-- ✍️--> A clear and concise description of the problem...
+
+### Has this worked before in a previous version?
+
+<!-- Did this behavior use to work in the previous version? -->
+<!-- ✍️--> Yes, the previous version in which this bug was not present was: ....
+
+## 🔬 Minimal Reproduction
+
+<!--
+Please let us know how we can reproduce this issue. Include the exact method you used to run Charon along with any flags used in your beacon chain and/or validator. Make sure you don't upload any confidential files or private keys!
+-->
+
+## 🔥 Error
+
+<pre><code>
+<!-- If the issue is accompanied by an error, please share the error logs with us below. If you have a lot of logs, place make a paste bin with your logs and share the link with us here: -->
+<!-- ✍️-->
+
+</code></pre>
+
+
+## 🌍  Your Environment
+
+**Operating System:**
+
+<pre>
+  <code>
+
+  </code>
+</pre>
+
+**What version of Charon are you running? (Which release)**
+
+<pre>
+  <code>
+
+  </code>
+</pre>
+
+**Anything else relevant (validator index / public key)?**

--- a/.github/ISSUE_TEMPLATE/feature_flag.md
+++ b/.github/ISSUE_TEMPLATE/feature_flag.md
@@ -1,0 +1,37 @@
+---
+name: "\U0001F984Feature Flag Tracking"
+about: Track a new feature, in development, in Charon. This issue template should only be used by developers or contributors!
+labels: Tracking
+---
+<!--
+Hey There! 😄
+
+Thanks for taking the time to file a tracking issue for your new feature. These issues really help
+us track progress of features as they work their way through development. Be sure to review
+docs/branching.md#controlled-introduction-of-change for the latest documentation around feature flags.
+
+-->
+
+# Feature Tracking
+
+**Current status** (opt-in or opt-out):
+
+**Opt-in feature flag name**:
+
+**Opt-out feature flag name**:
+
+### Feature Description
+
+<!-- --> A clear and concise description of the new feature. Provide links to your technical
+design document or other supporting information.
+
+### Tasks
+
+- [ ] Feature flag created as opt-in
+- [ ] Feature implemented / code complete
+- [ ] Feature tested in production for adequate amount of time
+- [ ] Feature flag is inverted to be opt-out and the opt-in flag is deprecated
+- [ ] Feature has made it to a tagged production release as an opt-out flag
+- [ ] Opt-out feature flag is deprecated and old code paths are cleaned up
+
+This issue should be closed after all of the above tasks are complete.

--- a/.github/ISSUE_TEMPLATE/feature_flag.md
+++ b/.github/ISSUE_TEMPLATE/feature_flag.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F984Feature Flag Tracking"
+name: "\U0001F984 Feature Flag Tracking"
 about: Track a new feature, in development, in Charon. This issue template should only be used by developers or contributors!
 labels: Tracking
 ---

--- a/.github/ISSUE_TEMPLATE/feature_ticket.md
+++ b/.github/ISSUE_TEMPLATE/feature_ticket.md
@@ -1,6 +1,12 @@
+---
+name: "\U0001F680Feature Ticket"
+about: Create a new feature for charon
+labels: Enhancement
+---
+
 ## Problem to be solved
 
-Describe the problem in detail.
+Describe the problem to be solved by this feature in detail.
 
 ## Proposed solution
 

--- a/.github/ISSUE_TEMPLATE/feature_ticket.md
+++ b/.github/ISSUE_TEMPLATE/feature_ticket.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F680Feature Ticket"
+name: "\U0001F680 Feature Ticket"
 about: Create a new feature for charon
 labels: Enhancement
 ---

--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,22 @@
+# This is a basic workflow adding every issue in this repo to the Obol Project Management Board.
+name: Add Issue To Project
+
+# Controls when the workflow will run - new issues
+on:
+  issues:
+    types:
+      - opened
+
+# This workflow contains a single job called "build"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    # Steps
+    steps:
+      - name: Add Issue To Project
+        uses: actions/add-to-project@v0.3.0
+        with:
+          # URL of the project to add issues to
+          project-url: https://github.com/orgs/ObolNetwork/projects/7
+          # A GitHub personal access token with write access to the project, need org admin's token with repo and project permissions, need to store the token outside the script if public
+          github-token: ${{ secrets.GH_ORG_ADMIN_SECRET }}


### PR DESCRIPTION
Also adds a github action that auto assigns issues to the new board, saving us all precious moments of our day 😇 

Should really have split this into two PRs, let me know if that would be preferred.

category: misc
ticket: none