### PR TITLE
cmd: write expanded form of enr in charon enr

### DIFF
--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -23,6 +23,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/p2p"
 )
 
@@ -52,7 +53,7 @@ func newCreateEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 func runCreateEnrCmd(w io.Writer, config p2p.Config, dataDir string) error {
 	_, err := p2p.LoadPrivKey(dataDir)
 	if err == nil {
-		return errors.New("charon-enr-private-key already exists")
+		return errors.New("charon-enr-private-key already exists", z.Str("enr_path", p2p.KeyPath(dataDir)))
 	}
 
 	key, err := p2p.NewSavedPrivKey(dataDir)

--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -48,7 +48,13 @@ func newCreateEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 }
 
 // runCreateEnrCmd stores a new charon-enr-private-key to disk and prints the ENR for the provided config.
+// It returns an error if the key already exists.
 func runCreateEnrCmd(w io.Writer, config p2p.Config, dataDir string) error {
+	_, err := p2p.LoadPrivKey(dataDir)
+	if err == nil {
+		return errors.New("charon-enr-private-key already exists")
+	}
+
 	key, err := p2p.NewSavedPrivKey(dataDir)
 	if err != nil {
 		return err

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -71,18 +71,18 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, silent bool) erro
 	defer db.Close()
 
 	newEnr := localEnode.Node().String()
-	r, err := p2p.DecodeENR(newEnr)
-	if err != nil {
-		return err
-	}
-
 	_, _ = fmt.Fprintln(w, newEnr)
 
 	if silent {
 		return nil
 	}
 
-	writeExpandedEnr(w, r.Signature(), r.Seq(), pubkeyBytes(&key.PublicKey))
+	r, err := p2p.DecodeENR(newEnr)
+	if err != nil {
+		return err
+	}
+
+	writeExpandedEnr(w, r.Signature(), r.Seq(), MarshalECDSAPubkey(&key.PublicKey))
 
 	return nil
 }
@@ -101,8 +101,8 @@ func writeExpandedEnr(w io.Writer, sig []byte, seq uint64, pubkey []byte) {
 	_, _ = w.Write([]byte(sb.String()))
 }
 
-// pubkeyBytes returns compressed public key bytes.
-func pubkeyBytes(pub *ecdsa.PublicKey) []byte {
+// MarshalECDSAPubkey returns compressed public key bytes.
+func MarshalECDSAPubkey(pub *ecdsa.PublicKey) []byte {
 	if pub == nil || pub.X == nil || pub.Y == nil {
 		return nil
 	}

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -76,20 +76,19 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string) error {
 
 	_, _ = fmt.Fprintln(w, newEnr)
 
-	writeExpandedEnr(w, r.Signature(), r.Seq(), r.IdentityScheme(), pubkeyBytes(&key.PublicKey))
+	writeExpandedEnr(w, r.Signature(), r.Seq(), pubkeyBytes(&key.PublicKey))
 
 	return nil
 }
 
 // writeExpandedEnr writes the expanded form of ENR to the terminal.
-func writeExpandedEnr(w io.Writer, sig []byte, seq uint64, id string, pubkey []byte) {
+func writeExpandedEnr(w io.Writer, sig []byte, seq uint64, pubkey []byte) {
 	var sb strings.Builder
 	_, _ = sb.WriteString("\n")
 	_, _ = sb.WriteString("***************** Decoded ENR (see https://enr-viewer.com/ for additional fields) **********************\n")
+	_, _ = sb.WriteString(fmt.Sprintf("secp256k1 pubkey: %#x\n", pubkey))
 	_, _ = sb.WriteString(fmt.Sprintf("signature: %#x\n", sig))
 	_, _ = sb.WriteString(fmt.Sprintf("seq: %d\n", seq))
-	_, _ = sb.WriteString(fmt.Sprintf("id: %s\n", id))
-	_, _ = sb.WriteString(fmt.Sprintf("secp256k1 pubkey: %#x\n", pubkey))
 	_, _ = sb.WriteString("********************************************************************************************************\n")
 	_, _ = sb.WriteString("\n")
 

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -35,7 +35,7 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, string, bool) error) *cobra.C
 	var (
 		config  p2p.Config
 		dataDir string
-		silent  bool
+		verbose bool
 	)
 
 	cmd := &cobra.Command{
@@ -44,19 +44,19 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, string, bool) error) *cobra.C
 		Long:  `Prints a newly generated Ethereum Node Record (ENR) from this node's charon-enr-private-key`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runFunc(cmd.OutOrStdout(), config, dataDir, silent)
+			return runFunc(cmd.OutOrStdout(), config, dataDir, verbose)
 		},
 	}
 
 	bindDataDirFlag(cmd.Flags(), &dataDir)
 	bindP2PFlags(cmd.Flags(), &config)
-	bindEnrFlags(cmd.Flags(), &silent)
+	bindEnrFlags(cmd.Flags(), &verbose)
 
 	return cmd
 }
 
 // runNewENR loads the p2pkey from disk and prints the ENR for the provided config.
-func runNewENR(w io.Writer, config p2p.Config, dataDir string, silent bool) error {
+func runNewENR(w io.Writer, config p2p.Config, dataDir string, verbose bool) error {
 	key, err := p2p.LoadPrivKey(dataDir)
 	if errors.Is(err, fs.ErrNotExist) {
 		return errors.New("private key not found. If this is your first time running this client, create one with `charon create enr`.", z.Str("enr_path", p2p.KeyPath(dataDir))) //nolint:revive
@@ -73,7 +73,7 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, silent bool) erro
 	newEnr := localEnode.Node().String()
 	_, _ = fmt.Fprintln(w, newEnr)
 
-	if silent {
+	if !verbose {
 		return nil
 	}
 
@@ -108,6 +108,6 @@ func pubkeyHex(pubkey ecdsa.PublicKey) string {
 	return fmt.Sprintf("%#x", b)
 }
 
-func bindEnrFlags(flags *pflag.FlagSet, silent *bool) {
-	flags.BoolVar(silent, "silent", false, "Prints the expanded form of ENR.")
+func bindEnrFlags(flags *pflag.FlagSet, verbose *bool) {
+	flags.BoolVar(verbose, "verbose", false, "Prints the expanded form of ENR.")
 }

--- a/cmd/enr_internal_test.go
+++ b/cmd/enr_internal_test.go
@@ -31,7 +31,7 @@ func TestRunNewEnr(t *testing.T) {
 	temp, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	got := runNewENR(io.Discard, p2p.Config{}, temp)
+	got := runNewENR(io.Discard, p2p.Config{}, temp, false)
 	expected := errors.New("private key not found. If this is your first time running this client, create one with `charon create enr`.", z.Str("enr_path", p2p.KeyPath(temp)))
 	require.Equal(t, expected.Error(), got.Error())
 }


### PR DESCRIPTION
- `charon create enr` now errors when `charon-enr-private-key` already exists.
- `charon enr` now also outputs`secp256k1 pubkey`, `signature` and `seq` in addition to the `enr` when the `--verbose` flag is provided.

category: refactor
ticket: #893 