### PR TITLE
dkg: improve sync failure errors

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -129,7 +129,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Info(ctx, "Connecting to peers...", z.Str("definition_hash", clusterID))
 
 	// Improve UX of "context cancelled" errors when sync fails.
-	ctx = withCtxErr(ctx, "at least one connection in p2p network broke")
+	ctx = withCtxErr(ctx, "p2p network connection broke, please retry DKG")
 
 	stopSync, err := startSyncProtocol(ctx, tcpNode, key, defHash, peerIds, cancel)
 	if err != nil {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -129,7 +129,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Info(ctx, "Connecting to peers...", z.Str("definition_hash", clusterID))
 
 	// Improve UX of "context cancelled" errors when sync fails.
-	ctx = withCtxErr(ctx, "p2p network connection broke, please retry DKG")
+	ctx = withCtxErr(ctx, "p2p connection failed, please retry DKG")
 
 	stopSync, err := startSyncProtocol(ctx, tcpNode, key, defHash, peerIds, cancel)
 	if err != nil {


### PR DESCRIPTION
Improves DKG sync protocol failure error logging:
 - prefix `context cancelled` errors with `p2p connection failed, please retry DKG`
 - Do not log redundant `context cancelled` errors for other peers.
 
category: refactor
ticket: none
