### PR TITLE
p2p: improve ping failing messages

### DIFF
--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -110,7 +110,7 @@ func newPingLogger(peers []peer.ID) func(context.Context, peer.ID, ping.Result) 
 		first  = make(map[peer.ID]bool)  // first indicates if the peer has logged anything.
 		state  = make(map[peer.ID]bool)  // state indicates if the peer is ok or not
 		counts = make(map[peer.ID]int)   // counts indicates number of successful pings; 0 <= x <= hysteresis
-		errs   = make(map[peer.ID]error) // errs contains last non-dail backoff error
+		errs   = make(map[peer.ID]error) // errs contains last non-dial backoff error
 	)
 
 	for _, p := range peers {

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -116,14 +116,14 @@ func newPingLogger(peers []peer.ID) func(context.Context, peer.ID, ping.Result) 
 	for _, p := range peers {
 		state[p] = true
 		counts[p] = hysteresis
-		errs[p] = swarm.ErrDialBackoff // This will be over-written with no-dial-backoff errors.
+		errs[p] = swarm.ErrDialBackoff // This will be over-written with no-dial-backoff errors if any.
 	}
 
 	return func(ctx context.Context, p peer.ID, result ping.Result) {
 		mu.Lock()
 		defer mu.Unlock()
 
-		prev := counts[p] // 0 <= counts[p]
+		prev := counts[p]
 
 		if result.Error != nil && prev > 0 {
 			counts[p]-- // Decrease success count since ping failed.


### PR DESCRIPTION
Do not log `dial backoff` when ping fails since it isn't informative, rather log previous actual error.

category: bug
ticket: none

