### PR TITLE
app: disable flapping monitoringapi test

### DIFF
--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -52,13 +52,14 @@ func TestStartChecker(t *testing.T) {
 			absentPeers: 0,
 			err:         errReadySyncing,
 		},
-		{
-			name:        "peer ping failing",
-			isSyncing:   false,
-			numPeers:    5,
-			absentPeers: 3,
-			err:         errReadyPingFailing,
-		},
+		// TODO(corver): Enable once flapping fixed with https://github.com/ObolNetwork/charon/issues/910.
+		//{
+		//	name:        "peer ping failing",
+		//	isSyncing:   false,
+		//	numPeers:    5,
+		//	absentPeers: 3,
+		//	err:         errReadyPingFailing,
+		// },
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Disables flapping monitoring API test until it is fixed. This isn't a critical test either.

category: test
ticket: #910 

