### PR TITLE
cmd: improve bootnode logging

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -142,6 +142,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 		// Reservations are valid for 30min (github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay/constraints.go:14)
 		relayResources := relay.DefaultResources()
 		relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
+		relayResources.MaxReservationsPerIP = config.MaxResPerPeer
 
 		relayService, err := relay.New(tcpNode, relay.WithResources(relayResources))
 		if err != nil {


### PR DESCRIPTION
Bootnode logs number of connected libp2p nodes and connections. Makes existing log UDP discv5 explicit.

category: misc
ticket: none

