### PR TITLE
cmd: remove bootnode relay log default

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -72,7 +72,7 @@ func bindBootnodeFlag(flags *pflag.FlagSet, config *BootnodeConfig) {
 	flags.BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
 	flags.BoolVar(&config.P2PRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
 	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 30, "Updates max circuit reservations per peer (each valid for 30min)")
-	flags.StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "info", "Libp2p circuit relay log level. E.g., debug, info, warn, error")
+	flags.StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error")
 }
 
 // RunBootnode starts a p2p-udp discv5 bootnode.

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -204,6 +204,7 @@ func (n debugLogger) Connected(_ network.Network, conn network.Conn) {
 	log.Debug(n.ctx, "Libp2p new connection",
 		z.Str("peer", PeerName(conn.RemotePeer())),
 		z.Any("peer_address", conn.RemoteMultiaddr()),
+		z.Any("direction", conn.Stat().Direction),
 	)
 }
 

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -54,6 +54,7 @@ type Eth2Provider interface {
 	eth2client.BlindedBeaconBlockSubmitter
 	eth2client.DomainProvider
 	eth2client.ProposerDutiesProvider
+	eth2client.Service
 	eth2client.SlotsPerEpochProvider
 	eth2client.SpecProvider
 	eth2client.ValidatorsProvider
@@ -134,7 +135,7 @@ func Attest(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
 
 // ProposeBlock proposes block for the given slot.
 func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
-	slot eth2p0.Slot, addr string, pubkeys ...eth2p0.BLSPubKey,
+	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
 	if err != nil {
@@ -186,7 +187,7 @@ func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
 		}
 
 		// Get Unsigned beacon block with given randao and slot
-		block, err = beaconBlockProposal(ctx, slot, randao, nil, addr)
+		block, err = beaconBlockProposal(ctx, slot, randao, nil, eth2Cl.Address())
 		if err != nil {
 			return errors.Wrap(err, "vmock beacon block proposal")
 		}
@@ -243,7 +244,7 @@ func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
 
 // ProposeBlindedBlock proposes blinded block for the given slot.
 func ProposeBlindedBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
-	slot eth2p0.Slot, addr string, pubkeys ...eth2p0.BLSPubKey,
+	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
 	if err != nil {
@@ -295,7 +296,7 @@ func ProposeBlindedBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc Sign
 		}
 
 		// Get Unsigned beacon block with given randao and slot
-		block, err = blindedBeaconBlockProposal(ctx, slot, randao, nil, addr)
+		block, err = blindedBeaconBlockProposal(ctx, slot, randao, nil, eth2Cl.Address())
 		if err != nil {
 			return errors.Wrap(err, "vmock blinded beacon block proposal")
 		}

--- a/testutil/validatormock/validatormock_test.go
+++ b/testutil/validatormock/validatormock_test.go
@@ -134,9 +134,13 @@ func TestProposeBlock(t *testing.T) {
 	}))
 	defer mockVAPI.Close()
 
+	provider := addrWrap{
+		Eth2Provider: beaconMock,
+		addr:         mockVAPI.URL,
+	}
+
 	// Call propose block function
-	addr := mockVAPI.URL
-	err = validatormock.ProposeBlock(ctx, beaconMock, signFunc, eth2p0.Slot(slotsPerEpoch), addr, valSet.PublicKeys()...)
+	err = validatormock.ProposeBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch), valSet.PublicKeys()...)
 	require.NoError(t, err)
 }
 
@@ -178,8 +182,21 @@ func TestProposeBlindedBlock(t *testing.T) {
 	}))
 	defer mockVAPI.Close()
 
+	provider := addrWrap{
+		Eth2Provider: beaconMock,
+		addr:         mockVAPI.URL,
+	}
+
 	// Call propose block function
-	addr := mockVAPI.URL
-	err = validatormock.ProposeBlindedBlock(ctx, beaconMock, signFunc, eth2p0.Slot(slotsPerEpoch), addr, valSet.PublicKeys()...)
+	err = validatormock.ProposeBlindedBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch), valSet.PublicKeys()...)
 	require.NoError(t, err)
+}
+
+type addrWrap struct {
+	validatormock.Eth2Provider
+	addr string
+}
+
+func (w addrWrap) Address() string {
+	return w.addr
 }


### PR DESCRIPTION
Removes `--p2p-relay-loglevel` default, so global libp2p log level default is used, which is error. 

Also sneak in cached validator mock eth2client.

category: refactor
ticket: none

