### PR TITLE
eth2util/deposit: update deposit_cli_version

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -432,6 +432,7 @@ func checksumAddr(a string) (string, error) {
 // validNetworks defines the set of valid networks.
 var validNetworks = map[string]bool{
 	"prater":  true,
+	"goerli":  true,
 	"kiln":    true,
 	"ropsten": true,
 	"gnosis":  true,

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -46,6 +46,7 @@ type createDKGConfig struct {
 
 var networkToForkVersion = map[string]string{
 	"prater":  "0x00001020",
+	"goerli":  "0x00001020",
 	"kiln":    "0x70000069",
 	"ropsten": "0x80000069",
 	"gnosis":  "0x00000064",

--- a/eth2util/deposit/deposit.go
+++ b/eth2util/deposit/deposit.go
@@ -40,7 +40,7 @@ var (
 	// DOMAIN_DEPOSIT. See spec: https://benjaminion.xyz/eth2-annotated-spec/phase0/beacon-chain/#domain-types
 	depositDomainType = eth2p0.DomainType([4]byte{0x03, 0x00, 0x00, 0x00})
 
-	depositCliVersion = "2.1.0"
+	depositCliVersion = "2.3.0"
 )
 
 // getMessageRoot returns a deposit message hash root created by the parameters.
@@ -180,6 +180,8 @@ func withdrawalCredsFromAddr(addr string) ([32]byte, error) {
 func networkToForkVersion(network string) eth2p0.Version {
 	switch network {
 	case "prater":
+		return [4]byte{0x00, 0x00, 0x10, 0x20}
+	case "goerli":
 		return [4]byte{0x00, 0x00, 0x10, 0x20}
 	case "kiln":
 		return [4]byte{0x70, 0x00, 0x00, 0x69}

--- a/eth2util/deposit/deposit_test.go
+++ b/eth2util/deposit/deposit_test.go
@@ -17,7 +17,6 @@ package deposit_test
 
 import (
 	"encoding/hex"
-	"os"
 	"testing"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -27,6 +26,7 @@ import (
 	"github.com/obolnetwork/charon/eth2util/deposit"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 const (
@@ -35,8 +35,9 @@ const (
 	network        = "prater"
 )
 
+//go:generate go test . -run=TestMarshalDepositData -update -clean
+
 func TestMarshalDepositData(t *testing.T) {
-	file := "testdata/deposit-data.json"
 	privKeys := []string{
 		"01477d4bfbbcebe1fef8d4d6f624ecbb6e3178558bb1b0d6286c816c66842a6d",
 		"5b77c0f0ef7c4ddc123d55b8bd93daeefbd7116764a941c0061a496649e145b5",
@@ -61,10 +62,7 @@ func TestMarshalDepositData(t *testing.T) {
 	actual, err := deposit.MarshalDepositData(sigsByKeys, withdrawalAddr, network)
 	require.NoError(t, err)
 
-	// Not using golden file since output MUST never change.
-	expected, err := os.ReadFile(file)
-	require.NoError(t, err)
-	require.Equal(t, expected, actual)
+	testutil.RequireGoldenBytes(t, actual)
 }
 
 // Get the private and public keys in appropriate format for the test.

--- a/eth2util/deposit/testdata/TestMarshalDepositData.golden
+++ b/eth2util/deposit/testdata/TestMarshalDepositData.golden
@@ -8,7 +8,7 @@
   "deposit_data_root": "892766707bb5d2bb9602d9620f942af9e0c2c915c4340ad22ef935dd999db85b",
   "fork_version": "00001020",
   "network_name": "prater",
-  "deposit_cli_version": "2.1.0"
+  "deposit_cli_version": "2.3.0"
  },
  {
   "pubkey": "813f5d2697f76841a752ef8c1ac11d1bb76e07003799c5745f8a569214653810def3b60920b54fb0ab3cb6deb08c3972",
@@ -19,7 +19,7 @@
   "deposit_data_root": "4d97bfb4ad862d7885586186d0c8c482d1b084e3d478d9b7e55bb4729d058dfc",
   "fork_version": "00001020",
   "network_name": "prater",
-  "deposit_cli_version": "2.1.0"
+  "deposit_cli_version": "2.3.0"
  },
  {
   "pubkey": "940a838cd88c10daa9c26fcdf8472dfe09657c4aa4030380c6cca5ddb573a8036dfb03e61137c4baacdc9d69061f1eb2",
@@ -30,7 +30,7 @@
   "deposit_data_root": "0c8b9be09c9e36bef37e9248ce262485d1ee21e005ecf3ff347a820ba0b3c69a",
   "fork_version": "00001020",
   "network_name": "prater",
-  "deposit_cli_version": "2.1.0"
+  "deposit_cli_version": "2.3.0"
  },
  {
   "pubkey": "b3d95c8790d63114ab1e813e8943f1bd59683927942df076ad724de8cc00974306c95d6614ef93505b5acd9719a6de78",
@@ -41,6 +41,6 @@
   "deposit_data_root": "a7de8c4c4e26b9751afcc1bc7ecc558c3d40ee3985d62c6ba07dc08c0aa64581",
   "fork_version": "00001020",
   "network_name": "prater",
-  "deposit_cli_version": "2.1.0"
+  "deposit_cli_version": "2.3.0"
  }
 ]


### PR DESCRIPTION
Updates deposit_cli_version to 2.3.0. Also adds goerli in networks with same fork version as of prater.

category: bug
ticket: none
