### PR TITLE
testutil/validatormock: mitigate future slot issues

### DIFF
--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -76,7 +76,7 @@ func Attest(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
 
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
 
-	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, fmt.Sprint(slot), pubkeys)
+	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys) // Using head to mitigate future slot issues.
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Similar to `scheduler` mitigate against `eth2http: failed to obtain validators` errors which happen when beacon node sync is behind by querying active validators by "head" instead of explicit "slot".

category: test
ticket: none

