### PR TITLE
core/parsigex: add verification function to parsigex

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -358,7 +358,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	if conf.TestConfig.ParSigExFunc != nil {
 		parSigEx = conf.TestConfig.ParSigExFunc()
 	} else {
-		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs)
+		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, parsigex.NewEth2Verifier(eth2Cl, pubSharesByKey))
 	}
 
 	sigAgg := sigagg.New(lock.Threshold)

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -99,7 +99,7 @@ func (m *ParSigEx) handle(s network.Stream) {
 	// Verify partial signature
 	for pubkey, data := range set {
 		if err = m.verifyFunc(ctx, pubkey, duty, data); err != nil {
-			log.Error(ctx, "", err)
+			log.Error(ctx, "Invalid signature from peer", err, z.Str("peer", p2p.PeerName(s.Conn().RemotePeer())))
 			return
 		}
 	}

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -40,7 +40,7 @@ import (
 
 const protocolID = "/charon/parsigex/1.0.0"
 
-func NewParSigEx(tcpNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []peer.ID, verifyFunc func(context.Context, core.PubKey, core.Duty, core.ParSignedData) error) *ParSigEx {
+func NewParSigEx(tcpNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []peer.ID, verifyFunc func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error) *ParSigEx {
 	parSigEx := &ParSigEx{
 		tcpNode:    tcpNode,
 		sendFunc:   sendFunc,
@@ -60,7 +60,7 @@ type ParSigEx struct {
 	sendFunc   p2p.SendFunc
 	peerIdx    int
 	peers      []peer.ID
-	verifyFunc func(context.Context, core.PubKey, core.Duty, core.ParSignedData) error
+	verifyFunc func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error
 	subs       []func(context.Context, core.Duty, core.ParSignedDataSet) error
 }
 
@@ -98,8 +98,8 @@ func (m *ParSigEx) handle(s network.Stream) {
 
 	// Verify partial signature
 	for pubkey, data := range set {
-		if err = m.verifyFunc(ctx, pubkey, duty, data); err != nil {
-			log.Error(ctx, "Invalid signature from peer", err, z.Str("peer", p2p.PeerName(s.Conn().RemotePeer())))
+		if err = m.verifyFunc(ctx, duty, pubkey, data); err != nil {
+			log.Error(ctx, "Peer exchanged invalid partial signature", err, z.Str("peer", p2p.PeerName(s.Conn().RemotePeer())))
 			return
 		}
 	}
@@ -147,10 +147,10 @@ func (m *ParSigEx) Subscribe(fn func(context.Context, core.Duty, core.ParSignedD
 }
 
 // NewEth2Verifier returns a verifyFunc instance which is responsible to verify the given partial signatures.
-func NewEth2Verifier(eth2Svc eth2client.Service, pubSharesByKey map[core.PubKey][]*bls_sig.PublicKey) func(context.Context, core.PubKey, core.Duty, core.ParSignedData) error {
+func NewEth2Verifier(eth2Svc eth2client.Service, pubSharesByKey map[core.PubKey][]*bls_sig.PublicKey) func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error {
 	eth2Cl := eth2Svc.(signing.Eth2Provider)
 
-	return func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
+	return func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error {
 		// ShareIdx is 1-indexed
 		pubshare := pubSharesByKey[pubkey][data.ShareIdx-1]
 

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -84,7 +84,7 @@ func TestParSigEx(t *testing.T) {
 	// create ParSigEx components for each host
 	for i := 0; i < n; i++ {
 		wg.Add(n - 1)
-		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, func(_ context.Context, _ core.PubKey, _ core.Duty, _ core.ParSignedData) error {
+		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, func(_ context.Context, _ core.Duty, _ core.PubKey, _ core.ParSignedData) error {
 			return nil
 		})
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
@@ -154,7 +154,7 @@ func TestParSigExVerifier(t *testing.T) {
 		att.Signature = sign(sigData[:])
 		data := core.NewPartialAttestation(att, shareIdx)
 
-		require.NoError(t, verifyFunc(ctx, pubkey, core.NewAttesterDuty(slot), data))
+		require.NoError(t, verifyFunc(ctx, core.NewAttesterDuty(slot), pubkey, data))
 	})
 
 	t.Run("Verify block", func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestParSigExVerifier(t *testing.T) {
 		data, err := core.NewPartialVersionedSignedBeaconBlock(block, shareIdx)
 		require.NoError(t, err)
 
-		require.NoError(t, verifyFunc(ctx, pubkey, core.NewProposerDuty(slot), data))
+		require.NoError(t, verifyFunc(ctx, core.NewProposerDuty(slot), pubkey, data))
 	})
 
 	t.Run("Verify blinded block", func(t *testing.T) {
@@ -182,7 +182,7 @@ func TestParSigExVerifier(t *testing.T) {
 		data, err := core.NewPartialVersionedSignedBlindedBeaconBlock(blindedBlock, shareIdx)
 		require.NoError(t, err)
 
-		require.NoError(t, verifyFunc(ctx, pubkey, core.NewBuilderProposerDuty(slot), data))
+		require.NoError(t, verifyFunc(ctx, core.NewBuilderProposerDuty(slot), pubkey, data))
 	})
 
 	t.Run("Verify Randao", func(t *testing.T) {
@@ -192,7 +192,7 @@ func TestParSigExVerifier(t *testing.T) {
 		require.NoError(t, err)
 		randao := core.NewPartialSignature(core.SigFromETH2(sign(sigData[:])), shareIdx)
 
-		require.NoError(t, verifyFunc(ctx, pubkey, core.NewRandaoDuty(slot), randao))
+		require.NoError(t, verifyFunc(ctx, core.NewRandaoDuty(slot), pubkey, randao))
 	})
 
 	t.Run("Verify Voluntary Exit", func(t *testing.T) {
@@ -206,7 +206,7 @@ func TestParSigExVerifier(t *testing.T) {
 		data := core.NewPartialSignedVoluntaryExit(exit, shareIdx)
 		require.NoError(t, err)
 
-		require.NoError(t, verifyFunc(ctx, pubkey, core.NewVoluntaryExit(slot), data))
+		require.NoError(t, verifyFunc(ctx, core.NewVoluntaryExit(slot), pubkey, data))
 	})
 
 	t.Run("Verify validator registration", func(t *testing.T) {
@@ -219,6 +219,6 @@ func TestParSigExVerifier(t *testing.T) {
 		data, err := core.NewPartialVersionedSignedValidatorRegistration(reg, shareIdx)
 		require.NoError(t, err)
 
-		require.NoError(t, verifyFunc(ctx, pubkey, core.NewBuilderRegistrationDuty(slot), data))
+		require.NoError(t, verifyFunc(ctx, core.NewBuilderRegistrationDuty(slot), pubkey, data))
 	})
 }

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -33,7 +33,6 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
-	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
@@ -260,7 +259,12 @@ func (c Component) SubmitAttestations(ctx context.Context, attestations []*eth2p
 		}
 
 		// Verify signature
-		if err = c.verifySignedData(ctx, c.eth2Cl, pubkey, att); err != nil {
+		pubshare, err := c.getVerifyShareFunc(pubkey)
+		if err != nil {
+			return err
+		}
+
+		if err = signing.VerifyAttestation(ctx, c.eth2Cl, pubshare, *att); err != nil {
 			return err
 		}
 
@@ -304,7 +308,13 @@ func (c Component) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, ra
 	// TODO(corver): Refactor RANDAO partial signature to contain epoch.
 	parSig := core.NewPartialSignature(core.SigFromETH2(randao), c.shareIdx)
 
-	if err := c.verifyRandaoParSig(ctx, slot, randao, pubkey); err != nil {
+	// Verify randao signature
+	pubshare, err := c.getVerifyShareFunc(pubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := signing.VerifyRandao(ctx, c.eth2Cl, pubshare, randao, slot); err != nil {
 		return nil, err
 	}
 
@@ -356,7 +366,13 @@ func (c Component) SubmitBeaconBlock(ctx context.Context, block *spec.VersionedS
 	duty := core.NewProposerDuty(int64(slot))
 	ctx = log.WithCtx(ctx, z.Any("duty", duty))
 
-	if err = c.verifySignedData(ctx, c.eth2Cl, pubkey, block); err != nil {
+	// Verify block signature
+	pubshare, err := c.getVerifyShareFunc(pubkey)
+	if err != nil {
+		return err
+	}
+
+	if err = signing.VerifyBlock(ctx, c.eth2Cl, pubshare, *block); err != nil {
 		return err
 	}
 
@@ -386,7 +402,13 @@ func (c Component) BlindedBeaconBlockProposal(ctx context.Context, slot eth2p0.S
 		return nil, err
 	}
 
-	if err := c.verifyRandaoParSig(ctx, slot, randao, pubkey); err != nil {
+	// Verify randao signature
+	pubshare, err := c.getVerifyShareFunc(pubkey)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := signing.VerifyRandao(ctx, c.eth2Cl, pubshare, randao, slot); err != nil {
 		return nil, err
 	}
 
@@ -441,7 +463,13 @@ func (c Component) SubmitBlindedBeaconBlock(ctx context.Context, block *eth2api.
 	duty := core.NewBuilderProposerDuty(int64(slot))
 	ctx = log.WithCtx(ctx, z.Any("duty", duty))
 
-	if err = c.verifySignedData(ctx, c.eth2Cl, pubkey, block); err != nil {
+	// Verify signature
+	pubshare, err := c.getVerifyShareFunc(pubkey)
+	if err != nil {
+		return err
+	}
+
+	if err = signing.VerifyBlindedBlock(ctx, c.eth2Cl, pubshare, *block); err != nil {
 		return err
 	}
 
@@ -489,7 +517,12 @@ func (c Component) submitRegistration(ctx context.Context, registration *eth2api
 	duty := core.NewBuilderRegistrationDuty(int64(slot))
 	ctx = log.WithCtx(ctx, z.Any("duty", duty))
 
-	if err = c.verifySignedData(ctx, c.eth2Cl, pubkey, registration); err != nil {
+	pubshare, err := c.getVerifyShareFunc(pubkey)
+	if err != nil {
+		return err
+	}
+
+	if err = signing.VerifyValidatorRegistration(ctx, c.eth2Cl, pubshare, *registration); err != nil {
 		return err
 	}
 
@@ -556,7 +589,12 @@ func (c Component) SubmitVoluntaryExit(ctx context.Context, exit *eth2p0.SignedV
 	duty := core.NewVoluntaryExit(int64(slotsPerEpoch) * int64(exit.Message.Epoch))
 	ctx = log.WithCtx(ctx, z.Any("duty", duty))
 
-	if err = c.verifySignedData(ctx, c.eth2Cl, pubkey, exit); err != nil {
+	pubshare, err := c.getVerifyShareFunc(pubkey)
+	if err != nil {
+		return err
+	}
+
+	if err = signing.VerifyVoluntaryExit(ctx, c.eth2Cl, pubshare, *exit); err != nil {
 		return err
 	}
 
@@ -701,47 +739,4 @@ func (c Component) getProposerPubkey(ctx context.Context, duty core.Duty) (core.
 	}
 
 	return pubkey, nil
-}
-
-// TODO(corver): Use verifySignedData once randao partial signature contains epoch.
-func (c Component) verifyRandaoParSig(ctx context.Context, slot eth2p0.Slot,
-	randao eth2p0.BLSSignature, pubkey core.PubKey,
-) error {
-	if c.insecureTest {
-		return nil
-	}
-
-	epoch, err := c.epochFromSlot(ctx, slot)
-	if err != nil {
-		return err
-	}
-
-	// Randao signing root is the epoch.
-	sigRoot, err := eth2util.EpochHashRoot(epoch)
-	if err != nil {
-		return err
-	}
-
-	pubshare, err := c.getVerifyShareFunc(pubkey)
-	if err != nil {
-		return err
-	}
-
-	return signing.Verify(ctx, c.eth2Cl, signing.DomainRandao, epoch, sigRoot, randao, pubshare)
-}
-
-// verifySignedData aliases signing.VerifySignedData skipping it for insecureTest.
-func (c Component) verifySignedData(ctx context.Context, eth2Cl signing.Eth2Provider,
-	pubkey core.PubKey, eth2SignedType interface{},
-) error {
-	if c.insecureTest {
-		return nil
-	}
-
-	pubshare, err := c.getVerifyShareFunc(pubkey)
-	if err != nil {
-		return err
-	}
-
-	return signing.VerifySignedData(ctx, eth2Cl, pubshare, eth2SignedType)
 }

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -60,7 +60,7 @@ type exchanger struct {
 }
 
 func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int,
-	verifyFunc func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error,
+	verifyFunc func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error,
 ) *exchanger {
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
@@ -124,8 +124,8 @@ func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, pk core.PubKey,
 // newDKGVerifier returns a verify function to verify partial signatures by parsigex.
 func newDKGVerifier(pubkeyToPubshares map[core.PubKey]map[int]*bls_sig.PublicKey, lockHash []byte,
 	depositDataMsgs map[core.PubKey][]byte,
-) func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
-	return func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
+) func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error {
+	return func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error {
 		switch sigType(duty.Slot) {
 		case sigLock:
 			pubshare := pubkeyToPubshares[pubkey][data.ShareIdx]

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -59,7 +59,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
 		sigdb:   parsigdb.NewMemDB(len(peers)),
-		sigex:   parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers),
+		sigex:   parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers, newDKGVerifier()),
 		sigChan: make(chan sigData, len(peers)),
 		numVals: vals,
 	}
@@ -113,4 +113,11 @@ func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, pk core.PubKey,
 	}
 
 	return nil
+}
+
+// TODO(dhruv): Implement verifyFunc for DKG
+func newDKGVerifier() func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
+	return func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
+		return nil
+	}
 }

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -96,7 +96,7 @@ func TestExchanger(t *testing.T) {
 	}
 
 	for i := 0; i < nodes; i++ {
-		ex := newExchanger(hosts[i], i, peers, dvs, func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
+		ex := newExchanger(hosts[i], i, peers, dvs, func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error {
 			return nil
 		})
 		exchangers = append(exchangers, ex)

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -96,7 +96,9 @@ func TestExchanger(t *testing.T) {
 	}
 
 	for i := 0; i < nodes; i++ {
-		ex := newExchanger(hosts[i], i, peers, dvs)
+		ex := newExchanger(hosts[i], i, peers, dvs, func(ctx context.Context, pubkey core.PubKey, duty core.Duty, data core.ParSignedData) error {
+			return nil
+		})
 		exchangers = append(exchangers, ex)
 	}
 
@@ -119,3 +121,6 @@ func TestExchanger(t *testing.T) {
 		reflect.DeepEqual(actual[i], expectedData)
 	}
 }
+
+// TODO(dhruv): add tests for DKG verifier.
+func TestNewDKGVerifier(t *testing.T) {}

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -17,14 +17,15 @@ package signing
 
 import (
 	"context"
+
 	eth2client "github.com/attestantio/go-eth2-client"
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
-	"github.com/obolnetwork/charon/eth2util"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -210,6 +210,18 @@ func RandomCoreVersionSignedBeaconBlock(t *testing.T) core.VersionedSignedBeacon
 	}
 }
 
+func RandomVersionSignedBeaconBlock(t *testing.T) *spec.VersionedSignedBeaconBlock {
+	t.Helper()
+
+	return &spec.VersionedSignedBeaconBlock{
+		Version: spec.DataVersionBellatrix,
+		Bellatrix: &bellatrix.SignedBeaconBlock{
+			Message:   RandomBellatrixBeaconBlock(t),
+			Signature: RandomEth2Signature(),
+		},
+	}
+}
+
 func RandomBellatrixBlindedBeaconBlock(t *testing.T) *eth2v1.BlindedBeaconBlock {
 	t.Helper()
 
@@ -268,6 +280,18 @@ func RandomCoreVersionSignedBlindedBeaconBlock(t *testing.T) core.VersionedSigne
 	}
 }
 
+func RandomVersionSignedBlindedBeaconBlock(t *testing.T) *eth2api.VersionedSignedBlindedBeaconBlock {
+	t.Helper()
+
+	return &eth2api.VersionedSignedBlindedBeaconBlock{
+		Version: spec.DataVersionBellatrix,
+		Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
+			Message:   RandomBellatrixBlindedBeaconBlock(t),
+			Signature: RandomEth2Signature(),
+		},
+	}
+}
+
 func RandomValidatorRegistration(t *testing.T) *eth2v1.ValidatorRegistration {
 	t.Helper()
 
@@ -300,6 +324,15 @@ func RandomCoreVersionedSignedValidatorRegistration(t *testing.T) core.Versioned
 			Version: spec.BuilderVersionV1,
 			V1:      RandomSignedValidatorRegistration(t),
 		},
+	}
+}
+
+func RandomVersionedSignedValidatorRegistration(t *testing.T) *eth2api.VersionedSignedValidatorRegistration {
+	t.Helper()
+
+	return &eth2api.VersionedSignedValidatorRegistration{
+		Version: spec.BuilderVersionV1,
+		V1:      RandomSignedValidatorRegistration(t),
 	}
 }
 


### PR DESCRIPTION
Adds a signature verification in parsigex along with Verification function constructors: `NewEth2Verifier` for core workflow and  `newDKGVerifier` for dkg/exchanger.

category: feature
ticket: #217 