### PR TITLE
cmd: increase bootnode max connection limits

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -256,6 +256,7 @@ func startBootnode(ctx context.Context, t *testing.T) (string, <-chan error) {
 			AutoP2PKey:    true,
 			P2PRelay:      true,
 			MaxResPerPeer: 8,
+			MaxConns:      1024,
 		})
 	}()
 

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -211,6 +211,7 @@ func startBootnode(ctx context.Context, t *testing.T) (string, <-chan error) {
 			},
 			AutoP2PKey: true,
 			P2PRelay:   true,
+			MaxConns:   1024,
 		})
 	}()
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/jsternberg/zap-logfmt v1.2.0
 	github.com/libp2p/go-libp2p v0.20.0
 	github.com/libp2p/go-libp2p-core v0.17.0
+	github.com/libp2p/go-libp2p-resource-manager v0.3.0
 	github.com/multiformats/go-multiaddr v0.6.0
 	github.com/prometheus/client_golang v1.13.0
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
@@ -104,7 +105,6 @@ require (
 	github.com/libp2p/go-flow-metrics v0.0.3 // indirect
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-peerstore v0.6.0 // indirect
-	github.com/libp2p/go-libp2p-resource-manager v0.3.0 // indirect
 	github.com/libp2p/go-msgio v0.2.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.0 // indirect

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -42,7 +42,7 @@ import (
 
 // NewTCPNode returns a started tcp-based libp2p host.
 func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater,
-	udpNode *discover.UDPv5, peers, relays []Peer) (host.Host, error,
+	udpNode *discover.UDPv5, peers, relays []Peer, opts ...libp2p.Option) (host.Host, error,
 ) {
 	addrs, err := cfg.Multiaddrs()
 	if err != nil {
@@ -55,7 +55,7 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater,
 	}
 
 	// Init options.
-	opts := []libp2p.Option{
+	defaultOpts := []libp2p.Option{
 		// Set P2P identity key.
 		libp2p.Identity(priv),
 		// Set listen addresses.
@@ -75,7 +75,9 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater,
 		}),
 	}
 
-	tcpNode, err := libp2p.New(opts...)
+	defaultOpts = append(defaultOpts, opts...)
+
+	tcpNode, err := libp2p.New(defaultOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "new libp2p node")
 	}


### PR DESCRIPTION
Increases bootnode max connections from 256 inbound to 1024 in and out.

category: misc
ticket: none

