### PR TITLE
app/retry: add another temporary error string

### DIFF
--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -177,6 +177,12 @@ func isTemporaryBeaconErr(err error) bool {
 		return true
 	}
 
+	// More timing issues:
+	//  - Attestations must be from the current or previous epoch
+	if strings.Contains(err.Error(), "current or previous") {
+		return true
+	}
+
 	// TODO(corver): Add more checks here.
 
 	return false


### PR DESCRIPTION
Catch and retry `Attestations must be from the current or previous epoch` errors when broadcasting.

category: feature
ticket: none

