### PR TITLE
p2p: continuously resolve bootnode ENRs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -242,22 +242,19 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
-	udpNode, err := p2p.NewUDPNode(conf.P2P, localEnode, p2pKey, bootnodes)
+	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, bootnodes)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	relays, err := p2p.NewRelays(conf.P2P, bootnodes)
-	if err != nil {
-		return nil, nil, err
-	}
+	relays := p2p.NewRelays(conf.P2P, bootnodes)
 
 	connGater, err := p2p.NewConnGater(peerIDs, relays)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	tcpNode, err := p2p.NewTCPNode(conf.P2P, p2pKey, connGater, udpNode, peers, relays)
+	tcpNode, err := p2p.NewTCPNode(conf.P2P, p2pKey, connGater)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -52,7 +52,7 @@ func TestPingCluster(t *testing.T) {
 	// Nodes bind to lock ENR addresses.
 	// Discv5 can just use those as bootnodes.
 	t.Run("bind_enrs", func(t *testing.T) {
-		pingClusterAB(t, pingTest{
+		pingCluster(t, pingTest{
 			Slow:         false,
 			BootLock:     true,
 			BindENRAddrs: true,
@@ -63,7 +63,7 @@ func TestPingCluster(t *testing.T) {
 	// Nodes bind to random localhost ports (not the lock ENRs), with only single bootnode.
 	// Discv5 will resolve peers via bootnode.
 	t.Run("bootnode_only", func(t *testing.T) {
-		pingClusterAB(t, pingTest{
+		pingCluster(t, pingTest{
 			BindLocalhost: true,
 			BootLock:      false,
 			Bootnode:      true,
@@ -73,7 +73,7 @@ func TestPingCluster(t *testing.T) {
 	// Nodes bind to random 0.0.0.0 ports (but use 127.0.0.1 as external IP), with only single bootnode.
 	// Discv5 will resolve peers via bootnode and external IP.
 	t.Run("external_ip", func(t *testing.T) {
-		pingClusterAB(t, pingTest{
+		pingCluster(t, pingTest{
 			ExternalIP: "127.0.0.1",
 			BindZeroIP: true,
 			BootLock:   false,
@@ -84,7 +84,7 @@ func TestPingCluster(t *testing.T) {
 	// Nodes bind to 0.0.0.0 (but use localhost as external host), with only single bootnode.
 	// Discv5 will resolve peers via bootnode and external host.
 	t.Run("external_host", func(t *testing.T) {
-		pingClusterAB(t, pingTest{
+		pingCluster(t, pingTest{
 			ExternalHost: "localhost",
 			BindZeroIP:   true,
 			BootLock:     false,
@@ -97,7 +97,7 @@ func TestPingCluster(t *testing.T) {
 	// Node discv5 will not resolve direct address, nodes will connect to bootnode,
 	// and libp2p will relay via bootnode.
 	t.Run("bootnode_relay", func(t *testing.T) {
-		pingClusterAB(t, pingTest{
+		pingCluster(t, pingTest{
 			BootnodeRelay: true,
 			BindZeroPort:  true,
 			Bootnode:      true,
@@ -109,7 +109,7 @@ func TestPingCluster(t *testing.T) {
 	// Discv5 times out resolving stale ENRs, then resolves peers via external node.
 	// This is slow due to discv5 internal timeouts, run with -slow.
 	t.Run("bootnode_and_stale_enrs", func(t *testing.T) {
-		pingClusterAB(t, pingTest{
+		pingCluster(t, pingTest{
 			Slow:          true,
 			BindLocalhost: true,
 			BootLock:      true,
@@ -133,19 +133,6 @@ type pingTest struct {
 
 	ExternalIP   string
 	ExternalHost string
-}
-
-// TODO(corver): Remove once featureset.InvertDiscv5 launched.
-func pingClusterAB(t *testing.T, test pingTest) {
-	t.Helper()
-	t.Run("pushdisc", func(t *testing.T) {
-		featureset.EnableForT(t, featureset.InvertLibP2PRouting)
-		pingCluster(t, test)
-	})
-	t.Run("pulldisc", func(t *testing.T) {
-		featureset.DisableForT(t, featureset.InvertLibP2PRouting)
-		pingCluster(t, test)
-	})
 }
 
 func pingCluster(t *testing.T, test pingTest) {

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -38,16 +38,12 @@ type Feature string
 const (
 	// QBFTConsensus introduces qbft consensus, see https://github.com/ObolNetwork/charon/issues/445.
 	QBFTConsensus Feature = "qbft_consensus"
-
-	// InvertLibP2PRouting enables the new push based libp2p routing and disables the old pull based.
-	InvertLibP2PRouting Feature = "invert_libp2p_routing"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		QBFTConsensus:       statusStable,
-		InvertLibP2PRouting: statusAlpha,
+		QBFTConsensus: statusStable,
 		// Add all features and there status here.
 	}
 

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -289,7 +289,8 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 			if participatedShares[peer.ShareIdx()] {
 				participationGauge.WithLabelValues(duty.Type.String(), peer.Name).Set(1)
 			} else if unexpectedShares[peer.ShareIdx()] {
-				log.Warn(ctx, "Unexpected event found", nil, z.Str("peer", peer.Name), z.Str("duty", duty.String()))
+				// TODO(corver): Enable with https://github.com/ObolNetwork/charon/issues/993
+				// log.Warn(ctx, "Unexpected event found", nil, z.Str("peer", peer.Name), z.Str("duty", duty.String()))
 				unexpectedEventsCounter.WithLabelValues(peer.Name).Inc()
 			} else {
 				absentPeers = append(absentPeers, peer.Name)

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -92,6 +92,8 @@ func NewUDPBootnodes(ctx context.Context, config Config, peers []Peer,
 	return nil, errors.Wrap(ctx.Err(), "timeout resolving bootnode ENR")
 }
 
+// resolveBootnode continuously resolves the bootnode ENR from the HTTP url and returns
+// the new bootnode ENR/Peer when it changes via the callback.
 func resolveBootnode(ctx context.Context, rawURL, lockHashHex string, callback func(Peer)) {
 	var prevENR string
 	for ctx.Err() == nil {

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -119,7 +119,7 @@ func resolveBootnode(ctx context.Context, rawURL, lockHashHex string, callback f
 			}
 		}
 
-		time.Sleep(time.Minute * 5) // Wait 5min before checking again.
+		time.Sleep(time.Minute * 2) // Wait 2min before checking again.
 	}
 }
 

--- a/p2p/discovery_internal_test.go
+++ b/p2p/discovery_internal_test.go
@@ -40,18 +40,20 @@ func TestQueryBootnodeENR(t *testing.T) {
 	err = enode.SignV4(&r, p2pKey)
 	require.NoError(t, err)
 
-	record, err := EncodeENR(r)
+	db, err := enode.OpenDB("")
 	require.NoError(t, err)
+
+	enrStr := enode.NewLocalNode(db, p2pKey).Node().String()
 
 	const header = "foo/bar"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, header, r.Header.Get("Charon-Cluster"))
-		_, _ = w.Write([]byte(record))
+		_, _ = w.Write([]byte(enrStr))
 	}))
 
 	resp, err := queryBootnodeENR(context.Background(), srv.URL, 0, header)
 	require.NoError(t, err)
-	require.Equal(t, record, resp)
+	require.Equal(t, enrStr, resp.String())
 }
 
 func TestQueryBootnodeENR_DNS(t *testing.T) {

--- a/p2p/discovery_test.go
+++ b/p2p/discovery_test.go
@@ -16,6 +16,7 @@
 package p2p_test
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"fmt"
 	"math/rand"
@@ -45,7 +46,7 @@ func TestExternalHost(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	udpNode, err := p2p.NewUDPNode(config, localNode, p2pKey, nil)
+	udpNode, err := p2p.NewUDPNode(context.Background(), config, localNode, p2pKey, nil)
 	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 	defer udpNode.Close()

--- a/p2p/gater_test.go
+++ b/p2p/gater_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 func TestInterceptSecured(t *testing.T) {
@@ -56,12 +57,20 @@ func TestP2PConnGating(t *testing.T) {
 
 	keyA, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
 	require.NoError(t, err)
-	nodeA, err := libp2p.New(libp2p.Identity(keyA), libp2p.ConnectionGater(c))
+	nodeA, err := libp2p.New(
+		libp2p.Identity(keyA),
+		libp2p.ConnectionGater(c),
+		libp2p.ListenAddrs(testutil.AvailableMultiAddr(t)))
+	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 
 	keyB, _, err := crypto.GenerateSecp256k1Key(rand.Reader)
 	require.NoError(t, err)
-	nodeB, err := libp2p.New(libp2p.Identity(keyB))
+	nodeB, err := libp2p.New(
+		libp2p.Identity(keyB),
+		libp2p.ListenAddrs(testutil.AvailableMultiAddr(t)),
+	)
+	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 
 	addr := peer.AddrInfo{

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/libp2p/go-libp2p"
 	libp2pcrypto "github.com/libp2p/go-libp2p-core/crypto"

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -514,6 +514,27 @@ func AvailableAddr(t *testing.T) *net.TCPAddr {
 	return addr
 }
 
+// AvailableMultiAddr returns an available local tcp address as a multiaddr.
+//
+// Note that this is unfortunately only best-effort. Since the port is not
+// "locked" or "reserved", other processes sometimes grab the port.
+// Remember to call SkipIfBindErr as workaround for this issue.
+func AvailableMultiAddr(t *testing.T) multiaddr.Multiaddr {
+	t.Helper()
+
+	l, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+	defer l.Close()
+
+	h, p, err := net.SplitHostPort(l.Addr().String())
+	require.NoError(t, err)
+
+	addr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%s", h, p))
+	require.NoError(t, err)
+
+	return addr
+}
+
 func CreateHost(t *testing.T, addr *net.TCPAddr) host.Host {
 	t.Helper()
 	pkey, _, err := p2pcrypto.GenerateSecp256k1Key(crand.Reader)


### PR DESCRIPTION
Introduces the `p2p.MutablePeer` that can change over time, integrate that with all the logic using relays/bootnodes. Continuously resolve HTTP bootnode ENRs, and update `MutablePeer`.

category: feature
ticket: #952 

