### PR TITLE
app: correct charon status calculation

### DIFF
--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -167,7 +167,8 @@ func quorumPeersConnected(peerIDs []peer.ID, tcpNode host.Host) bool {
 		}
 	}
 
-	return count >= cluster.Threshold(len(peerIDs))
+	// Excluding self when comparing with threshold, since we need to connect to threshold - 1 no. of peers.
+	return count >= cluster.Threshold(len(peerIDs))-1
 }
 
 func writeResponse(w http.ResponseWriter, status int, msg string) {

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -59,6 +59,12 @@ func TestStartChecker(t *testing.T) {
 			absentPeers: 3,
 			err:         errReadyTooFewPeers,
 		},
+		{
+			name:        "success",
+			isSyncing:   false,
+			numPeers:    4,
+			absentPeers: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -91,8 +97,8 @@ func TestStartChecker(t *testing.T) {
 			}
 
 			// connect each host with its peers
-			for i := 0; i < tt.numPeers; i++ {
-				for k := tt.absentPeers; k < tt.numPeers; k++ {
+			for i := 0; i < tt.numPeers-tt.absentPeers; i++ {
+				for k := 0; k < tt.numPeers-tt.absentPeers; k++ {
 					if i == k {
 						continue
 					}

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -96,7 +96,7 @@ func TestStartChecker(t *testing.T) {
 				hosts = append(hosts, h)
 			}
 
-			// connect each host with its peers
+			// connect first peer with other peers, excluding absent ones
 			for i := tt.absentPeers + 1; i < tt.numPeers; i++ {
 				err := hosts[0].Connect(ctx, hostsInfo[i])
 				require.NoError(t, err)

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -97,15 +97,9 @@ func TestStartChecker(t *testing.T) {
 			}
 
 			// connect each host with its peers
-			for i := 0; i < tt.numPeers-tt.absentPeers; i++ {
-				for k := 0; k < tt.numPeers-tt.absentPeers; k++ {
-					if i == k {
-						continue
-					}
-
-					err := hosts[i].Connect(ctx, hostsInfo[k])
-					require.NoError(t, err)
-				}
+			for i := tt.absentPeers + 1; i < tt.numPeers; i++ {
+				err := hosts[0].Connect(ctx, hostsInfo[i])
+				require.NoError(t, err)
 			}
 
 			clock := clockwork.NewFakeClock()


### PR DESCRIPTION
Corrects calculation of charon status where it needs to exclude self when comparing the number of connected peers with threshold. Also updates tests.

category: bug
ticket: none
