### PR TITLE
core/validatorapi: omit if empty on the proposer config

### DIFF
--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -32,7 +32,7 @@ type TekuProposerConfig struct {
 
 type TekuBuilder struct {
 	Enabled   bool              `json:"enabled"`
-	Overrides map[string]string `json:"registration_overrides"`
+	Overrides map[string]string `json:"registration_overrides,omitempty"`
 }
 
 const dead = "0x000000000000000000000000000000000000dead"


### PR DESCRIPTION
- omit if empty on propser config overrides currently getting -,"builder":{"enabled":false,"registration_overrides":null} 

category: feature
ticket: #849 
