### PR TITLE
core/parsigex: instrument signature verification

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -26,7 +26,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"
-	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -65,7 +64,7 @@ type ParSigEx struct {
 }
 
 func (m *ParSigEx) handle(s network.Stream) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	ctx = log.WithTopic(ctx, "parsigex")
 	ctx = log.WithCtx(ctx, z.Str("peer", p2p.PeerName(s.Conn().RemotePeer())))
 	defer cancel()
@@ -92,8 +91,7 @@ func (m *ParSigEx) handle(s network.Stream) {
 		return
 	}
 
-	var span trace.Span
-	ctx, span = core.StartDutyTrace(ctx, duty, "core/parsigex.Handle")
+	ctx, span := core.StartDutyTrace(ctx, duty, "core/parsigex.Handle")
 	defer span.End()
 
 	// Verify partial signature

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -25,6 +25,7 @@ import (
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/tracer"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -203,6 +204,9 @@ func VerifyValidatorRegistration(ctx context.Context, eth2Cl Eth2Provider, pubke
 func verify(ctx context.Context, eth2Cl Eth2Provider, domain DomainName, epoch eth2p0.Epoch,
 	sigRoot [32]byte, sig eth2p0.BLSSignature, pubshare *bls_sig.PublicKey,
 ) error {
+	ctx, span := tracer.Start(ctx, "eth2util.verify")
+	defer span.End()
+
 	sigData, err := GetDataRoot(ctx, eth2Cl, domain, epoch, sigRoot)
 	if err != nil {
 		return err
@@ -219,6 +223,7 @@ func verify(ctx context.Context, eth2Cl Eth2Provider, domain DomainName, epoch e
 		return errors.Wrap(err, "convert signature")
 	}
 
+	span.AddEvent("tbls.Verify")
 	ok, err := tbls.Verify(pubshare, sigData[:], s)
 	if err != nil {
 		return err

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -117,6 +117,9 @@ func newDockerCmd(use string, short string, runFunc runFunc) *cobra.Command {
 	dir := addDirFlag(cmd.Flags())
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		_, err := newRunnerFunc(use, *dir, *up, runFunc)(cmd.Context())
+		if err != nil {
+			log.Error(cmd.Context(), "Fatal error", err)
+		}
 		return err
 	}
 
@@ -137,6 +140,11 @@ func newAutoCmd(tmplCallbacks map[string]func(data *compose.TmplData)) *cobra.Co
 	printYML := cmd.Flags().Bool("print-yml", false, "Print generated docker-compose.yml files.")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) (err error) {
+		defer func() {
+			if err != nil {
+				log.Error(cmd.Context(), "Fatal error", err)
+			}
+		}()
 		runFuncs := map[string]func(context.Context) (compose.TmplData, error){
 			"define": newRunnerFunc("define", *dir, false, compose.Define),
 			"lock":   newRunnerFunc("lock", *dir, false, compose.Lock),

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -35,6 +35,13 @@ const (
 	cmdCreateDKG     = "[create,dkg]"
 )
 
+var charonPorts = []port{
+	{External: 3600, Internal: 3600}, // # Validator API
+	{External: 3610, Internal: 3610}, // # Libp2p
+	{External: 3620, Internal: 3620}, // # Monitoring
+	{External: 3630, Internal: 3630}, // # Discv5
+}
+
 // VCType defines a validator client type.
 type VCType string
 

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -45,6 +45,12 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 		vcs = append(vcs, vc)
 
 		n := TmplNode{EnvVars: newNodeEnvs(i, typ == VCMock, conf)}
+		if !conf.DisableMonitoringPorts {
+			for _, p := range charonPorts {
+				p.External += 10000 * i
+				n.Ports = append(n.Ports, p)
+			}
+		}
 		nodes = append(nodes, n)
 	}
 

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -77,7 +77,24 @@
      "Value": "alpha"
     }
    ],
-   "Ports": null
+   "Ports": [
+    {
+     "External": 3600,
+     "Internal": 3600
+    },
+    {
+     "External": 3610,
+     "Internal": 3610
+    },
+    {
+     "External": 3620,
+     "Internal": 3620
+    },
+    {
+     "External": 3630,
+     "Internal": 3630
+    }
+   ]
   },
   {
    "ImageTag": "",
@@ -152,7 +169,24 @@
      "Value": "alpha"
     }
    ],
-   "Ports": null
+   "Ports": [
+    {
+     "External": 13600,
+     "Internal": 3600
+    },
+    {
+     "External": 13610,
+     "Internal": 3610
+    },
+    {
+     "External": 13620,
+     "Internal": 3620
+    },
+    {
+     "External": 13630,
+     "Internal": 3630
+    }
+   ]
   },
   {
    "ImageTag": "",
@@ -227,7 +261,24 @@
      "Value": "alpha"
     }
    ],
-   "Ports": null
+   "Ports": [
+    {
+     "External": 23600,
+     "Internal": 3600
+    },
+    {
+     "External": 23610,
+     "Internal": 3610
+    },
+    {
+     "External": 23620,
+     "Internal": 3620
+    },
+    {
+     "External": 23630,
+     "Internal": 3630
+    }
+   ]
   },
   {
    "ImageTag": "",
@@ -302,7 +353,24 @@
      "Value": "alpha"
     }
    ],
-   "Ports": null
+   "Ports": [
+    {
+     "External": 33600,
+     "Internal": 3600
+    },
+    {
+     "External": 33610,
+     "Internal": 3610
+    },
+    {
+     "External": 33620,
+     "Internal": 3620
+    },
+    {
+     "External": 33630,
+     "Internal": 3630
+    }
+   ]
   }
  ],
  "VCs": [

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -31,6 +31,15 @@ services:
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
     
+    ports:
+      - "3600:3600"
+      
+      - "3610:3610"
+      
+      - "3620:3620"
+      
+      - "3630:3630"
+      
   node1:
     <<: *node-base
     
@@ -53,6 +62,15 @@ services:
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
     
+    ports:
+      - "13600:3600"
+      
+      - "13610:3610"
+      
+      - "13620:3620"
+      
+      - "13630:3630"
+      
   node2:
     <<: *node-base
     
@@ -75,6 +93,15 @@ services:
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
     
+    ports:
+      - "23600:3600"
+      
+      - "23610:3610"
+      
+      - "23620:3620"
+      
+      - "23630:3630"
+      
   node3:
     <<: *node-base
     
@@ -97,6 +124,15 @@ services:
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
     
+    ports:
+      - "33600:3600"
+      
+      - "33610:3610"
+      
+      - "33620:3620"
+      
+      - "33630:3630"
+      
   bootnode:
     <<: *node-base
     command: bootnode


### PR DESCRIPTION
Adds tracing spans to signature verification in parsigex.

- Also increase parsigex handle timeout from 1s to 5s since signature verification takes 200ms per sig...
- Also allow compose to bind to ports to allow pprof on charon.


category: misc
ticket: none
