### PR TITLE
core/consensus: fix memory leak

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -538,7 +538,7 @@ func newConsensus(conf Config, lock cluster.Lock, tcpNode host.Host, p2pKey *ecd
 			return nil, nil, err
 		}
 
-		return comp, lifecycle.HookFuncCtx(comp.Start), nil
+		return comp, lifecycle.HookFuncMin(comp.Start), nil
 	}
 
 	var lcastTransport leadercast.Transport

--- a/app/app.go
+++ b/app/app.go
@@ -392,19 +392,22 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	if err != nil {
 		return err
 	}
-	deadliner := core.NewDeadliner(ctx, deadlineFunc)
+
+	deadlinerFunc := func() core.Deadliner {
+		return core.NewDeadliner(ctx, deadlineFunc)
+	}
 
 	retryer, err := retry.New[core.Duty](deadlineFunc)
 	if err != nil {
 		return err
 	}
 
-	cons, startCons, err := newConsensus(conf, lock, tcpNode, p2pKey, sender, nodeIdx)
+	cons, startCons, err := newConsensus(conf, lock, tcpNode, p2pKey, sender, nodeIdx, deadlinerFunc())
 	if err != nil {
 		return err
 	}
 
-	wireTracker(life, deadliner, peers, sched, fetch, cons, vapi, parSigDB, parSigEx, sigAgg)
+	wireTracker(life, deadlinerFunc(), peers, sched, fetch, cons, vapi, parSigDB, parSigEx, sigAgg)
 
 	core.Wire(sched, fetch, cons, dutyDB, vapi,
 		parSigDB, parSigEx, sigAgg, aggSigDB, broadcaster,
@@ -521,7 +524,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 
 // newConsensus returns a new consensus component and its start lifecycle hook.
 func newConsensus(conf Config, lock cluster.Lock, tcpNode host.Host, p2pKey *ecdsa.PrivateKey,
-	sender *p2p.Sender, nodeIdx cluster.NodeIdx,
+	sender *p2p.Sender, nodeIdx cluster.NodeIdx, deadliner core.Deadliner,
 ) (core.Consensus, lifecycle.IHookFunc, error) {
 	peers, err := lock.Peers()
 	if err != nil {
@@ -533,12 +536,12 @@ func newConsensus(conf Config, lock cluster.Lock, tcpNode host.Host, p2pKey *ecd
 	}
 
 	if featureset.Enabled(featureset.QBFTConsensus) {
-		comp, err := consensus.New(tcpNode, sender, peers, p2pKey)
+		comp, err := consensus.New(tcpNode, sender, peers, p2pKey, deadliner)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		return comp, lifecycle.HookFuncMin(comp.Start), nil
+		return comp, lifecycle.HookFuncCtx(comp.Start), nil
 	}
 
 	var lcastTransport leadercast.Transport

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -87,13 +87,13 @@ func TestComponent(t *testing.T) {
 			hosts[i].Peerstore().AddAddrs(hostsInfo[j].ID, hostsInfo[j].Addrs, peerstore.PermanentAddrTTL)
 		}
 
-		c, err := consensus.New(hosts[i], new(p2p.Sender), peers, p2pkeys[i])
+		c, err := consensus.New(hosts[i], new(p2p.Sender), peers, p2pkeys[i], testDeadliner{})
 		require.NoError(t, err)
 		c.Subscribe(func(_ context.Context, _ core.Duty, set core.UnsignedDataSet) error {
 			results <- set
 			return nil
 		})
-		c.Start()
+		c.Start(log.WithCtx(ctx, z.Int("node", i)))
 
 		components = append(components, c)
 	}
@@ -132,4 +132,17 @@ func TestComponent(t *testing.T) {
 			}
 		}
 	}
+}
+
+// testDeadliner is a mock deadliner implementation.
+type testDeadliner struct {
+	deadlineChan chan core.Duty
+}
+
+func (testDeadliner) Add(core.Duty) bool {
+	return true
+}
+
+func (t testDeadliner) C() <-chan core.Duty {
+	return t.deadlineChan
 }

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -93,7 +93,7 @@ func TestComponent(t *testing.T) {
 			results <- set
 			return nil
 		})
-		c.Start(log.WithCtx(ctx, z.Int("node", i)))
+		c.Start()
 
 		components = append(components, c)
 	}


### PR DESCRIPTION
Fixes leaked context in consensus stream handler due to variable shadowing.

Also trim receive channel on duty deadline.

category: bug
ticket: #974 
