### PR TITLE
core/scheduler: improve builder-api config error

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -139,6 +139,12 @@ func (s *Scheduler) Run() error {
 
 // GetDutyDefinition returns the definition for a duty if resolved already, otherwise an error.
 func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+	if duty.Type == core.DutyBuilderProposer && !s.builderAPI {
+		return nil, errors.New("builder-api not enabled, but duty builder proposer requested")
+	} else if duty.Type == core.DutyProposer && s.builderAPI {
+		return nil, errors.New("builder-api enabled, but duty proposer requested")
+	}
+
 	slotsPerEpoch, err := s.eth2Cl.SlotsPerEpoch(ctx)
 	if err != nil {
 		return nil, err

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -316,10 +316,11 @@ func TestScheduler_GetDuty(t *testing.T) {
 	clock := newTestClock(t0)
 	sched := scheduler.NewForT(t, clock, new(delayer).delay, pubkeys, eth2Cl, false)
 
-	_, err = sched.GetDutyDefinition(context.Background(), core.Duty{Slot: 0, Type: core.DutyAttester})
-	// due to current design we will return an error if we request the duty of a slot that has not been resolved
-	// by the scheduler yet. With DutyResolver, we will have always an answer
-	require.Error(t, err, "epoch not resolved yet")
+	_, err = sched.GetDutyDefinition(context.Background(), core.NewAttesterDuty(0))
+	require.ErrorContains(t, err, "epoch not resolved yet")
+
+	_, err = sched.GetDutyDefinition(context.Background(), core.NewBuilderProposerDuty(0))
+	require.ErrorContains(t, err, "builder-api not enabled")
 
 	slotDuration, err := eth2Cl.SlotDuration(context.Background())
 	require.NoError(t, err)


### PR DESCRIPTION
Improve scheduler errors when querying mismatching proposer duties ito builder-api config.

category: misc
ticket: none

