### PR TITLE
core/validatorapi: teku proposer config updates

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -365,7 +365,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	dutyDB := dutydb.NewMemDB(deadlinerFunc())
 
-	vapi, err := validatorapi.NewComponent(eth2Cl, pubSharesByKey, nodeIdx.ShareIdx)
+	vapi, err := validatorapi.NewComponent(eth2Cl, pubSharesByKey, nodeIdx.ShareIdx, lock.FeeRecipientAddress)
 	if err != nil {
 		return err
 	}

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -164,6 +164,7 @@ func newSimnetArgs(t *testing.T) simnetArgs {
 
 	const n = 3
 	lock, p2pKeys, secretShares := cluster.NewForT(t, 1, n, n, 99)
+	// set lock["fee_recipient"] to 0x000000000000000000000000000000000000dead ?
 
 	var secrets []*bls_sig.SecretKey
 	for _, share := range secretShares[0] {

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -164,7 +164,6 @@ func newSimnetArgs(t *testing.T) simnetArgs {
 
 	const n = 3
 	lock, p2pKeys, secretShares := cluster.NewForT(t, 1, n, n, 99)
-	// set lock["fee_recipient"] to 0x000000000000000000000000000000000000dead ?
 
 	var secrets []*bls_sig.SecretKey
 	for _, share := range secretShares[0] {

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -36,16 +36,6 @@ type TekuBuilder struct {
 	Overrides map[string]string `json:"registration_overrides,omitempty"`
 }
 
-var feeRecipient = "0x000000000000000000000000000000000000dead"
-
-// var cluster.Lock lock
-
-// if address, ok := lock["fee_recipient"]; ok {
-//     feeRecipient = lock["fee_recipient"]
-// } else {
-// 	feeRecipient = lock["withdrawal_address"]
-// }
-
 const gasLimit = 30000000
 
 type TekuProposerConfigProvider interface {
@@ -56,7 +46,7 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 	resp := TekuProposerConfigResponse{
 		Proposers: make(map[string]TekuProposerConfig),
 		Default: TekuProposerConfig{ // Default doesn't make sense, disable for now.
-			FeeRecipient: feeRecipient,
+			FeeRecipient: c.feeRecipient,
 			Builder: TekuBuilder{
 				Enabled:  false,
 				GasLimit: gasLimit,
@@ -71,7 +61,7 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 
 	for pubkey, pubshare := range c.sharesByKey {
 		resp.Proposers[string(pubshare)] = TekuProposerConfig{
-			FeeRecipient: feeRecipient,
+			FeeRecipient: c.feeRecipient,
 			Builder: TekuBuilder{
 				Enabled:  true,
 				GasLimit: gasLimit,

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -36,7 +36,7 @@ type TekuBuilder struct {
 	Overrides map[string]string `json:"registration_overrides,omitempty"`
 }
 
-var feeRecipient = ""
+var feeRecipient = "0x000000000000000000000000000000000000dead"
 
 // var cluster.Lock lock
 

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -32,10 +32,21 @@ type TekuProposerConfig struct {
 
 type TekuBuilder struct {
 	Enabled   bool              `json:"enabled"`
+	GasLimit  uint              `json:"gas_limit"`
 	Overrides map[string]string `json:"registration_overrides,omitempty"`
 }
 
-const dead = "0x000000000000000000000000000000000000dead"
+var feeRecipient = ""
+
+// var cluster.Lock lock
+
+// if address, ok := lock["fee_recipient"]; ok {
+//     feeRecipient = lock["fee_recipient"]
+// } else {
+// 	feeRecipient = lock["withdrawal_address"]
+// }
+
+const gasLimit = 30000000
 
 type TekuProposerConfigProvider interface {
 	TekuProposerConfig(ctx context.Context) (TekuProposerConfigResponse, error)
@@ -45,9 +56,10 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 	resp := TekuProposerConfigResponse{
 		Proposers: make(map[string]TekuProposerConfig),
 		Default: TekuProposerConfig{ // Default doesn't make sense, disable for now.
-			FeeRecipient: dead,
+			FeeRecipient: feeRecipient,
 			Builder: TekuBuilder{
-				Enabled: false,
+				Enabled:  false,
+				GasLimit: gasLimit,
 			},
 		},
 	}
@@ -59,9 +71,10 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 
 	for pubkey, pubshare := range c.sharesByKey {
 		resp.Proposers[string(pubshare)] = TekuProposerConfig{
-			FeeRecipient: dead,
+			FeeRecipient: feeRecipient,
 			Builder: TekuBuilder{
-				Enabled: true,
+				Enabled:  true,
+				GasLimit: gasLimit,
 				Overrides: map[string]string{
 					"timestamp":  fmt.Sprint(genesis.Unix()),
 					"public_key": string(pubkey),

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -74,7 +74,9 @@ func NewComponentInsecure(_ *testing.T, eth2Svc eth2client.Service, shareIdx int
 }
 
 // NewComponent returns a new instance of the validator API core workflow component.
-func NewComponent(eth2Svc eth2client.Service, pubShareByKey map[*bls_sig.PublicKey]*bls_sig.PublicKey, shareIdx int) (*Component, error) {
+func NewComponent(eth2Svc eth2client.Service, pubShareByKey map[*bls_sig.PublicKey]*bls_sig.PublicKey,
+	shareIdx int, feeRecipient string,
+) (*Component, error) {
 	eth2Cl, ok := eth2Svc.(eth2Provider)
 	if !ok {
 		return nil, errors.New("invalid eth2 service")
@@ -142,6 +144,7 @@ func NewComponent(eth2Svc eth2client.Service, pubShareByKey map[*bls_sig.PublicK
 		sharesByKey:        coreSharesByKey,
 		eth2Cl:             eth2Cl,
 		shareIdx:           shareIdx,
+		feeRecipient:       feeRecipient,
 	}, nil
 }
 
@@ -149,6 +152,7 @@ type Component struct {
 	eth2Cl       eth2Provider
 	shareIdx     int
 	insecureTest bool
+	feeRecipient string
 
 	// getVerifyShareFunc maps public shares (what the VC thinks as its public key)
 	// to public keys (the DV root public key)

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -187,7 +187,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error) {
@@ -280,7 +280,7 @@ func TestSignAndVerify(t *testing.T) {
 	// Setup validatorapi component.
 	vapi, err := validatorapi.NewComponent(bmock, map[*bls_sig.PublicKey]*bls_sig.PublicKey{
 		pubkey: pubkey,
-	}, 0)
+	}, 0, "")
 	require.NoError(t, err)
 	vapi.RegisterPubKeyByAttestation(func(context.Context, int64, int64, int64) (core.PubKey, error) {
 		return tblsconv.KeyToCore(pubkey)
@@ -397,7 +397,7 @@ func TestComponent_SubmitBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -475,7 +475,7 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -539,7 +539,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -692,7 +692,7 @@ func TestComponent_SubmitBlindedBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -770,7 +770,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -834,7 +834,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -904,7 +904,7 @@ func TestComponent_SubmitVoluntaryExit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned voluntary exit
@@ -966,7 +966,7 @@ func TestComponent_SubmitVoluntaryExitInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Register subscriber
@@ -1016,7 +1016,7 @@ func TestComponent_ProposerDuties(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	duties, err := vapi.ProposerDuties(ctx, eth2p0.Epoch(0), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
@@ -1044,7 +1044,7 @@ func TestComponent_SubmitValidatorRegistration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	unsigned := &eth2api.VersionedValidatorRegistration{
@@ -1108,7 +1108,7 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	unsigned := &eth2api.VersionedValidatorRegistration{
@@ -1139,4 +1139,56 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 
 	err = vapi.SubmitValidatorRegistrations(ctx, []*eth2api.VersionedSignedValidatorRegistration{signed})
 	require.ErrorContains(t, err, "invalid signature")
+}
+
+func TestComponent_TekuProposerConfig(t *testing.T) {
+	ctx := context.Background()
+
+	// Create keys (just use normal keys, not split tbls)
+	pubkey, _, err := tbls.Keygen()
+	require.NoError(t, err)
+
+	// Convert pubkey
+	pubShareByKey := map[*bls_sig.PublicKey]*bls_sig.PublicKey{pubkey: pubkey} // Maps self to self since not tbls
+
+	// Configure beacon mock
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	feeRecipient := "0x123"
+	// Construct the validator api component
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, feeRecipient)
+	require.NoError(t, err)
+
+	resp, err := vapi.TekuProposerConfig(ctx)
+	require.NoError(t, err)
+
+	pk, err := tblsconv.KeyToCore(pubkey)
+	require.NoError(t, err)
+
+	genesis, err := bmock.GenesisTime(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, validatorapi.TekuProposerConfigResponse{
+		Proposers: map[string]validatorapi.TekuProposerConfig{
+			string(pk): {
+				FeeRecipient: feeRecipient,
+				Builder: validatorapi.TekuBuilder{
+					Enabled:  true,
+					GasLimit: 30000000,
+					Overrides: map[string]string{
+						"timestamp":  fmt.Sprint(genesis.Unix()),
+						"public_key": string(pk),
+					},
+				},
+			},
+		},
+		Default: validatorapi.TekuProposerConfig{
+			FeeRecipient: feeRecipient,
+			Builder: validatorapi.TekuBuilder{
+				Enabled:  false,
+				GasLimit: 30000000,
+			},
+		},
+	}, resp)
 }


### PR DESCRIPTION
- Use fee recipient from cluster lock or withdrawal address if fee recipient not set for builder api registrations
- Add gas limit to proposer config as hardcoded const - while the VC's will default to a value this value may be different between VC clients so between to hardcode it to a known value

category: feature
ticket: #849 