### PR TITLE
p2p: invert peer discovery integration

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -276,6 +276,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartRelay, p2p.NewRelayReserver(tcpNode, relay))
 	}
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PEventCollector, p2p.NewEventCollector(tcpNode))
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PDiscAdapter, p2p.NewDiscoveryAdapter(tcpNode, udpNode, peers))
 
 	return tcpNode, localEnode, nil
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -44,7 +44,7 @@ import (
 )
 
 //go:generate go test . -v -run=TestPingCluster -slow
-var slow = flag.Bool("slow", true, "enable slow tests")
+var slow = flag.Bool("slow", false, "enable slow tests")
 
 // TestPingCluster starts a cluster of charon nodes and waits for each node to ping all the others.
 // It relies on discv5 for peer discovery.

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -38,12 +38,16 @@ type Feature string
 const (
 	// QBFTConsensus introduces qbft consensus, see https://github.com/ObolNetwork/charon/issues/445.
 	QBFTConsensus Feature = "qbft_consensus"
+
+	// InvertDiscv5 enables the new push based discv5 integration and disables the old pull based.
+	InvertDiscv5 Feature = "invert_discv5"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
 		QBFTConsensus: statusStable,
+		InvertDiscv5:  statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -32,6 +32,7 @@ const (
 	StartMonitoringAPI
 	StartValidatorAPI
 	StartP2PPing
+	StartP2PDiscAdapter
 	StartP2PConsensus
 	StartSimulator
 	StartScheduler

--- a/app/lifecycle/orderstart_string.go
+++ b/app/lifecycle/orderstart_string.go
@@ -29,15 +29,16 @@ func _() {
 	_ = x[StartMonitoringAPI-3]
 	_ = x[StartValidatorAPI-4]
 	_ = x[StartP2PPing-5]
-	_ = x[StartP2PConsensus-6]
-	_ = x[StartSimulator-7]
-	_ = x[StartScheduler-8]
-	_ = x[StartP2PEventCollector-9]
+	_ = x[StartP2PDiscAdapter-6]
+	_ = x[StartP2PConsensus-7]
+	_ = x[StartSimulator-8]
+	_ = x[StartScheduler-9]
+	_ = x[StartP2PEventCollector-10]
 }
 
-const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PConsensusSimulatorSchedulerP2PEventCollector"
+const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PDiscAdapterP2PConsensusSimulatorSchedulerP2PEventCollector"
 
-var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 64, 73, 82, 99}
+var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 66, 78, 87, 96, 113}
 
 func (i OrderStart) String() string {
 	if i < 0 || i >= OrderStart(len(_OrderStart_index)-1) {

--- a/p2p/gater_test.go
+++ b/p2p/gater_test.go
@@ -71,7 +71,7 @@ func TestP2PConnGating(t *testing.T) {
 
 	err = nodeA.Connect(context.Background(), addr)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), fmt.Sprintf("gater rejected connection with peer %s and addr %s", addr.ID, addr.Addrs[0]))
+	require.Contains(t, err.Error(), fmt.Sprintf("gater rejected connection with peer %s", addr.ID))
 }
 
 func TestOpenGater(t *testing.T) {


### PR DESCRIPTION
Inverts the integration between  discv5 and libp2p from pull to push.

category: refactor
ticket: #985 
feature_flag: invert_discv5
