### PR TITLE
core/validatorapi: add lighthouse route for validator definitions

### DIFF
--- a/core/validatorapi/lighthouse.go
+++ b/core/validatorapi/lighthouse.go
@@ -15,7 +15,7 @@
 
 package validatorapi
 
-type LighthouseValidatorDefinitionJSON struct {
+type LighthouseValidatorDefinition struct {
 	Enabled                    bool   `json:"enabled"`
 	VotingPublicKey            string `json:"voting_public_key"`
 	Type                       string `json:"type"`
@@ -27,39 +27,27 @@ type LighthouseValidatorDefinitionJSON struct {
 	BuilderPubkeyOverride      string `json:"builder_pubkey_override"`
 }
 
-// type LighthouseValidatorDefinitionYAML struct {
-// 	Enabled                    bool   `yaml:"enabled"`
-// 	VotingPublicKey            string `yaml:"voting_public_key"`
-// 	Type                       string `yaml:"type"`
-// 	VotingKeystorePath         string `yaml:"voting_keystore_path"`
-// 	VotingKeystorePasswordPath string `yaml:"voting_keystore_password_path"`
-// 	SuggestedFeeRecipient      string `yaml:"suggested_fee_recipient"`
-// 	GasLimit                   uint   `yaml:"gas_limit"`
-// 	BuilderProposals           bool   `yaml:"builder_proposals"`
-// 	BuilderPubkeyOverride      string `yaml:"builder_pubkey_override"`
-// }
-
 const gasLimit = 30000000
 
 type LighthouseValidatorDefinitionsProvider interface {
-	LighthouseValidatorDefinitions() ([]LighthouseValidatorDefinitionJSON, error)
+	LighthouseValidatorDefinitions() ([]LighthouseValidatorDefinition, error)
 }
 
-func (c Component) LighthouseValidatorDefinitions() ([]LighthouseValidatorDefinitionJSON, error) {
-	resp := []LighthouseValidatorDefinitionJSON{}
+func (c Component) LighthouseValidatorDefinitions() ([]LighthouseValidatorDefinition, error) {
+	var resp []LighthouseValidatorDefinition
 
 	for pubkey, pubshare := range c.sharesByKey {
-		resp = append(resp, LighthouseValidatorDefinitionJSON{
+		resp = append(resp, LighthouseValidatorDefinition{
 			Enabled:         true,
 			VotingPublicKey: string(pubshare),
 			// Asking whether these need to be defined in lighthouse discord
 			// Type: dead,
 			// VotingKeystorePath: dead,
 			// VotingKeystorePasswordPath: dead,
-			SuggestedFeeRecipient: string(pubkey),
+			SuggestedFeeRecipient: c.feeRecipient,
 			GasLimit:              gasLimit,
 			BuilderProposals:      true,
-			BuilderPubkeyOverride: dead,
+			BuilderPubkeyOverride: string(pubkey),
 		})
 	}
 

--- a/core/validatorapi/lighthouse.go
+++ b/core/validatorapi/lighthouse.go
@@ -1,0 +1,69 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package validatorapi
+
+import (
+	"context"
+	"fmt"
+)
+
+type LighthouseValidatorDefinitionsResponse struct {
+	Proposers map[string]TekuProposerConfig `json:"proposer_config"`
+	Default   TekuProposerConfig            `json:"default_config"`
+}
+
+type LighthouseValidatorDefinitions struct {
+	FeeRecipient string      `json:"fee_recipient"`
+	Builder      TekuBuilder `json:"builder"`
+}
+
+const dead = "0x000000000000000000000000000000000000dead"
+
+type LighthouseValidatorDefinitionsProvider interface {
+	LighthouseValidatorDefinitions(ctx context.Context) (LighthouseValidatorDefinitionsResponse, error)
+}
+
+func (c Component) LighthouseValidatorDefinitions(ctx context.Context) (LighthouseValidatorDefinitionsResponse, error) {
+	resp := LighthouseValidatorDefinitionsResponse{
+		Proposers: make(map[string]TekuProposerConfig),
+		Default: TekuProposerConfig{ // Default doesn't make sense, disable for now.
+			FeeRecipient: dead,
+			Builder: TekuBuilder{
+				Enabled: false,
+			},
+		},
+	}
+
+	genesis, err := c.eth2Cl.GenesisTime(ctx)
+	if err != nil {
+		return TekuProposerConfigResponse{}, nil
+	}
+
+	for pubkey, pubshare := range c.sharesByKey {
+		resp.Proposers[string(pubshare)] = TekuProposerConfig{
+			FeeRecipient: dead,
+			Builder: TekuBuilder{
+				Enabled: true,
+				Overrides: map[string]string{
+					"timestamp":  fmt.Sprint(genesis.Unix()),
+					"public_key": string(pubkey),
+				},
+			},
+		}
+	}
+
+	return resp, nil
+}

--- a/core/validatorapi/lighthouse.go
+++ b/core/validatorapi/lighthouse.go
@@ -15,6 +15,8 @@
 
 package validatorapi
 
+import "context"
+
 type LighthouseValidatorDefinition struct {
 	Enabled                    bool   `json:"enabled"`
 	VotingPublicKey            string `json:"voting_public_key"`
@@ -27,13 +29,11 @@ type LighthouseValidatorDefinition struct {
 	BuilderPubkeyOverride      string `json:"builder_pubkey_override"`
 }
 
-const gasLimit = 30000000
-
 type LighthouseValidatorDefinitionsProvider interface {
-	LighthouseValidatorDefinitions() ([]LighthouseValidatorDefinition, error)
+	LighthouseValidatorDefinitions(ctx context.Context) ([]LighthouseValidatorDefinition, error)
 }
 
-func (c Component) LighthouseValidatorDefinitions() ([]LighthouseValidatorDefinition, error) {
+func (c Component) LighthouseValidatorDefinitions(_ context.Context) ([]LighthouseValidatorDefinition, error) {
 	var resp []LighthouseValidatorDefinition
 
 	for pubkey, pubshare := range c.sharesByKey {

--- a/core/validatorapi/lighthouse.go
+++ b/core/validatorapi/lighthouse.go
@@ -38,12 +38,8 @@ func (c Component) LighthouseValidatorDefinitions() ([]LighthouseValidatorDefini
 
 	for pubkey, pubshare := range c.sharesByKey {
 		resp = append(resp, LighthouseValidatorDefinition{
-			Enabled:         true,
-			VotingPublicKey: string(pubshare),
-			// Asking whether these need to be defined in lighthouse discord
-			// Type: dead,
-			// VotingKeystorePath: dead,
-			// VotingKeystorePasswordPath: dead,
+			Enabled:               true,
+			VotingPublicKey:       string(pubshare),
 			SuggestedFeeRecipient: c.feeRecipient,
 			GasLimit:              gasLimit,
 			BuilderProposals:      true,

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -64,6 +64,7 @@ type Handler interface {
 	eth2client.ValidatorsProvider
 	eth2client.ValidatorRegistrationsSubmitter
 	eth2client.VoluntaryExitSubmitter
+	LighthouseValidatorDefinitionsProvider
 	TekuProposerConfigProvider
 	// Above sorted alphabetically.
 }
@@ -550,6 +551,12 @@ func submitExit(p eth2client.VoluntaryExitSubmitter) handlerFunc {
 func tekuProposerConfig(p TekuProposerConfigProvider) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, _ []byte) (interface{}, error) {
 		return p.TekuProposerConfig(ctx)
+	}
+}
+
+func lighthouseValidatorDefinitions(p LighthouseValidatorDefinitionsProvider) handlerFunc {
+	return func(ctx context.Context, _ map[string]string, _ url.Values, _ []byte) (interface{}, error) {
+		return p.LighthouseValidatorDefinitions()
 	}
 }
 

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -556,7 +556,7 @@ func tekuProposerConfig(p TekuProposerConfigProvider) handlerFunc {
 
 func lighthouseValidatorDefinitions(p LighthouseValidatorDefinitionsProvider) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, _ []byte) (interface{}, error) {
-		return p.LighthouseValidatorDefinitions()
+		return p.LighthouseValidatorDefinitions(ctx)
 	}
 }
 

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -143,6 +143,11 @@ func NewRouter(h Handler, eth2Cl eth2client.Service) (*mux.Router, error) {
 			Path:    "/teku_proposer_config",
 			Handler: tekuProposerConfig(h),
 		},
+		{
+			Name:    "lighthouse_validator_definitions",
+			Path:    "/lighthouse_validator_definitions",
+			Handler: lighthouseValidatorDefinitions(h),
+		},
 	}
 
 	r := mux.NewRouter()


### PR DESCRIPTION
- add lighthouse route for validator defintions, returned in JSON user will have to convert to yaml

category: feature
ticket: #849 
