### PR TITLE
p2p: invert relay address routing

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -276,7 +276,8 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartRelay, p2p.NewRelayReserver(tcpNode, relay))
 	}
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PEventCollector, p2p.NewEventCollector(tcpNode))
-	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PDiscAdapter, p2p.NewDiscoveryAdapter(tcpNode, udpNode, peers))
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewDiscoveryRouter(tcpNode, udpNode, peers))
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewRelayRouter(tcpNode, peers, relays))
 
 	return tcpNode, localEnode, nil
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -169,7 +169,7 @@ func pingCluster(t *testing.T, test pingTest) {
 		bootnodes = append(bootnodes, bootAddr)
 	}
 
-	const n = 2
+	const n = 3
 	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, 0)
 	asserter := &pingAsserter{
 		asserter: asserter{

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -139,11 +139,11 @@ type pingTest struct {
 func pingClusterAB(t *testing.T, test pingTest) {
 	t.Helper()
 	t.Run("pushdisc", func(t *testing.T) {
-		featureset.EnableForT(t, featureset.InvertDiscv5)
+		featureset.EnableForT(t, featureset.InvertLibP2PRouting)
 		pingCluster(t, test)
 	})
 	t.Run("pulldisc", func(t *testing.T) {
-		featureset.DisableForT(t, featureset.InvertDiscv5)
+		featureset.DisableForT(t, featureset.InvertLibP2PRouting)
 		pingCluster(t, test)
 	})
 }
@@ -169,7 +169,7 @@ func pingCluster(t *testing.T, test pingTest) {
 		bootnodes = append(bootnodes, bootAddr)
 	}
 
-	const n = 3
+	const n = 2
 	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, 0)
 	asserter := &pingAsserter{
 		asserter: asserter{

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -39,15 +39,15 @@ const (
 	// QBFTConsensus introduces qbft consensus, see https://github.com/ObolNetwork/charon/issues/445.
 	QBFTConsensus Feature = "qbft_consensus"
 
-	// InvertDiscv5 enables the new push based discv5 integration and disables the old pull based.
-	InvertDiscv5 Feature = "invert_discv5"
+	// InvertLibP2PRouting enables the new push based libp2p routing and disables the old pull based.
+	InvertLibP2PRouting Feature = "invert_libp2p_routing"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		QBFTConsensus: statusStable,
-		InvertDiscv5:  statusAlpha,
+		QBFTConsensus:       statusStable,
+		InvertLibP2PRouting: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -32,7 +32,7 @@ const (
 	StartMonitoringAPI
 	StartValidatorAPI
 	StartP2PPing
-	StartP2PDiscAdapter
+	StartP2PRouters
 	StartP2PConsensus
 	StartSimulator
 	StartScheduler

--- a/app/lifecycle/orderstart_string.go
+++ b/app/lifecycle/orderstart_string.go
@@ -29,16 +29,16 @@ func _() {
 	_ = x[StartMonitoringAPI-3]
 	_ = x[StartValidatorAPI-4]
 	_ = x[StartP2PPing-5]
-	_ = x[StartP2PDiscAdapter-6]
+	_ = x[StartP2PRouters-6]
 	_ = x[StartP2PConsensus-7]
 	_ = x[StartSimulator-8]
 	_ = x[StartScheduler-9]
 	_ = x[StartP2PEventCollector-10]
 }
 
-const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PDiscAdapterP2PConsensusSimulatorSchedulerP2PEventCollector"
+const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersP2PConsensusSimulatorSchedulerP2PEventCollector"
 
-var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 66, 78, 87, 96, 113}
+var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 62, 74, 83, 92, 109}
 
 func (i OrderStart) String() string {
 	if i < 0 || i >= OrderStart(len(_OrderStart_index)-1) {


### PR DESCRIPTION
Inverts relay address routing from pull based to pull based.

category: refactor
ticket: #989 
feature_flag: invert_libp2p_routing
