### PR TITLE
core/tracker: add analyser and deleter

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -409,7 +409,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	wireTracker(life, deadlinerFunc(), peers, sched, fetch, cons, vapi, parSigDB, parSigEx, sigAgg)
+	wireTracker(ctx, life, deadlineFunc, peers, sched, fetch, cons, vapi, parSigDB, parSigEx, sigAgg)
 
 	core.Wire(sched, fetch, cons, dutyDB, vapi,
 		parSigDB, parSigEx, sigAgg, aggSigDB, broadcaster,
@@ -439,11 +439,21 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 }
 
 // wireTracker creates a new tracker instance and wires it to the components with "output events".
-func wireTracker(life *lifecycle.Manager, deadliner core.Deadliner, peers []p2p.Peer,
+func wireTracker(ctx context.Context, life *lifecycle.Manager, deadlineFunc func(duty core.Duty) (time.Time, bool), peers []p2p.Peer,
 	sched core.Scheduler, fetcher core.Fetcher, cons core.Consensus, vapi core.ValidatorAPI,
 	parSigDB core.ParSigDB, parSigEx core.ParSigEx, sigAgg core.SigAgg,
 ) {
-	trackr := tracker.New(deadliner, peers)
+	analyser := core.NewDeadliner(ctx, deadlineFunc)
+	deleter := core.NewDeadliner(ctx, func(duty core.Duty) (time.Time, bool) {
+		d, ok := deadlineFunc(duty)
+		if !ok {
+			return d, false
+		}
+
+		// To delete duties after 2 * deadline.
+		return d.Add(time.Until(d)), true
+	})
+	trackr := tracker.New(analyser, deleter, peers)
 
 	sched.Subscribe(trackr.SchedulerEvent)
 	fetcher.Subscribe(trackr.FetcherEvent)

--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -38,8 +38,10 @@ import (
 func New[T any](timeoutFunc func(T) (time.Time, bool)) (*Retryer[T], error) {
 	// ctxTimeoutFunc returns a context that is cancelled when duties for a slot have elapsed.
 	ctxTimeoutFunc := func(ctx context.Context, t T) (context.Context, context.CancelFunc) {
-		// Ignoring boolean value as it is of no use here.
-		timeout, _ := timeoutFunc(t)
+		timeout, ok := timeoutFunc(t)
+		if !ok {
+			return ctx, func() {}
+		}
 
 		return context.WithDeadline(ctx, timeout)
 	}

--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -35,10 +35,13 @@ import (
 )
 
 // New returns a new Retryer instance.
-func New[T any](timeoutFunc func(T) time.Time) (*Retryer[T], error) {
+func New[T any](timeoutFunc func(T) (time.Time, bool)) (*Retryer[T], error) {
 	// ctxTimeoutFunc returns a context that is cancelled when duties for a slot have elapsed.
 	ctxTimeoutFunc := func(ctx context.Context, t T) (context.Context, context.CancelFunc) {
-		return context.WithDeadline(ctx, timeoutFunc(t))
+		// Ignoring boolean value as it is of no use here.
+		timeout, _ := timeoutFunc(t)
+
+		return context.WithDeadline(ctx, timeout)
 	}
 
 	// backoffProvider is a naive constant 1s backoff function.

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -121,7 +121,6 @@ func (d *deadliner) run(ctx context.Context, deadlineFunc func(Duty) (time.Time,
 		case <-ctx.Done():
 			return
 		case input := <-d.inputChan:
-			// Ignoring boolean value
 			deadline, canExpire := deadlineFunc(input.duty)
 			expired := deadline.Before(d.clock.Now())
 

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -122,13 +122,13 @@ func (d *deadliner) run(ctx context.Context, deadlineFunc func(Duty) (time.Time,
 			return
 		case input := <-d.inputChan:
 			// Ignoring boolean value
-			deadline, _ := deadlineFunc(input.duty)
+			deadline, canExpire := deadlineFunc(input.duty)
 			expired := deadline.Before(d.clock.Now())
 
 			input.success <- !expired
 
-			// Ignore expired duties.
-			if expired {
+			// Ignore expired duties or the ones that cannot expire.
+			if expired || !canExpire {
 				continue
 			}
 

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -35,18 +35,18 @@ func TestDeadliner(t *testing.T) {
 	expiredDuties, nonExpiredDuties, voluntaryExits, dutyExpired := setupData(t)
 	clock := clockwork.NewFakeClock()
 
-	deadlineFuncProvider := func() func(duty core.Duty) time.Time {
+	deadlineFuncProvider := func() func(duty core.Duty) (time.Time, bool) {
 		startTime := clock.Now()
-		return func(duty core.Duty) time.Time {
+		return func(duty core.Duty) (time.Time, bool) {
 			if duty.Type == core.DutyExit {
-				return startTime.Add(time.Hour)
+				return startTime.Add(time.Hour), true
 			}
 
 			if dutyExpired(duty) {
-				return startTime.Add(-1 * time.Hour)
+				return startTime.Add(-1 * time.Hour), true
 			}
 
-			return startTime.Add(time.Duration(duty.Slot) * time.Second)
+			return startTime.Add(time.Duration(duty.Slot) * time.Second), true
 		}
 	}
 

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -74,9 +74,12 @@ type Tracker struct {
 	input chan event
 
 	// events stores all the events corresponding to a particular duty.
-	events    map[core.Duty][]event
-	deadliner core.Deadliner
-	quit      chan struct{}
+	events map[core.Duty][]event
+	// analyser returns duty from analyser.C() when it is deadlined to analyse for failures and participation.
+	analyser core.Deadliner
+	// deleter returns duty from deleter.C() after 2 * deadline time to delete from memory.
+	deleter core.Deadliner
+	quit    chan struct{}
 
 	// failedDutyReporter instruments duty failures.
 	failedDutyReporter func(ctx context.Context, duty core.Duty, failed bool, component component, reason string)
@@ -86,12 +89,13 @@ type Tracker struct {
 }
 
 // New returns a new Tracker.
-func New(deadliner core.Deadliner, peers []p2p.Peer) *Tracker {
+func New(analyser core.Deadliner, deleter core.Deadliner, peers []p2p.Peer) *Tracker {
 	t := &Tracker{
 		input:                 make(chan event),
 		events:                make(map[core.Duty][]event),
 		quit:                  make(chan struct{}),
-		deadliner:             deadliner,
+		analyser:              analyser,
+		deleter:               deleter,
 		failedDutyReporter:    failedDutyReporter,
 		participationReporter: newParticipationReporter(peers),
 	}
@@ -110,13 +114,13 @@ func (t *Tracker) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case e := <-t.input:
-			if !t.deadliner.Add(e.duty) {
+			if !t.analyser.Add(e.duty) && !t.deleter.Add(e.duty) {
 				// Ignore expired duties
 				continue
 			}
 
 			t.events[e.duty] = append(t.events[e.duty], e)
-		case duty := <-t.deadliner.C():
+		case duty := <-t.analyser.C():
 			ctx := log.WithCtx(ctx, z.Any("duty", duty))
 
 			// Analyse failed duties
@@ -126,7 +130,7 @@ func (t *Tracker) Run(ctx context.Context) error {
 			// Analyse peer participation
 			participatedShares, unexpectedShares := analyseParticipation(duty, t.events)
 			t.participationReporter(ctx, duty, participatedShares, unexpectedShares)
-
+		case duty := <-t.deleter.C():
 			delete(t.events, duty)
 		}
 	}
@@ -223,14 +227,7 @@ func analyseParticipation(duty core.Duty, allEvents map[core.Duty][]event) (map[
 	for _, e := range allEvents[duty] {
 		// If we get a parSigDBInternal event, then the current node participated successfully.
 		// If we get a parSigEx event, then the corresponding peer with e.shareIdx participated successfully.
-		if e.component == parSigEx {
-			if !isParSigEventExpected(duty, e.pubkey, allEvents) {
-				unexpectedShares[e.shareIdx] = true
-				continue
-			}
-
-			resp[e.shareIdx] = true
-		} else if e.component == parSigDBInternal {
+		if e.component == parSigEx || e.component == parSigDBInternal {
 			if !isParSigEventExpected(duty, e.pubkey, allEvents) {
 				unexpectedShares[e.shareIdx] = true
 				continue


### PR DESCRIPTION
Adds 2 deadliners in tracker: analyser and deleter. When analyser deadline hits, tracker analyser failures and participation. When deleter deadline hits track trims internal state of duties.

category: bug
ticket: #993 
