### PR TITLE
precommit: add timeout to pre-commit tests

### DIFF
--- a/.pre-commit/run_tests.sh
+++ b/.pre-commit/run_tests.sh
@@ -4,4 +4,4 @@
 MOD=$(go list -m)
 PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
 
-go test $PKGS
+go test -timeout=5m $PKGS

--- a/.pre-commit/run_tests.sh
+++ b/.pre-commit/run_tests.sh
@@ -4,4 +4,4 @@
 MOD=$(go list -m)
 PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
 
-go test -timeout=5m $PKGS
+go test -timeout=2m $PKGS


### PR DESCRIPTION
Adds timeout flag to pre-commit tests so that they timeout early rather than blocking forever.

category: misc
ticket: none
