### PR TITLE
cmd: remove bootnode reservation limits

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -74,9 +74,11 @@ func bindBootnodeFlag(flags *pflag.FlagSet, config *BootnodeConfig) {
 	flags.StringVar(&config.HTTPAddr, "bootnode-http-address", "127.0.0.1:3640", "Listening address (ip and port) for the bootnode http server serving runtime ENR")
 	flags.BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (ecdsa private key used for p2p authentication and ENR) if none found in data directory")
 	flags.BoolVar(&config.P2PRelay, "p2p-relay", true, "Enable libp2p tcp host providing circuit relay to charon clusters")
-	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 30, "Updates max circuit reservations per peer (each valid for 30min)")
 	flags.StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error")
-	flags.IntVar(&config.MaxConns, "p2p-max-connections", 1024, "Libp2p maximum number of peers that can connect to this bootnode.")
+
+	// Decrease defaults after this has been addressed https://github.com/libp2p/go-libp2p/issues/1713
+	flags.IntVar(&config.MaxResPerPeer, "max-reservations", 512, "Updates max circuit reservations per peer (each valid for 30min)") // TODO(corver): Align flag name to p2p-max-reservations
+	flags.IntVar(&config.MaxConns, "p2p-max-connections", 16384, "Libp2p maximum number of peers that can connect to this bootnode.")
 }
 
 // RunBootnode starts a p2p-udp discv5 bootnode.

--- a/p2p/name_test.go
+++ b/p2p/name_test.go
@@ -18,6 +18,7 @@ package p2p_test
 import (
 	"testing"
 
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/p2p"
@@ -32,4 +33,23 @@ func TestPeerName(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, peer.Name, "happy-floor")
+}
+
+func Test(t *testing.T) {
+	tests := []struct {
+		peerID string
+		name   string
+	}{
+		{
+			peerID: "16Uiu2HAmDTemdrDfAgG1DX5q3NmfART3PcTFZe69yrNHdde3Qq3v",
+			name:   "different-course",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			p, err := peer.Decode(test.peerID)
+			require.NoError(t, err)
+			require.Equal(t, test.name, p2p.PeerName(p))
+		})
+	}
 }


### PR DESCRIPTION
Libp2p relay reservation limits are quirky, the act more as "rate-limits" than "active reservation limits", see https://github.com/libp2p/go-libp2p/issues/1713. Remove these limits for now since charon nodes that are crash looping, easily exceed rate limits even though no additional resources are used on the bootnode. 

Also improve reservation backoff to decrease log frequency.

category: misc
ticket: none
