### PR TITLE
core/bcast: add recaster to rebroadcast registrations every epoch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -440,7 +440,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 // This is not done in core.Wire since recaster isn't really part of the official core workflow (yet).
 func wireRecaster(sched core.Scheduler, sigAgg core.SigAgg, broadcaster core.Broadcaster) {
 	recaster := bcast.NewRecaster()
-	sched.SubscribeSlots(recaster.SlotTicket)
+	sched.SubscribeSlots(recaster.SlotTicked)
 	sigAgg.Subscribe(recaster.Store)
 	recaster.Subscribe(broadcaster.Broadcast)
 }

--- a/core/bcast/recast.go
+++ b/core/bcast/recast.go
@@ -87,6 +87,7 @@ func (r *Recaster) SlotTicked(ctx context.Context, slot core.Slot) error {
 	if !slot.FirstInEpoch() {
 		return nil
 	}
+	ctx = log.WithTopic(ctx, "bcast")
 
 	// Copy locked things before doing IO
 	var (
@@ -107,8 +108,6 @@ func (r *Recaster) SlotTicked(ctx context.Context, slot core.Slot) error {
 			err := sub(ctx, tuple.duty, pubkey, tuple.aggData)
 			if err != nil {
 				log.Error(ctx, "Rebroadcast duty error (will retry next epoch)", err)
-			} else {
-				log.Debug(ctx, "Rebroadcasted duty")
 			}
 		}
 	}

--- a/core/bcast/recast.go
+++ b/core/bcast/recast.go
@@ -1,0 +1,115 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bcast
+
+import (
+	"context"
+	"sync"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/core"
+)
+
+type recastTuple struct {
+	duty    core.Duty
+	aggData core.SignedData
+}
+
+// NewRecaster returns a new recaster.
+func NewRecaster() *Recaster {
+	return &Recaster{
+		tuples: make(map[core.PubKey]recastTuple),
+	}
+}
+
+// Recaster rebroadcasts core.DutyBuilderRegistration aggregate signatures every epoch.
+type Recaster struct {
+	mu     sync.Mutex
+	tuples map[core.PubKey]recastTuple
+	subs   []func(context.Context, core.Duty, core.PubKey, core.SignedData) error
+}
+
+// Subscribe subscribes to rebroadcasted duties.
+func (r *Recaster) Subscribe(sub func(context.Context, core.Duty, core.PubKey, core.SignedData) error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.subs = append(r.subs, sub)
+}
+
+func (r *Recaster) Store(_ context.Context, duty core.Duty,
+	pubkey core.PubKey, aggData core.SignedData,
+) (err error) {
+	if duty.Type != core.DutyBuilderRegistration {
+		return nil
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	tuple, ok := r.tuples[pubkey]
+	if ok && tuple.duty.Slot >= duty.Slot {
+		// Not storing duplicate or older registration.
+		return nil
+	}
+
+	// Clone before storing
+	data, err := aggData.Clone()
+	if err != nil {
+		return err
+	}
+
+	r.tuples[pubkey] = recastTuple{
+		duty:    duty,
+		aggData: data,
+	}
+
+	return nil
+}
+
+func (r *Recaster) SlotTicket(ctx context.Context, slot core.Slot) error {
+	if !slot.FirstInEpoch() {
+		return nil
+	}
+
+	// Copy locked things before doing IO
+	var (
+		clonedTuples = make(map[core.PubKey]recastTuple)
+		clonedSubs   []func(context.Context, core.Duty, core.PubKey, core.SignedData) error
+	)
+
+	r.mu.Lock()
+	for k, v := range r.tuples {
+		clonedTuples[k] = v
+		clonedSubs = append(clonedSubs, r.subs...)
+	}
+	r.mu.Unlock()
+
+	for pubkey, tuple := range clonedTuples {
+		ctx := log.WithCtx(ctx, z.Any("duty", tuple.duty))
+		for _, sub := range clonedSubs {
+			err := sub(ctx, tuple.duty, pubkey, tuple.aggData)
+			if err != nil {
+				log.Error(ctx, "Rebroadcast duty error (will retry next epoch)", err)
+			} else {
+				log.Debug(ctx, "Rebroadcasted duty")
+			}
+		}
+	}
+
+	return nil
+}

--- a/core/bcast/recast.go
+++ b/core/bcast/recast.go
@@ -96,9 +96,9 @@ func (r *Recaster) SlotTicked(ctx context.Context, slot core.Slot) error {
 	)
 
 	r.mu.Lock()
+	clonedSubs = append(clonedSubs, r.subs...)
 	for k, v := range r.tuples {
 		clonedTuples[k] = v
-		clonedSubs = append(clonedSubs, r.subs...)
 	}
 	r.mu.Unlock()
 

--- a/core/bcast/recast.go
+++ b/core/bcast/recast.go
@@ -51,6 +51,7 @@ func (r *Recaster) Subscribe(sub func(context.Context, core.Duty, core.PubKey, c
 	r.subs = append(r.subs, sub)
 }
 
+// Store stores aggregate signed duty registrations for rebroadcasting.
 func (r *Recaster) Store(_ context.Context, duty core.Duty,
 	pubkey core.PubKey, aggData core.SignedData,
 ) (err error) {
@@ -81,7 +82,8 @@ func (r *Recaster) Store(_ context.Context, duty core.Duty,
 	return nil
 }
 
-func (r *Recaster) SlotTicket(ctx context.Context, slot core.Slot) error {
+// SlotTicked is called when new slots tick.
+func (r *Recaster) SlotTicked(ctx context.Context, slot core.Slot) error {
 	if !slot.FirstInEpoch() {
 		return nil
 	}

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -53,7 +53,7 @@ var (
 )
 
 // instrumentSlot sets the current slot and epoch metrics.
-func instrumentSlot(slot slot) {
+func instrumentSlot(slot core.Slot) {
 	slotGauge.Set(float64(slot.Slot))
 	epochGauge.Set(float64(slot.Epoch()))
 }

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -146,6 +146,7 @@ func (s *Scheduler) Run() error {
 	}
 }
 
+// emitCoreSlot calls all slot subscribes with the provided slot.
 func (s *Scheduler) emitCoreSlot(ctx context.Context, slot core.Slot) {
 	for _, sub := range s.slotSubs {
 		err := sub(ctx, slot)

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -94,14 +94,21 @@ type Scheduler struct {
 	resolvedEpoch uint64
 	duties        map[core.Duty]core.DutyDefinitionSet
 	dutiesMutex   sync.Mutex
-	subs          []func(context.Context, core.Duty, core.DutyDefinitionSet) error
+	dutySubs      []func(context.Context, core.Duty, core.DutyDefinitionSet) error
+	slotSubs      []func(context.Context, core.Slot) error
 	builderAPI    bool
 }
 
-// Subscribe registers a callback for triggering a duty.
+// SubscribeDuties subscribes a callback function for triggered duties.
 // Note this should be called *before* Start.
-func (s *Scheduler) Subscribe(fn func(context.Context, core.Duty, core.DutyDefinitionSet) error) {
-	s.subs = append(s.subs, fn)
+func (s *Scheduler) SubscribeDuties(fn func(context.Context, core.Duty, core.DutyDefinitionSet) error) {
+	s.dutySubs = append(s.dutySubs, fn)
+}
+
+// SubscribeSlots subscribes a callback function for triggered slots.
+// Note this should be called *before* Start.
+func (s *Scheduler) SubscribeSlots(fn func(context.Context, core.Slot) error) {
+	s.slotSubs = append(s.slotSubs, fn)
 }
 
 func (s *Scheduler) Stop() {
@@ -132,7 +139,18 @@ func (s *Scheduler) Run() error {
 
 			instrumentSlot(slot)
 
+			go s.emitCoreSlot(slotCtx, slot)
+
 			s.scheduleSlot(slotCtx, slot)
+		}
+	}
+}
+
+func (s *Scheduler) emitCoreSlot(ctx context.Context, slot core.Slot) {
+	for _, sub := range s.slotSubs {
+		err := sub(ctx, slot)
+		if err != nil {
+			log.Error(ctx, "Emit scheduled slot event", err)
 		}
 	}
 }
@@ -165,7 +183,7 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 }
 
 // scheduleSlot resolves upcoming duties and triggers resolved duties for the slot.
-func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) {
+func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 	if s.getResolvedEpoch() != uint64(slot.Epoch()) {
 		err := s.resolveDuties(ctx, slot)
 		if err != nil {
@@ -196,7 +214,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) {
 			ctx, span := core.StartDutyTrace(ctx, duty, "core/scheduler.scheduleSlot")
 			defer span.End()
 
-			for _, sub := range s.subs {
+			for _, sub := range s.dutySubs {
 				clone, err := defSet.Clone() // Clone for each subscriber.
 				if err != nil {
 					log.Error(ctx, "Cloning duty definition set", err)
@@ -210,7 +228,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) {
 		}()
 	}
 
-	if slot.IsLastInEpoch() {
+	if slot.LastInEpoch() {
 		err := s.resolveDuties(ctx, slot.Next())
 		if err != nil {
 			log.Warn(ctx, "Resolving duties error (retrying next slot)", err)
@@ -220,7 +238,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot slot) {
 
 // delaySlotOffset blocks until the slot offset for the duty has been reached and return true.
 // It returns false if the context is cancelled.
-func delaySlotOffset(ctx context.Context, slot slot, duty core.Duty, delayFunc delayFunc) bool {
+func delaySlotOffset(ctx context.Context, slot core.Slot, duty core.Duty, delayFunc delayFunc) bool {
 	fn, ok := slotOffsets[duty.Type]
 	if !ok {
 		return true
@@ -239,7 +257,7 @@ func delaySlotOffset(ctx context.Context, slot slot, duty core.Duty, delayFunc d
 }
 
 // resolveDuties resolves the duties for the slot's epoch, caching the results.
-func (s *Scheduler) resolveDuties(ctx context.Context, slot slot) error {
+func (s *Scheduler) resolveDuties(ctx context.Context, slot core.Slot) error {
 	vals, err := resolveActiveValidators(ctx, s.eth2Cl, s.pubkeys, slot.Slot)
 	if err != nil {
 		return err
@@ -268,8 +286,8 @@ func (s *Scheduler) resolveDuties(ctx context.Context, slot slot) error {
 }
 
 // resolveAttDuties resolves attester duties for the given validators.
-func (s *Scheduler) resolveAttDuties(ctx context.Context, slot slot, vals validators) error {
-	attDuties, err := s.eth2Cl.AttesterDuties(ctx, slot.Epoch(), vals.Indexes())
+func (s *Scheduler) resolveAttDuties(ctx context.Context, slot core.Slot, vals validators) error {
+	attDuties, err := s.eth2Cl.AttesterDuties(ctx, eth2p0.Epoch(slot.Epoch()), vals.Indexes())
 	if err != nil {
 		return err
 	}
@@ -317,8 +335,8 @@ func (s *Scheduler) resolveAttDuties(ctx context.Context, slot slot, vals valida
 }
 
 // resolveProposerDuties resolves proposer duties for the given validators.
-func (s *Scheduler) resolveProDuties(ctx context.Context, slot slot, vals validators) error {
-	proDuties, err := s.eth2Cl.ProposerDuties(ctx, slot.Epoch(), vals.Indexes())
+func (s *Scheduler) resolveProDuties(ctx context.Context, slot core.Slot, vals validators) error {
+	proDuties, err := s.eth2Cl.ProposerDuties(ctx, eth2p0.Epoch(slot.Epoch()), vals.Indexes())
 	if err != nil {
 		return err
 	}
@@ -415,34 +433,9 @@ func (s *Scheduler) isEpochResolved(epoch uint64) bool {
 	return s.getResolvedEpoch() >= epoch
 }
 
-// slot is a beacon chain slot and includes chain metadata to infer epoch and next slot.
-type slot struct {
-	Slot          int64
-	Time          time.Time
-	SlotsPerEpoch int64
-	SlotDuration  time.Duration
-}
-
-func (s slot) Next() slot {
-	return slot{
-		Slot:          s.Slot + 1,
-		Time:          s.Time.Add(s.SlotDuration),
-		SlotsPerEpoch: s.SlotsPerEpoch,
-		SlotDuration:  s.SlotDuration,
-	}
-}
-
-func (s slot) Epoch() eth2p0.Epoch {
-	return eth2p0.Epoch(s.Slot / s.SlotsPerEpoch)
-}
-
-func (s slot) IsLastInEpoch() bool {
-	return s.Slot%s.SlotsPerEpoch == s.SlotsPerEpoch-1
-}
-
 // newSlotTicker returns a blocking channel that will be populated with new slots in real time.
 // It is also populated with the current slot immediately.
-func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clock) (<-chan slot, error) {
+func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clock) (<-chan core.Slot, error) {
 	genesis, err := eth2Cl.GenesisTime(ctx)
 	if err != nil {
 		return nil, err
@@ -462,11 +455,11 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2Provider, clock clockwork.Clo
 	height := int64(chainAge / slotDuration)
 	startTime := genesis.Add(time.Duration(height) * slotDuration)
 
-	resp := make(chan slot)
+	resp := make(chan core.Slot)
 
 	go func() {
 		for {
-			resp <- slot{
+			resp <- core.Slot{
 				Slot:          height,
 				Time:          startTime,
 				SlotsPerEpoch: int64(slotsPerEpoch),

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -74,7 +74,7 @@ func TestIntegration(t *testing.T) {
 
 	count := 10
 
-	s.Subscribe(func(ctx context.Context, duty core.Duty, set core.DutyDefinitionSet) error {
+	s.SubscribeDuties(func(ctx context.Context, duty core.Duty, set core.DutyDefinitionSet) error {
 		for idx, data := range set {
 			t.Logf("Duty triggered: vidx=%v slot=%v committee=%v\n", idx, duty.Slot, data.(core.AttesterDefinition).CommitteeIndex)
 		}
@@ -248,7 +248,7 @@ func TestSchedulerDuties(t *testing.T) {
 				results []result
 				mu      sync.Mutex
 			)
-			sched.Subscribe(func(ctx context.Context, duty core.Duty, set core.DutyDefinitionSet) error {
+			sched.SubscribeDuties(func(ctx context.Context, duty core.Duty, set core.DutyDefinitionSet) error {
 				// Make result human-readable
 				resultSet := make(map[core.PubKey]string)
 				for pubkey, def := range set {

--- a/core/types.go
+++ b/core/types.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
@@ -314,4 +315,37 @@ func (s ParSignedDataSet) Clone() (ParSignedDataSet, error) {
 	}
 
 	return resp, nil
+}
+
+// Slot is a beacon chain slot including chain metadata to infer epoch and next slot.
+type Slot struct {
+	Slot          int64
+	Time          time.Time
+	SlotDuration  time.Duration
+	SlotsPerEpoch int64
+}
+
+// Next returns the next slot.
+func (s Slot) Next() Slot {
+	return Slot{
+		Slot:          s.Slot + 1,
+		Time:          s.Time.Add(s.SlotDuration),
+		SlotsPerEpoch: s.SlotsPerEpoch,
+		SlotDuration:  s.SlotDuration,
+	}
+}
+
+// Epoch returns the epoch of the slot.
+func (s Slot) Epoch() int64 {
+	return s.Slot / s.SlotsPerEpoch
+}
+
+// LastInEpoch returns true if this is the last slot in the epoch.
+func (s Slot) LastInEpoch() bool {
+	return s.Slot%s.SlotsPerEpoch == s.SlotsPerEpoch-1
+}
+
+// FirstInEpoch returns true if this is the first slot in the epoch.
+func (s Slot) FirstInEpoch() bool {
+	return s.Slot%s.SlotsPerEpoch == 0
 }


### PR DESCRIPTION
Adds the recaster component to rebroadcast builder registrations every epoch.

category: feature
ticket: #1009
