### PR TITLE
cluster: verify config signatures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.48.0
+    rev: v1.45.2
     hooks:
       - id: golangci-lint
         args: [ -n ] # See .golangci.yml for config

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.45.2
+    rev: v1.48.0
     hooks:
       - id: golangci-lint
         args: [ -n ] # See .golangci.yml for config

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -37,7 +37,7 @@ type NodeIdx struct {
 	ShareIdx int
 }
 
-// NewDefinition returns a new definition with populated latest version, timestamp and UUID.
+// NewDefinition returns a new definition populated with the latest version, timestamp and UUID.
 func NewDefinition(name string, numVals int, threshold int, feeRecipient string, withdrawalAddress string,
 	forkVersionHex string, operators []Operator, random io.Reader,
 ) Definition {

--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -58,7 +58,7 @@ func verifySig(addr string, digest []byte, sig []byte) (bool, error) {
 	return actual == expect, nil
 }
 
-// signOperator return the operator with config hash and enr EIP712 signatures by the provided k1 private key.
+// signOperator returns the operator with signed config hash and enr.
 func signOperator(secret *ecdsa.PrivateKey, operator Operator, configHash [32]byte) (Operator, error) {
 	var err error
 	operator.ConfigSignature, err = signEIP712(secret, operator.Address, configHash[:])
@@ -104,7 +104,7 @@ func aggSign(secrets [][]*bls_sig.SecretKeyShare, message []byte) ([]byte, error
 	return b, nil
 }
 
-// signEIP712 signs the config hash digest and returns the signature.
+// signEIP712 signs the message and returns the signature.
 func signEIP712(secret *ecdsa.PrivateKey, address string, message []byte) ([]byte, error) {
 	const nonce = 0
 
@@ -121,7 +121,7 @@ func signEIP712(secret *ecdsa.PrivateKey, address string, message []byte) ([]byt
 	return sig, nil
 }
 
-// digestEIP712 returns EIP712 digest hash.
+// digestEIP712 returns a EIP712 digest hash.
 // See reference https://medium.com/alpineintel/issuing-and-verifying-eip-712-challenges-with-go-32635ca78aaf.
 func digestEIP712(address string, message []byte, nonce int) ([32]byte, error) {
 	signerData := apitypes.TypedData{

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -1,0 +1,30 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package cluster_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/cluster"
+)
+
+func TestVerifyLock(t *testing.T) {
+	lock, _, _ := cluster.NewForT(t, 3, 3, 4, 0)
+	require.NoError(t, lock.Definition.Verify())
+	require.NoError(t, lock.Verify())
+}

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -41,22 +41,6 @@ type Operator struct {
 	ENRSignature []byte
 }
 
-// VerifySignature returns an error if the ENR signature doesn't match the address and enr fields.
-func (o Operator) VerifySignature() error {
-	digest, err := digestEIP712(o.Address, []byte(o.ENR), o.Nonce)
-	if err != nil {
-		return err
-	}
-
-	if ok, err := verifySig(o.Address, digest[:], o.ENRSignature); err != nil {
-		return err
-	} else if !ok {
-		return errors.New("invalid operator enr signature")
-	}
-
-	return nil
-}
-
 // getName returns a deterministic name for operator based on its ENR.
 func (o Operator) getName() (string, error) {
 	enr, err := p2p.DecodeENR(o.ENR)

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -41,6 +41,7 @@ this command at the same time.`,
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
 	bindDefDirFlag(cmd.Flags(), &config.DefFile)
+	bindNoVerifyFlag(cmd.Flags(), &config.NoVerify)
 	bindP2PFlags(cmd.Flags(), &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,12 +47,17 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 	}
 
 	bindRunFlags(cmd, &conf)
+	bindNoVerifyFlag(cmd.Flags(), &conf.NoVerify)
 	bindDataDirFlag(cmd.Flags(), &conf.DataDir)
 	bindP2PFlags(cmd.Flags(), &conf.P2P)
 	bindLogFlags(cmd.Flags(), &conf.Log)
 	bindFeatureFlags(cmd.Flags(), &conf.Feature)
 
 	return cmd
+}
+
+func bindNoVerifyFlag(flags *pflag.FlagSet, config *bool) {
+	flags.BoolVar(config, "no-verify", false, "Disables cluster definition and lock file verification.")
 }
 
 func bindRunFlags(cmd *cobra.Command, config *app.Config) {

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -43,7 +43,7 @@ func TestComponent(t *testing.T) {
 		nodes = 4
 	)
 
-	lock, p2pkeys, _ := cluster.NewForT(t, 0, 0, nodes, 0)
+	lock, p2pkeys, _ := cluster.NewForT(t, 1, nodes, nodes, 0)
 
 	var (
 		peers       []p2p.Peer

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -42,10 +42,11 @@ import (
 )
 
 type Config struct {
-	DefFile string
-	DataDir string
-	P2P     p2p.Config
-	Log     log.Config
+	DefFile  string
+	NoVerify bool
+	DataDir  string
+	P2P      p2p.Config
+	Log      log.Config
 
 	TestDef     *cluster.Definition
 	TestSigning bool
@@ -70,6 +71,12 @@ func Run(ctx context.Context, conf Config) (err error) {
 	def, err := loadDefinition(conf)
 	if err != nil {
 		return err
+	}
+
+	if err := def.Verify(); err != nil && !conf.NoVerify {
+		return errors.Wrap(err, "cluster definition signature verification failed. Run with --no-verify to bypass verification at own risk")
+	} else if err != nil && conf.NoVerify {
+		log.Warn(ctx, "Ignoring failed cluster definition signature verification due to --no-verify flag", err)
 	}
 
 	if err = checkWrites(conf.DataDir); err != nil {
@@ -320,17 +327,17 @@ func signAndAggLockHash(ctx context.Context, shares []share, def cluster.Definit
 		Validators: dvs,
 	}
 
-	hash, err := lock.HashTreeRoot()
+	lockHash, err := lock.HashTreeRoot()
 	if err != nil {
-		return cluster.Lock{}, errors.Wrap(err, "hash lock")
+		return cluster.Lock{}, errors.Wrap(err, "lockHash lock")
 	}
 
-	sigLockHash, err := signLockHash(nodeIdx.ShareIdx, shares, hash[:])
+	lockHashSig, err := signLockHash(nodeIdx.ShareIdx, shares, lockHash[:])
 	if err != nil {
 		return cluster.Lock{}, err
 	}
 
-	peerSigs, err := ex.exchange(ctx, sigLock, sigLockHash)
+	peerSigs, err := ex.exchange(ctx, sigLock, lockHashSig)
 	if err != nil {
 		return cluster.Lock{}, err
 	}
@@ -345,17 +352,12 @@ func signAndAggLockHash(ctx context.Context, shares []share, def cluster.Definit
 		pubkeyToShares[pk] = sh
 	}
 
-	aggSigLockHash, aggPkLockHash, err := aggLockHashSig(peerSigs, pubkeyToShares, hash[:])
+	aggSigLockHash, aggPkLockHash, err := aggLockHashSig(peerSigs, pubkeyToShares, lockHash[:])
 	if err != nil {
 		return cluster.Lock{}, err
 	}
 
-	msg, err := lock.HashTreeRoot()
-	if err != nil {
-		return cluster.Lock{}, err
-	}
-
-	verified, err := tbls.Scheme().VerifyMultiSignature(aggPkLockHash, msg[:], aggSigLockHash)
+	verified, err := tbls.Scheme().VerifyMultiSignature(aggPkLockHash, lockHash[:], aggSigLockHash)
 	if err != nil {
 		return cluster.Lock{}, errors.Wrap(err, "verify multisignature")
 	} else if !verified {
@@ -367,6 +369,10 @@ func signAndAggLockHash(ctx context.Context, shares []share, def cluster.Definit
 		return cluster.Lock{}, errors.Wrap(err, "marshal binary aggSigLockHash")
 	}
 	lock.SignatureAggregate = sigBytes
+
+	if err := lock.Verify(); err != nil {
+		return cluster.Lock{}, errors.Wrap(err, "invalid lock file")
+	}
 
 	return lock, nil
 }
@@ -405,7 +411,7 @@ func signAndAggDepositData(ctx context.Context, ex *exchanger, shares []share, w
 }
 
 // aggLockHashSig returns the aggregated multi signature of the lock hash
-// signed by all the distributed validator group private keys.
+// signed by all the private key shares of all the distributed validators.
 func aggLockHashSig(data map[core.PubKey][]core.ParSignedData, shares map[core.PubKey]share, hash []byte) (*bls_sig.MultiSignature, *bls_sig.MultiPublicKey, error) {
 	var (
 		sigs    []*bls_sig.Signature

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -173,6 +173,11 @@ func Run(ctx context.Context, conf Config) (err error) {
 	if err != nil {
 		return err
 	}
+	if !conf.NoVerify {
+		if err := lock.Verify(); err != nil {
+			return errors.Wrap(err, "invalid lock file")
+		}
+	}
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
 	// Sign, exchange and aggregate Deposit Data signatures
@@ -369,10 +374,6 @@ func signAndAggLockHash(ctx context.Context, shares []share, def cluster.Definit
 		return cluster.Lock{}, errors.Wrap(err, "marshal binary aggSigLockHash")
 	}
 	lock.SignatureAggregate = sigBytes
-
-	if err := lock.Verify(); err != nil {
-		return cluster.Lock{}, errors.Wrap(err, "invalid lock file")
-	}
 
 	return lock, nil
 }

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -48,21 +48,27 @@ func TestDKG(t *testing.T) {
 		vals  = 2
 	)
 
+	withAlgo := func(algo string) func(*cluster.Definition) {
+		return func(d *cluster.Definition) {
+			d.DKGAlgorithm = algo
+		}
+	}
+
 	t.Run("keycast", func(t *testing.T) {
-		lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 0)
-		lock.Definition.DKGAlgorithm = "keycast"
+		lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 0, withAlgo("keycast"))
 		testDKG(t, lock.Definition, keys)
 	})
 
 	t.Run("frost", func(t *testing.T) {
-		lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 0)
-		lock.Definition.DKGAlgorithm = "frost"
+		lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 0, withAlgo("frost"))
 		testDKG(t, lock.Definition, keys)
 	})
 }
 
 func testDKG(t *testing.T, def cluster.Definition, p2pKeys []*ecdsa.PrivateKey) {
 	t.Helper()
+
+	require.NoError(t, def.Verify())
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -143,6 +149,7 @@ func testDKG(t *testing.T, def cluster.Definition, p2pKeys []*ecdsa.PrivateKey) 
 
 		var lock cluster.Lock
 		require.NoError(t, json.Unmarshal(lockFile, &lock))
+		require.NoError(t, lock.Verify())
 		locks = append(locks, lock)
 	}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -112,6 +112,7 @@ Flags:
       --log-format string               Log format; console, logfmt or json (default "console")
       --log-level string                Log level; debug, info, warn or error (default "info")
       --monitoring-address string       Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
+      --no-verify                       Disables cluster definition and lock file verification.
       --p2p-allowlist string            Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
       --p2p-bootnode-relay              Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
       --p2p-bootnodes strings           Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.gcp.obol.tech:3640/enr])

--- a/tbls/tblsconv/tblsconv.go
+++ b/tbls/tblsconv/tblsconv.go
@@ -86,7 +86,7 @@ func KeyToCore(key *bls_sig.PublicKey) (core.PubKey, error) {
 	return core.PubKeyFromBytes(b)
 }
 
-// SigFromBytes converts a bytes into a kryptology bls signature.
+// SigFromBytes converts bytes into a kryptology bls signature.
 func SigFromBytes(sig []byte) (*bls_sig.Signature, error) {
 	point, err := new(bls12381.G2).FromCompressed((*[96]byte)(sig))
 	if err != nil {

--- a/tbls/tblsconv/tblsconv.go
+++ b/tbls/tblsconv/tblsconv.go
@@ -86,6 +86,16 @@ func KeyToCore(key *bls_sig.PublicKey) (core.PubKey, error) {
 	return core.PubKeyFromBytes(b)
 }
 
+// SigFromBytes converts a bytes into a kryptology bls signature.
+func SigFromBytes(sig []byte) (*bls_sig.Signature, error) {
+	point, err := new(bls12381.G2).FromCompressed((*[96]byte)(sig))
+	if err != nil {
+		return nil, errors.Wrap(err, "uncompress sig")
+	}
+
+	return &bls_sig.Signature{Value: *point}, nil
+}
+
 // SigFromETH2 converts an eth2 phase0 bls signature into a kryptology bls signature.
 func SigFromETH2(sig eth2p0.BLSSignature) (*bls_sig.Signature, error) {
 	point, err := new(bls12381.G2).FromCompressed((*[96]byte)(sig[:]))

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -134,6 +134,7 @@ func newNodeEnvs(index int, validatorMock bool, conf Config) []kv {
 		{"simnet-beacon_mock", fmt.Sprintf(`"%v"`, beaconMock)},
 		{"log-level", "debug"},
 		{"feature-set", conf.FeatureSet},
+		{"no-verify", `"true"`},
 	}
 }
 

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
@@ -75,6 +75,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": null
@@ -150,6 +154,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": null
@@ -225,6 +233,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": null
@@ -300,6 +312,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": null

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -30,6 +30,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
   node1:
     <<: *node-base
@@ -52,6 +53,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
   node2:
     <<: *node-base
@@ -74,6 +76,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
   node3:
     <<: *node-base
@@ -96,6 +99,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
   bootnode:
     <<: *node-base

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -75,6 +75,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -167,6 +171,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -259,6 +267,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -351,6 +363,10 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
+    },
+    {
+     "Key": "no-verify",
+     "Value": "\"true\""
     }
    ],
    "Ports": [

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -30,6 +30,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
     ports:
       - "3600:3600"
@@ -61,6 +62,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
     ports:
       - "13600:3600"
@@ -92,6 +94,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
     ports:
       - "23600:3600"
@@ -123,6 +126,7 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
+      CHARON_NO_VERIFY: "true"
     
     ports:
       - "33600:3600"


### PR DESCRIPTION
Adds `--no-verify` flags to `charon run` and `charon dkg`. Verify config otherwise.

Note that `charon create cluster` requires `--no-verify` since it doesn't sign the generated lock file.
 
category: feature
ticket: #589 
