### PR TITLE
compose: fix golangci-lint

### DIFF
--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -86,8 +86,24 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 			},
 		},
-		// TODO(dhruv): enable version matrix tests for dkg once we have compatible versions also add pegImageTag
-		//  function when enable dkg version matrix test
+		// TODO(dhruv): enable version matrix tests for dkg once we have compatible versions also uncomment pegImageTag function.
+		//{
+		//	Name:     "run version matrix with dkg",
+		//	PrintYML: true,
+		//	ConfigFunc: func(conf *compose.Config) {
+		//		conf.KeyGen = compose.KeyGenDKG
+		//	},
+		//	DefineTmplFunc: func(data *compose.TmplData) {
+		//		// v0.8.0 of charon generates v1.0.0 definition files required by older versions.
+		//		pegImageTag(data.Nodes, 0, "v0.9.0")
+		//	},
+		//	RunTmplFunc: func(data *compose.TmplData) {
+		//		// Node 0 is latest
+		//		pegImageTag(data.Nodes, 1, "v0.8.0")
+		//		pegImageTag(data.Nodes, 2, "v0.8.0")
+		//		pegImageTag(data.Nodes, 3, "v0.7.0")
+		//	},
+		// },
 		{
 			Name: "teku versions", // TODO(corver): Do the same for lighthouse.
 			ConfigFunc: func(conf *compose.Config) {
@@ -155,3 +171,10 @@ func copyPrebuiltBinary(t *testing.T, dir string, binary string) {
 
 	require.NoError(t, os.WriteFile(path.Join(dir, "charon"), b, 0o555))
 }
+
+// pegImageTag pegs the charon docker image tag for one of the nodes.
+// It overrides the default that uses locally built latest version.
+// func pegImageTag(nodes []compose.TmplNode, index int, imageTag string) {
+//	nodes[index].ImageTag = imageTag
+//	nodes[index].Entrypoint = "/usr/local/bin/charon" // Use contains binary, not locally built latest version.
+//}

--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -86,24 +86,8 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 			},
 		},
-		// TODO(dhruv): enable version matrix tests for dkg once we have compatible versions
-		//{
-		//	Name:     "run version matrix with dkg",
-		//	PrintYML: true,
-		//	ConfigFunc: func(conf *compose.Config) {
-		//		conf.KeyGen = compose.KeyGenDKG
-		//	},
-		//	DefineTmplFunc: func(data *compose.TmplData) {
-		//		// v0.8.0 of charon generates v1.0.0 definition files required by older versions.
-		//		pegImageTag(data.Nodes, 0, "v0.9.0")
-		//	},
-		//	RunTmplFunc: func(data *compose.TmplData) {
-		//		// Node 0 is latest
-		//		pegImageTag(data.Nodes, 1, "v0.8.0")
-		//		pegImageTag(data.Nodes, 2, "v0.8.0")
-		//		pegImageTag(data.Nodes, 3, "v0.7.0")
-		//	},
-		// },
+		// TODO(dhruv): enable version matrix tests for dkg once we have compatible versions also add pegImageTag
+		//  function when enable dkg version matrix test
 		{
 			Name: "teku versions", // TODO(corver): Do the same for lighthouse.
 			ConfigFunc: func(conf *compose.Config) {
@@ -170,11 +154,4 @@ func copyPrebuiltBinary(t *testing.T, dir string, binary string) {
 	require.NoError(t, err)
 
 	require.NoError(t, os.WriteFile(path.Join(dir, "charon"), b, 0o555))
-}
-
-// pegImageTag pegs the charon docker image tag for one of the nodes.
-// It overrides the default that uses locally built latest version.
-func pegImageTag(nodes []compose.TmplNode, index int, imageTag string) {
-	nodes[index].ImageTag = imageTag
-	nodes[index].Entrypoint = "/usr/local/bin/charon" // Use contains binary, not locally built latest version.
 }


### PR DESCRIPTION
Fixes golangci-lint by removing deadcode and commented code.

category: fixbuild
ticket: none
