### PR TITLE
precommit: update golangci

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint
-    rev: v1.45.2
+    rev: v1.48.0
     hooks:
       - id: golangci-lint
         args: [ -n ] # See .golangci.yml for config


### PR DESCRIPTION
Updates golangci-lint to lateset version which adds support for go1.18 to many linters.

category: misc
ticket: none
