### PR TITLE
app: fix global concurrent write issue

### DIFF
--- a/app/featureset/config.go
+++ b/app/featureset/config.go
@@ -50,6 +50,9 @@ func DefaultConfig() Config {
 
 // Init initialises the global feature set state.
 func Init(ctx context.Context, config Config) error {
+	initMu.Lock()
+	defer initMu.Unlock()
+
 	var ok bool
 	for s := statusAlpha; s < statusSentinel; s++ {
 		if strings.ToLower(config.MinStatus) == strings.ToLower(s.String()) {

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -16,6 +16,8 @@
 // Package featureset defines a set of global features and their rollout status.
 package featureset
 
+import "sync"
+
 //go:generate stringer -type=status -trimprefix=status
 
 // status enumerates the rollout status of a feature.
@@ -49,6 +51,8 @@ var (
 
 	// minStatus defines the minimum enabled status.
 	minStatus = statusStable
+
+	initMu sync.Mutex
 )
 
 // Enabled returns true if the feature is enabled.

--- a/app/log/config.go
+++ b/app/log/config.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	zaplogfmt "github.com/jsternberg/zap-logfmt"
@@ -32,7 +33,10 @@ import (
 )
 
 // logger is the global logger.
-var logger = newConsoleLogger(zapcore.DebugLevel)
+var (
+	logger = newConsoleLogger(zapcore.DebugLevel)
+	initMu sync.Mutex
+)
 
 // Config defines the logging configuration.
 type Config struct {
@@ -60,6 +64,9 @@ func DefaultConfig() Config {
 
 // InitLogger initialises the global logger based on the provided config.
 func InitLogger(config Config) error {
+	initMu.Lock()
+	defer initMu.Unlock()
+
 	level, err := config.ZapLevel()
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes concurrent-map-write issue in unit tests that do multiple `app.Run`.

category: misc
ticket: none

