### PR TITLE
p2p: override ping backoff during testing

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,9 +72,10 @@ issues:
     - path: '(.+)_test\.go'
       linters:
         - bodyclose
+        - exhaustruct
+        - gosec
         - noctx
         - revive
-        - gosec
   exclude:
     - "error returned from interface method should be wrapped" # Relax wrapcheck
     - "defer: prefer not to defer chains of function calls" # Relax revive

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -175,9 +175,12 @@ func pingCluster(t *testing.T, test pingTest) {
 			MonitoringAddr:   testutil.AvailableAddr(t).String(), // Random monitoring address
 			ValidatorAPIAddr: testutil.AvailableAddr(t).String(), // Random validatorapi address
 			TestConfig: app.TestConfig{
+				TestPingConfig: p2p.TestPingConfig{
+					Callback:   asserter.Callback(t, i),
+					MaxBackoff: time.Second,
+				},
 				Lock:            &lock,
 				P2PKey:          p2pKeys[i],
-				PingCallback:    asserter.Callback(t, i),
 				DisablePromWrap: true,
 				SimnetBMockOpts: []beaconmock.Option{
 					beaconmock.WithNoAttesterDuties(),

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -225,8 +225,8 @@ func testSimnet(t *testing.T, args simnetArgs) {
 			TestConfig: app.TestConfig{
 				Lock:               &args.Lock,
 				P2PKey:             args.P2PKeys[i],
-				DisablePing:        true,
 				DisablePromWrap:    true,
+				TestPingConfig:     p2p.TestPingConfig{Disable: true},
 				SimnetKeys:         []*bls_sig.SecretKey{args.SimnetKeys[i]},
 				ParSigExFunc:       parSigExFunc,
 				LcastTransportFunc: lcastTransportFunc,


### PR DESCRIPTION
Attempt to fix flapping `TestPing/bootnode_and_stale_enrs` test which is caused by large backoff.

category: test 
ticket: none

