### PR TITLE
app: use eth2wrap client throughout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,6 @@ issues:
     - path: '(.+)_test\.go'
       linters:
         - bodyclose
-        - exhaustruct
         - gosec
         - noctx
         - revive
@@ -83,6 +82,7 @@ issues:
     - "shadows an import name" # Relax revive
     - "confusing-naming" # Relax revive
     - "shadow: declaration of \"err\" shadows declaration" # Relax govet
+    - "bls_sig contains underscore" # Relax nosnakecase
 
 linters:
   enable-all: true
@@ -91,6 +91,7 @@ linters:
     - containedctx
     - cyclop
     - exhaustivestruct
+    - exhaustruct
     - funlen
     - forcetypeassert
     - gci

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -19,29 +19,17 @@ import (
 	"context"
 	"fmt"
 
-	eth2client "github.com/attestantio/go-eth2-client"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
 )
 
-// eth2Provider defines the eth2 provider subset used by this package.
-type eth2Provider interface {
-	eth2client.AttestationDataProvider
-	eth2client.BeaconBlockProposalProvider
-	eth2client.BlindedBeaconBlockProposalProvider
-}
-
 // New returns a new fetcher instance.
-func New(eth2Svc eth2client.Service) (*Fetcher, error) {
-	eth2Cl, ok := eth2Svc.(eth2Provider)
-	if !ok {
-		return nil, errors.New("invalid eth2 service")
-	}
-
+func New(eth2Cl eth2wrap.Client) (*Fetcher, error) {
 	return &Fetcher{
 		eth2Cl: eth2Cl,
 	}, nil
@@ -49,7 +37,7 @@ func New(eth2Svc eth2client.Service) (*Fetcher, error) {
 
 // Fetcher fetches proposed duty data.
 type Fetcher struct {
-	eth2Cl       eth2Provider
+	eth2Cl       eth2wrap.Client
 	subs         []func(context.Context, core.Duty, core.UnsignedDataSet) error
 	aggSigDBFunc func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
 }

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"time"
 
-	eth2client "github.com/attestantio/go-eth2-client"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -29,6 +28,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
@@ -145,12 +145,7 @@ func (m *ParSigEx) Subscribe(fn func(context.Context, core.Duty, core.ParSignedD
 }
 
 // NewEth2Verifier returns a partial signature verification function for core workflow eth2 signatures.
-func NewEth2Verifier(eth2Svc eth2client.Service, pubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey) (func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error, error) {
-	eth2Cl, ok := eth2Svc.(signing.Eth2Provider)
-	if !ok {
-		return nil, errors.New("invalid eth2 service")
-	}
-
+func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey) (func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error, error) {
 	return func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error {
 		pubshares, ok := pubSharesByKey[pubkey]
 		if !ok {

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -25,12 +25,12 @@ import (
 	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
-	eth2http "github.com/attestantio/go-eth2-client/http"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/scheduler"
 	"github.com/obolnetwork/charon/testutil"
@@ -57,7 +57,7 @@ func TestIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	eth2Cl, err := eth2http.New(ctx, eth2http.WithAddress(beaconURL), eth2http.WithLogLevel(infoLevel))
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second*2, beaconURL)
 	require.NoError(t, err)
 
 	// Use random actual mainnet validators

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -52,7 +53,7 @@ func TestRouterIntegration(t *testing.T) {
 		t.Skip("Skipping integration test since BEACON_URL not found")
 	}
 
-	r, err := NewRouter(Handler(nil), testBeaconAddr(beaconURL))
+	r, err := NewRouter(Handler(nil), testBeaconAddr{addr: beaconURL})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -551,7 +552,7 @@ func testRouter(t *testing.T, handler testHandler, callback func(context.Context
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, testBeaconAddr(proxy.URL))
+	r, err := NewRouter(handler, testBeaconAddr{addr: proxy.URL})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -572,7 +573,7 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(handler, testBeaconAddr(proxy.URL))
+	r, err := NewRouter(handler, testBeaconAddr{addr: proxy.URL})
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)
@@ -701,12 +702,11 @@ func nest(data interface{}, nests ...string) interface{} {
 }
 
 // testBeaconAddr implements eth2client.Service only returning an address.
-type testBeaconAddr string
-
-func (t testBeaconAddr) Name() string {
-	return string(t)
+type testBeaconAddr struct {
+	eth2wrap.Client
+	addr string
 }
 
 func (t testBeaconAddr) Address() string {
-	return string(t)
+	return t.addr
 }

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -44,7 +44,7 @@ import (
 
 func TestComponent_ValidSubmitAttestations(t *testing.T) {
 	ctx := context.Background()
-	eth2Svc, err := beaconmock.New()
+	eth2Cl, err := beaconmock.New()
 	require.NoError(t, err)
 
 	const (
@@ -62,7 +62,7 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 		vIdxB: testutil.RandomCorePubKey(t),
 	}
 
-	component, err := validatorapi.NewComponentInsecure(t, eth2Svc, 0)
+	component, err := validatorapi.NewComponentInsecure(t, eth2Cl, 0)
 	require.NoError(t, err)
 
 	aggBitsA := bitfield.NewBitlist(commLen)
@@ -122,7 +122,7 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 
 func TestComponent_InvalidSubmitAttestations(t *testing.T) {
 	ctx := context.Background()
-	eth2Svc, err := beaconmock.New()
+	eth2Cl, err := beaconmock.New()
 	require.NoError(t, err)
 
 	const (
@@ -133,7 +133,7 @@ func TestComponent_InvalidSubmitAttestations(t *testing.T) {
 		commLen    = 8
 	)
 
-	component, err := validatorapi.NewComponentInsecure(t, eth2Svc, vIdx)
+	component, err := validatorapi.NewComponentInsecure(t, eth2Cl, vIdx)
 	require.NoError(t, err)
 
 	aggBits := bitfield.NewBitlist(commLen)
@@ -322,7 +322,7 @@ func padTo(b []byte, size int) []byte {
 
 func TestComponent_BeaconBlockProposal(t *testing.T) {
 	ctx := context.Background()
-	eth2Svc, err := beaconmock.New()
+	eth2Cl, err := beaconmock.New()
 	require.NoError(t, err)
 
 	const (
@@ -330,7 +330,7 @@ func TestComponent_BeaconBlockProposal(t *testing.T) {
 		vIdx = 1
 	)
 
-	component, err := validatorapi.NewComponentInsecure(t, eth2Svc, vIdx)
+	component, err := validatorapi.NewComponentInsecure(t, eth2Cl, vIdx)
 	require.NoError(t, err)
 
 	pk, secret, err := tbls.Keygen()
@@ -617,7 +617,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 
 func TestComponent_BlindedBeaconBlockProposal(t *testing.T) {
 	ctx := context.Background()
-	eth2Svc, err := beaconmock.New()
+	eth2Cl, err := beaconmock.New()
 	require.NoError(t, err)
 
 	const (
@@ -625,7 +625,7 @@ func TestComponent_BlindedBeaconBlockProposal(t *testing.T) {
 		vIdx = 1
 	)
 
-	component, err := validatorapi.NewComponentInsecure(t, eth2Svc, vIdx)
+	component, err := validatorapi.NewComponentInsecure(t, eth2Cl, vIdx)
 	require.NoError(t, err)
 
 	pk, secret, err := tbls.Keygen()

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -50,24 +50,13 @@ import (
 	"github.com/jonboulle/clockwork"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 )
 
 // Interface assertions.
 var (
-	_ HTTPMock                                      = Mock{}
-	_ eth2client.AttestationDataProvider            = Mock{}
-	_ eth2client.AttestationsSubmitter              = Mock{}
-	_ eth2client.AttesterDutiesProvider             = Mock{}
-	_ eth2client.BlindedBeaconBlockProposalProvider = Mock{}
-	_ eth2client.BlindedBeaconBlockSubmitter        = Mock{}
-	_ eth2client.BeaconBlockProposalProvider        = Mock{}
-	_ eth2client.BeaconBlockSubmitter               = Mock{}
-	_ eth2client.ProposerDutiesProvider             = Mock{}
-	_ eth2client.Service                            = Mock{}
-	_ eth2client.ValidatorsProvider                 = Mock{}
-	_ eth2client.VoluntaryExitSubmitter             = Mock{}
-	_ eth2client.EventsProvider                     = Mock{}
-	_ eth2client.ValidatorRegistrationsSubmitter    = Mock{}
+	_ HTTPMock        = Mock{}
+	_ eth2wrap.Client = Mock{}
 )
 
 // New returns a new beacon client mock configured with the default and provided options.
@@ -122,7 +111,7 @@ func defaultHTTPMock() Mock {
 	}
 }
 
-// Mock provides a mock beacon client and implements eth2client.Service and many of the eth2client Providers.
+// Mock provides a mock beacon client and implements eth2wrap.Client.
 // Create a new instance with default behaviour via New and then override any function.
 type Mock struct {
 	HTTPMock

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -25,7 +25,6 @@ import (
 	"net/url"
 	"strings"
 
-	eth2client "github.com/attestantio/go-eth2-client"
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
@@ -36,6 +35,7 @@ import (
 	"github.com/prysmaticlabs/go-bitfield"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
@@ -43,30 +43,11 @@ import (
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
-// Eth2Provider defines the eth2 beacon api providers required to perform attestations.
-type Eth2Provider interface {
-	eth2client.AttestationDataProvider
-	eth2client.AttestationsSubmitter
-	eth2client.AttesterDutiesProvider
-	eth2client.BeaconBlockProposalProvider
-	eth2client.BeaconBlockSubmitter
-	eth2client.BlindedBeaconBlockProposalProvider
-	eth2client.BlindedBeaconBlockSubmitter
-	eth2client.DomainProvider
-	eth2client.ProposerDutiesProvider
-	eth2client.Service
-	eth2client.SlotsPerEpochProvider
-	eth2client.SpecProvider
-	eth2client.ValidatorsProvider
-	eth2client.ValidatorRegistrationsSubmitter
-	// Above sorted alphabetically.
-}
-
 // SignFunc abstract signing done by the validator client.
 type SignFunc func(pubshare eth2p0.BLSPubKey, data []byte) (eth2p0.BLSSignature, error)
 
 // Attest performs attestation duties for the provided slot and pubkeys (validators).
-func Attest(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
+func Attest(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
 	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
@@ -134,7 +115,7 @@ func Attest(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
 }
 
 // ProposeBlock proposes block for the given slot.
-func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
+func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
 	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
@@ -243,7 +224,7 @@ func ProposeBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
 }
 
 // ProposeBlindedBlock proposes blinded block for the given slot.
-func ProposeBlindedBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
+func ProposeBlindedBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
 	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
@@ -344,7 +325,7 @@ func ProposeBlindedBlock(ctx context.Context, eth2Cl Eth2Provider, signFunc Sign
 }
 
 // Register signs and submits the validator builder registration to the validator API.
-func Register(ctx context.Context, eth2Cl Eth2Provider, signFunc SignFunc,
+func Register(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
 	registration *eth2api.VersionedValidatorRegistration, pubshare eth2p0.BLSPubKey,
 ) error {
 	sigRoot, err := registration.Root()

--- a/testutil/validatormock/validatormock_test.go
+++ b/testutil/validatormock/validatormock_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 	"github.com/obolnetwork/charon/testutil/validatormock"
@@ -135,8 +136,8 @@ func TestProposeBlock(t *testing.T) {
 	defer mockVAPI.Close()
 
 	provider := addrWrap{
-		Eth2Provider: beaconMock,
-		addr:         mockVAPI.URL,
+		Client: beaconMock,
+		addr:   mockVAPI.URL,
 	}
 
 	// Call propose block function
@@ -183,8 +184,8 @@ func TestProposeBlindedBlock(t *testing.T) {
 	defer mockVAPI.Close()
 
 	provider := addrWrap{
-		Eth2Provider: beaconMock,
-		addr:         mockVAPI.URL,
+		Client: beaconMock,
+		addr:   mockVAPI.URL,
 	}
 
 	// Call propose block function
@@ -193,7 +194,7 @@ func TestProposeBlindedBlock(t *testing.T) {
 }
 
 type addrWrap struct {
-	validatormock.Eth2Provider
+	eth2wrap.Client
 	addr string
 }
 


### PR DESCRIPTION
Use new `eth2wrap.Client` instead of `eth2client.Service` and the many different eth2Providers and casting.

Also fix some linting issues.

category: refactor 
ticket: none
