### PR TITLE
cluster: skip verification if locally created

### DIFF
--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -155,6 +155,10 @@ func (l Lock) Verify() error {
 	}
 
 	if len(l.SignatureAggregate) == 0 {
+		if isJSONv1x1(l.Version) {
+			return nil // Earlier versions of `charon create cluster` didn't populate SignatureAggregate.
+		}
+
 		return errors.New("empty lock aggregate signature")
 	}
 

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -140,6 +140,10 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 
 	def.DKGAlgorithm = conf.DKGAlgo
 
+	if err := def.Verify(); err != nil {
+		return err
+	}
+
 	b, err := json.MarshalIndent(def, "", " ")
 	if err != nil {
 		return errors.Wrap(err, "marshal definition")

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -134,7 +134,6 @@ func newNodeEnvs(index int, validatorMock bool, conf Config) []kv {
 		{"simnet-beacon_mock", fmt.Sprintf(`"%v"`, beaconMock)},
 		{"log-level", "debug"},
 		{"feature-set", conf.FeatureSet},
-		{"no-verify", `"true"`},
 	}
 }
 

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
@@ -75,10 +75,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": null
@@ -154,10 +150,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": null
@@ -233,10 +225,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": null
@@ -312,10 +300,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": null

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -30,7 +30,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
   node1:
     <<: *node-base
@@ -53,7 +52,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
   node2:
     <<: *node-base
@@ -76,7 +74,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
   node3:
     <<: *node-base
@@ -99,7 +96,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
   bootnode:
     <<: *node-base

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -75,10 +75,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -171,10 +167,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -267,10 +259,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -363,10 +351,6 @@
     {
      "Key": "feature-set",
      "Value": "alpha"
-    },
-    {
-     "Key": "no-verify",
-     "Value": "\"true\""
     }
    ],
    "Ports": [

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -30,7 +30,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
     ports:
       - "3600:3600"
@@ -62,7 +61,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
     ports:
       - "13600:3600"
@@ -94,7 +92,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
     ports:
       - "23600:3600"
@@ -126,7 +123,6 @@ services:
       CHARON_SIMNET_BEACON_MOCK: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
-      CHARON_NO_VERIFY: "true"
     
     ports:
       - "33600:3600"


### PR DESCRIPTION
Verification of unsigned `charon create cluster` lock files succeed avoiding the need for `--no-verify`.

category: bug
ticket: #1025 
