### PR TITLE
github: mark auto-generated release as draft

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1
       with:
+        draft: true
         files: cli-reference.txt
         body_path: changelog.md
         token: ${{ secrets.RELEASE_SECRET }}


### PR DESCRIPTION
Marks the auto-generated release as draft allowing manual editing before publishing the release.

category: misc
ticket: none
