### PR TITLE
cmd/createenr: make ENR creation deteministic

### DIFF
--- a/cmd/createenr_internal_test.go
+++ b/cmd/createenr_internal_test.go
@@ -16,10 +16,14 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
 	"io"
+	"math/rand"
 	"os"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/p2p"
@@ -31,4 +35,23 @@ func TestRunCreateEnr(t *testing.T) {
 
 	err = runCreateEnrCmd(io.Discard, p2p.Config{}, temp)
 	require.NoError(t, err)
+}
+
+func TestCreateENR(t *testing.T) {
+	config := p2p.Config{
+		TCPAddrs: []string{"127.0.0.1:3610"},
+		UDPAddr:  "127.0.0.1:3630",
+	}
+
+	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(time.Now().Unix())))
+	require.NoError(t, err)
+
+	originalENR, err := createENR(key, config)
+	require.NoError(t, err)
+
+	for i := 0; i < 100; i++ {
+		enrStr, err := createENR(key, config)
+		require.NoError(t, err)
+		require.Equal(t, originalENR, enrStr)
+	}
 }

--- a/cmd/createenr_internal_test.go
+++ b/cmd/createenr_internal_test.go
@@ -46,12 +46,10 @@ func TestCreateENR(t *testing.T) {
 	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(time.Now().Unix())))
 	require.NoError(t, err)
 
-	originalENR, err := createENR(key, config)
+	enr1, err := createENR(key, config)
 	require.NoError(t, err)
 
-	for i := 0; i < 100; i++ {
-		enrStr, err := createENR(key, config)
-		require.NoError(t, err)
-		require.Equal(t, originalENR, enrStr)
-	}
+	enr2, err := createENR(key, config)
+	require.NoError(t, err)
+	require.Equal(t, enr1, enr2)
 }

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -64,13 +64,11 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, verbose bool) err
 		return err
 	}
 
-	localEnode, db, err := p2p.NewLocalEnode(config, key)
+	newEnr, err := createENR(key, config)
 	if err != nil {
-		return errors.Wrap(err, "failed to open peer DB")
+		return err
 	}
-	defer db.Close()
 
-	newEnr := localEnode.Node().String()
 	_, _ = fmt.Fprintln(w, newEnr)
 
 	if !verbose {

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -64,18 +64,18 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, verbose bool) err
 		return err
 	}
 
-	newEnr, err := createENR(key, config)
+	enrStr, err := createENR(key, config)
 	if err != nil {
 		return err
 	}
 
-	_, _ = fmt.Fprintln(w, newEnr)
+	_, _ = fmt.Fprintln(w, enrStr)
 
 	if !verbose {
 		return nil
 	}
 
-	r, err := p2p.DecodeENR(newEnr)
+	r, err := p2p.DecodeENR(enrStr)
 	if err != nil {
 		return err
 	}

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -64,7 +64,12 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, verbose bool) err
 		return err
 	}
 
-	enrStr, err := createENR(key, config)
+	r, err := createENR(key, config)
+	if err != nil {
+		return err
+	}
+
+	enrStr, err := p2p.EncodeENR(r)
 	if err != nil {
 		return err
 	}
@@ -73,11 +78,6 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, verbose bool) err
 
 	if !verbose {
 		return nil
-	}
-
-	r, err := p2p.DecodeENR(enrStr)
-	if err != nil {
-		return err
 	}
 
 	writeExpandedEnr(w, r.Signature(), r.Seq(), pubkeyHex(key.PublicKey))


### PR DESCRIPTION
Makes ENR creation deterministic by creating ENRs directly from enr.Record.

category: refactor
ticket: none
