### PR TITLE
docs: fix broken URIs and remove nonce field from example object

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -20,7 +20,6 @@ The schema of the `cluster-definition.json` is defined as:
     {
       "address": "0x123..abfc",                 // ETH1 address of the operator
       "enr": "enr://abcdef...12345",            // Charon node ENR
-      "nonce": 1,                               // Nonce (incremented each time the ENR is added/signed)
       "config_signature": "0x123456...abcdef",    // EIP712 Signature of config_hash by ETH1 address priv key
       "enr_signature": "0x123654...abcedf"        // EIP712 Signature of ENR by ETH1 address priv key
     }
@@ -67,13 +66,13 @@ The following is the historical change log of the cluster config:
     - Refactored definition operator signatures: `config_signature` and `enr_signature`.
     - Refactored definition fields: `config_hash` and `definition_hash`.
     - Refactored lock fields: `lock_hash`, `signature_aggregate` and `distributed_validators.public_shares`.
-  - See example [definition.json](../cluster/testdata/definition_v1_2_0.json) and [lock.json](../cluster/testdata/lock_v1_2_0.json)
+  - See example [cluster-definition.json](../cluster/testdata/cluster_definition_v1_2_0.json) and [cluster-lock.json](../cluster/testdata/cluster_lock_v1_2_0.json)
 - `v1.1.0` **default**:
   - Added cosmetic `Timestamp` field to cluster definition to help identification by humans.
-  - See example [definition.json](../cluster/testdata/definition_v1_1_0.json) and [lock.json](../cluster/testdata/lock_v1_1_0.json)
+  - See example [cluster-definition.json](../cluster/testdata/cluster_definition_v1_1_0.json) and [cluster-lock.json](../cluster/testdata/cluster_lock_v1_1_0.json)
 - `v1.0.0`:
   - Initial definition and lock versions.
-  - See example [definition.json](../cluster/testdata/definition_v1_0_0.json) and [lock.json](../cluster/testdata/lock_v1_0_0.json)
+  - See example [cluster-definition.json](../cluster/testdata/cluster_definition_v1_0_0.json) and [cluster-lock.json](../cluster/testdata/cluster_lock_v1_0_0.json)
 
 This version of Charon (logic) supports the following cluster config versions (files): `v1.0.0`, `v1.1.0`, `v1.2.0`.
 


### PR DESCRIPTION
Fix URI and out of date doc

category: docs
ticket: none
