### PR TITLE
core/scheduler: add hex pubkey and beaconcha.in URIs

### DIFF
--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -57,7 +57,7 @@ var (
 		Subsystem: "scheduler",
 		Name:      "validator_balance_gwei",
 		Help:      "Total balance of a validator by public key",
-	}, []string{"pubkey"})
+	}, []string{"pubkey_full", "pubkey"})
 )
 
 // instrumentSlot sets the current slot and epoch metrics.
@@ -73,5 +73,5 @@ func instrumentDuty(duty core.Duty, defSet core.DutyDefinitionSet) {
 
 // instrumentValidator sets the validator balance.
 func instrumentValidator(pubkey core.PubKey, totalBal eth2p0.Gwei) {
-	balanceGauge.WithLabelValues(string(pubkey)).Set(float64(totalBal))
+	balanceGauge.WithLabelValues(string(pubkey), pubkey.String()).Set(float64(totalBal))
 }

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -73,5 +73,5 @@ func instrumentDuty(duty core.Duty, defSet core.DutyDefinitionSet) {
 
 // instrumentValidator sets the validator balance.
 func instrumentValidator(pubkey core.PubKey, totalBal eth2p0.Gwei) {
-	balanceGauge.WithLabelValues(pubkey.String()).Set(float64(totalBal))
+	balanceGauge.WithLabelValues(string(pubkey)).Set(float64(totalBal))
 }

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -281,6 +281,7 @@ func newNewCmd() *cobra.Command {
 	extBootnode := cmd.Flags().String("external-bootnode", "", "Optional external bootnode HTTP url.")
 	splitKeys := cmd.Flags().String("split-keys-dir", conf.SplitKeysDir, "Directory containing keys to split for keygen==create, or empty not to split.")
 	featureSet := cmd.Flags().String("feature-set", conf.FeatureSet, "Minimum feature set to enable: alpha, beta, stable")
+	numVals := cmd.Flags().Int("num-validators", conf.NumValidators, "Number of distributed validators.")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		conf.KeyGen = compose.KeyGen(*keygen)
@@ -289,6 +290,7 @@ func newNewCmd() *cobra.Command {
 		conf.SplitKeysDir = *splitKeys
 		conf.FeatureSet = *featureSet
 		conf.ExternalBootnode = *extBootnode
+		conf.NumValidators = *numVals
 
 		ctx := log.WithTopic(cmd.Context(), "new")
 		if err := compose.New(ctx, *dir, conf); err != nil {

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -50,6 +50,7 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 			{"cluster-dir", "/compose"},
 			{"split-existing-keys", fmt.Sprintf(`"%v"`, conf.SplitKeysDir != "")},
 			{"split-keys-dir", splitKeysDir},
+			{"num-validators", fmt.Sprint(conf.NumValidators)},
 		}}
 
 		data = TmplData{

--- a/testutil/compose/static/grafana/dash_simnet.json
+++ b/testutil/compose/static/grafana/dash_simnet.json
@@ -1272,7 +1272,7 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
-      "description": "Total balance of validators",
+      "description": "Total balance of validators with links to beaconcha.in for each public key.",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1288,7 +1288,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
+                "color": "light-blue",
                 "value": null
               },
               {
@@ -1352,6 +1352,28 @@
                 "value": "ETH"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Public Key"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "targetBlank": true,
+                    "title": "beaconcha.in",
+                    "url": "http://beaconcha.in/validator/${__data.fields[\"Public Key\"]}"
+                  }
+                ]
+              },
+              {
+                "id": "custom.displayMode",
+                "value": "color-text"
+              }
+            ]
           }
         ]
       },
@@ -1390,7 +1412,7 @@
           "refId": "B"
         }
       ],
-      "title": "Validator Balance",
+      "title": "Validators",
       "transformations": [
         {
           "id": "organize",
@@ -1828,8 +1850,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1921,8 +1942,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2014,8 +2034,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2108,8 +2127,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",

--- a/testutil/compose/static/grafana/dash_simnet.json
+++ b/testutil/compose/static/grafana/dash_simnet.json
@@ -1429,14 +1429,17 @@
               "instance 2": true,
               "job": true,
               "job 1": true,
-              "job 2": true
+              "job 2": true,
+              "pubkey": true,
+              "pubkey_full": false
             },
             "indexByName": {},
             "renameByName": {
               "Value": "Balance",
               "Value #A": "Effectiveness",
               "Value #B": "Balance",
-              "pubkey": "Public Key"
+              "pubkey": "Public Key",
+              "pubkey_full": "Public Key"
             }
           }
         }
@@ -1850,7 +1853,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1942,7 +1946,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2034,7 +2039,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2127,7 +2133,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2247,7 +2254,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2353,7 +2361,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
@@ -27,6 +27,10 @@
     {
      "Key": "split-keys-dir",
      "Value": ""
+    },
+    {
+     "Key": "num-validators",
+     "Value": "1"
     }
    ],
    "Ports": null

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
@@ -18,6 +18,7 @@ services:
       CHARON_CLUSTER_DIR: /compose
       CHARON_SPLIT_EXISTING_KEYS: "false"
       CHARON_SPLIT_KEYS_DIR: 
+      CHARON_NUM_VALIDATORS: 1
     
 networks:
   compose:


### PR DESCRIPTION
Replaces short pubkey to long hex pubkey and adds beaconcha.in URIs to simnet dashboard. Also configure simnet to take multiple validators.
ref: https://github.com/ObolNetwork/charon-distributed-validator-node/issues/43

category: misc
ticket: none
