### PR TITLE
dkg: fix dkg and smoke test

### DIFF
--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -65,7 +65,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
 		sigdb:   parsigdb.NewMemDB(len(peers)),
 		sigex:   parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers, noopVerifier),
-		sigChan: make(chan sigData, vals),
+		sigChan: make(chan sigData, vals), // Allow buffering all signature sets
 		numVals: vals,
 	}
 

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -65,7 +65,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
 		sigdb:   parsigdb.NewMemDB(len(peers)),
 		sigex:   parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers, noopVerifier),
-		sigChan: make(chan sigData, len(peers)),
+		sigChan: make(chan sigData, vals),
 		numVals: vals,
 	}
 

--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -82,7 +82,7 @@ func TestSmoke(t *testing.T) {
 			ConfigFunc: func(conf *compose.Config) {
 				conf.NumNodes = 21
 				conf.Threshold = 14
-				conf.NumValidators = 1000
+				conf.NumValidators = 100
 				conf.KeyGen = compose.KeyGenCreate
 			},
 		},

--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -82,6 +82,7 @@ func TestSmoke(t *testing.T) {
 			ConfigFunc: func(conf *compose.Config) {
 				conf.NumNodes = 21
 				conf.Threshold = 14
+
 				conf.NumValidators = 100
 				conf.KeyGen = compose.KeyGenCreate
 			},

--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -82,8 +82,7 @@ func TestSmoke(t *testing.T) {
 			ConfigFunc: func(conf *compose.Config) {
 				conf.NumNodes = 21
 				conf.Threshold = 14
-
-				conf.NumValidators = 100
+				conf.NumValidators = 100 // TODO(dhruv): Increase to 1000 once we have faster way to create keystores
 				conf.KeyGen = compose.KeyGenCreate
 			},
 		},


### PR DESCRIPTION
Fixes deadlock in dkg and reduce NumValidators in "very large" smoke test which was causing timeout in our github actions.

category: bug
ticket: none
