### PR TITLE
app/eth2wrap: add BeaconCommitteeSubscriptionsSubmitter interface to eth2wrap

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -719,10 +719,9 @@ func newVMockEth2Client(conf Config) func() (eth2wrap.Client, error) {
 				continue
 			}
 
-			var ok bool
-			eth2Cl, ok = eth2Svc.(eth2wrap.Client)
-			if !ok {
-				return nil, errors.New("invalid eth2 service")
+			eth2Cl, err = eth2wrap.NewWrapHTTP(eth2Svc)
+			if err != nil {
+				return nil, err
 			}
 
 			cached = eth2Cl

--- a/app/app.go
+++ b/app/app.go
@@ -192,7 +192,7 @@ func Run(ctx context.Context, conf Config) (err error) { //nolint:nonamedreturn 
 		z.Str("enr", localEnode.Node().String()))
 
 	if !conf.TestConfig.DisablePromWrap {
-		// Wrap prometheus metrics with cluster and node identifiers.
+		// Instrument prometheus metrics with cluster and node identifiers.
 		prometheus.DefaultRegisterer = prometheus.WrapRegistererWith(prometheus.Labels{
 			"cluster_hash":      lockHashHex,
 			"cluster_name":      lock.Name,
@@ -511,7 +511,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 			return nil, err
 		}
 
-		wrap, err := eth2wrap.Wrap(bmock)
+		wrap, err := eth2wrap.Instrument(bmock)
 		if err != nil {
 			return nil, err
 		}
@@ -703,10 +703,7 @@ func newVMockEth2Client(conf Config) func() (eth2wrap.Client, error) {
 		}
 
 		// Try three times to reduce test startup issues.
-		var (
-			eth2Cl eth2wrap.Client
-			err    error
-		)
+		var err error
 		for i := 0; i < 3; i++ {
 			var eth2Svc eth2client.Service
 			eth2Svc, err = eth2http.New(context.Background(),
@@ -718,16 +715,15 @@ func newVMockEth2Client(conf Config) func() (eth2wrap.Client, error) {
 				time.Sleep(time.Millisecond * 100) // Test startup backoff
 				continue
 			}
-
-			eth2Cl, err = eth2wrap.NewWrapHTTP(eth2Svc)
-			if err != nil {
-				return nil, err
+			eth2Http, ok := eth2Svc.(*eth2http.Service)
+			if !ok {
+				return nil, errors.New("invalid eth2 http service")
 			}
 
-			cached = eth2Cl
+			cached = eth2wrap.AdaptEth2HTTP(eth2Http)
 		}
 
-		return eth2Cl, err
+		return cached, err
 	}
 }
 

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -177,12 +177,15 @@ func httpPost(ctx context.Context, base string, endpoint string, body io.Reader)
 		return nil, errors.Wrap(err, "invalid endpoint")
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, time.Second*2) // refer eth2ClientTimeout in app/app.go#71
+	defer cancel()
+
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), body)
 	if err != nil {
 		return nil, errors.Wrap(err, "new POST request with ctx")
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := new(http.Client).Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call POST endpoint")
 	}

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -33,6 +33,7 @@ import (
 // Client defines all go-eth2-client interfaces used in charon.
 type Client interface {
 	eth2client.Service
+	eth2exp.BeaconCommitteeSubscriptionsSubmitterV2
 
 	eth2client.AttestationDataProvider
 	eth2client.AttestationsSubmitter
@@ -58,7 +59,6 @@ type Client interface {
 	eth2client.ValidatorRegistrationsSubmitter
 	eth2client.ValidatorsProvider
 	eth2client.VoluntaryExitSubmitter
-	eth2exp.BeaconCommitteeSubscriptionsSubmitterV2
 }
 
 // NodeVersion returns a free-text string with the node version.

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -582,3 +582,21 @@ func (m multi) GenesisTime(ctx context.Context) (time.Time, error) {
 
 	return res0, err
 }
+
+func (m multi) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+	const label = "submit_beacon_committee_subscriptions"
+
+	res0, err := provide(ctx, m.clients,
+		func(ctx context.Context, cl Client) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+			return cl.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions)
+		},
+		nil,
+	)
+
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2wrap")
+	}
+
+	return res0, err
+}

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -19,7 +19,6 @@ package eth2wrap
 
 import (
 	"context"
-	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
@@ -28,6 +27,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
 // Client defines all go-eth2-client interfaces used in charon.
@@ -40,7 +40,6 @@ type Client interface {
 	eth2client.BeaconBlockProposalProvider
 	eth2client.BeaconBlockSubmitter
 	eth2client.BeaconCommitteesProvider
-	eth2exp.BeaconCommitteeSubscriptionsSubmitter
 	eth2client.BlindedBeaconBlockProposalProvider
 	eth2client.BlindedBeaconBlockSubmitter
 	eth2client.DepositContractProvider
@@ -59,6 +58,7 @@ type Client interface {
 	eth2client.ValidatorRegistrationsSubmitter
 	eth2client.ValidatorsProvider
 	eth2client.VoluntaryExitSubmitter
+	eth2exp.BeaconCommitteeSubscriptionsSubmitterV2
 }
 
 // NodeVersion returns a free-text string with the node version.
@@ -571,24 +571,6 @@ func (m multi) GenesisTime(ctx context.Context) (time.Time, error) {
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (time.Time, error) {
 			return cl.GenesisTime(ctx)
-		},
-		nil,
-	)
-
-	if err != nil {
-		incError(label)
-		err = errors.Wrap(err, "eth2wrap")
-	}
-
-	return res0, err
-}
-
-func (m multi) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
-	const label = "submit_beacon_committee_subscriptions"
-
-	res0, err := provide(ctx, m.clients,
-		func(ctx context.Context, cl Client) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
-			return cl.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions)
 		},
 		nil,
 	)

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -19,6 +19,7 @@ package eth2wrap
 
 import (
 	"context"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
@@ -39,6 +40,7 @@ type Client interface {
 	eth2client.BeaconBlockProposalProvider
 	eth2client.BeaconBlockSubmitter
 	eth2client.BeaconCommitteesProvider
+	eth2exp.BeaconCommitteeSubscriptionsSubmitter
 	eth2client.BlindedBeaconBlockProposalProvider
 	eth2client.BlindedBeaconBlockSubmitter
 	eth2client.DepositContractProvider

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -131,7 +131,7 @@ func TestMulti(t *testing.T) {
 				}
 			}
 
-			eth2Cl, err := eth2wrap.Wrap(cl1, cl2)
+			eth2Cl, err := eth2wrap.Instrument(cl1, cl2)
 			require.NoError(t, err)
 
 			go test.handle(cl1Resp, cl2Resp, cancel)
@@ -156,7 +156,7 @@ func TestSyncState(t *testing.T) {
 		return &eth2v1.SyncState{IsSyncing: true}, nil
 	}
 
-	eth2Cl, err := eth2wrap.Wrap(cl1, cl2)
+	eth2Cl, err := eth2wrap.Instrument(cl1, cl2)
 	require.NoError(t, err)
 
 	resp, err := eth2Cl.NodeSyncing(context.Background())

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -55,10 +55,10 @@ import (
 // Client defines all go-eth2-client interfaces used in charon.
 type Client interface {
     eth2client.Service
+	eth2exp.BeaconCommitteeSubscriptionsSubmitterV2
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
-	eth2exp.BeaconCommitteeSubscriptionsSubmitterV2
 }
 
 {{range .Methods}}

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -46,6 +46,7 @@ var (
 import (
 	"github.com/obolnetwork/charon/app/errors"
 	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 {{- range .Imports}}
 	{{.}}
 {{- end}}
@@ -57,6 +58,7 @@ type Client interface {
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
+	eth2exp.BeaconCommitteeSubscriptionsSubmitterV2
 }
 
 {{range .Methods}}

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -31,9 +31,9 @@ import (
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
-// httpWrap implements Client by wrapping eth2http.Service,
-// also implements experimental interfaces which are absent in eth2http.Service.
-type httpWrap struct {
+// httpAdapter implements Client by wrapping eth2http.Service adding the experimental
+// interfaces not present go-eth2-client.
+type httpAdapter struct {
 	*eth2http.Service
 }
 
@@ -42,7 +42,7 @@ type submitBeaconCommitteeSubscriptionsV2JSON struct {
 }
 
 // SubmitBeaconCommitteeSubscriptionsV2 implements eth2exp.BeaconCommitteeSubscriptionsSubmitterV2.
-func (h httpWrap) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+func (h httpAdapter) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
 	reqBody, err := json.Marshal(subscriptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal submit beacon committee subscriptions V2 request")

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -1,0 +1,99 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2wrap
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	eth2http "github.com/attestantio/go-eth2-client/http"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
+)
+
+// httpWrap implements Client by wrapping eth2http.Service,
+// also implements experimental interfaces which are absent in eth2http.Service.
+type httpWrap struct {
+	*eth2http.Service
+}
+
+type submitBeaconCommitteeSubscriptionsV2JSON struct {
+	Data []*eth2exp.BeaconCommitteeSubscriptionResponse `json:"data"`
+}
+
+// SubmitBeaconCommitteeSubscriptionsV2 implements eth2exp.BeaconCommitteeSubscriptionsSubmitterV2.
+func (h httpWrap) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+	reqBody, err := json.Marshal(subscriptions)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal submit beacon committee subscriptions V2 request")
+	}
+
+	respBody, err := httpPost(ctx, h.Address(), "/eth/v2/validator/beacon_committee_subscriptions", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, errors.Wrap(err, "post submit beacon committee subscriptions v2")
+	}
+
+	var resp submitBeaconCommitteeSubscriptionsV2JSON
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, errors.Wrap(err, "failed to parse submit beacon committee subscriptions V2 response")
+	}
+
+	return resp.Data, nil
+}
+
+func httpPost(ctx context.Context, base string, endpoint string, body io.Reader) ([]byte, error) {
+	addr, err := url.JoinPath(base, endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid address")
+	}
+
+	url, err := url.Parse(addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid endpoint")
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, time.Second*2) // TODO(dhruv): use actual configured timeout.
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), body)
+	if err != nil {
+		return nil, errors.Wrap(err, "new POST request with ctx")
+	}
+
+	res, err := new(http.Client).Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to call POST endpoint")
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read GET response")
+	}
+
+	if res.StatusCode/100 != 2 {
+		return nil, errors.New("get failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
+	}
+
+	return data, nil
+}

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -207,7 +207,7 @@ func TestSchedulerDuties(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			// Wrap ProposerDuties to returns some errors
+			// Instrument ProposerDuties to returns some errors
 			origFunc := eth2Cl.ProposerDutiesFunc
 			eth2Cl.ProposerDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
 				if test.PropErrs > 0 {

--- a/core/validatorapi/eth2types.go
+++ b/core/validatorapi/eth2types.go
@@ -27,6 +27,7 @@ import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
 // errorResponse an error response from the beacon-node api.
@@ -109,6 +110,10 @@ type validatorsResponse struct {
 
 type validatorResponse struct {
 	Data v1Validator `json:"data"`
+}
+
+type submitBeaconCommitteeSubscriptionsV2JSON struct {
+	Data []*eth2exp.BeaconCommitteeSubscriptionResponse `json:"data"`
 }
 
 // root wraps eth2p0 root adding proper json marshalling.

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -567,7 +567,25 @@ func TestBeaconCommitteeSubscriptionsV2(t *testing.T) {
 
 	bmock, err := beaconmock.New(beaconmock.WithAttestationAggregation(aggregators))
 	require.NoError(t, err)
+	testHandler := testHandler{SubmitBeaconCommitteeSubscriptionsV2Func: bmock.SubmitBeaconCommitteeSubscriptionsFunc}
 
+	proxy := httptest.NewServer(testHandler.newBeaconHandler(t))
+	defer proxy.Close()
+
+	r, err := NewRouter(testHandler, testBeaconAddr{addr: proxy.URL})
+	require.NoError(t, err)
+
+	server := httptest.NewServer(r)
+	defer server.Close()
+
+	var eth2Svc eth2client.Service
+	eth2Svc, err = eth2http.New(ctx,
+		eth2http.WithLogLevel(1),
+		eth2http.WithAddress(server.URL),
+	)
+	require.NoError(t, err)
+
+	// Submit subscriptions to beaconmock through validatorapi.
 	expected := []*eth2exp.BeaconCommitteeSubscriptionResponse{
 		{ValidatorIndex: vIdxA, IsAggregator: true},
 		{ValidatorIndex: vIdxB, IsAggregator: true},
@@ -598,26 +616,7 @@ func TestBeaconCommitteeSubscriptionsV2(t *testing.T) {
 		},
 	}
 
-	vapi, err := NewComponentInsecure(t, bmock, 0)
-	require.NoError(t, err)
-
-	vapiRouter, err := NewRouter(vapi, bmock)
-	require.NoError(t, err)
-
-	server := httptest.NewServer(vapiRouter)
-	defer server.Close()
-
-	var eth2Svc eth2client.Service
-	eth2Svc, err = eth2http.New(ctx,
-		eth2http.WithLogLevel(1),
-		eth2http.WithAddress(server.URL),
-	)
-	require.NoError(t, err)
-
-	eth2Cl, err := eth2wrap.NewWrapHTTP(eth2Svc)
-	require.NoError(t, err)
-
-	// Submit subscriptions to beaconmock through validatorapi.
+	eth2Cl := eth2wrap.AdaptEth2HTTP(eth2Svc.(*eth2http.Service))
 	actual, err := eth2Cl.SubmitBeaconCommitteeSubscriptionsV2(ctx, subs)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
@@ -665,18 +664,19 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 // mocked beacon-node endpoints required by the eth2http client during startup.
 type testHandler struct {
 	Handler
-	ProxyHandler                     http.HandlerFunc
-	AttestationDataFunc              func(ctx context.Context, slot eth2p0.Slot, commIdx eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
-	AttesterDutiesFunc               func(ctx context.Context, epoch eth2p0.Epoch, il []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
-	BeaconBlockProposalFunc          func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
-	SubmitBeaconBlockFunc            func(ctx context.Context, block *spec.VersionedSignedBeaconBlock) error
-	BlindedBeaconBlockProposalFunc   func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
-	SubmitBlindedBeaconBlockFunc     func(ctx context.Context, block *eth2api.VersionedSignedBlindedBeaconBlock) error
-	ProposerDutiesFunc               func(ctx context.Context, epoch eth2p0.Epoch, il []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
-	ValidatorsFunc                   func(ctx context.Context, stateID string, indices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
-	ValidatorsByPubKeyFunc           func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
-	SubmitVoluntaryExitFunc          func(ctx context.Context, exit *eth2p0.SignedVoluntaryExit) error
-	SubmitValidatorRegistrationsFunc func(ctx context.Context, registrations []*eth2api.VersionedSignedValidatorRegistration) error
+	ProxyHandler                             http.HandlerFunc
+	AttestationDataFunc                      func(ctx context.Context, slot eth2p0.Slot, commIdx eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
+	AttesterDutiesFunc                       func(ctx context.Context, epoch eth2p0.Epoch, il []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
+	BeaconBlockProposalFunc                  func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
+	SubmitBeaconBlockFunc                    func(ctx context.Context, block *spec.VersionedSignedBeaconBlock) error
+	BlindedBeaconBlockProposalFunc           func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
+	SubmitBlindedBeaconBlockFunc             func(ctx context.Context, block *eth2api.VersionedSignedBlindedBeaconBlock) error
+	ProposerDutiesFunc                       func(ctx context.Context, epoch eth2p0.Epoch, il []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
+	ValidatorsFunc                           func(ctx context.Context, stateID string, indices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
+	ValidatorsByPubKeyFunc                   func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
+	SubmitVoluntaryExitFunc                  func(ctx context.Context, exit *eth2p0.SignedVoluntaryExit) error
+	SubmitValidatorRegistrationsFunc         func(ctx context.Context, registrations []*eth2api.VersionedSignedValidatorRegistration) error
+	SubmitBeaconCommitteeSubscriptionsV2Func func(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error)
 }
 
 func (h testHandler) AttestationData(ctx context.Context, slot eth2p0.Slot, commIdx eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error) {
@@ -721,6 +721,10 @@ func (h testHandler) SubmitVoluntaryExit(ctx context.Context, exit *eth2p0.Signe
 
 func (h testHandler) SubmitValidatorRegistrations(ctx context.Context, registrations []*eth2api.VersionedSignedValidatorRegistration) error {
 	return h.SubmitValidatorRegistrationsFunc(ctx, registrations)
+}
+
+func (h testHandler) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+	return h.SubmitBeaconCommitteeSubscriptionsV2Func(ctx, subscriptions)
 }
 
 // newBeaconHandler returns a mock beacon node handler. It registers a few mock handlers required by the

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -34,6 +34,7 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
@@ -604,6 +605,12 @@ func (c Component) SubmitVoluntaryExit(ctx context.Context, exit *eth2p0.SignedV
 	}
 
 	return nil
+}
+
+// SubmitBeaconCommitteeSubscriptionsV2 submits slot signatures to determine aggregators for attestation aggregation.
+// TODO(dhruv): Implement this as part of https://github.com/ObolNetwork/charon/issues/1067
+func (c Component) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+	return c.eth2Cl.SubmitBeaconCommitteeSubscriptionsV2(ctx, subscriptions)
 }
 
 func (c Component) AttesterDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -1,7 +1,23 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package eth2exp
 
 import (
 	"context"
+
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 )
 

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -1,0 +1,34 @@
+package eth2exp
+
+import (
+	"context"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// BeaconCommitteeSubscriptionsSubmitter is the interface for submitting beacon committee subnet subscription requests.
+type BeaconCommitteeSubscriptionsSubmitter interface {
+	// SubmitBeaconCommitteeSubscriptions subscribes to beacon committees.
+	SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*BeaconCommitteeSubscription) ([]BeaconCommitteeSubscriptionResponse, error)
+}
+
+// BeaconCommitteeSubscription is the data required for a beacon committee subscription.
+type BeaconCommitteeSubscription struct {
+	// ValidatorIdex is the index of the validator making the subscription request.
+	ValidatorIndex eth2p0.ValidatorIndex
+	// Slot is the slot for which the validator is attesting.
+	Slot eth2p0.Slot
+	// CommitteeIndex is the index of the committee of which the validator is a member at the given slot.
+	CommitteeIndex eth2p0.CommitteeIndex
+	// CommitteesAtSlot is the number of committees at the given slot.
+	CommitteesAtSlot uint64
+	// SlotSignature is the slot signature required to calculate whether the validator is an aggregator.
+	SlotSignature eth2p0.BLSSignature
+}
+
+// BeaconCommitteeSubscriptionResponse is the response from beacon node after submitting BeaconCommitteeSubscription.
+type BeaconCommitteeSubscriptionResponse struct {
+	// ValidatorIndex is the index of the validator that made the subscription request.
+	ValidatorIndex eth2p0.ValidatorIndex
+	// IsAggregator indicates whether the validator is an attestation aggregator.
+	IsAggregator bool
+}

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -22,6 +22,7 @@ import (
 )
 
 // BeaconCommitteeSubscriptionsSubmitter is the interface for submitting beacon committee subnet subscription requests.
+// TODO(dhruv): Should be removed once it is supported by go-eth2-client.
 type BeaconCommitteeSubscriptionsSubmitter interface {
 	// SubmitBeaconCommitteeSubscriptions subscribes to beacon committees.
 	SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*BeaconCommitteeSubscription) ([]BeaconCommitteeSubscriptionResponse, error)

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -133,13 +133,13 @@ func (b *BeaconCommitteeSubscription) UnmarshalJSON(input []byte) error {
 }
 
 // String returns a string version of the structure.
-func (b *BeaconCommitteeSubscription) String() string {
+func (b *BeaconCommitteeSubscription) String() (string, error) {
 	data, err := json.Marshal(b)
 	if err != nil {
-		return fmt.Sprintf("ERR: %v", err)
+		return "", errors.Wrap(err, "marshal BeaconCommitteeSubscription")
 	}
 
-	return string(data)
+	return string(data), nil
 }
 
 // BeaconCommitteeSubscriptionResponse is the response from beacon node after submitting BeaconCommitteeSubscription.

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -137,7 +137,7 @@ type Mock struct {
 	EventsFunc                             func(context.Context, []string, eth2client.EventHandlerFunc) error
 	SubmitValidatorRegistrationsFunc       func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error
 	SlotsPerEpochFunc                      func(context.Context) (uint64, error)
-	SubmitBeaconCommitteeSubscriptionsFunc func(context.Context, []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error)
+	SubmitBeaconCommitteeSubscriptionsFunc func(context.Context, []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error)
 }
 
 func (m Mock) SubmitAttestations(ctx context.Context, attestations []*eth2p0.Attestation) error {
@@ -200,7 +200,7 @@ func (m Mock) SubmitValidatorRegistrations(ctx context.Context, registrations []
 	return m.SubmitValidatorRegistrationsFunc(ctx, registrations)
 }
 
-func (m Mock) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+func (m Mock) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
 	return m.SubmitBeaconCommitteeSubscriptionsFunc(ctx, subscriptions)
 }
 

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -39,6 +39,7 @@ package beaconmock
 import (
 	"context"
 	"fmt"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"net/http"
 	"time"
 
@@ -120,22 +121,23 @@ type Mock struct {
 	overrides  []staticOverride
 	clock      clockwork.Clock
 
-	AttestationDataFunc              func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
-	AttesterDutiesFunc               func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
-	BlindedBeaconBlockProposalFunc   func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
-	BeaconBlockProposalFunc          func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
-	ProposerDutiesFunc               func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
-	SubmitAttestationsFunc           func(context.Context, []*eth2p0.Attestation) error
-	SubmitBeaconBlockFunc            func(context.Context, *spec.VersionedSignedBeaconBlock) error
-	SubmitBlindedBeaconBlockFunc     func(context.Context, *eth2api.VersionedSignedBlindedBeaconBlock) error
-	SubmitVoluntaryExitFunc          func(context.Context, *eth2p0.SignedVoluntaryExit) error
-	ValidatorsByPubKeyFunc           func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
-	ValidatorsFunc                   func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
-	GenesisTimeFunc                  func(context.Context) (time.Time, error)
-	NodeSyncingFunc                  func(context.Context) (*eth2v1.SyncState, error)
-	EventsFunc                       func(context.Context, []string, eth2client.EventHandlerFunc) error
-	SubmitValidatorRegistrationsFunc func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error
-	SlotsPerEpochFunc                func(context.Context) (uint64, error)
+	AttestationDataFunc                    func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
+	AttesterDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
+	BlindedBeaconBlockProposalFunc         func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
+	BeaconBlockProposalFunc                func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
+	ProposerDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
+	SubmitAttestationsFunc                 func(context.Context, []*eth2p0.Attestation) error
+	SubmitBeaconBlockFunc                  func(context.Context, *spec.VersionedSignedBeaconBlock) error
+	SubmitBlindedBeaconBlockFunc           func(context.Context, *eth2api.VersionedSignedBlindedBeaconBlock) error
+	SubmitVoluntaryExitFunc                func(context.Context, *eth2p0.SignedVoluntaryExit) error
+	ValidatorsByPubKeyFunc                 func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
+	ValidatorsFunc                         func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
+	GenesisTimeFunc                        func(context.Context) (time.Time, error)
+	NodeSyncingFunc                        func(context.Context) (*eth2v1.SyncState, error)
+	EventsFunc                             func(context.Context, []string, eth2client.EventHandlerFunc) error
+	SubmitValidatorRegistrationsFunc       func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error
+	SlotsPerEpochFunc                      func(context.Context) (uint64, error)
+	SubmitBeaconCommitteeSubscriptionsFunc func(context.Context, []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error)
 }
 
 func (m Mock) SubmitAttestations(ctx context.Context, attestations []*eth2p0.Attestation) error {
@@ -196,6 +198,10 @@ func (m Mock) Events(ctx context.Context, topics []string, handler eth2client.Ev
 
 func (m Mock) SubmitValidatorRegistrations(ctx context.Context, registrations []*eth2api.VersionedSignedValidatorRegistration) error {
 	return m.SubmitValidatorRegistrationsFunc(ctx, registrations)
+}
+
+func (m Mock) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+	return m.SubmitBeaconCommitteeSubscriptionsFunc(ctx, subscriptions)
 }
 
 func (m Mock) SlotsPerEpoch(ctx context.Context) (uint64, error) {

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -39,7 +39,6 @@ package beaconmock
 import (
 	"context"
 	"fmt"
-	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"net/http"
 	"time"
 
@@ -52,6 +51,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
 // Interface assertions.

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -340,10 +340,10 @@ func WithClock(clock clockwork.Clock) Option {
 // WithAttestationAggregation configures the mock to override SubmitBeaconCommitteeSubscriptionsFunc.
 func WithAttestationAggregation(aggregators map[eth2p0.Slot]eth2p0.ValidatorIndex) Option {
 	return func(mock *Mock) {
-		mock.SubmitBeaconCommitteeSubscriptionsFunc = func(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
-			var resp []eth2exp.BeaconCommitteeSubscriptionResponse
+		mock.SubmitBeaconCommitteeSubscriptionsFunc = func(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+			var resp []*eth2exp.BeaconCommitteeSubscriptionResponse
 			for _, sub := range subscriptions {
-				resp = append(resp, eth2exp.BeaconCommitteeSubscriptionResponse{
+				resp = append(resp, &eth2exp.BeaconCommitteeSubscriptionResponse{
 					ValidatorIndex: sub.ValidatorIndex,
 					IsAggregator:   aggregators[sub.Slot] == sub.ValidatorIndex,
 				})

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -39,6 +39,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -333,6 +334,23 @@ func WithNoAttesterDuties() Option {
 func WithClock(clock clockwork.Clock) Option {
 	return func(mock *Mock) {
 		mock.clock = clock
+	}
+}
+
+// WithAttestationAggregation configures the mock to override SubmitBeaconCommitteeSubscriptionsFunc.
+func WithAttestationAggregation(aggregators map[eth2p0.Slot]eth2p0.ValidatorIndex) Option {
+	return func(mock *Mock) {
+		mock.SubmitBeaconCommitteeSubscriptionsFunc = func(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+			var resp []eth2exp.BeaconCommitteeSubscriptionResponse
+			for _, sub := range subscriptions {
+				resp = append(resp, eth2exp.BeaconCommitteeSubscriptionResponse{
+					ValidatorIndex: sub.ValidatorIndex,
+					IsAggregator:   aggregators[sub.Slot] == sub.ValidatorIndex,
+				})
+			}
+
+			return resp, nil
+		}
 	}
 }
 


### PR DESCRIPTION
Adds BeaconCommitteeSubscriptionsSubmitter interface to eth2wrap and beaconmock.

category: feature
ticket: #1061 
