### PR TITLE
core: add signed data type for BeaconCommitteeSubscription

### DIFF
--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -66,4 +67,21 @@ func TestSetVersionedValidatorRegistrationSig(t *testing.T) {
 	clone, err := registration.SetSignature(testutil.RandomCoreSignature())
 	require.NoError(t, err)
 	require.NotEqual(t, clone.Signature(), registration.Signature())
+}
+
+func TestSetBeaconCommitteeSubscription(t *testing.T) {
+	const commAtSlot = 123
+	sub := core.SignedBeaconCommitteeSubscription{
+		BeaconCommitteeSubscription: eth2exp.BeaconCommitteeSubscription{
+			ValidatorIndex:   testutil.RandomVIdx(),
+			Slot:             testutil.RandomSlot(),
+			CommitteeIndex:   testutil.RandomCommIdx(),
+			CommitteesAtSlot: commAtSlot,
+			SlotSignature:    testutil.RandomEth2Signature(),
+		},
+	}
+
+	clone, err := sub.SetSignature(testutil.RandomCoreSignature())
+	require.NoError(t, err)
+	require.NotEqual(t, clone.Signature(), sub.Signature())
 }

--- a/core/types.go
+++ b/core/types.go
@@ -40,9 +40,10 @@ const (
 	DutyBuilderProposer     DutyType = 5
 	DutyBuilderRegistration DutyType = 6
 	DutyRandao              DutyType = 7
+	DutyPrepareAggregator   DutyType = 8
 	// Only ever append new types here...
 
-	dutySentinel DutyType = 8 // Must always be last
+	dutySentinel DutyType = 9 // Must always be last
 )
 
 func (d DutyType) Valid() bool {
@@ -59,6 +60,7 @@ func (d DutyType) String() string {
 		DutyBuilderProposer:     "builder_proposer",
 		DutyBuilderRegistration: "builder_registration",
 		DutySignature:           "signature",
+		DutyPrepareAggregator:   "prepare_aggregator",
 	}[d]
 }
 
@@ -172,6 +174,19 @@ func NewSignatureDuty(slot int64) Duty {
 	return Duty{
 		Slot: slot,
 		Type: DutySignature,
+	}
+}
+
+// NewPrepareAggregatorDuty returns a new prepare aggregator duty. It is a convenience function that is
+// slightly more readable and concise than the struct literal equivalent:
+//
+//	core.Duty{Slot: slot, Type: core.DutyPrepareAggregator}
+//	vs
+//	core.NewPrepareAggregatorDuty(slot)
+func NewPrepareAggregatorDuty(slot int64) Duty {
+	return Duty{
+		Slot: slot,
+		Type: DutyPrepareAggregator,
 	}
 }
 

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -35,9 +35,10 @@ func TestBackwardsCompatability(t *testing.T) {
 	require.EqualValues(t, 5, core.DutyBuilderProposer)
 	require.EqualValues(t, 6, core.DutyBuilderRegistration)
 	require.EqualValues(t, 7, core.DutyRandao)
+	require.EqualValues(t, 8, core.DutyPrepareAggregator)
 	// Add more types here.
 
-	const sentinel = core.DutyType(8)
+	const sentinel = core.DutyType(9)
 	for i := core.DutyUnknown; i <= sentinel; i++ {
 		if i == core.DutyUnknown {
 			require.False(t, i.Valid())


### PR DESCRIPTION
Adds DutyPrepareAggregator and signed data type for BeaconCommitteeSubscription.

category: feature
ticket: #1064 
