### PR TITLE
core/validatorapi: add support for DutyPrepareAggregator to vapi

### DIFF
--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -70,6 +70,8 @@ func (db *MemDB) Shutdown() {
 }
 
 // Store implements core.DutyDB, see its godoc.
+//
+//nolint:gocognit
 func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.UnsignedDataSet) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -692,10 +692,15 @@ func (s SignedRandao) clone() (SignedRandao, error) {
 	return resp, nil
 }
 
+// NewBeaconCommitteeSubscription is a convenience function which returns new signed BeaconCommitteeSubscription.
+func NewBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSubscription) SignedBeaconCommitteeSubscription {
+	return SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *sub}
+}
+
 // NewPartialSignedBeaconCommitteeSubscription is a convenience function which returns new partially signed BeaconCommitteeSubscription.
-func NewPartialSignedBeaconCommitteeSubscription(sub eth2exp.BeaconCommitteeSubscription, shareIdx int) ParSignedData {
+func NewPartialSignedBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSubscription, shareIdx int) ParSignedData {
 	return ParSignedData{
-		SignedData: SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: sub},
+		SignedData: NewBeaconCommitteeSubscription(sub),
 		ShareIdx:   shareIdx,
 	}
 }

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -628,12 +628,6 @@ func (c Component) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, sub
 
 	psigsBySlot := make(map[eth2p0.Slot]core.ParSignedDataSet)
 	for _, sub := range subscriptions {
-		data := core.NewPartialSignedBeaconCommitteeSubscription(*sub, c.shareIdx)
-		_, ok := psigsBySlot[sub.Slot]
-		if !ok {
-			psigsBySlot[sub.Slot] = make(core.ParSignedDataSet)
-		}
-
 		eth2Pubkey, err := vals[sub.ValidatorIndex].PubKey(ctx)
 		if err != nil {
 			return nil, err
@@ -652,7 +646,12 @@ func (c Component) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, sub
 			return nil, err
 		}
 
-		psigsBySlot[sub.Slot][pubkey] = data
+		_, ok := psigsBySlot[sub.Slot]
+		if !ok {
+			psigsBySlot[sub.Slot] = make(core.ParSignedDataSet)
+		}
+
+		psigsBySlot[sub.Slot][pubkey] = core.NewPartialSignedBeaconCommitteeSubscription(sub, c.shareIdx)
 	}
 
 	for slot, data := range psigsBySlot {

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -141,12 +141,13 @@ type Component struct {
 
 	// Registered input functions
 
-	pubKeyByAttFunc       func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error)
-	awaitAttFunc          func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error)
-	awaitBlockFunc        func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
-	awaitBlindedBlockFunc func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error)
-	dutyDefFunc           func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
-	subs                  []func(context.Context, core.Duty, core.ParSignedDataSet) error
+	pubKeyByAttFunc                  func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error)
+	awaitAttFunc                     func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error)
+	awaitBlockFunc                   func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
+	awaitBlindedBlockFunc            func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error)
+	awaitCommitteeSubnetResponseFunc func(ctx context.Context, validatorIndex eth2p0.ValidatorIndex, slot eth2p0.Slot) (*eth2exp.BeaconCommitteeSubscriptionResponse, error)
+	dutyDefFunc                      func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
+	subs                             []func(context.Context, core.Duty, core.ParSignedDataSet) error
 }
 
 func (c *Component) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
@@ -210,6 +211,12 @@ func (c *Component) RegisterAwaitBeaconBlock(fn func(ctx context.Context, slot i
 // It supports a single function, since it is an input of the component.
 func (c *Component) RegisterAwaitBlindedBeaconBlock(fn func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error)) {
 	c.awaitBlindedBlockFunc = fn
+}
+
+// RegisterAwaitCommitteeSubnetResponse registers a function to query BeaconCommitteeResponse.
+// It supports a single function, since it is an input of the component.
+func (c *Component) RegisterAwaitCommitteeSubnetResponse(fn func(ctx context.Context, validatorIndex eth2p0.ValidatorIndex, slot eth2p0.Slot) (*eth2exp.BeaconCommitteeSubscriptionResponse, error)) {
+	c.awaitCommitteeSubnetResponseFunc = fn
 }
 
 // AttestationData implements the eth2client.AttesterDutiesProvider for the router.
@@ -608,9 +615,68 @@ func (c Component) SubmitVoluntaryExit(ctx context.Context, exit *eth2p0.SignedV
 }
 
 // SubmitBeaconCommitteeSubscriptionsV2 submits slot signatures to determine aggregators for attestation aggregation.
-// TODO(dhruv): Implement this as part of https://github.com/ObolNetwork/charon/issues/1067
 func (c Component) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*eth2exp.BeaconCommitteeSubscription) ([]*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
-	return c.eth2Cl.SubmitBeaconCommitteeSubscriptionsV2(ctx, subscriptions)
+	var valIdxs []eth2p0.ValidatorIndex
+	for _, sub := range subscriptions {
+		valIdxs = append(valIdxs, sub.ValidatorIndex)
+	}
+
+	vals, err := c.eth2Cl.Validators(ctx, "head", valIdxs)
+	if err != nil {
+		return nil, err
+	}
+
+	psigsBySlot := make(map[eth2p0.Slot]core.ParSignedDataSet)
+	for _, sub := range subscriptions {
+		data := core.NewPartialSignedBeaconCommitteeSubscription(*sub, c.shareIdx)
+		_, ok := psigsBySlot[sub.Slot]
+		if !ok {
+			psigsBySlot[sub.Slot] = make(core.ParSignedDataSet)
+		}
+
+		eth2Pubkey, err := vals[sub.ValidatorIndex].PubKey(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		pubkey, err := core.PubKeyFromBytes(eth2Pubkey[:])
+		if err != nil {
+			return nil, err
+		}
+
+		// Verify slot signature.
+		err = c.verifyPartialSig(pubkey, func(pubshare *bls_sig.PublicKey) error {
+			return signing.VerifyBeaconCommitteeSubscription(ctx, c.eth2Cl, pubshare, sub)
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		psigsBySlot[sub.Slot][pubkey] = data
+	}
+
+	for slot, data := range psigsBySlot {
+		duty := core.NewPrepareAggregatorDuty(int64(slot))
+		for _, sub := range c.subs {
+			err = sub(ctx, duty, data)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	// Query BeaconCommitteeSubscriptionResponse (this is blocking).
+	var resp []*eth2exp.BeaconCommitteeSubscriptionResponse
+	for _, sub := range subscriptions {
+		res, err := c.awaitCommitteeSubnetResponseFunc(ctx, sub.ValidatorIndex, sub.Slot)
+		if err != nil {
+			return nil, err
+		}
+
+		resp = append(resp, res)
+	}
+
+	return resp, nil
 }
 
 func (c Component) AttesterDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1251,8 +1251,8 @@ func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
 	vapi, err := validatorapi.NewComponentInsecure(t, eth2Cl, 0)
 	require.NoError(t, err)
 
-	vapi.RegisterAwaitCommitteeSubnetResponse(func(ctx context.Context, validatorIndex eth2p0.ValidatorIndex, slot eth2p0.Slot) (*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
-		return vIdxToResp[validatorIndex], nil
+	vapi.RegisterAwaitCommitteeSubscriptionResponse(func(_ context.Context, _ int64, validatorIndex int64) (*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+		return vIdxToResp[eth2p0.ValidatorIndex(validatorIndex)], nil
 	})
 
 	actual, err := vapi.SubmitBeaconCommitteeSubscriptionsV2(ctx, subs)

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	mrand "math/rand"
 	"sync"
 	"testing"
 
@@ -34,6 +35,7 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/validatorapi"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -1181,4 +1183,80 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 			},
 		},
 	}, resp)
+}
+
+func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		slotA = 123
+		slotB = 456
+		vIdxA = 1
+		vIdxB = 2
+		vIdxC = 3
+	)
+
+	eth2Cl, err := beaconmock.New(beaconmock.WithValidatorSet(beaconmock.ValidatorSet{
+		vIdxA: &eth2v1.Validator{
+			Index:     vIdxA,
+			Validator: &eth2p0.Validator{PublicKey: testutil.RandomEth2PubKey(t)},
+		},
+		vIdxB: &eth2v1.Validator{
+			Index:     vIdxB,
+			Validator: &eth2p0.Validator{PublicKey: testutil.RandomEth2PubKey(t)},
+		},
+		vIdxC: &eth2v1.Validator{
+			Index:     vIdxC,
+			Validator: &eth2p0.Validator{PublicKey: testutil.RandomEth2PubKey(t)},
+		},
+	}))
+	require.NoError(t, err)
+
+	// Submit subscriptions to validatorapi.
+	expected := []*eth2exp.BeaconCommitteeSubscriptionResponse{
+		{ValidatorIndex: vIdxA, IsAggregator: true},
+		{ValidatorIndex: vIdxB, IsAggregator: true},
+		{ValidatorIndex: vIdxC, IsAggregator: false},
+	}
+
+	vIdxToResp := make(map[eth2p0.ValidatorIndex]*eth2exp.BeaconCommitteeSubscriptionResponse)
+	for _, res := range expected {
+		vIdxToResp[res.ValidatorIndex] = res
+	}
+
+	subs := []*eth2exp.BeaconCommitteeSubscription{
+		{
+			Slot:             slotA,
+			ValidatorIndex:   vIdxA,
+			CommitteesAtSlot: mrand.Uint64(),
+			CommitteeIndex:   eth2p0.CommitteeIndex(mrand.Uint64()),
+			SlotSignature:    testutil.RandomEth2Signature(),
+		},
+		{
+			Slot:             slotB,
+			ValidatorIndex:   vIdxB,
+			CommitteesAtSlot: mrand.Uint64(),
+			CommitteeIndex:   eth2p0.CommitteeIndex(mrand.Uint64()),
+			SlotSignature:    testutil.RandomEth2Signature(),
+		},
+		{
+			Slot:             slotA,
+			ValidatorIndex:   vIdxC,
+			CommitteesAtSlot: mrand.Uint64(),
+			CommitteeIndex:   eth2p0.CommitteeIndex(mrand.Uint64()),
+			SlotSignature:    testutil.RandomEth2Signature(),
+		},
+	}
+
+	vapi, err := validatorapi.NewComponentInsecure(t, eth2Cl, 0)
+	require.NoError(t, err)
+
+	vapi.RegisterAwaitCommitteeSubnetResponse(func(ctx context.Context, validatorIndex eth2p0.ValidatorIndex, slot eth2p0.Slot) (*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+		return vIdxToResp[validatorIndex], nil
+	})
+
+	actual, err := vapi.SubmitBeaconCommitteeSubscriptionsV2(ctx, subs)
+	require.NoError(t, err)
+
+	require.Equal(t, expected, actual)
 }

--- a/eth2util/hash.go
+++ b/eth2util/hash.go
@@ -1,0 +1,42 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2util
+
+import (
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+// SlotHashRoot returns the ssz hash root of the slot.
+func SlotHashRoot(slot eth2p0.Slot) ([32]byte, error) {
+	hasher := ssz.DefaultHasherPool.Get()
+	defer ssz.DefaultHasherPool.Put(hasher)
+
+	indx := hasher.Index()
+
+	hasher.PutUint64(uint64(slot))
+
+	hasher.Merkleize(indx)
+
+	hash, err := hasher.HashRoot()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash epoch")
+	}
+
+	return hash, nil
+}

--- a/eth2util/hash_test.go
+++ b/eth2util/hash_test.go
@@ -1,0 +1,34 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2util_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/eth2util"
+)
+
+func TestSlotHashRoot(t *testing.T) {
+	resp, err := eth2util.SlotHashRoot(2)
+	require.NoError(t, err)
+	require.Equal(t,
+		"0200000000000000000000000000000000000000000000000000000000000000",
+		hex.EncodeToString(resp[:]),
+	)
+}

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -22,7 +22,6 @@ import (
 	"github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
-	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
@@ -195,7 +194,7 @@ func VerifyBeaconCommitteeSubscription(ctx context.Context, eth2Cl eth2wrap.Clie
 		return err
 	}
 
-	sigRoot, err := SlotHashRoot(sub.Slot)
+	sigRoot, err := eth2util.SlotHashRoot(sub.Slot)
 	if err != nil {
 		return err
 	}
@@ -244,23 +243,4 @@ func epochFromSlot(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.Slot
 	}
 
 	return eth2p0.Epoch(uint64(slot) / slotsPerEpoch), nil
-}
-
-// SlotHashRoot returns the ssz hash root of the slot.
-func SlotHashRoot(slot eth2p0.Slot) ([32]byte, error) {
-	hasher := ssz.DefaultHasherPool.Get()
-	defer ssz.DefaultHasherPool.Put(hasher)
-
-	indx := hasher.Index()
-
-	hasher.PutUint64(uint64(slot))
-
-	hasher.Merkleize(indx)
-
-	hash, err := hasher.HashRoot()
-	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "hash epoch")
-	}
-
-	return hash, nil
 }

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -224,7 +224,7 @@ func TestVerifyBeaconCommitteeSubscription(t *testing.T) {
 		CommitteeIndex:   eth2p0.CommitteeIndex(rand.Uint64()),
 	}
 
-	sigRoot, err := signing.SlotHashRoot(sub.Slot)
+	sigRoot, err := eth2util.SlotHashRoot(sub.Slot)
 	require.NoError(t, err)
 
 	slotsPerEpoch, err := bmock.SlotsPerEpoch(context.Background())

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -224,8 +224,7 @@ func TestVerifyBeaconCommitteeSubscription(t *testing.T) {
 		CommitteeIndex:   eth2p0.CommitteeIndex(rand.Uint64()),
 	}
 
-	sszUint64 := signing.SSZUint64(sub.Slot)
-	sigRoot, err := sszUint64.HashTreeRoot()
+	sigRoot, err := signing.SlotHashRoot(sub.Slot)
 	require.NoError(t, err)
 
 	slotsPerEpoch, err := bmock.SlotsPerEpoch(context.Background())

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"testing"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -29,6 +30,7 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -209,6 +211,34 @@ func TestVerifyBuilderRegistration(t *testing.T) {
 	registration.V1.Signature = tblsconv.SigToETH2(sig)
 
 	require.NoError(t, signing.VerifyValidatorRegistration(context.Background(), bmock, pubkey, &registration))
+}
+
+func TestVerifyBeaconCommitteeSubscription(t *testing.T) {
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	sub := &eth2exp.BeaconCommitteeSubscription{
+		Slot:             testutil.RandomSlot(),
+		ValidatorIndex:   testutil.RandomVIdx(),
+		CommitteesAtSlot: rand.Uint64(),
+		CommitteeIndex:   eth2p0.CommitteeIndex(rand.Uint64()),
+	}
+
+	sszUint64 := signing.SSZUint64(sub.Slot)
+	sigRoot, err := sszUint64.HashTreeRoot()
+	require.NoError(t, err)
+
+	slotsPerEpoch, err := bmock.SlotsPerEpoch(context.Background())
+	require.NoError(t, err)
+	epoch := eth2p0.Epoch(uint64(sub.Slot) / slotsPerEpoch)
+
+	sigData, err := signing.GetDataRoot(context.Background(), bmock, signing.DomainSelectionProof, epoch, sigRoot)
+	require.NoError(t, err)
+
+	sig, pubkey := sign(t, sigData[:])
+	sub.SlotSignature = tblsconv.SigToETH2(sig)
+
+	require.NoError(t, signing.VerifyBeaconCommitteeSubscription(context.Background(), bmock, pubkey, sub))
 }
 
 func sign(t *testing.T, data []byte) (*bls_sig.Signature, *bls_sig.PublicKey) {


### PR DESCRIPTION
Adds support for DutyPrepareAggregator to validatorapi. Also adds signature verification function as `VerifyBeaconCommitteeSubscription` to eth2util/signing/signing.go.

category: feature
ticket: #1067 