### PR TITLE
core/dutydb: add support for DutyPrepareAggregator to DutyDB

### DIFF
--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -26,6 +26,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
 // NewMemDB returns a new in-memory dutyDB instance.
@@ -53,6 +54,9 @@ type MemDB struct {
 	builderProQueries []builderProQuery
 	proDuties         map[int64]*spec.VersionedBeaconBlock
 	proQueries        []proQuery
+	commResDuties     map[commResKey]*eth2exp.BeaconCommitteeSubscriptionResponse
+	commResQueries    []commResQuery
+	commResKeysBySlot map[int64][]commResKey
 	shutdown          chan struct{}
 	deadliner         core.Deadliner
 }
@@ -105,6 +109,14 @@ func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.Unsig
 			}
 		}
 		db.resolveAttQueriesUnsafe()
+	case core.DutyPrepareAggregator:
+		for _, unsignedData := range unsignedSet {
+			err := db.storeBeaconCommitteeSubscriptionResponseUnsafe(duty.Slot, unsignedData)
+			if err != nil {
+				return err
+			}
+		}
+		db.resolveCommResQueriesUnsafe()
 	default:
 		return errors.New("unsupported duty type", z.Str("type", duty.Type.String()))
 	}
@@ -184,6 +196,30 @@ func (db *MemDB) AwaitAttestation(ctx context.Context, slot int64, commIdx int64
 		Response: response,
 	})
 	db.resolveAttQueriesUnsafe()
+	db.mu.Unlock()
+
+	select {
+	case <-db.shutdown:
+		return nil, errors.New("dutydb shutdown")
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case value := <-response:
+		return value, nil
+	}
+}
+
+// AwaitCommitteeSubscriptionResponse implements core.DutyDB, see its godoc.
+func (db *MemDB) AwaitCommitteeSubscriptionResponse(ctx context.Context, slot int64, vIdx int64) (*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
+	db.mu.Lock()
+	response := make(chan *eth2exp.BeaconCommitteeSubscriptionResponse, 1) // Buffer of one so resolving never blocks
+	db.commResQueries = append(db.commResQueries, commResQuery{
+		Key: commResKey{
+			Slot: slot,
+			Vidx: vIdx,
+		},
+		Response: response,
+	})
+	db.resolveCommResQueriesUnsafe()
 	db.mu.Unlock()
 
 	select {
@@ -335,6 +371,36 @@ func (db *MemDB) storeBlindedBeaconBlockUnsafe(unsignedData core.UnsignedData) e
 	return nil
 }
 
+// storeBeaconCommitteeSubscriptionResponseUnsafe stores BeaconCommitteeSubscriptionResponse.
+// It is unsafe since it assumes the lock is held.
+func (db *MemDB) storeBeaconCommitteeSubscriptionResponseUnsafe(slot int64, unsignedData core.UnsignedData) error {
+	cloned, err := unsignedData.Clone()
+	if err != nil {
+		return err
+	}
+
+	res, ok := cloned.(core.BeaconCommitteeSubscriptionResponse)
+	if !ok {
+		return errors.New("invalid committee subscription response")
+	}
+
+	key := commResKey{
+		Slot: slot,
+		Vidx: int64(res.ValidatorIndex),
+	}
+
+	if existing, ok := db.commResDuties[key]; ok {
+		if existing.ValidatorIndex != res.ValidatorIndex || existing.IsAggregator != res.IsAggregator {
+			return errors.New("clashing committee subscription response", z.Any("key", key))
+		}
+	} else {
+		db.commResDuties[key] = &res.BeaconCommitteeSubscriptionResponse
+		db.commResKeysBySlot[slot] = append(db.commResKeysBySlot[slot], key)
+	}
+
+	return nil
+}
+
 // resolveAttQueriesUnsafe resolve any attQuery to a result if found.
 // It is unsafe since it assume that the lock is held.
 func (db *MemDB) resolveAttQueriesUnsafe() {
@@ -386,6 +452,23 @@ func (db *MemDB) resolveBuilderProQueriesUnsafe() {
 	db.builderProQueries = unresolved
 }
 
+// resolveCommResQueriesUnsafe resolve any commResQuery to a result if found.
+// It is unsafe since it assume that the lock is held.
+func (db *MemDB) resolveCommResQueriesUnsafe() {
+	var unresolved []commResQuery
+	for _, query := range db.commResQueries {
+		value, ok := db.commResDuties[query.Key]
+		if !ok {
+			unresolved = append(unresolved, query)
+			continue
+		}
+
+		query.Response <- value
+	}
+
+	db.commResQueries = unresolved
+}
+
 // deleteDutyUnsafe deletes the duty from the database. It is unsafe since it assumes the lock is held.
 func (db *MemDB) deleteDutyUnsafe(duty core.Duty) error {
 	switch duty.Type {
@@ -399,6 +482,11 @@ func (db *MemDB) deleteDutyUnsafe(duty core.Duty) error {
 			delete(db.attDuties, attKey{Slot: key.Slot, CommIdx: key.CommIdx})
 		}
 		delete(db.attKeysBySlot, duty.Slot)
+	case core.DutyPrepareAggregator:
+		for _, key := range db.commResKeysBySlot[duty.Slot] {
+			delete(db.commResDuties, key)
+		}
+		delete(db.commResKeysBySlot, duty.Slot)
 	default:
 		return errors.New("unknown duty type")
 	}
@@ -419,6 +507,12 @@ type pkKey struct {
 	ValCommIdx int64
 }
 
+// commResKey is the key to lookup committee subnet response in the DB.
+type commResKey struct {
+	Slot int64
+	Vidx int64
+}
+
 // attQuery is a waiting attQuery with a response channel.
 type attQuery struct {
 	Key      attKey
@@ -435,4 +529,10 @@ type proQuery struct {
 type builderProQuery struct {
 	Key      int64
 	Response chan<- *eth2api.VersionedBlindedBeaconBlock
+}
+
+// commResQuery is a waiting commResQuery with a response channel.
+type commResQuery struct {
+	Key      commResKey
+	Response chan<- *eth2exp.BeaconCommitteeSubscriptionResponse
 }

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -32,13 +32,15 @@ import (
 // NewMemDB returns a new in-memory dutyDB instance.
 func NewMemDB(deadliner core.Deadliner) *MemDB {
 	return &MemDB{
-		attDuties:        make(map[attKey]*eth2p0.AttestationData),
-		attPubKeys:       make(map[pkKey]core.PubKey),
-		attKeysBySlot:    make(map[int64][]pkKey),
-		builderProDuties: make(map[int64]*eth2api.VersionedBlindedBeaconBlock),
-		proDuties:        make(map[int64]*spec.VersionedBeaconBlock),
-		shutdown:         make(chan struct{}),
-		deadliner:        deadliner,
+		attDuties:         make(map[attKey]*eth2p0.AttestationData),
+		attPubKeys:        make(map[pkKey]core.PubKey),
+		attKeysBySlot:     make(map[int64][]pkKey),
+		builderProDuties:  make(map[int64]*eth2api.VersionedBlindedBeaconBlock),
+		proDuties:         make(map[int64]*spec.VersionedBeaconBlock),
+		commResDuties:     make(map[commResKey]*eth2exp.BeaconCommitteeSubscriptionResponse),
+		commResKeysBySlot: make(map[int64][]commResKey),
+		shutdown:          make(chan struct{}),
+		deadliner:         deadliner,
 	}
 }
 
@@ -390,7 +392,7 @@ func (db *MemDB) storeBeaconCommitteeSubscriptionResponseUnsafe(slot int64, unsi
 	}
 
 	if existing, ok := db.commResDuties[key]; ok {
-		if existing.ValidatorIndex != res.ValidatorIndex || existing.IsAggregator != res.IsAggregator {
+		if existing.IsAggregator != res.IsAggregator {
 			return errors.New("clashing committee subscription response", z.Any("key", key))
 		}
 	} else {

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/dutydb"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -425,6 +426,77 @@ func TestDutyExpiry(t *testing.T) {
 	// Pubkey not found.
 	_, err = db.PubKeyByAttestation(ctx, int64(att1.Data.Slot), int64(att1.Data.Index), int64(att1.Duty.ValidatorCommitteeIndex))
 	require.Error(t, err)
+}
+
+func TestMemDBCommSubResponse(t *testing.T) {
+	ctx := context.Background()
+	db := dutydb.NewMemDB(new(testDeadliner))
+
+	const queries = 3
+	slots := [queries]int64{123, 456, 789}
+	vIdxs := [queries]int64{1, 2, 3}
+
+	type response struct {
+		commSubRes *eth2exp.BeaconCommitteeSubscriptionResponse
+	}
+	var awaitResponse [queries]chan response
+	for i := 0; i < queries; i++ {
+		awaitResponse[i] = make(chan response)
+		go func(slot int) {
+			res, err := db.AwaitCommitteeSubscriptionResponse(ctx, slots[slot], vIdxs[slot])
+			require.NoError(t, err)
+			awaitResponse[slot] <- response{commSubRes: res}
+		}(i)
+	}
+
+	data := make([]*eth2exp.BeaconCommitteeSubscriptionResponse, queries)
+	pubkeysByIdx := make(map[eth2p0.ValidatorIndex]core.PubKey)
+	for i := 0; i < queries; i++ {
+		data[i] = &eth2exp.BeaconCommitteeSubscriptionResponse{
+			ValidatorIndex: eth2p0.ValidatorIndex(vIdxs[i]),
+			IsAggregator:   false,
+		}
+		pubkeysByIdx[eth2p0.ValidatorIndex(i)] = testutil.RandomCorePubKey(t)
+
+		require.NoError(t, db.Store(ctx, core.NewPrepareAggregatorDuty(slots[i]), core.UnsignedDataSet{
+			pubkeysByIdx[eth2p0.ValidatorIndex(vIdxs[i])]: core.BeaconCommitteeSubscriptionResponse{BeaconCommitteeSubscriptionResponse: *data[i]},
+		}))
+	}
+
+	// Get and assert the responses
+	for i := 0; i < queries; i++ {
+		actualData := <-awaitResponse[i]
+		require.Equal(t, data[i], actualData.commSubRes)
+	}
+}
+
+func TestMemDBClashingCommSubResponse(t *testing.T) {
+	ctx := context.Background()
+	db := dutydb.NewMemDB(new(testDeadliner))
+
+	const (
+		slot = 123
+		vIdx = 1
+	)
+	res1 := &eth2exp.BeaconCommitteeSubscriptionResponse{
+		ValidatorIndex: vIdx,
+		IsAggregator:   false,
+	}
+	res2 := &eth2exp.BeaconCommitteeSubscriptionResponse{
+		ValidatorIndex: vIdx,
+		IsAggregator:   true,
+	}
+	pubkey := testutil.RandomCorePubKey(t)
+
+	// Store the responses
+	duty := core.NewPrepareAggregatorDuty(slot)
+	require.NoError(t, db.Store(ctx, duty, core.UnsignedDataSet{
+		pubkey: core.BeaconCommitteeSubscriptionResponse{BeaconCommitteeSubscriptionResponse: *res1},
+	}))
+
+	require.ErrorContains(t, db.Store(ctx, duty, core.UnsignedDataSet{
+		pubkey: core.BeaconCommitteeSubscriptionResponse{BeaconCommitteeSubscriptionResponse: *res2},
+	}), "clashing committee subscription response")
 }
 
 // testDeadliner is a mock deadliner implementation.

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -21,6 +21,8 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	"github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
 // Scheduler triggers the start of a duty workflow.
@@ -70,6 +72,10 @@ type DutyDB interface {
 	// slot, committee index and validator committee index. This allows mapping of attestation
 	// data response to validator.
 	PubKeyByAttestation(ctx context.Context, slot, commIdx, valCommIdx int64) (PubKey, error)
+
+	// AwaitCommitteeSubscriptionResponse returns the BeaconCommitteeSubscriptionResponse
+	// for the provided slot and validator index.
+	AwaitCommitteeSubscriptionResponse(ctx context.Context, slot, vIdx int64) (*eth2exp.BeaconCommitteeSubscriptionResponse, error)
 }
 
 // Consensus comes to consensus on proposed duty data.

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -26,12 +26,14 @@ import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
 var (
 	_ UnsignedData = AttestationData{}
 	_ UnsignedData = VersionedBeaconBlock{}
 	_ UnsignedData = VersionedBlindedBeaconBlock{}
+	_ UnsignedData = BeaconCommitteeSubscriptionResponse{}
 )
 
 // AttestationData wraps the eth2 attestation data and adds the original duty.
@@ -257,6 +259,49 @@ func (b *VersionedBlindedBeaconBlock) UnmarshalJSON(input []byte) error {
 	*b = VersionedBlindedBeaconBlock{VersionedBlindedBeaconBlock: resp}
 
 	return nil
+}
+
+type BeaconCommitteeSubscriptionResponse struct {
+	eth2exp.BeaconCommitteeSubscriptionResponse
+}
+
+func (b BeaconCommitteeSubscriptionResponse) Clone() (UnsignedData, error) {
+	var resp BeaconCommitteeSubscriptionResponse
+	err := cloneJSONMarshaler(b, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "clone subscription response")
+	}
+
+	return resp, nil
+}
+
+func (b BeaconCommitteeSubscriptionResponse) MarshalJSON() ([]byte, error) {
+	resp, err := json.Marshal(beaconCommitteeSubscriptionResponseJSON{
+		ValidatorIndex: b.ValidatorIndex,
+		IsAggregator:   b.IsAggregator,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal subscription response")
+	}
+
+	return resp, nil
+}
+
+func (b *BeaconCommitteeSubscriptionResponse) UnmarshalJSON(input []byte) error {
+	var resp beaconCommitteeSubscriptionResponseJSON
+	if err := json.Unmarshal(input, &resp); err != nil {
+		return errors.Wrap(err, "unmarshal subscription response")
+	}
+
+	b.IsAggregator = resp.IsAggregator
+	b.ValidatorIndex = resp.ValidatorIndex
+
+	return nil
+}
+
+type beaconCommitteeSubscriptionResponseJSON struct {
+	ValidatorIndex eth2p0.ValidatorIndex `json:"validator_index"`
+	IsAggregator   bool                  `json:"is_aggregator"`
 }
 
 // UnmarshalUnsignedData returns an instantiated unsigned data based on the duty type.

--- a/core/unsigneddata_test.go
+++ b/core/unsigneddata_test.go
@@ -26,35 +26,6 @@ import (
 	"github.com/obolnetwork/charon/testutil"
 )
 
-func TestCloneVersionedBeaconBlock(t *testing.T) {
-	block := testutil.RandomCoreVersionBeaconBlock(t)
-	slot1, err := block.Slot()
-	require.NoError(t, err)
-
-	clone, err := block.Clone()
-	require.NoError(t, err)
-	block2 := clone.(core.VersionedBeaconBlock)
-	slot2, err := block2.Slot()
-	require.NoError(t, err)
-
-	require.Equal(t, slot1, slot2)
-}
-
-func TestCloneVersionedBlindedBeaconBlock(t *testing.T) {
-	block := testutil.RandomCoreVersionBlindedBeaconBlock(t)
-	slot1, err := block.Slot()
-	require.NoError(t, err)
-
-	clone, err := block.Clone()
-	require.NoError(t, err)
-	block2 := clone.(core.VersionedBlindedBeaconBlock)
-	slot2, err := block2.Slot()
-	require.NoError(t, err)
-
-	require.Equal(t, slot1, slot2)
-	require.True(t, reflect.DeepEqual(block, block2))
-}
-
 func TestCloneUnsignedData(t *testing.T) {
 	tests := []struct {
 		name string

--- a/core/unsigneddata_test.go
+++ b/core/unsigneddata_test.go
@@ -16,11 +16,13 @@
 package core_test
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -50,4 +52,38 @@ func TestCloneVersionedBlindedBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, slot1, slot2)
+	require.True(t, reflect.DeepEqual(block, block2))
+}
+
+func TestCloneUnsignedData(t *testing.T) {
+	tests := []struct {
+		name string
+		data core.UnsignedData
+	}{
+		{
+			name: "versioned beacon block",
+			data: testutil.RandomCoreVersionBeaconBlock(t),
+		},
+		{
+			name: "versioned blinded beacon block",
+			data: testutil.RandomCoreVersionBlindedBeaconBlock(t),
+		},
+		{
+			name: "beacon committee subscription response",
+			data: core.BeaconCommitteeSubscriptionResponse{
+				BeaconCommitteeSubscriptionResponse: eth2exp.BeaconCommitteeSubscriptionResponse{
+					ValidatorIndex: testutil.RandomVIdx(),
+					IsAggregator:   false,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			clone, err := test.data.Clone()
+			require.NoError(t, err)
+			require.True(t, reflect.DeepEqual(test.data, clone))
+		})
+	}
 }


### PR DESCRIPTION
Adds support for DutyPrepareAggregatir to DutyDB.

category: feature
ticket: #1064 
