### PR TITLE
core/parsigex: add support for DutyPrepareAggregator to parsigex

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -199,6 +199,13 @@ func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[
 			}
 
 			return signing.VerifyVoluntaryExit(ctx, eth2Cl, pubshare, &exit.SignedVoluntaryExit)
+		case core.DutyPrepareAggregator:
+			subscription, ok := data.SignedData.(core.SignedBeaconCommitteeSubscription)
+			if !ok {
+				return errors.New("invalid beacon committee subscription")
+			}
+
+			return signing.VerifyBeaconCommitteeSubscription(ctx, eth2Cl, pubshare, &subscription.BeaconCommitteeSubscription)
 		default:
 			return errors.New("unknown duty type")
 		}

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -229,4 +229,18 @@ func TestParSigExVerifier(t *testing.T) {
 
 		require.NoError(t, verifyFunc(ctx, core.NewBuilderRegistrationDuty(slot), pubkey, data))
 	})
+
+	t.Run("Verify beacon committee subscription", func(t *testing.T) {
+		sub := testutil.RandomBeaconCommitteeSubscription(t)
+		sub.Slot = slot
+		sigRoot, err := eth2util.SlotHashRoot(sub.Slot)
+		require.NoError(t, err)
+		sigData, err := signing.GetDataRoot(ctx, bmock, signing.DomainSelectionProof, epoch, sigRoot)
+		require.NoError(t, err)
+		sub.SlotSignature = sign(sigData[:])
+		data := core.NewPartialSignedBeaconCommitteeSubscription(sub, shareIdx)
+		require.NoError(t, err)
+
+		require.NoError(t, verifyFunc(ctx, core.NewPrepareAggregatorDuty(slot), pubkey, data))
+	})
 }

--- a/core/proto.go
+++ b/core/proto.go
@@ -84,6 +84,12 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (ParSignedDa
 			return ParSignedData{}, errors.Wrap(err, "unmarshal signature")
 		}
 		signedData = s
+	case DutyPrepareAggregator:
+		var s SignedBeaconCommitteeSubscription
+		if err := json.Unmarshal(data.Data, &s); err != nil {
+			return ParSignedData{}, errors.Wrap(err, "unmarshal beacon committee subscription")
+		}
+		signedData = s
 	default:
 		return ParSignedData{}, errors.New("unsupported duty type")
 	}

--- a/core/proto_test.go
+++ b/core/proto_test.go
@@ -65,6 +65,10 @@ func TestParSignedDataSetProto(t *testing.T) {
 			Type: core.DutyBuilderRegistration,
 			Data: testutil.RandomCoreVersionedSignedValidatorRegistration(t),
 		},
+		{
+			Type: core.DutyPrepareAggregator,
+			Data: core.SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *testutil.RandomBeaconCommitteeSubscription(t)},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Type.String(), func(t *testing.T) {
@@ -213,5 +217,6 @@ func randomSignedData(t *testing.T) map[core.DutyType]core.SignedData {
 				},
 			},
 		},
+		core.DutyPrepareAggregator: core.SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *testutil.RandomBeaconCommitteeSubscription(t)},
 	}
 }

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
@@ -333,6 +334,18 @@ func RandomVersionedSignedValidatorRegistration(t *testing.T) *eth2api.Versioned
 	return &eth2api.VersionedSignedValidatorRegistration{
 		Version: spec.BuilderVersionV1,
 		V1:      RandomSignedValidatorRegistration(t),
+	}
+}
+
+func RandomBeaconCommitteeSubscription(t *testing.T) *eth2exp.BeaconCommitteeSubscription {
+	t.Helper()
+
+	return &eth2exp.BeaconCommitteeSubscription{
+		ValidatorIndex:   RandomVIdx(),
+		Slot:             RandomSlot(),
+		CommitteeIndex:   RandomCommIdx(),
+		CommitteesAtSlot: rand.Uint64(),
+		SlotSignature:    RandomEth2Signature(),
 	}
 }
 


### PR DESCRIPTION
Add support for `DutyPrepareAggregator` to `parsigex` component.

category: feature
ticket: https://github.com/ObolNetwork/charon/issues/1065
