### PR TITLE
core/bcast: fix linter

### DIFF
--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -52,9 +52,7 @@ type Broadcaster struct {
 }
 
 // Broadcast broadcasts the aggregated signed duty data object to the beacon-node.
-func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty,
-	pubkey core.PubKey, aggData core.SignedData,
-) (err error) { //nolint:nonamedreturn // Handled in defer
+func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, pubkey core.PubKey, aggData core.SignedData) (err error) { //nolint:nonamedreturn,gocognit // Handled in defer
 	ctx = log.WithTopic(ctx, "bcast")
 	ctx = log.WithCtx(ctx, z.Any("pubkey", pubkey))
 	defer func() {


### PR DESCRIPTION
Fix linter error by adding `gocognit` nolint directive to `Broadcast()` method.

category: fixbuild
ticket: none 
