### PR TITLE
dkg: add --no-verify for hash verifications

### DIFF
--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -305,27 +305,32 @@ func (d *Definition) UnmarshalJSON(data []byte) error {
 		return errors.New("unsupported version")
 	}
 
+	*d = def
+
+	return nil
+}
+
+// VerifyHashes returns an error if hashes populated from json object doesn't matches actual hashes.
+func (d Definition) VerifyHashes() error {
 	// Verify config_hash
-	configHash, err := hashDefinition(def, true)
+	configHash, err := hashDefinition(d, true)
 	if err != nil {
 		return errors.Wrap(err, "config hash")
 	}
 
-	if !bytes.Equal(def.ConfigHash, configHash[:]) {
+	if !bytes.Equal(d.ConfigHash, configHash[:]) {
 		return errors.New("invalid config hash")
 	}
 
 	// Verify definition_hash
-	defHash, err := hashDefinition(def, false)
+	defHash, err := hashDefinition(d, false)
 	if err != nil {
 		return errors.Wrap(err, "definition hash")
 	}
 
-	if !bytes.Equal(def.DefinitionHash, defHash[:]) {
+	if !bytes.Equal(d.DefinitionHash, defHash[:]) {
 		return errors.New("invalid definition hash")
 	}
-
-	*d = def
 
 	return nil
 }

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -310,8 +310,8 @@ func (d *Definition) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// VerifyHashes returns an error if hashes populated from json object doesn't matches actual hashes.
-func (d Definition) VerifyHashes() error {
+// VerifyDefinitionHashes returns an error if hashes populated from json object doesn't matches actual hashes.
+func (d Definition) VerifyDefinitionHashes() error {
 	// Verify config_hash
 	configHash, err := hashDefinition(d, true)
 	if err != nil {

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -30,6 +30,7 @@ import (
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/core"
@@ -57,6 +58,12 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 	err = json.Unmarshal(buf, &res)
 	if err != nil {
 		return cluster.Definition{}, errors.Wrap(err, "unmarshal definition")
+	}
+
+	if err := res.VerifyHashes(); err != nil && !conf.NoVerify {
+		return cluster.Definition{}, errors.Wrap(err, "cluster definition hashes verification failed. Run with --no-verify to bypass verification at own risk")
+	} else if err != nil && conf.NoVerify {
+		log.Warn(ctx, "Ignoring failed cluster definition hashes verification due to --no-verify flag", err)
 	}
 
 	return res, nil

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -60,7 +60,7 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 		return cluster.Definition{}, errors.Wrap(err, "unmarshal definition")
 	}
 
-	if err := res.VerifyHashes(); err != nil && !conf.NoVerify {
+	if err := res.VerifyDefinitionHashes(); err != nil && !conf.NoVerify {
 		return cluster.Definition{}, errors.Wrap(err, "cluster definition hashes verification failed. Run with --no-verify to bypass verification at own risk")
 	} else if err != nil && conf.NoVerify {
 		log.Warn(ctx, "Ignoring failed cluster definition hashes verification due to --no-verify flag", err)

--- a/dkg/disk_internal_test.go
+++ b/dkg/disk_internal_test.go
@@ -95,43 +95,78 @@ func TestLoadDefinition(t *testing.T) {
 	err = os.WriteFile(invalidFile, []byte{1, 2, 3}, 0o666)
 	require.NoError(t, err)
 
+	// Invalid definition without definition_hash and config_hash
+	invalidFile2 := "invalid-cluster-definition2.json"
+	var rawJSONString map[string]any
+	require.NoError(t, json.Unmarshal(b, &rawJSONString))
+
+	delete(rawJSONString, "config_hash")
+	delete(rawJSONString, "definition_hash")
+
+	b2, err := json.Marshal(rawJSONString)
+	require.NoError(t, err)
+
+	err = os.WriteFile(invalidFile2, b2, 0o666)
+	require.NoError(t, err)
+
 	defer func() {
 		require.NoError(t, os.Remove(validFile))
 		require.NoError(t, os.Remove(invalidFile))
+		require.NoError(t, os.Remove(invalidFile2))
 	}()
 
 	tests := []struct {
-		name    string
-		defFile string
-		want    cluster.Definition
-		wantErr bool
+		name     string
+		defFile  string
+		want     cluster.Definition
+		noVerify bool
+		wantErr  bool
 	}{
 		{
-			name:    "Load valid definition",
-			defFile: validFile,
-			want:    validDef,
-			wantErr: false,
+			name:     "Load valid definition",
+			defFile:  validFile,
+			want:     validDef,
+			noVerify: false,
+			wantErr:  false,
 		},
 		{
-			name:    "Definition file doesn't exist",
-			defFile: "",
-			want:    invalidDef,
-			wantErr: true,
+			name:     "Definition file doesn't exist",
+			defFile:  "",
+			want:     invalidDef,
+			noVerify: false,
+			wantErr:  true,
 		},
 		{
-			name:    "Load invalid definition",
-			defFile: invalidFile,
-			want:    invalidDef,
-			wantErr: true,
+			name:     "Load invalid definition",
+			defFile:  invalidFile,
+			want:     invalidDef,
+			noVerify: false,
+			wantErr:  true,
+		},
+		{
+			name:     "Load invalid definition with no verify",
+			defFile:  invalidFile2,
+			want:     validDef,
+			noVerify: true,
+			wantErr:  false,
+		},
+		{
+			name:     "Load invalid definition without no verify",
+			defFile:  invalidFile2,
+			noVerify: false,
+			wantErr:  true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := loadDefinition(context.Background(), Config{DefFile: tt.defFile})
+			got, err := loadDefinition(context.Background(), Config{DefFile: tt.defFile, NoVerify: tt.noVerify})
 			if tt.wantErr {
 				require.Error(t, err)
 				return
 			}
+			require.NoError(t, err)
+
+			got, err = got.SetHashes()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
Configure --no-verify for config_hash and definition_hash verifications by adding VerifyHashes method to Definition.

category: refactor
ticket: #1084 