### PR TITLE
cluster: align lock hash with canonical ssz types

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -159,11 +159,7 @@ func Run(ctx context.Context, conf Config) (err error) { //nolint:nonamedreturn 
 		log.Warn(ctx, "Ignoring failed cluster lock signature verification due to --no-verify flag", err)
 	}
 
-	lockHash, err := lock.HashTreeRoot()
-	if err != nil {
-		return err
-	}
-	lockHashHex := hex.EncodeToString(lockHash[:])[:7]
+	lockHashHex := hex.EncodeToString(lock.LockHash)[:7]
 
 	p2pKey := conf.TestConfig.P2PKey
 	if p2pKey == nil {

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -322,13 +322,15 @@ func testSimnet(t *testing.T, args simnetArgs) {
 func newRegistrationProvider(t *testing.T, args simnetArgs) func() <-chan *eth2api.VersionedValidatorRegistration {
 	t.Helper()
 
+	pubkey, err := core.PubKey(args.Lock.Validators[0].PublicKeyHex()).ToETH2()
+	require.NoError(t, err)
 	reg := &eth2api.VersionedValidatorRegistration{
 		Version: spec.BuilderVersionV1,
 		V1: &eth2v1.ValidatorRegistration{
 			FeeRecipient: testutil.RandomExecutionAddress(),
 			GasLimit:     99,
 			Timestamp:    time.Now(),
-			Pubkey:       args.Lock.Validators[0].PublicKeyETH2(),
+			Pubkey:       pubkey,
 		},
 	}
 

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -268,7 +268,7 @@ func testSimnet(t *testing.T, args simnetArgs) {
 			case res = <-results:
 			}
 
-			require.EqualValues(t, args.Lock.Validators[0].PubKey, res.Pubkey)
+			require.EqualValues(t, args.Lock.Validators[0].PublicKeyHex(), res.Pubkey)
 
 			// Assert the data and signature from all nodes are the same per duty.
 			if counts[res.Duty] == 0 {
@@ -322,15 +322,13 @@ func testSimnet(t *testing.T, args simnetArgs) {
 func newRegistrationProvider(t *testing.T, args simnetArgs) func() <-chan *eth2api.VersionedValidatorRegistration {
 	t.Helper()
 
-	pubkey, err := core.PubKey(args.Lock.Validators[0].PubKey).ToETH2()
-	require.NoError(t, err)
 	reg := &eth2api.VersionedValidatorRegistration{
 		Version: spec.BuilderVersionV1,
 		V1: &eth2v1.ValidatorRegistration{
 			FeeRecipient: testutil.RandomExecutionAddress(),
 			GasLimit:     99,
 			Timestamp:    time.Now(),
-			Pubkey:       pubkey,
+			Pubkey:       args.Lock.Validators[0].PublicKeyETH2(),
 		},
 	}
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -46,7 +46,7 @@ func TestEncode(t *testing.T) {
 				{
 					Address:         testutil.RandomBytes20(),
 					ENR:             fmt.Sprintf("enr://%x", testutil.RandomBytes32()),
-					ConfigSignature: testutil.RandomBytes32(),
+					ConfigSignature: testutil.RandomBytes32(), // TODO(corver): Change sigs to Bytes65.
 					ENRSignature:    testutil.RandomBytes32(),
 				},
 				{
@@ -79,7 +79,7 @@ func TestEncode(t *testing.T) {
 
 		require.Equal(t, b1, b2)
 
-		definition, err = definition.SetHashes()
+		definition, err = definition.SetDefinitionHashes()
 		require.NoError(t, err)
 		require.Equal(t, definition, definition2)
 
@@ -88,13 +88,13 @@ func TestEncode(t *testing.T) {
 			SignatureAggregate: testutil.RandomBytes32(),
 			Validators: []cluster.DistValidator{
 				{
-					PubKey: testutil.RandomETHAddress(),
+					PubKey: testutil.RandomBytes20(), // TODO(corver): Change sigs to Bytes48.
 					PubShares: [][]byte{
-						testutil.RandomBytes32(),
+						testutil.RandomBytes32(), // TODO(corver): Change sigs to Bytes48.
 						testutil.RandomBytes32(),
 					},
 				}, {
-					PubKey: testutil.RandomETHAddress(),
+					PubKey: testutil.RandomBytes20(),
 					PubShares: [][]byte{
 						testutil.RandomBytes32(),
 						testutil.RandomBytes32(),
@@ -108,12 +108,6 @@ func TestEncode(t *testing.T) {
 				testutil.WithFilename("cluster_lock_"+vStr+".json"))
 		})
 
-		hash1, err := lock.HashTreeRoot()
-		require.NoError(t, err)
-		hash2, err := lock.HashTreeRoot()
-		require.NoError(t, err)
-		require.Equal(t, hash1, hash2)
-
 		b1, err = json.Marshal(lock)
 		require.NoError(t, err)
 
@@ -125,6 +119,9 @@ func TestEncode(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, b1, b2)
+
+		lock, err = lock.SetLockHash()
+		require.NoError(t, err)
 		require.Equal(t, lock, lock2)
 	}
 }

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -234,8 +234,8 @@ func (d Definition) PeerIDs() ([]peer.ID, error) {
 	return resp, nil
 }
 
-// SetHashes returns a copy of the definition with the config hash and definition hash populated.
-func (d Definition) SetHashes() (Definition, error) {
+// SetDefinitionHashes returns a copy of the definition with the config hash and definition hash populated.
+func (d Definition) SetDefinitionHashes() (Definition, error) {
 	// Marshal config hash
 	configHash, err := hashDefinition(d, true)
 	if err != nil {
@@ -256,7 +256,7 @@ func (d Definition) SetHashes() (Definition, error) {
 }
 
 func (d Definition) MarshalJSON() ([]byte, error) {
-	d, err := d.SetHashes()
+	d, err := d.SetDefinitionHashes()
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/distvalidator.go
+++ b/cluster/distvalidator.go
@@ -16,7 +16,6 @@
 package cluster
 
 import (
-	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -43,14 +42,6 @@ func (v DistValidator) PublicKey() (*bls_sig.PublicKey, error) {
 // PublicKeyHex returns the validator hex group public key.
 func (v DistValidator) PublicKeyHex() string {
 	return to0xHex(v.PubKey)
-}
-
-// PublicKeyETH2 returns the validator eth2client group public key.
-func (v DistValidator) PublicKeyETH2() eth2p0.BLSPubKey {
-	var resp eth2p0.BLSPubKey
-	copy(resp[:], v.PubKey)
-
-	return resp
 }
 
 // PublicShare returns a peer's threshold BLS public share.

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -36,10 +36,10 @@ type Operator struct {
 	ENR string `json:"enr" ssz:"ByteList[1024]" config_hash:"-" definition_hash:"1"`
 
 	// ConfigSignature is an EIP712 signature of the config_hash using privkey corresponding to operator Ethereum Address.
-	ConfigSignature []byte `json:"config_signature,0xhex" ssz:"Bytes32" config_hash:"-" definition_hash:"2"`
+	ConfigSignature []byte `json:"config_signature,0xhex" ssz:"Bytes65" config_hash:"-" definition_hash:"2"`
 
 	// ENRSignature is a EIP712 signature of the ENR by the Address, authorising the charon node to act on behalf of the operator in the cluster.
-	ENRSignature []byte `json:"enr_signature,0xhex" ssz:"Bytes32" config_hash:"-" definition_hash:"3"`
+	ENRSignature []byte `json:"enr_signature,0xhex" ssz:"Bytes65" config_hash:"-" definition_hash:"3"`
 }
 
 // getName returns a deterministic name for operator based on its ENR.

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -248,6 +248,7 @@ func hashLock(l Lock) ([32]byte, error) {
 	return resp, nil
 }
 
+// hashLockV1x3 hashes the latest lock hash.
 func hashLockV1x3(l Lock, hh ssz.HashWalker) error {
 	indx := hh.Index()
 
@@ -273,6 +274,7 @@ func hashLockV1x3(l Lock, hh ssz.HashWalker) error {
 	return nil
 }
 
+// hashValidatorV1x3 hashes the distributed validator.
 func hashValidatorV1x3(v DistValidator, hh ssz.HashWalker) error {
 	indx := hh.Index()
 
@@ -297,6 +299,7 @@ func hashValidatorV1x3(v DistValidator, hh ssz.HashWalker) error {
 	return nil
 }
 
+// hashLockLegacy hashes the legacy lock.
 func hashLockLegacy(l Lock, hh ssz.HashWalker) error {
 	indx := hh.Index()
 
@@ -322,6 +325,7 @@ func hashLockLegacy(l Lock, hh ssz.HashWalker) error {
 	return nil
 }
 
+// hashValidatorLegacy hashes the legacy distributed validator.
 func hashValidatorLegacy(v DistValidator, hh ssz.HashWalker) error {
 	indx := hh.Index()
 

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -75,7 +75,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 		}
 
 		vals = append(vals, DistValidator{
-			PubKey:    to0xHex(pk),
+			PubKey:    pk,
 			PubShares: pubshares,
 		})
 		dvShares = append(dvShares, shares)
@@ -127,7 +127,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 		require.NoError(t, err)
 	}
 
-	def, err = def.SetHashes()
+	def, err = def.SetDefinitionHashes()
 	require.NoError(t, err)
 
 	lock := Lock{
@@ -136,10 +136,10 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 		SignatureAggregate: nil,
 	}
 
-	lockHash, err := lock.HashTreeRoot()
+	lock, err = lock.SetLockHash()
 	require.NoError(t, err)
 
-	lock.SignatureAggregate, err = aggSign(dvShares, lockHash[:])
+	lock.SignatureAggregate, err = aggSign(dvShares, lock.LockHash)
 	require.NoError(t, err)
 
 	return lock, p2pKeys, dvShares

--- a/cluster/testdata/cluster_lock_v1_3_0.json
+++ b/cluster/testdata/cluster_lock_v1_3_0.json
@@ -44,5 +44,5 @@
   }
  ],
  "signature_aggregate": "0x3bea6f5b3af6de0374366c4719e43a1b067d89bc7f01f1f573981659a44ff17a",
- "lock_hash": "0xf7e059237ffc9e0c7d9282178f6b073cd65c3df730ce394187a716830819ce7c"
+ "lock_hash": "0x3d93d2a5980d7782d8e98bc99f5c6cf1629891e2fba86e31ccf267c9bf2a4a11"
 }

--- a/dkg/disk_internal_test.go
+++ b/dkg/disk_internal_test.go
@@ -166,7 +166,7 @@ func TestLoadDefinition(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			got, err = got.SetHashes()
+			got, err = got.SetDefinitionHashes()
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -156,12 +156,10 @@ func testDKG(t *testing.T, def cluster.Definition, p2pKeys []*ecdsa.PrivateKey) 
 	// Ensure locks hashes are identical.
 	var hash []byte
 	for i, lock := range locks {
-		h, err := lock.HashTreeRoot()
-		require.NoError(t, err)
 		if i == 0 {
-			hash = h[:]
+			hash = lock.LockHash
 		} else {
-			require.Equal(t, hash, h[:])
+			require.Equal(t, hash, lock.LockHash)
 		}
 	}
 


### PR DESCRIPTION
Aligns lock hash with canonical ssz types.

category: feature
ticket: #1082 
