### PR TITLE
core/validatorapi: add CalculateCommitteeSubscriptionResponse in vapi

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -141,13 +141,13 @@ type Component struct {
 
 	// Registered input functions
 
-	pubKeyByAttFunc                        func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error)
-	awaitAttFunc                           func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error)
-	awaitBlockFunc                         func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
-	awaitBlindedBlockFunc                  func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error)
-	awaitCommitteeSubscriptionResponseFunc func(ctx context.Context, slot int64, validatorIndex int64) (*eth2exp.BeaconCommitteeSubscriptionResponse, error)
-	dutyDefFunc                            func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
-	subs                                   []func(context.Context, core.Duty, core.ParSignedDataSet) error
+	pubKeyByAttFunc       func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error)
+	awaitAttFunc          func(ctx context.Context, slot, commIdx int64) (*eth2p0.AttestationData, error)
+	awaitBlockFunc        func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)
+	awaitBlindedBlockFunc func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error)
+	aggSigDBFunc          func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
+	dutyDefFunc           func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
+	subs                  []func(context.Context, core.Duty, core.ParSignedDataSet) error
 }
 
 func (c *Component) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
@@ -213,10 +213,9 @@ func (c *Component) RegisterAwaitBlindedBeaconBlock(fn func(ctx context.Context,
 	c.awaitBlindedBlockFunc = fn
 }
 
-// RegisterAwaitCommitteeSubscriptionResponse registers a function to query BeaconCommitteeResponse.
-// It supports a single function, since it is an input of the component.
-func (c *Component) RegisterAwaitCommitteeSubscriptionResponse(fn func(ctx context.Context, slot int64, validatorIndex int64) (*eth2exp.BeaconCommitteeSubscriptionResponse, error)) {
-	c.awaitCommitteeSubscriptionResponseFunc = fn
+// RegisterAggSigDB registers a function to get resolved aggregated signed data from the AggSigDB.
+func (c *Component) RegisterAggSigDB(fn func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)) {
+	c.aggSigDBFunc = fn
 }
 
 // AttestationData implements the eth2client.AttesterDutiesProvider for the router.
@@ -664,15 +663,28 @@ func (c Component) SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, sub
 		}
 	}
 
-	// Query BeaconCommitteeSubscriptionResponse (this is blocking).
 	var resp []*eth2exp.BeaconCommitteeSubscriptionResponse
-	for _, sub := range subscriptions {
-		res, err := c.awaitCommitteeSubscriptionResponseFunc(ctx, int64(sub.Slot), int64(sub.ValidatorIndex))
-		if err != nil {
-			return nil, err
-		}
+	for slot, data := range psigsBySlot {
+		duty := core.NewPrepareAggregatorDuty(int64(slot))
+		for pk := range data {
+			// Query aggregated subscription from aggsigdb for each duty and public key (this is blocking).
+			s, err := c.aggSigDBFunc(ctx, duty, pk)
+			if err != nil {
+				return nil, err
+			}
 
-		resp = append(resp, res)
+			sub, ok := s.(core.SignedBeaconCommitteeSubscription)
+			if !ok {
+				return nil, errors.New("invalid beacon committee subscription")
+			}
+
+			res, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, c.eth2Cl, &sub.BeaconCommitteeSubscription)
+			if err != nil {
+				return nil, err
+			}
+
+			resp = append(resp, res)
+		}
 	}
 
 	return resp, nil

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	mrand "math/rand"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -37,6 +38,7 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/validatorapi"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
@@ -1194,74 +1196,74 @@ func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
 	ctx := context.Background()
 
 	const (
-		slotA = 123
-		slotB = 456
-		vIdxA = 1
-		vIdxB = 2
-		vIdxC = 3
+		slot    = 1
+		vIdx    = 1
+		commIdx = 1
+		commLen = 43
 	)
 
-	eth2Cl, err := beaconmock.New(beaconmock.WithValidatorSet(beaconmock.ValidatorSet{
-		vIdxA: &eth2v1.Validator{
-			Index:     vIdxA,
-			Validator: &eth2p0.Validator{PublicKey: testutil.RandomEth2PubKey(t)},
-		},
-		vIdxB: &eth2v1.Validator{
-			Index:     vIdxB,
-			Validator: &eth2p0.Validator{PublicKey: testutil.RandomEth2PubKey(t)},
-		},
-		vIdxC: &eth2v1.Validator{
-			Index:     vIdxC,
-			Validator: &eth2p0.Validator{PublicKey: testutil.RandomEth2PubKey(t)},
-		},
-	}))
+	eth2Cl, err := beaconmock.New(beaconmock.WithValidatorSet(beaconmock.ValidatorSetA))
 	require.NoError(t, err)
 
-	// Submit subscriptions to validatorapi.
-	expected := []*eth2exp.BeaconCommitteeSubscriptionResponse{
-		{ValidatorIndex: vIdxA, IsAggregator: true},
-		{ValidatorIndex: vIdxB, IsAggregator: true},
-		{ValidatorIndex: vIdxC, IsAggregator: false},
-	}
+	_, secret, err := tbls.KeygenWithSeed(mrand.New(mrand.NewSource(1)))
+	require.NoError(t, err)
 
-	vIdxToResp := make(map[eth2p0.ValidatorIndex]*eth2exp.BeaconCommitteeSubscriptionResponse)
-	for _, res := range expected {
-		vIdxToResp[res.ValidatorIndex] = res
-	}
+	sigRoot, err := eth2util.SlotHashRoot(slot)
+	require.NoError(t, err)
 
-	subs := []*eth2exp.BeaconCommitteeSubscription{
-		{
-			Slot:             slotA,
-			ValidatorIndex:   vIdxA,
-			CommitteesAtSlot: mrand.Uint64(),
-			CommitteeIndex:   eth2p0.CommitteeIndex(mrand.Uint64()),
-			SlotSignature:    testutil.RandomEth2Signature(),
-		},
-		{
-			Slot:             slotB,
-			ValidatorIndex:   vIdxB,
-			CommitteesAtSlot: mrand.Uint64(),
-			CommitteeIndex:   eth2p0.CommitteeIndex(mrand.Uint64()),
-			SlotSignature:    testutil.RandomEth2Signature(),
-		},
-		{
-			Slot:             slotA,
-			ValidatorIndex:   vIdxC,
-			CommitteesAtSlot: mrand.Uint64(),
-			CommitteeIndex:   eth2p0.CommitteeIndex(mrand.Uint64()),
-			SlotSignature:    testutil.RandomEth2Signature(),
-		},
+	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+	require.NoError(t, err)
+
+	sigData, err := signing.GetDataRoot(ctx, eth2Cl, signing.DomainSelectionProof, eth2p0.Epoch(uint64(slot)/slotsPerEpoch), sigRoot)
+	require.NoError(t, err)
+
+	sig, _ := tbls.Sign(secret, sigData[:])
+	blssig := tblsconv.SigToETH2(sig)
+
+	eth2Cl.BeaconCommitteesAtEpochFunc = func(_ context.Context, stateID string, epoch eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
+		require.Equal(t, "head", stateID)
+		require.Equal(t, eth2p0.Epoch(uint64(slot)/slotsPerEpoch), epoch)
+
+		var vals []eth2p0.ValidatorIndex
+		for idx := 1; idx <= commLen; idx++ {
+			vals = append(vals, eth2p0.ValidatorIndex(idx))
+		}
+
+		return []*eth2v1.BeaconCommittee{
+			{
+				Slot:       slot,
+				Index:      commIdx,
+				Validators: vals,
+			},
+		}, nil
 	}
 
 	vapi, err := validatorapi.NewComponentInsecure(t, eth2Cl, 0)
 	require.NoError(t, err)
 
-	vapi.RegisterAwaitCommitteeSubscriptionResponse(func(_ context.Context, _ int64, validatorIndex int64) (*eth2exp.BeaconCommitteeSubscriptionResponse, error) {
-		return vIdxToResp[eth2p0.ValidatorIndex(validatorIndex)], nil
+	subs := []*eth2exp.BeaconCommitteeSubscription{
+		{
+			ValidatorIndex: vIdx,
+			Slot:           slot,
+			CommitteeIndex: commIdx,
+			SlotSignature:  blssig,
+		},
+	}
+
+	vapi.RegisterAggSigDB(func(_ context.Context, duty core.Duty, _ core.PubKey) (core.SignedData, error) {
+		require.Equal(t, core.NewPrepareAggregatorDuty(slot), duty)
+
+		return core.SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *subs[0]}, nil
 	})
+
+	expected := []*eth2exp.BeaconCommitteeSubscriptionResponse{
+		{
+			ValidatorIndex: vIdx,
+			IsAggregator:   true,
+		},
+	}
 
 	actual, err := vapi.SubmitBeaconCommitteeSubscriptionsV2(ctx, subs)
 	require.NoError(t, err)
-
-	require.Equal(t, expected, actual)
+	require.True(t, reflect.DeepEqual(expected, actual))
 }

--- a/eth2util/eth2exp/attagg_test.go
+++ b/eth2util/eth2exp/attagg_test.go
@@ -50,14 +50,15 @@ func TestCalculateCommitteeSubscriptionResponse(t *testing.T) {
 	sigRoot, err := eth2util.SlotHashRoot(slot)
 	require.NoError(t, err)
 
-	slotsPerEpoch, err := bmock.SlotsPerEpoch(context.Background())
+	slotsPerEpoch, err := bmock.SlotsPerEpoch(ctx)
 	require.NoError(t, err)
 
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
-	sigData, err := signing.GetDataRoot(context.Background(), bmock, signing.DomainSelectionProof, epoch, sigRoot)
+	sigData, err := signing.GetDataRoot(ctx, bmock, signing.DomainSelectionProof, epoch, sigRoot)
 	require.NoError(t, err)
 
-	sig, _ := tbls.Sign(secret, sigData[:])
+	sig, err := tbls.Sign(secret, sigData[:])
+	require.NoError(t, err)
 	blssig := tblsconv.SigToETH2(sig)
 
 	subscription := eth2exp.BeaconCommitteeSubscription{


### PR DESCRIPTION
Adds CalculateCommitteeSubscriptionResponse for calculating response for an aggregated subscription obtained from aggsigdb in validatorapi.

category: feature
ticket: #1067
