### PR TITLE
cmd/createdkg: add existing cluster definition check

### DIFF
--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -102,6 +102,10 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 		}
 	}()
 
+	if _, err := os.Stat(path.Join(conf.OutputDir, "cluster-definition.json")); err == nil {
+		return errors.New("existing cluster-definition.json found. Try again after deleting it")
+	}
+
 	// Don't allow cluster size to be less than 4.
 	if len(conf.OperatorENRs) < minNodes {
 		return errors.New("insufficient operator ENRs (min = 4)")

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -18,6 +18,7 @@ package cmd
 import (
 	"context"
 	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -125,4 +126,18 @@ func TestRequireOperatorENRFlag(t *testing.T) {
 			require.EqualError(t, cmd.Execute(), test.err)
 		})
 	}
+}
+
+func TestExistingClusterDefinition(t *testing.T) {
+	outDir := ".charon"
+	b := []byte("sample definition")
+	require.NoError(t, os.Mkdir(".charon", 0o755))
+	require.NoError(t, os.WriteFile(path.Join(outDir, "cluster-definition.json"), b, 0o600))
+	defer func() {
+		require.NoError(t, os.RemoveAll(outDir))
+	}()
+
+	cmd := newCreateCmd(newCreateDKGCmd(runCreateDKG))
+	cmd.SetArgs([]string{"dkg", "--operator-enrs=enr:-JG4QG472ZVvl8ySSnUK9uNVDrP_hjkUrUqIxUC75aayzmDVQedXkjbqc7QKyOOS71VmlqnYzri_taV8ZesFYaoQSIOGAYHtv1WsgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKwwq_CAld6oVKOrixE-JzMtvvNgb9yyI-_rwq4NFtajIN0Y3CCDhqDdWRwgg4u"})
+	require.EqualError(t, cmd.Execute(), "existing cluster-definition.json found. Try again after deleting it")
 }


### PR DESCRIPTION
Add a check for existing cluster-definition.json file. This will error out and leave the current file intact.

category: bug
ticket: #1062
