### PR TITLE
dkg: use calculated definition hash if no verify

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -159,13 +159,6 @@ func Run(ctx context.Context, conf Config) (err error) { //nolint:nonamedreturn 
 		log.Warn(ctx, "Ignoring failed cluster lock signature verification due to --no-verify flag", err)
 	}
 
-	if len(lock.LockHash) == 0 { // Ensure we have a lock hash
-		lock, err = lock.SetLockHash()
-		if err != nil {
-			return err
-		}
-	}
-
 	lockHashHex := hex.EncodeToString(lock.LockHash)[:7]
 
 	p2pKey := conf.TestConfig.P2PKey

--- a/app/app.go
+++ b/app/app.go
@@ -159,6 +159,13 @@ func Run(ctx context.Context, conf Config) (err error) { //nolint:nonamedreturn 
 		log.Warn(ctx, "Ignoring failed cluster lock signature verification due to --no-verify flag", err)
 	}
 
+	if conf.NoVerify { // Ensure we have a definition hash
+		lock, err = lock.SetLockHash()
+		if err != nil {
+			return err
+		}
+	}
+
 	lockHashHex := hex.EncodeToString(lock.LockHash)[:7]
 
 	p2pKey := conf.TestConfig.P2PKey

--- a/app/app.go
+++ b/app/app.go
@@ -159,7 +159,7 @@ func Run(ctx context.Context, conf Config) (err error) { //nolint:nonamedreturn 
 		log.Warn(ctx, "Ignoring failed cluster lock signature verification due to --no-verify flag", err)
 	}
 
-	if conf.NoVerify { // Ensure we have a definition hash
+	if len(lock.LockHash) == 0 { // Ensure we have a lock hash
 		lock, err = lock.SetLockHash()
 		if err != nil {
 			return err

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -80,7 +80,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		log.Warn(ctx, "Ignoring failed cluster definition signature verification due to --no-verify flag", err)
 	}
 
-	if conf.NoVerify { // Ensure we have a definition hash
+	if len(def.DefinitionHash) == 0 { // Ensure we have a definition hash
 		def, err = def.SetDefinitionHashes()
 		if err != nil {
 			return err

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -80,6 +80,13 @@ func Run(ctx context.Context, conf Config) (err error) {
 		log.Warn(ctx, "Ignoring failed cluster definition signature verification due to --no-verify flag", err)
 	}
 
+	if conf.NoVerify { // Ensure we have a definition hash
+		def, err = def.SetDefinitionHashes()
+		if err != nil {
+			return err
+		}
+	}
+
 	if err = checkWrites(conf.DataDir); err != nil {
 		return err
 	}


### PR DESCRIPTION
Use freshly calculated definition hashes when it is empty (`--no-verify` flag is used).

category: bug 
ticket: none

