### PR TITLE
core/parsigex: add signature verification to parsigex for DutyAggregator

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -206,6 +206,13 @@ func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[
 			}
 
 			return signing.VerifyBeaconCommitteeSubscription(ctx, eth2Cl, pubshare, &subscription.BeaconCommitteeSubscription)
+		case core.DutyAggregator:
+			aggAndProof, ok := data.SignedData.(core.SignedAggregateAndProof)
+			if !ok {
+				return errors.New("invalid aggregate and proof")
+			}
+
+			return signing.VerifyAggregateAndProof(ctx, eth2Cl, pubshare, &aggAndProof.SignedAggregateAndProof)
 		default:
 			return errors.New("unknown duty type")
 		}

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -239,8 +239,26 @@ func TestParSigExVerifier(t *testing.T) {
 		require.NoError(t, err)
 		sub.SlotSignature = sign(sigData[:])
 		data := core.NewPartialSignedBeaconCommitteeSubscription(sub, shareIdx)
-		require.NoError(t, err)
 
 		require.NoError(t, verifyFunc(ctx, core.NewPrepareAggregatorDuty(slot), pubkey, data))
+	})
+
+	t.Run("Verify aggregate and proof", func(t *testing.T) {
+		agg := &eth2p0.SignedAggregateAndProof{
+			Message: &eth2p0.AggregateAndProof{
+				AggregatorIndex: 0,
+				Aggregate:       testutil.RandomAttestation(),
+				SelectionProof:  testutil.RandomEth2Signature(),
+			},
+		}
+		agg.Message.Aggregate.Data.Slot = slot
+		sigRoot, err := agg.Message.HashTreeRoot()
+		require.NoError(t, err)
+		sigData, err := signing.GetDataRoot(ctx, bmock, signing.DomainAggregateAndProof, epoch, sigRoot)
+		require.NoError(t, err)
+		agg.Signature = sign(sigData[:])
+		data := core.NewPartialSignedAggregateAndProof(agg, shareIdx)
+
+		require.NoError(t, verifyFunc(ctx, core.NewAggregatorDuty(slot), pubkey, data))
 	})
 }


### PR DESCRIPTION
Adds signature verification to parsigex for DutyAggregator.

category: feature
ticket: #1095 
