### PR TITLE
core/bcast: add support for `DutyAggregator`

### DIFF
--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -179,6 +179,18 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, pubkey core.
 		}
 
 		return err
+	case core.DutyAggregator:
+		aggAndProof, ok := aggData.(core.SignedAggregateAndProof)
+		if !ok {
+			return errors.New("invalid aggregate and proof")
+		}
+
+		err = b.eth2Cl.SubmitAggregateAttestations(ctx, []*eth2p0.SignedAggregateAndProof{&aggAndProof.SignedAggregateAndProof})
+		if err == nil {
+			log.Info(ctx, "Attestation aggregation successfully submitted to beacon node", nil)
+		}
+
+		return err
 	default:
 		return errors.New("unsupported duty type")
 	}

--- a/core/bcast/bcast_test.go
+++ b/core/bcast/bcast_test.go
@@ -289,3 +289,28 @@ func TestBroadcastBeaconCommitteeSubscriptionV1(t *testing.T) {
 
 	<-ctx.Done()
 }
+
+func TestBroadcastAggregateAttestation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	mock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	aggAndProof := testutil.RandomSignedAggregateAndProof()
+	data := core.SignedAggregateAndProof{SignedAggregateAndProof: *aggAndProof}
+
+	mock.SubmitAggregateAttestationsFunc = func(ctx context.Context, aggregateAndProofs []*eth2p0.SignedAggregateAndProof) error {
+		require.Equal(t, aggAndProof, aggregateAndProofs[0])
+		cancel()
+
+		return ctx.Err()
+	}
+
+	bcaster, err := bcast.New(ctx, mock)
+	require.NoError(t, err)
+
+	err = bcaster.Broadcast(ctx, core.Duty{Type: core.DutyAggregator}, "", data)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+
+	<-ctx.Done()
+}

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -360,6 +360,21 @@ func RandomSignedBeaconCommitteeSubscription(vIdx, slot, commIdx int) core.Signe
 	}
 }
 
+func RandomSignedAggregateAndProof() *eth2p0.SignedAggregateAndProof {
+	return &eth2p0.SignedAggregateAndProof{
+		Message:   RandomAggregateAndProof(),
+		Signature: RandomEth2Signature(),
+	}
+}
+
+func RandomAggregateAndProof() *eth2p0.AggregateAndProof {
+	return &eth2p0.AggregateAndProof{
+		AggregatorIndex: RandomVIdx(),
+		Aggregate:       RandomAttestation(),
+		SelectionProof:  RandomEth2Signature(),
+	}
+}
+
 func RandomSyncAggregate(t *testing.T) *altair.SyncAggregate {
 	t.Helper()
 


### PR DESCRIPTION
Add support for `DutyAggregator` to bcast.

category: feature
ticket: #1096 
