### PR TITLE
core: add missing methods to `ValidatorAPI` interface

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -48,8 +48,7 @@ type Fetcher interface {
 	RegisterAggSigDB(func(context.Context, Duty, PubKey) (SignedData, error))
 }
 
-// DutyDB persists unsigned duty data sets and makes it available for querying. It also acts
-// as slashing database.
+// DutyDB persists unsigned duty data sets and makes it available for querying. It also acts as slashing database.
 type DutyDB interface {
 	// Store stores the unsigned duty data set.
 	Store(context.Context, Duty, UnsignedDataSet) error
@@ -81,8 +80,7 @@ type Consensus interface {
 	Subscribe(func(context.Context, Duty, UnsignedDataSet) error)
 }
 
-// ValidatorAPI provides a beacon node API to validator clients. It serves duty data from the
-// DutyDB and stores partial signed data in the ParSigDB.
+// ValidatorAPI provides a beacon node API to validator clients. It serves duty data from the DutyDB and stores partial signed data in the ParSigDB.
 type ValidatorAPI interface {
 	// RegisterAwaitBeaconBlock registers a function to query a unsigned beacon block by slot.
 	RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error))
@@ -99,14 +97,14 @@ type ValidatorAPI interface {
 	// RegisterGetDutyDefinition registers a function to query duty definitions.
 	RegisterGetDutyDefinition(func(context.Context, Duty) (DutyDefinitionSet, error))
 
-	// Subscribe registers a function to store partially signed data sets.
-	Subscribe(func(context.Context, Duty, ParSignedDataSet) error)
-
-	// RegisterAwaitAggregatedAttestation registers a function to query attestation.
+	// RegisterAwaitAggregatedAttestation registers a function to query aggregated attestation.
 	RegisterAwaitAggregatedAttestation(fn func(ctx context.Context, slot int64, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error))
 
 	// RegisterAggSigDB registers a function to query aggregated signed data from aggSigDB.
 	RegisterAggSigDB(fn func(context.Context, Duty, PubKey) (SignedData, error))
+
+	// Subscribe registers a function to store partially signed data sets.
+	Subscribe(func(context.Context, Duty, ParSignedDataSet) error)
 }
 
 // ParSigDB persists partial signatures and sends them to the

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -82,10 +82,10 @@ type Consensus interface {
 
 // ValidatorAPI provides a beacon node API to validator clients. It serves duty data from the DutyDB and stores partial signed data in the ParSigDB.
 type ValidatorAPI interface {
-	// RegisterAwaitBeaconBlock registers a function to query a unsigned beacon block by slot.
+	// RegisterAwaitBeaconBlock registers a function to query unsigned beacon block by slot.
 	RegisterAwaitBeaconBlock(func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error))
 
-	// RegisterAwaitBlindedBeaconBlock registers a function to query a unsigned blinded beacon block by slot.
+	// RegisterAwaitBlindedBeaconBlock registers a function to query unsigned blinded beacon block by slot.
 	RegisterAwaitBlindedBeaconBlock(func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error))
 
 	// RegisterAwaitAttestation registers a function to query attestation data.

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -101,6 +101,12 @@ type ValidatorAPI interface {
 
 	// Subscribe registers a function to store partially signed data sets.
 	Subscribe(func(context.Context, Duty, ParSignedDataSet) error)
+
+	// RegisterAwaitAggregatedAttestation registers a function to query attestation.
+	RegisterAwaitAggregatedAttestation(fn func(ctx context.Context, slot int64, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error))
+
+	// RegisterAggSigDB registers a function to query aggregated signed data from aggSigDB.
+	RegisterAggSigDB(fn func(context.Context, Duty, PubKey) (SignedData, error))
 }
 
 // ParSigDB persists partial signatures and sends them to the

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -151,7 +151,7 @@ type Component struct {
 	subs                  []func(context.Context, core.Duty, core.ParSignedDataSet) error
 }
 
-// RegisterAwaitBeaconBlock registers a function to query unsigned block.
+// RegisterAwaitBeaconBlock registers a function to query unsigned beacon block.
 // It supports a single function, since it is an input of the component.
 func (c *Component) RegisterAwaitBeaconBlock(fn func(ctx context.Context, slot int64) (*spec.VersionedBeaconBlock, error)) {
 	c.awaitBlockFunc = fn
@@ -187,7 +187,7 @@ func (c *Component) RegisterAwaitAggregatedAttestation(fn func(ctx context.Conte
 	c.awaitAggAttFunc = fn
 }
 
-// RegisterAggSigDB registers a function to get resolved aggregated signed data from AggSigDB.
+// RegisterAggSigDB registers a function to query aggregated signed data from aggSigDB.
 func (c *Component) RegisterAggSigDB(fn func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)) {
 	c.aggSigDBFunc = fn
 }

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -157,7 +157,7 @@ func (c *Component) RegisterAwaitBeaconBlock(fn func(ctx context.Context, slot i
 	c.awaitBlockFunc = fn
 }
 
-// RegisterAwaitBlindedBeaconBlock registers a function to query unsigned blinded block.
+// RegisterAwaitBlindedBeaconBlock registers a function to query unsigned blinded beacon block.
 // It supports a single function, since it is an input of the component.
 func (c *Component) RegisterAwaitBlindedBeaconBlock(fn func(ctx context.Context, slot int64) (*eth2api.VersionedBlindedBeaconBlock, error)) {
 	c.awaitBlindedBlockFunc = fn
@@ -181,6 +181,17 @@ func (c *Component) RegisterGetDutyDefinition(fn func(ctx context.Context, duty 
 	c.dutyDefFunc = fn
 }
 
+// RegisterAwaitAggregatedAttestation registers a function to query aggregated attestation.
+// It supports a single function, since it is an input of the component.
+func (c *Component) RegisterAwaitAggregatedAttestation(fn func(ctx context.Context, slot int64, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error)) {
+	c.awaitAggAttFunc = fn
+}
+
+// RegisterAggSigDB registers a function to get resolved aggregated signed data from AggSigDB.
+func (c *Component) RegisterAggSigDB(fn func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)) {
+	c.aggSigDBFunc = fn
+}
+
 // Subscribe registers a partial signed data set store function.
 // It supports multiple functions since it is the output of the component.
 func (c *Component) Subscribe(fn func(context.Context, core.Duty, core.ParSignedDataSet) error) {
@@ -193,15 +204,6 @@ func (c *Component) Subscribe(fn func(context.Context, core.Duty, core.ParSigned
 
 		return fn(ctx, duty, clone)
 	})
-}
-
-func (c *Component) RegisterAwaitAggregatedAttestation(fn func(ctx context.Context, slot int64, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error)) {
-	c.awaitAggAttFunc = fn
-}
-
-// RegisterAggSigDB registers a function to get resolved aggregated signed data from AggSigDB.
-func (c *Component) RegisterAggSigDB(fn func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)) {
-	c.aggSigDBFunc = fn
 }
 
 // AttestationData implements the eth2client.AttesterDutiesProvider for the router.


### PR DESCRIPTION
Add missing methods to `ValidatorAPI` interface.

category: refactor
ticket: none 