### PR TITLE
eth2util/eth2exp: add selection proof to committee response

### DIFF
--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -165,10 +165,10 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, pubkey core.
 
 		subs := []*eth2v1.BeaconCommitteeSubscription{
 			{
-				ValidatorIndex:   sub.ValidatorIndex,
-				Slot:             sub.Slot,
-				CommitteeIndex:   sub.CommitteeIndex,
-				CommitteesAtSlot: sub.CommitteesAtSlot,
+				ValidatorIndex:   res.ValidatorIndex,
+				Slot:             res.Slot,
+				CommitteeIndex:   res.CommitteeIndex,
+				CommitteesAtSlot: res.CommitteesAtSlot,
 				IsAggregator:     res.IsAggregator,
 			},
 		}

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -21,7 +21,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	mrand "math/rand"
-	"reflect"
 	"strings"
 	"sync"
 	"testing"
@@ -1258,14 +1257,17 @@ func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
 
 	expected := []*eth2exp.BeaconCommitteeSubscriptionResponse{
 		{
+			Slot:           slot,
+			CommitteeIndex: commIdx,
 			ValidatorIndex: vIdx,
 			IsAggregator:   true,
+			SelectionProof: blssig,
 		},
 	}
 
 	actual, err := vapi.SubmitBeaconCommitteeSubscriptionsV2(ctx, subs)
 	require.NoError(t, err)
-	require.True(t, reflect.DeepEqual(expected, actual))
+	require.Equal(t, expected, actual)
 }
 
 func TestComponent_SubmitAggregateAttestations(t *testing.T) {

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -214,7 +214,11 @@ func isAggregator(ctx context.Context, eth2Cl eth2Provider, commLen uint64, slot
 		return false, errors.Wrap(err, "calculate sha256")
 	}
 
-	return binary.LittleEndian.Uint64(h.Sum(nil)[:8])%modulo == 0, nil
+	hash := h.Sum(nil)
+	last8bytes := hash[:8]
+	asUint64 := binary.LittleEndian.Uint64(last8bytes)
+
+	return asUint64%modulo == 0, nil
 }
 
 // getCommitteeLength returns the number of validators in the input committee at the given slot.

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -154,27 +154,39 @@ func (b *BeaconCommitteeSubscription) String() (string, error) {
 
 // BeaconCommitteeSubscriptionResponse is the response from beacon node after submitting BeaconCommitteeSubscription.
 type BeaconCommitteeSubscriptionResponse struct {
-	// ValidatorIndex is the index of the validator that made the subscription request.
+	// ValidatorIdex is the index of the validator making the subscription request.
 	ValidatorIndex eth2p0.ValidatorIndex
+	// Slot is the slot for which the validator is attesting.
+	Slot eth2p0.Slot
+	// CommitteeIndex is the index of the committee of which the validator is a member at the given slot.
+	CommitteeIndex eth2p0.CommitteeIndex
+	// CommitteesAtSlot is the number of committees at the given slot.
+	CommitteesAtSlot uint64
 	// IsAggregator indicates whether the validator is an attestation aggregator.
 	IsAggregator bool
+	// SelectionProof is the slot signature proving the validator is an aggregator for this slot and committee.
+	SelectionProof eth2p0.BLSSignature
 }
 
 // CalculateCommitteeSubscriptionResponse returns a BeaconCommitteeSubscriptionResponse with isAggregator field set to true if the validator is an aggregator.
-func CalculateCommitteeSubscriptionResponse(ctx context.Context, eth2Cl eth2Provider, subscription *BeaconCommitteeSubscription) (*BeaconCommitteeSubscriptionResponse, error) {
-	committeeLen, err := getCommitteeLength(ctx, eth2Cl, subscription.CommitteeIndex, subscription.Slot)
+func CalculateCommitteeSubscriptionResponse(ctx context.Context, eth2Cl eth2Provider, sub *BeaconCommitteeSubscription) (*BeaconCommitteeSubscriptionResponse, error) {
+	committeeLen, err := getCommitteeLength(ctx, eth2Cl, sub.CommitteeIndex, sub.Slot)
 	if err != nil {
 		return nil, err
 	}
 
-	isAgg, err := isAggregator(ctx, eth2Cl, uint64(committeeLen), subscription.SlotSignature)
+	isAgg, err := isAggregator(ctx, eth2Cl, uint64(committeeLen), sub.SlotSignature)
 	if err != nil {
 		return nil, err
 	}
 
 	return &BeaconCommitteeSubscriptionResponse{
-		ValidatorIndex: subscription.ValidatorIndex,
-		IsAggregator:   isAgg,
+		ValidatorIndex:   sub.ValidatorIndex,
+		Slot:             sub.Slot,
+		CommitteeIndex:   sub.CommitteeIndex,
+		CommitteesAtSlot: sub.CommitteesAtSlot,
+		SelectionProof:   sub.SlotSignature,
+		IsAggregator:     isAgg,
 	}, nil
 }
 
@@ -211,6 +223,8 @@ func getCommitteeLength(ctx context.Context, eth2Cl eth2Provider, commIdx eth2p0
 	if err != nil {
 		return 0, err
 	}
+
+	// TODO(corver): Maybe refactor to either use specific slot when querying or ignore slot in check below.
 
 	comms, err := eth2Cl.BeaconCommitteesAtEpoch(ctx, "head", epoch)
 	if err != nil {

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -215,8 +215,8 @@ func isAggregator(ctx context.Context, eth2Cl eth2Provider, commLen uint64, slot
 	}
 
 	hash := h.Sum(nil)
-	last8bytes := hash[:8]
-	asUint64 := binary.LittleEndian.Uint64(last8bytes)
+	lowest8bytes := hash[0:8]
+	asUint64 := binary.LittleEndian.Uint64(lowest8bytes)
 
 	return asUint64%modulo == 0, nil
 }

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -154,7 +154,7 @@ func (b *BeaconCommitteeSubscription) String() (string, error) {
 
 // BeaconCommitteeSubscriptionResponse is the response from beacon node after submitting BeaconCommitteeSubscription.
 type BeaconCommitteeSubscriptionResponse struct {
-	// ValidatorIdex is the index of the validator making the subscription request.
+	// ValidatorIndex is the index of the validator the made the subscription request.
 	ValidatorIndex eth2p0.ValidatorIndex
 	// Slot is the slot for which the validator is attesting.
 	Slot eth2p0.Slot


### PR DESCRIPTION
Add the selection proof (and all other related fields) to the `BeaconCommitteeSubscriptionResponse`

category: feature
ticket: none

