### PR TITLE
cmd: increase bootnode number of connections per peer

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -161,6 +161,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 		relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
 		relayResources.MaxReservationsPerIP = config.MaxResPerPeer
 		relayResources.MaxReservations = config.MaxConns
+		relayResources.MaxCircuits = config.MaxResPerPeer
 
 		relayService, err := relay.New(tcpNode, relay.WithResources(relayResources))
 		if err != nil {


### PR DESCRIPTION
Also increase max number of connections per peer. Found while trying to create large clusters.

category: misc
ticket: none
