### PR TITLE
core: add support for duty aggregator to proto

### DIFF
--- a/core/proto.go
+++ b/core/proto.go
@@ -90,6 +90,12 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (ParSignedDa
 			return ParSignedData{}, errors.Wrap(err, "unmarshal beacon committee subscription")
 		}
 		signedData = s
+	case DutyAggregator:
+		var s SignedAggregateAndProof
+		if err := json.Unmarshal(data.Data, &s); err != nil {
+			return ParSignedData{}, errors.Wrap(err, "unmarshal signed aggregate and proof")
+		}
+		signedData = s
 	default:
 		return ParSignedData{}, errors.New("unsupported duty type")
 	}

--- a/core/proto_test.go
+++ b/core/proto_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -69,6 +70,13 @@ func TestParSignedDataSetProto(t *testing.T) {
 			Type: core.DutyPrepareAggregator,
 			Data: core.SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *testutil.RandomBeaconCommitteeSubscription()},
 		},
+		{
+			Type: core.DutyAggregator,
+			Data: core.SignedAggregateAndProof{SignedAggregateAndProof: eth2p0.SignedAggregateAndProof{
+				Message:   testutil.RandomAggregateAndProof(),
+				Signature: testutil.RandomEth2Signature(),
+			}},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Type.String(), func(t *testing.T) {
@@ -115,6 +123,10 @@ func TestUnsignedDataToProto(t *testing.T) {
 		{
 			Type: core.DutyBuilderProposer,
 			Data: testutil.RandomCoreVersionBlindedBeaconBlock(t),
+		},
+		{
+			Type: core.DutyAggregator,
+			Data: core.NewAggregatedAttestation(testutil.RandomAttestation()),
 		},
 	}
 
@@ -218,5 +230,9 @@ func randomSignedData(t *testing.T) map[core.DutyType]core.SignedData {
 			},
 		},
 		core.DutyPrepareAggregator: core.SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *testutil.RandomBeaconCommitteeSubscription()},
+		core.DutyAggregator: core.SignedAggregateAndProof{SignedAggregateAndProof: eth2p0.SignedAggregateAndProof{
+			Message:   testutil.RandomAggregateAndProof(),
+			Signature: testutil.RandomEth2Signature(),
+		}},
 	}
 }

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -320,6 +320,13 @@ func UnmarshalUnsignedData(typ DutyType, data []byte) (UnsignedData, error) {
 		}
 
 		return resp, nil
+	case DutyAggregator:
+		var resp AggregatedAttestation
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return nil, errors.Wrap(err, "unmarshal aggregated attestation")
+		}
+
+		return resp, nil
 	default:
 		return nil, errors.New("unsupported unsigned data duty type")
 	}


### PR DESCRIPTION
Adds support for duty aggregator signed data and unsigned data types to proto unmarshal.

category: feature
ticket: none
