### PR TITLE
dkg: increase GET remote definition timeout

### DIFF
--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -54,6 +54,8 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 		if err != nil {
 			return cluster.Definition{}, errors.Wrap(err, "read definition")
 		}
+
+		log.Info(ctx, "Definition file loaded from remote URI", z.Str("URI", conf.DefFile))
 	} else {
 		buf, err := os.ReadFile(conf.DefFile)
 		if err != nil {
@@ -63,6 +65,8 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 		if err = json.Unmarshal(buf, &def); err != nil {
 			return cluster.Definition{}, errors.Wrap(err, "unmarshal definition")
 		}
+
+		log.Info(ctx, "Definition file loaded from disk", z.Str("location", conf.DefFile))
 	}
 
 	// Verify
@@ -93,7 +97,7 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 
 // fetchDefinition fetches cluster definition file from a remote URI.
 func fetchDefinition(ctx context.Context, url string) (cluster.Definition, error) {
-	ctx, cancel := context.WithTimeout(ctx, time.Second*5)
+	ctx, cancel := context.WithTimeout(ctx, time.Second*10)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -18,6 +18,7 @@ package dkg
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -55,7 +56,8 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 			return cluster.Definition{}, errors.Wrap(err, "read definition")
 		}
 
-		log.Info(ctx, "Definition file loaded from remote URI", z.Str("URI", conf.DefFile))
+		log.Info(ctx, "Cluster definition downloaded from URL", z.Str("URL", conf.DefFile),
+			z.Str("definition_hash", fmt.Sprintf("%#x", def.DefinitionHash)))
 	} else {
 		buf, err := os.ReadFile(conf.DefFile)
 		if err != nil {
@@ -66,7 +68,8 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 			return cluster.Definition{}, errors.Wrap(err, "unmarshal definition")
 		}
 
-		log.Info(ctx, "Definition file loaded from disk", z.Str("location", conf.DefFile))
+		log.Info(ctx, "Cluster definition loaded from disk", z.Str("path", conf.DefFile),
+			z.Str("definition_hash", fmt.Sprintf("%#x", def.DefinitionHash)))
 	}
 
 	// Verify

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -101,8 +101,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 
 	log.Info(ctx, "Starting local DKG peer...",
-		z.Str("local_peer", p2p.PeerName(pID)),
-		z.Str("definition_hash", clusterID))
+		z.Str("local_peer", p2p.PeerName(pID)))
 
 	tcpNode, shutdown, err := setupP2P(ctx, key, conf.P2P, peers, clusterID)
 	if err != nil {
@@ -133,7 +132,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	tp := newFrostP2P(ctx, tcpNode, peerMap, clusterID)
 
-	log.Info(ctx, "Waiting to connecting to all peers...", z.Str("definition_hash", clusterID))
+	log.Info(ctx, "Waiting to connecting to all peers...")
 
 	// Improve UX of "context cancelled" errors when sync fails.
 	ctx = withCtxErr(ctx, "p2p connection failed, please retry DKG")


### PR DESCRIPTION
Increases GET remote definition timeout to 10s from 5s. Also add logs.

category: misc
ticket: none
