### PR TITLE
cluster: fix hashing of legacy checksummed addresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -353,7 +353,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	dutyDB := dutydb.NewMemDB(deadlinerFunc())
 
-	vapi, err := validatorapi.NewComponent(eth2Cl, pubSharesByKey, nodeIdx.ShareIdx, string(lock.FeeRecipientAddress))
+	vapi, err := validatorapi.NewComponent(eth2Cl, pubSharesByKey, nodeIdx.ShareIdx, lock.FeeRecipientAddress)
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -353,7 +353,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	dutyDB := dutydb.NewMemDB(deadlinerFunc())
 
-	vapi, err := validatorapi.NewComponent(eth2Cl, pubSharesByKey, nodeIdx.ShareIdx, lock.FeeRecipientAddress)
+	vapi, err := validatorapi.NewComponent(eth2Cl, pubSharesByKey, nodeIdx.ShareIdx, string(lock.FeeRecipientAddress))
 	if err != nil {
 		return err
 	}

--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -59,7 +59,7 @@ func randomOperator(t *testing.T) (*ecdsa.PrivateKey, Operator) {
 	addr := crypto.PubkeyToAddress(secret.PublicKey)
 
 	return secret, Operator{
-		Address: EthAddr(addr.Hex()),
+		Address: addr.Hex(),
 		ENR:     fmt.Sprintf("enr://%x", testutil.RandomBytes32()),
 	}
 }

--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -59,7 +59,7 @@ func randomOperator(t *testing.T) (*ecdsa.PrivateKey, Operator) {
 	addr := crypto.PubkeyToAddress(secret.PublicKey)
 
 	return secret, Operator{
-		Address: addr[:],
+		Address: EthAddr(addr.Hex()),
 		ENR:     fmt.Sprintf("enr://%x", testutil.RandomBytes32()),
 	}
 }

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -28,7 +28,10 @@ import (
 	"github.com/obolnetwork/charon/p2p"
 )
 
-const forkVersionLen = 4
+const (
+	forkVersionLen = 4
+	addressLen     = 20
+)
 
 // NodeIdx represents the index of a node/peer/share in the cluster as operator order in cluster definition.
 type NodeIdx struct {
@@ -50,8 +53,8 @@ func NewDefinition(name string, numVals int, threshold int, feeRecipientAddress 
 		NumValidators:       numVals,
 		Threshold:           threshold,
 		DKGAlgorithm:        dkgAlgo,
-		WithdrawalAddress:   EthAddr(withdrawalAddress),
-		FeeRecipientAddress: EthAddr(feeRecipientAddress),
+		WithdrawalAddress:   withdrawalAddress,
+		FeeRecipientAddress: feeRecipientAddress,
 		Operators:           operators,
 	}
 
@@ -92,10 +95,10 @@ type Definition struct {
 	Threshold int `json:"threshold" ssz:"uint64" config_hash:"5" definition_hash:"5"`
 
 	// FeeRecipientAddress 20 byte Ethereum address.
-	FeeRecipientAddress EthAddr `json:"fee_recipient_address,0xhex" ssz:"Bytes20" config_hash:"6" definition_hash:"6"`
+	FeeRecipientAddress string `json:"fee_recipient_address,0xhex" ssz:"Bytes20" config_hash:"6" definition_hash:"6"`
 
 	// WithdrawalAddress 20 byte Ethereum address.
-	WithdrawalAddress EthAddr `json:"withdrawal_address,0xhex" ssz:"Bytes20" config_hash:"7" definition_hash:"7"`
+	WithdrawalAddress string `json:"withdrawal_address,0xhex" ssz:"Bytes20" config_hash:"7" definition_hash:"7"`
 
 	// DKGAlgorithm to use for key generation. Max 32 chars.
 	DKGAlgorithm string `json:"dkg_algorithm" ssz:"ByteList[32]" config_hash:"8" definition_hash:"8"`
@@ -144,7 +147,7 @@ func (d Definition) VerifySignatures() error {
 	var noSigs int
 	for _, o := range d.Operators {
 		// Completely unsigned operators are also fine, assuming a single cluster-wide operator.
-		if len(o.Address) == 0 && len(o.ENRSignature) == 0 && len(o.ConfigSignature) == 0 {
+		if o.Address == "" && len(o.ENRSignature) == 0 && len(o.ConfigSignature) == 0 {
 			noSigs++
 			continue
 		}
@@ -437,8 +440,8 @@ type definitionJSONv1x0or1 struct {
 	Timestamp           string             `json:"timestamp,omitempty"`
 	NumValidators       int                `json:"num_validators"`
 	Threshold           int                `json:"threshold"`
-	FeeRecipientAddress EthAddr            `json:"fee_recipient_address,omitempty"`
-	WithdrawalAddress   EthAddr            `json:"withdrawal_address,omitempty"`
+	FeeRecipientAddress string             `json:"fee_recipient_address,omitempty"`
+	WithdrawalAddress   string             `json:"withdrawal_address,omitempty"`
 	DKGAlgorithm        string             `json:"dkg_algorithm"`
 	ForkVersion         string             `json:"fork_version"`
 	ConfigHash          []byte             `json:"config_hash"`
@@ -454,8 +457,8 @@ type definitionJSONv1x2or3 struct {
 	Timestamp           string             `json:"timestamp,omitempty"`
 	NumValidators       int                `json:"num_validators"`
 	Threshold           int                `json:"threshold"`
-	FeeRecipientAddress EthAddr            `json:"fee_recipient_address,omitempty"`
-	WithdrawalAddress   EthAddr            `json:"withdrawal_address,omitempty"`
+	FeeRecipientAddress string             `json:"fee_recipient_address,omitempty"`
+	WithdrawalAddress   string             `json:"withdrawal_address,omitempty"`
 	DKGAlgorithm        string             `json:"dkg_algorithm"`
 	ForkVersion         ethHex             `json:"fork_version"`
 	ConfigHash          ethHex             `json:"config_hash"`

--- a/cluster/examples/cluster-lock-000.json
+++ b/cluster/examples/cluster-lock-000.json
@@ -1,0 +1,95 @@
+{
+  "cluster_definition": {
+    "name": "Obol Core Team 3 of 4",
+    "operators": [
+      {
+        "address": "",
+        "enr": "enr:-JG4QKxA4c5JCRVsxyHV2x1VYYKIjMOvOzrgvLn2MrxKKZExGK_iFy6gOjdt2ciMUuqc-CaCWCfsat2JpNzsV2pTELqGAYJE19-DgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJdmxjcoFYP8gfZiVVSZXbGhOLiu7bijKRac5hWEhcGg4N0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QGcZTWSgiRXx0Wd_znS56PcjCUlY5Qk7Ja8KqlTeyvzBVcJ9Q-D7VyVX27smhtV-OkUwsn3rpgOk5qFbOYiQXKyGAYJFB9mzgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKGzfYZoH6ImLs20B7QHfOHt7pNB2FJX0P6eXMNIeF1yYN0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QM2lHxfVhQX78Pby5--uuilN6jTFZMIhgxRjs1i51y6kPrx5JkvoiGCPN-XWJ4qzVKLrfxXvHGVhysO-7xPlHTSGAYJFBgEigmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQIMOdWK9zJOA9RfAtGSy_nirSERXfoxHxmdLRIWalQVJ4N0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QG2QA-0OTnzUAmWtYuuAJ5QwhQRQTT0pTBuapBHgU75sBAnBZieYVR8fpHMzRc66sqgDYkhMJicLdz1ejhXjRV-GAYJFBnlQgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQORVX5d5U7HULLj_qfh0qP6RrO35tieBwJcKGj4GNBaiYN0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      }
+    ],
+    "uuid": "A5E888D3-9A64-6D9D-8555-CE27DACC9AF4",
+    "version": "v1.1.0",
+    "timestamp": "2022-07-28T13:42:54Z",
+    "num_validators": 5,
+    "threshold": 3,
+    "fee_recipient_address": "0x9FD17880D4F5aE131D62CE6b48dF7ba7D426a410",
+    "withdrawal_address": "0x9FD17880D4F5aE131D62CE6b48dF7ba7D426a410",
+    "dkg_algorithm": "default",
+    "fork_version": "0x00001020",
+    "config_hash": "Utqli530wzgEkKCr9P8GYZSmzz2Msh5TqSBRtvspbsE=",
+    "definition_hash": "MAszxw0c4fQJ0qhWDwLXCbBf3OhCTKGyxTykR9ay0qo="
+  },
+  "distributed_validators": [
+    {
+      "distributed_public_key": "0xa10e810052eee9d66a7351386b9e91ef3860c31d3f32d2de89466a8ceb34f899518dd5a48ad2ce6af94d842fa2611e6d",
+      "public_shares": [
+        "hmeYNbX7P64JFPzNOwp1i5zdYOAOs5CzxYQbwn9kwVBNdhGD5jkd5SH7ZrriGURt",
+        "iUQ54qXJyKbqYJh0yj28jMy0aWijuDgmY/koorV344TEYRlhsfgytVhloVLmCGT9",
+        "o6xxk9HDNXLBCUNALxyPJkYCUbAA6qP+brvs3SEdEoHzb8KEAWL/ccC76rGUovch",
+        "qIVTpfwM+Pgh3lEOx/WQjBbtcrVVMjStV5NZF/eu/8MFrCTIYcoqcqRYOGKJDNtR"
+      ]
+    },
+    {
+      "distributed_public_key": "0xafd55095b1390d6f075aaac8673bde501d9ec0459cc32b96ba311b4f36d47cf3b2dd846be3833260c92703c26f8c6423",
+      "public_shares": [
+        "qgdMHpiMdQyuluhGc6C2JIaXhbbSeaBLr3YjiDmZX9R6aaPJ83GOUZXp/hrxWCNg",
+        "omlDGLpa6Fw9NCOHkF+c0Ialj9/8VT+8fWUNJNQoAHAQATx03ylnl74GraLA9wV5",
+        "uOUBueW7PMbu5WDXUEIBYWEjvLporuKHJAE7rE+rLI2scj5LI5HDx/ZARvIAO0MA",
+        "qDFF9HD0oYDNouiChSQmXFw1ft1v4HsxWveZg3t6HAnF/0WUUGVlyFwlrzifDpQ2"
+      ]
+    },
+    {
+      "distributed_public_key": "0x98b8b7ea8a305c400d3d84b04952df9dcc7fa76c51e8cae6e28e515aabf103f8a01e0dbd7518c4b5c5149edc6d162bab",
+      "public_shares": [
+        "q1NUrzXCHSbYorKSCdtuU509qXu2TqdEn+6WXOyWaofOr+zSMXlXR+xhYJGFrlPQ",
+        "jp5MFr6qgYMmYJ97B9MQ5GHDoJCPlzAtYEvGkPab1IShahpLp42ZoawdanqC4r+3",
+        "qCqWsp+UoVeD4ljwFLzZtypFd6mEFZNqgdEFlWd2gRbMYyaAFGEhUQULpMR/G90W",
+        "k2pxOQi+ioBb7PCSEGXZGvDHNqw1ySDgHfAu/v4BpZFYl8d1I5c12ntZKXQ21CKU"
+      ]
+    },
+    {
+      "distributed_public_key": "0xb7c21a0a47df787ce1870c822143a8e5a8da677f68fe16c118e88b7d050be4e07c2d9cb78a16fbae80f1f34b3f7d22f4",
+      "public_shares": [
+        "liAUSJVwf3gsO4qaqLEdL4pG/6tCAaCjsBMG8mnABLc0h3SAlUqDkq2zj9mH+VoI",
+        "qtsR+bQz7GqZVuQmW4v6Zy+GJ4qXjpqL0yqj811yVk/zLXDs6oZGZKWW8Z6Ycvbp",
+        "i93JFbwUH+9JMOCJz0ZfhrsIc+81pQ9ZS2FVX2k3gWVhWig8S9N0wr7qOha+MyAG",
+        "sjUrS4S2skaIaX98h2e1XzKSqqekmtCnI3kUT40Rvp5JfaOMdzHqj7R4hvc3jvIB"
+      ]
+    },
+    {
+      "distributed_public_key": "0x8a46154bd294e0fcd57ac3cd30fbbec84cd2b83c08087687aa679ef9da7a684d3f8754f864c456f63ce964d065987f53",
+      "public_shares": [
+        "ilT1z2udzTtayn4gkkVGwBS1T0mrqPcftUJ4R/G1KxZ1Y+gg8Jkh/7bV748K725v",
+        "hN0iFfd0xz85rrkzhccS/+o3CLvvDaMy86tLK3Yy4pHPxvIguK0fganVBmPSFdp6",
+        "uUdxlpNhHqtEns7NOR6iVFKtzsRm3xX9AZyl6ymYhBp1kUVR4TOj8yBT8/29U4tD",
+        "hiQctMiBoiRbi91RSw8zIsDuIutAKIpD57sSFSYtaX3wXA7Hu9afKxU2efpr3+k9"
+      ]
+    }
+  ],
+  "signature_aggregate": "ltrRvt3P0uYVzPqzf1LDODKZSockAD9xU4BTHxeY09AMA2sMAHYDMssWYSJ8IKauBA6y0FTKu9yAvYVGV2Ap40xrMGpvJ+kz185FL+MGkZQiT71UPoR5Kw2kiWn5+RJw",
+  "lock_hash": "c2wSLsCp1HvxUTsnS0yKfsikQUzHfQiGEnxZoClIAxY="
+}

--- a/cluster/examples/cluster-lock-001.json
+++ b/cluster/examples/cluster-lock-001.json
@@ -1,0 +1,75 @@
+{
+  "cluster_definition": {
+    "name": "obol-freaks",
+    "operators": [
+      {
+        "address": "",
+        "enr": "enr:-JG4QBFNZ3gJI1igztDrZRI_8pq6vr4ycBk2cx109avmTJgefi1e91F5DGwTjgMsGuBWbZb8UYiyzqn8xdz38KXX9uWGAYJlcUZqgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQLnvKw3S01576fiDtt0KY3m5KX3f91N56qElHk82umVkIN0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QL0b0uwte4R2tKCpWEiZDQ_6jf0N_UoCO4LZ3Z9Hlz8RUDb4EO2RIrA0nkOEuEKRbS333FrP2hqok5RKjqUYV2uGAYIArh29gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJPG6P6p5EDv6TDKLlt_U3I2GlRm7gnuIlFDkUxW_1kEIN0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QCMY39ky3GgPQnf0LMV-bgttNvxgV9kmDZREVe88RrfBVox2BelY8sHZ5UGhDbnzd1Luv9ShQ_yngFKAEg1ycd2GAYJkSjIUgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQOVqFlpvx9pmYCaR-zblQ9ui5W2-ai9kTWqmapKABMIf4N0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QDR_arRTF7xNEKQhlgGFt38uGjvJoHLq_dso8gYRI3okSJB4E_DYy8VkKdlh9VoS006UUwGq6hMMTDVFF0_QTZCGAYJjdC7egmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQNvIwVC-ADE17Yu7DjVq77CcOr2bVy2fHtKiLxfgERvY4N0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QDqwJl6Ow-rTzeaGqTxZgv5kjUuI2vldh7akoH5Av8aOAKM9CDBi7HvMe6G6uJdUAEdS69Ut_ji38C8jmxlg8syGAYJUwLEggmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQPoKq-cjL7VCsGjo19RuaqUTbzlIak8Fytk7xtlNmu4B4N0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      },
+      {
+        "address": "",
+        "enr": "enr:-JG4QOPFSxwfu-Xo1gZlbYL1GDB4eoIqMBbXZghNEfM8gpPiSNuzbkp3CPSOQV5X5DPK_WL_tVu09cZDfPDukiHFEB2GAYIhWNpKgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQLb1frk-ZuCT0__HpHJpHpAPyz1vl1e8c8c3hZJhucRkIN0Y3CCDhqDdWRwgg4u",
+        "nonce": 0,
+        "config_signature": null,
+        "enr_signature": null
+      }
+    ],
+    "uuid": "1A552471-380F-27AE-0A15-8F37C3E8DA97",
+    "version": "v1.1.0",
+    "timestamp": "2022-08-04T13:11:27Z",
+    "num_validators": 1,
+    "threshold": 5,
+    "fee_recipient_address": "0xc2cEb46062BDEa381fc70c18525770784BdBE12c",
+    "withdrawal_address": "0xc2cEb46062BDEa381fc70c18525770784BdBE12c",
+    "dkg_algorithm": "default",
+    "fork_version": "0x00001020",
+    "config_hash": "4529ul0gFBrX/ryfEz81cjK86l3Wa5o/P2y9xOtqH28=",
+    "definition_hash": "RnMyDYhl9wDXalQVrcl8tAOSJAeBMO55wveo697xYLA="
+  },
+  "distributed_validators": [
+    {
+      "distributed_public_key": "0x8fc71a2b406542ab4f1b18e4078924ff99788028751a84aed3e213b5fc86c32cb25d5215617ebf74debb06471c5d5afc",
+      "public_shares": [
+        "hE6MgMG/sCcvt6nwR9PJd4XjhlWyO7XCoQbNUtT+4I+zgEYiNTx1V5fZcGfUi4s5",
+        "t0DRHGBARQaZIDWMsYhAwXwBPJQzn83YEnpdkNAzF6MgGV6bwxJTJZNfol09k1si",
+        "mZ6sneWIwJ/olcOrnE1EEmi2DTfjSN4CUfHhGaPrhv4f4TwuxNBU8cBjINLU5p8k",
+        "k4rlmh0Y1Lsq0JEO0rCdXIHi2eK+FHFdYgvG91sI1DKC4hNaYnTqS7deDsG2npTT",
+        "o4ItNPC3qQ4/Pmy/U0+sfDsGKuoc9DQQFvxEP919iPaTtpDcsoMBkueXWYF4FgSN",
+        "o7dvguWpo7Aa9/C7b5uoNF/wz/f4BdSH12YbBHPK0zwGM6iSkax7x8YEUR42eyCZ"
+      ]
+    }
+  ],
+  "signature_aggregate": "jmsxqfJ3NtwMRb6DLSdSLKymCGB4c6sxV4ZFpI9E5jvP6q6jlUcvak9tdZK+7G3OB9GmmuW5tWSomv2BSwr/difeMhFV9IAsDOhgreAVzBNpClS8fspdh/wBVIXOmL36",
+  "lock_hash": "9yn/deC5L/GPfVY5HCsUQQHsxJJ0Sh+ExZ6an0KeDzo="
+}

--- a/cluster/examples/cluster-lock-002.json
+++ b/cluster/examples/cluster-lock-002.json
@@ -1,0 +1,53 @@
+{
+ "cluster_definition": {
+  "operators": [
+   {
+    "address": "",
+    "enr": "enr:-HW4QO2jhGDd344Z2EX1N--buWYb-1z9iXm_C0loYu_KjoJUaI3U5DTu9X_8cCeROuqM4Z5h_kHlcehV82g8AmXT0hiAgmlkgnY0iXNlY3AyNTZrMaECLl0mTvEFTSKpCqV27mD_wSwSD2ao0EDAgIIpphuO3p4",
+    "config_signature": "",
+    "enr_signature": ""
+   },
+   {
+    "address": "",
+    "enr": "enr:-HW4QNnv0C97ZAl8Rn15T6w9RGthIXXmzaL3bqw7IOb1Ro3bZo8QmOLxzU5WxgIx0pBFD4ckE1C4nwhXcJWVXtVlM7iAgmlkgnY0iXNlY3AyNTZrMaECFPYf-EILk473NRft-8hODjIyfPbpzhYH5-oVydpA-QY",
+    "config_signature": "",
+    "enr_signature": ""
+   },
+   {
+    "address": "",
+    "enr": "enr:-HW4QNjh1NldUY5eK9NV7yxbE4JwZNj5Z3iMNTN5OyRN-KtNF26olG_cHYA_K6oqKvs7CpK63TqNsXliIV7OoKKLUfuAgmlkgnY0iXNlY3AyNTZrMaEC6OIF7AmR-YvOvKS4UQmmkp4k31Npyk4Q48aWjr07fCM",
+    "config_signature": "",
+    "enr_signature": ""
+   },
+   {
+    "address": "",
+    "enr": "enr:-HW4QBB8SQOxews5EtL7wTrvOj9-VmxN6ZbPuVTxU_q1SPwiS13DVc6EjQn0amFcMFhwhK0oBn4m-VYSVTgQ24uSWBiAgmlkgnY0iXNlY3AyNTZrMaEDpL-qsdNH9bwvY4W5Bx4bZTwGBTkmQrLn7a7P0QLUs34",
+    "config_signature": "",
+    "enr_signature": ""
+   }
+  ],
+  "uuid": "B13CF764-AFB4-1783-C620-205ABF26B9FE",
+  "version": "v1.2.0",
+  "timestamp": "2022-09-22T18:19:43+02:00",
+  "num_validators": 1,
+  "threshold": 3,
+  "withdrawal_address": "0x040c94af7e82Be87295880f83ea44f96A7a4ce3C",
+  "dkg_algorithm": "default",
+  "fork_version": "0x00001020",
+  "config_hash": "0x44c189a433cc7325c10eff28d40cd95dcf0bbfb49dc0f0c47fc62893e92e7c3f",
+  "definition_hash": "0x38b028fb56a6f49ef7a6bcff7a7df39f7a7b3ef94cbf1c6b8f4f8aeb69142522"
+ },
+ "distributed_validators": [
+  {
+   "distributed_public_key": "0x970a41e8c62816529da9622ae98a9dea3be44fc13779a78ae82f1a3d52194f4fecc1fb11c2ed70dca286a3868700cba5",
+   "public_shares": [
+    "0xb6cfaa15fdd88aeb4a46c6260b74b380f783c5a6df103f39c6e8ec4fbda4aae6a0f63f10874e8e877ca1a6de6c3423ce",
+    "0xb9673ea6efb7a7fe7749148f2ded9c70b61aa74f200ff34bb4f6ce462229180e2ac1d174b8a7c47662cda32fea443b86",
+    "0xaf4a11e072748b5ecef004440c5f224a114cec72cfb4c41f10d1b25c9635206dc7aa177227d6a1f58b1726dacb022740",
+    "0xb8474c3fb80d77f60de976bc3f743b8f7941eda5e5d12d473e48ed048ca0e1c6c824c22dde68d439e081edd7676457df"
+   ]
+  }
+ ],
+ "signature_aggregate": "0x8a97e1c49e83b63baba99994d6832a80e2ffc8159827573671f6f73559b56bb2ba03eb21bf8cb97b9e7fc37c1c990b2c138ac99805469996b620b6cb19f0000c74b2510f864ed7cf0074915319cf8cede6f672f355009a7e4882b68f7615667f",
+ "lock_hash": "0x59d5440d155cdb5bce74c0ae208cde2839363c6450cb829a1986a461a30d0a35"
+}

--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -37,8 +37,12 @@ import (
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
-// The length of secp256k1 signatures.
-const k1SigLen = 65
+const (
+	// k1SigLen is the length of secp256k1 signatures.
+	k1SigLen = 65
+	// k1RecIdx is the secp256k1 signature recovery id index.
+	k1RecIdx = 64
+)
 
 // uuid returns a random uuid.
 func uuid(random io.Reader) string {
@@ -50,25 +54,18 @@ func uuid(random io.Reader) string {
 
 // verifySig returns true if the signature matches the digest and address.
 func verifySig(expectedAddr string, digest []byte, sig []byte) (bool, error) {
-<<<<<<< HEAD
 	if len(sig) != k1SigLen {
 		return false, errors.New("invalid signature length", z.Int("siglen", len(sig)))
 	}
 
-
 	// https://github.com/ethereum/go-ethereum/issues/19751#issuecomment-504900739
 	// TL;DR: Metamask signatures end with 0x1b (27) or 0x1c (28) while go-ethereum/crypto signatures end with 0x0(0) or 0x1(1) and both are correct.
-	if sig[64] != 0 && sig[64] != 1 && sig[64] != 27 && sig[64] != 28 {
-		return false, errors.New("invalid recovery id", z.Any("id", sig[64]))
+	if sig[k1RecIdx] != 0 && sig[k1RecIdx] != 1 && sig[k1RecIdx] != 27 && sig[k1RecIdx] != 28 {
+		return false, errors.New("invalid recovery id", z.Any("id", sig[k1RecIdx]))
 	}
 
-	if sig[64] == 27 || sig[64] == 28 {
-		sig[64] -= 27 // Make the last byte 0 or 1 since that is the canonical V value.
-=======
-	addrBytes, err := from0xHex(expectedAddr, addressLen)
-	if err != nil {
-		return false, err
->>>>>>> 743a008 (cleanup)
+	if sig[k1RecIdx] == 27 || sig[k1RecIdx] == 28 {
+		sig[k1RecIdx] -= 27 // Make the last byte 0 or 1 since that is the canonical V value.
 	}
 
 	pubkey, err := crypto.SigToPub(digest, sig)

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -30,7 +30,7 @@ import (
 //   - definition_hash: field ordering when calculating definition hash. Some fields are excluded indicated by `-`.
 type Operator struct {
 	// The 20 byte Ethereum address of the operator
-	Address EthAddr `json:"address,0xhex" ssz:"Bytes20" config_hash:"0" definition_hash:"0"`
+	Address string `json:"address,0xhex" ssz:"Bytes20" config_hash:"0" definition_hash:"0"`
 
 	// ENR identifies the charon node. Max 1024 chars.
 	ENR string `json:"enr" ssz:"ByteList[1024]" config_hash:"-" definition_hash:"1"`
@@ -59,19 +59,19 @@ func (o Operator) getName() (string, error) {
 
 // operatorJSONv1x1 is the json formatter of Operator for versions v1.0.0 and v1.1.0.
 type operatorJSONv1x1 struct {
-	Address         EthAddr `json:"address"`
-	ENR             string  `json:"enr"`
-	Nonce           int     `json:"nonce"` // Always 0
-	ConfigSignature []byte  `json:"config_signature"`
-	ENRSignature    []byte  `json:"enr_signature"`
+	Address         string `json:"address"`
+	ENR             string `json:"enr"`
+	Nonce           int    `json:"nonce"` // Always 0
+	ConfigSignature []byte `json:"config_signature"`
+	ENRSignature    []byte `json:"enr_signature"`
 }
 
 // operatorJSONv1x2 is the json formatter of Operator for versions v1.2.
 type operatorJSONv1x2 struct {
-	Address         EthAddr `json:"address"`
-	ENR             string  `json:"enr"`
-	ConfigSignature ethHex  `json:"config_signature"`
-	ENRSignature    ethHex  `json:"enr_signature"`
+	Address         string `json:"address"`
+	ENR             string `json:"enr"`
+	ConfigSignature ethHex `json:"config_signature"`
+	ENRSignature    ethHex `json:"enr_signature"`
 }
 
 func operatorsFromV1x1(operators []operatorJSONv1x1) ([]Operator, error) {

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -29,8 +29,8 @@ import (
 //   - config_hash: field ordering when calculating config hash. Some fields are excluded indicated by `-`.
 //   - definition_hash: field ordering when calculating definition hash. Some fields are excluded indicated by `-`.
 type Operator struct {
-	// The Ethereum address of the operator
-	Address []byte `json:"address,0xhex" ssz:"Bytes20" config_hash:"0" definition_hash:"0"`
+	// The 20 byte Ethereum address of the operator
+	Address EthAddr `json:"address,0xhex" ssz:"Bytes20" config_hash:"0" definition_hash:"0"`
 
 	// ENR identifies the charon node. Max 1024 chars.
 	ENR string `json:"enr" ssz:"ByteList[1024]" config_hash:"-" definition_hash:"1"`
@@ -59,19 +59,19 @@ func (o Operator) getName() (string, error) {
 
 // operatorJSONv1x1 is the json formatter of Operator for versions v1.0.0 and v1.1.0.
 type operatorJSONv1x1 struct {
-	Address         string `json:"address"`
-	ENR             string `json:"enr"`
-	Nonce           int    `json:"nonce"` // Always 0
-	ConfigSignature []byte `json:"config_signature"`
-	ENRSignature    []byte `json:"enr_signature"`
+	Address         EthAddr `json:"address"`
+	ENR             string  `json:"enr"`
+	Nonce           int     `json:"nonce"` // Always 0
+	ConfigSignature []byte  `json:"config_signature"`
+	ENRSignature    []byte  `json:"enr_signature"`
 }
 
 // operatorJSONv1x2 is the json formatter of Operator for versions v1.2.
 type operatorJSONv1x2 struct {
-	Address         ethHex `json:"address"`
-	ENR             string `json:"enr"`
-	ConfigSignature ethHex `json:"config_signature"`
-	ENRSignature    ethHex `json:"enr_signature"`
+	Address         EthAddr `json:"address"`
+	ENR             string  `json:"enr"`
+	ConfigSignature ethHex  `json:"config_signature"`
+	ENRSignature    ethHex  `json:"enr_signature"`
 }
 
 func operatorsFromV1x1(operators []operatorJSONv1x1) ([]Operator, error) {
@@ -80,13 +80,9 @@ func operatorsFromV1x1(operators []operatorJSONv1x1) ([]Operator, error) {
 		if o.Nonce != 0 {
 			return nil, errors.New("non-zero operator nonce not supported")
 		}
-		addr, err := from0xHex(o.Address, addrLen)
-		if err != nil {
-			return nil, errors.Wrap(err, "decode address", z.Str("address", o.Address))
-		}
 
 		resp = append(resp, Operator{
-			Address:         addr,
+			Address:         o.Address,
 			ENR:             o.ENR,
 			ConfigSignature: o.ConfigSignature,
 			ENRSignature:    o.ENRSignature,
@@ -100,7 +96,7 @@ func operatorsToV1x1(operators []Operator) []operatorJSONv1x1 {
 	var resp []operatorJSONv1x1
 	for _, o := range operators {
 		resp = append(resp, operatorJSONv1x1{
-			Address:         to0xHex(o.Address),
+			Address:         o.Address,
 			ENR:             o.ENR,
 			Nonce:           zeroNonce,
 			ConfigSignature: o.ConfigSignature,

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -144,12 +144,12 @@ func hashDefinitionLegacy(d Definition, hh ssz.HashWalker, configOnly bool) erro
 
 // hashDefinitionV1x3 hashes the latest definition.
 func hashDefinitionV1x3(d Definition, hh ssz.HashWalker, configOnly bool) error {
-	feeRecipientAddress, err := d.FeeRecipientAddress.Bytes()
+	feeRecipientAddress, err := from0xHex(d.FeeRecipientAddress, addressLen)
 	if err != nil {
 		return err
 	}
 
-	withdrawalAddress, err := d.WithdrawalAddress.Bytes()
+	withdrawalAddress, err := from0xHex(d.WithdrawalAddress, addressLen)
 	if err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func hashDefinitionV1x3(d Definition, hh ssz.HashWalker, configOnly bool) error 
 			indx := hh.Index()
 
 			// Field (0) 'Address' Bytes20
-			addrBytes, err := o.Address.Bytes()
+			addrBytes, err := from0xHex(o.Address, addressLen)
 			if err != nil {
 				return err
 			}

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -79,10 +79,10 @@ func hashDefinitionLegacy(d Definition, hh ssz.HashWalker, configOnly bool) erro
 	hh.PutUint64(uint64(d.Threshold))
 
 	// Field (5) 'feeRecipientAddress'
-	hh.PutBytes([]byte(to0xHex(d.FeeRecipientAddress)))
+	hh.PutBytes([]byte(d.FeeRecipientAddress))
 
 	// Field (6) 'withdrawalAddress'
-	hh.PutBytes([]byte(to0xHex(d.WithdrawalAddress)))
+	hh.PutBytes([]byte(d.WithdrawalAddress))
 
 	// Field (7) 'dkgAlgorithm'
 	hh.PutBytes([]byte(d.DKGAlgorithm))
@@ -96,29 +96,31 @@ func hashDefinitionLegacy(d Definition, hh ssz.HashWalker, configOnly bool) erro
 		num := uint64(len(d.Operators))
 		for _, o := range d.Operators {
 			if configOnly {
-				hh.PutBytes([]byte(to0xHex(o.Address)))
-			} else {
-				subIdx := hh.Index()
+				hh.PutBytes([]byte(o.Address))
 
-				// Field (0) 'Address'
-				hh.PutBytes([]byte(to0xHex(o.Address)))
-
-				// Field (1) 'ENR'
-				hh.PutBytes([]byte(o.ENR))
-
-				if isJSONv1x0(d.Version) || isJSONv1x1(d.Version) {
-					// Field (2) 'Nonce'
-					hh.PutUint64(zeroNonce) // Older versions had a zero nonce
-				}
-
-				// Field (2 or 3) 'ConfigSignature'
-				hh.PutBytes(o.ConfigSignature)
-
-				// Field (3 or 4) 'ENRSignature'
-				hh.PutBytes(o.ENRSignature)
-
-				hh.Merkleize(subIdx)
+				continue
 			}
+
+			subIdx := hh.Index()
+
+			// Field (0) 'Address'
+			hh.PutBytes([]byte(o.Address))
+
+			// Field (1) 'ENR'
+			hh.PutBytes([]byte(o.ENR))
+
+			if isJSONv1x0(d.Version) || isJSONv1x1(d.Version) {
+				// Field (2) 'Nonce'
+				hh.PutUint64(zeroNonce) // Older versions had a zero nonce
+			}
+
+			// Field (2 or 3) 'ConfigSignature'
+			hh.PutBytes(o.ConfigSignature)
+
+			// Field (3 or 4) 'ENRSignature'
+			hh.PutBytes(o.ENRSignature)
+
+			hh.Merkleize(subIdx)
 		}
 		hh.MerkleizeWithMixin(subIndx, num, num)
 	}
@@ -142,6 +144,16 @@ func hashDefinitionLegacy(d Definition, hh ssz.HashWalker, configOnly bool) erro
 
 // hashDefinitionV1x3 hashes the latest definition.
 func hashDefinitionV1x3(d Definition, hh ssz.HashWalker, configOnly bool) error {
+	feeRecipientAddress, err := d.FeeRecipientAddress.Bytes()
+	if err != nil {
+		return err
+	}
+
+	withdrawalAddress, err := d.WithdrawalAddress.Bytes()
+	if err != nil {
+		return err
+	}
+
 	indx := hh.Index()
 
 	// Field (0) 'UUID' ByteList[64]
@@ -171,10 +183,10 @@ func hashDefinitionV1x3(d Definition, hh ssz.HashWalker, configOnly bool) error 
 	hh.PutUint64(uint64(d.Threshold))
 
 	// Field (6) 'FeeRecipientAddress' Bytes20
-	hh.PutBytes(d.FeeRecipientAddress)
+	hh.PutBytes(feeRecipientAddress)
 
 	// Field (7) 'WithdrawalAddress' Bytes20
-	hh.PutBytes(d.WithdrawalAddress)
+	hh.PutBytes(withdrawalAddress)
 
 	// Field (8) 'DKGAlgorithm' ByteList[32]
 	if err := putByteList(hh, []byte(d.DKGAlgorithm), sszMaxDKGAlgorithm, "dkg_algorithm"); err != nil {
@@ -192,7 +204,11 @@ func hashDefinitionV1x3(d Definition, hh ssz.HashWalker, configOnly bool) error 
 			indx := hh.Index()
 
 			// Field (0) 'Address' Bytes20
-			hh.PutBytes(o.Address)
+			addrBytes, err := o.Address.Bytes()
+			if err != nil {
+				return err
+			}
+			hh.PutBytes(addrBytes)
 
 			if !configOnly {
 				// Field (1) 'ENR' ByteList[1024]

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -103,7 +103,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 
 		addr := crypto.PubkeyToAddress(p2pKey.PublicKey)
 		op := Operator{
-			Address: EthAddr(addr.Hex()),
+			Address: addr.Hex(),
 			ENR:     enrStr,
 		}
 

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -103,7 +103,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 
 		addr := crypto.PubkeyToAddress(p2pKey.PublicKey)
 		op := Operator{
-			Address: addr[:],
+			Address: EthAddr(addr.Hex()),
 			ENR:     enrStr,
 		}
 

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -46,7 +46,7 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 	resp := TekuProposerConfigResponse{
 		Proposers: make(map[string]TekuProposerConfig),
 		Default: TekuProposerConfig{ // Default doesn't make sense, disable for now.
-			FeeRecipient: fmt.Sprintf("%#x", c.feeRecipientAddress),
+			FeeRecipient: c.feeRecipientAddress,
 			Builder: TekuBuilder{
 				Enabled:  false,
 				GasLimit: gasLimit,
@@ -61,7 +61,7 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 
 	for pubkey, pubshare := range c.sharesByKey {
 		resp.Proposers[string(pubshare)] = TekuProposerConfig{
-			FeeRecipient: fmt.Sprintf("%#x", c.feeRecipientAddress),
+			FeeRecipient: c.feeRecipientAddress,
 			Builder: TekuBuilder{
 				Enabled:  true,
 				GasLimit: gasLimit,

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -55,7 +55,7 @@ func NewComponentInsecure(_ *testing.T, eth2Cl eth2wrap.Client, shareIdx int) (*
 
 // NewComponent returns a new instance of the validator API core workflow component.
 func NewComponent(eth2Cl eth2wrap.Client, pubShareByKey map[*bls_sig.PublicKey]*bls_sig.PublicKey,
-	shareIdx int, feeRecipientAddress []byte,
+	shareIdx int, feeRecipientAddress string,
 ) (*Component, error) {
 	// Create pubkey mappings.
 	var (
@@ -127,7 +127,7 @@ type Component struct {
 	eth2Cl              eth2wrap.Client
 	shareIdx            int
 	insecureTest        bool
-	feeRecipientAddress []byte
+	feeRecipientAddress string
 
 	// getVerifyShareFunc maps public shares (what the VC thinks as its public key)
 	// to public keys (the DV root public key)

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -18,10 +18,8 @@ package validatorapi_test
 import (
 	"context"
 	"crypto/rand"
-	"encoding/hex"
 	"fmt"
 	mrand "math/rand"
-	"strings"
 	"sync"
 	"testing"
 
@@ -192,7 +190,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error) {
@@ -292,7 +290,7 @@ func TestSignAndVerify(t *testing.T) {
 	// Setup validatorapi component.
 	vapi, err := validatorapi.NewComponent(bmock, map[*bls_sig.PublicKey]*bls_sig.PublicKey{
 		pubkey: pubkey,
-	}, 0, nil)
+	}, 0, "")
 	require.NoError(t, err)
 	vapi.RegisterPubKeyByAttestation(func(context.Context, int64, int64, int64) (core.PubKey, error) {
 		return tblsconv.KeyToCore(pubkey)
@@ -414,7 +412,7 @@ func TestComponent_SubmitBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -492,7 +490,7 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -550,7 +548,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -708,7 +706,7 @@ func TestComponent_SubmitBlindedBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -782,7 +780,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -842,7 +840,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -912,7 +910,7 @@ func TestComponent_SubmitVoluntaryExit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Prepare unsigned voluntary exit
@@ -974,7 +972,7 @@ func TestComponent_SubmitVoluntaryExitInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	// Register subscriber
@@ -1024,7 +1022,7 @@ func TestComponent_ProposerDuties(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	duties, err := vapi.ProposerDuties(ctx, eth2p0.Epoch(0), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
@@ -1052,7 +1050,7 @@ func TestComponent_SubmitValidatorRegistration(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	unsigned := testutil.RandomValidatorRegistration(t)
@@ -1113,7 +1111,7 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, nil)
+	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, "")
 	require.NoError(t, err)
 
 	unsigned := testutil.RandomValidatorRegistration(t)
@@ -1157,9 +1155,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	feeRecipientHex := "0x123456"
-	feeRecipient, err := hex.DecodeString(strings.TrimPrefix(feeRecipientHex, "0x"))
-	require.NoError(t, err)
+	feeRecipient := "0x123456"
 
 	// Construct the validator api component
 	vapi, err := validatorapi.NewComponent(bmock, pubShareByKey, 0, feeRecipient)
@@ -1177,7 +1173,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 	require.Equal(t, validatorapi.TekuProposerConfigResponse{
 		Proposers: map[string]validatorapi.TekuProposerConfig{
 			string(pk): {
-				FeeRecipient: feeRecipientHex,
+				FeeRecipient: feeRecipient,
 				Builder: validatorapi.TekuBuilder{
 					Enabled:  true,
 					GasLimit: 30000000,
@@ -1189,7 +1185,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 			},
 		},
 		Default: validatorapi.TekuProposerConfig{
-			FeeRecipient: feeRecipientHex,
+			FeeRecipient: feeRecipient,
 			Builder: validatorapi.TekuBuilder{
 				Enabled:  false,
 				GasLimit: 30000000,

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -165,7 +165,7 @@ func writeLock(datadir string, lock cluster.Lock) error {
 }
 
 // writeDepositData writes deposit data file to disk.
-func writeDepositData(aggSigs map[core.PubKey]*bls_sig.Signature, withdrawalAddr []byte, network string, dataDir string) error {
+func writeDepositData(aggSigs map[core.PubKey]*bls_sig.Signature, withdrawalAddr string, network string, dataDir string) error {
 	// Create deposit message signatures
 	aggSigsEth2 := make(map[eth2p0.BLSPubKey]eth2p0.BLSSignature)
 	for pk, sig := range aggSigs {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -180,7 +180,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
 	// Sign, exchange and aggregate Deposit Data signatures
-	aggSigDepositData, err := signAndAggDepositData(ctx, ex, shares, string(def.WithdrawalAddress), network, nodeIdx)
+	aggSigDepositData, err := signAndAggDepositData(ctx, ex, shares, def.WithdrawalAddress, network, nodeIdx)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Saved lock file to disk")
 
-	if err := writeDepositData(aggSigDepositData, string(def.WithdrawalAddress), network, conf.DataDir); err != nil {
+	if err := writeDepositData(aggSigDepositData, def.WithdrawalAddress, network, conf.DataDir); err != nil {
 		return err
 	}
 	log.Debug(ctx, "Saved deposit data file to disk")

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -180,7 +180,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
 	// Sign, exchange and aggregate Deposit Data signatures
-	aggSigDepositData, err := signAndAggDepositData(ctx, ex, shares, def.WithdrawalAddress, network, nodeIdx)
+	aggSigDepositData, err := signAndAggDepositData(ctx, ex, shares, string(def.WithdrawalAddress), network, nodeIdx)
 	if err != nil {
 		return err
 	}
@@ -203,7 +203,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Saved lock file to disk")
 
-	if err := writeDepositData(aggSigDepositData, def.WithdrawalAddress, network, conf.DataDir); err != nil {
+	if err := writeDepositData(aggSigDepositData, string(def.WithdrawalAddress), network, conf.DataDir); err != nil {
 		return err
 	}
 	log.Debug(ctx, "Saved deposit data file to disk")
@@ -378,7 +378,7 @@ func signAndAggLockHash(ctx context.Context, shares []share, def cluster.Definit
 }
 
 // signAndAggDepositData returns aggregated signatures per DV after signing, exchange and aggregation of partial signatures.
-func signAndAggDepositData(ctx context.Context, ex *exchanger, shares []share, withdrawalAddr []byte, network string, nodeIdx cluster.NodeIdx) (map[core.PubKey]*bls_sig.Signature, error) {
+func signAndAggDepositData(ctx context.Context, ex *exchanger, shares []share, withdrawalAddr string, network string, nodeIdx cluster.NodeIdx) (map[core.PubKey]*bls_sig.Signature, error) {
 	parSig, msgs, err := signDepositData(shares, nodeIdx.ShareIdx, withdrawalAddr, network)
 	if err != nil {
 		return nil, err
@@ -490,7 +490,7 @@ func signLockHash(shareIdx int, shares []share, hash []byte) (core.ParSignedData
 }
 
 // signDepositData returns a partially signed dataset containing signatures of the deposit data signing root.
-func signDepositData(shares []share, shareIdx int, withdrawalAddr []byte, network string) (core.ParSignedDataSet, map[core.PubKey][]byte, error) {
+func signDepositData(shares []share, shareIdx int, withdrawalAddr string, network string) (core.ParSignedDataSet, map[core.PubKey][]byte, error) {
 	withdrawalHex := checksumAddr(withdrawalAddr)
 
 	msgs := make(map[core.PubKey][]byte)
@@ -587,8 +587,8 @@ func aggDepositDataSigs(data map[core.PubKey][]core.ParSignedData, shares []shar
 	return resp, nil
 }
 
-func checksumAddr(a []byte) string {
-	return common.BytesToAddress(a).Hex()
+func checksumAddr(addr string) string {
+	return common.HexToAddress(addr).Hex()
 }
 
 // dvsFromShares returns the shares as a slice of cluster distributed validator types.


### PR DESCRIPTION
Fixes issue of "invalid lock hash" when older versions of cluster locks contains checksummed addresses.

category: bug
ticket: #1153 
