### PR TITLE
app: verify p2pkey before starting libp2p

### DIFF
--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -16,11 +16,15 @@
 package app
 
 import (
+	"crypto/ecdsa"
 	"encoding/json"
+	"math/rand"
 	"os"
 	"path"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/cluster"
@@ -47,4 +51,16 @@ func TestLoadLock(t *testing.T) {
 	b2, err := json.Marshal(actual)
 	require.NoError(t, err)
 	require.JSONEq(t, string(b), string(b2))
+}
+
+func TestVerifyP2PKey(t *testing.T) {
+	lock, keys, _ := cluster.NewForT(t, 1, 3, 4, 0)
+
+	for _, key := range keys {
+		require.NoError(t, verifyP2PKey(lock, key))
+	}
+
+	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(time.Now().Unix())))
+	require.NoError(t, err)
+	require.Error(t, verifyP2PKey(lock, key))
 }


### PR DESCRIPTION
Fail fast when p2pkey doesn't match any lock file operator ENRs.

category: feature
ticket: #937 

