### PR TITLE
app: add metric for num_validators

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -197,7 +197,14 @@ func Run(ctx context.Context, conf Config) (err error) {
 			"cluster_peer_name": p2p.PeerName(tcpNode.ID()),
 		}, prometheus.DefaultRegisterer)
 	}
-	initStartupMetrics(lockHashHex, p2p.PeerName(tcpNode.ID()), lock.Threshold, len(lock.Operators))
+
+	initStartupMetrics(
+		lockHashHex,
+		p2p.PeerName(tcpNode.ID()),
+		lock.Threshold,
+		len(lock.Operators),
+		len(lock.Validators),
+	)
 
 	eth2Cl, err := newETH2Client(ctx, conf, life, lock.Validators)
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -197,7 +197,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 			"cluster_peer_name": p2p.PeerName(tcpNode.ID()),
 		}, prometheus.DefaultRegisterer)
 	}
-	initStartupMetrics(lockHashHex, p2p.PeerName(tcpNode.ID()), lock.Threshold, len(lock.Operators), lock.NumValidators)
+	initStartupMetrics(lockHashHex, p2p.PeerName(tcpNode.ID()), lock.Threshold, len(lock.Operators))
 
 	eth2Cl, err := newETH2Client(ctx, conf, life, lock.Validators)
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -197,7 +197,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 			"cluster_peer_name": p2p.PeerName(tcpNode.ID()),
 		}, prometheus.DefaultRegisterer)
 	}
-	initStartupMetrics(lockHashHex, p2p.PeerName(tcpNode.ID()), lock.Threshold, len(lock.Operators))
+	initStartupMetrics(lockHashHex, p2p.PeerName(tcpNode.ID()), lock.Threshold, len(lock.Operators), lock.NumValidators)
 
 	eth2Cl, err := newETH2Client(ctx, conf, life, lock.Validators)
 	if err != nil {

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -62,19 +62,19 @@ var (
 
 	thresholdGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",
-		Name:      "threshold_number",
+		Name:      "threshold",
 		Help:      "Aggregation threshold in the cluster lock",
 	})
 
 	operatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",
-		Name:      "operators_number",
+		Name:      "operators",
 		Help:      "Number of operators in the cluster lock",
 	})
 
 	validatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",
-		Name:      "validators_number",
+		Name:      "validators",
 		Help:      "Number of validators in the cluster lock",
 	})
 )

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -29,18 +29,6 @@ var (
 		Help:      "Constant gauge with label set to current app version",
 	}, []string{"version"})
 
-	thresholdGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "app",
-		Name:      "threshold",
-		Help:      "Threshold for the cluster",
-	})
-
-	numOperatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "app",
-		Name:      "num_operators",
-		Help:      "Number of operators in the cluster",
-	})
-
 	peerNameGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "app",
 		Name:      "peer_name",
@@ -52,12 +40,6 @@ var (
 		Name:      "git_commit",
 		Help:      "Constant gauge with label set to current git commit hash",
 	}, []string{"git_hash"})
-
-	lockHashGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "app",
-		Name:      "lock_hash",
-		Help:      "Constant gauge with label set to current cluster lock hash",
-	}, []string{"lock_hash"})
 
 	startGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "app",
@@ -71,9 +53,33 @@ var (
 		Name:      "readyz",
 		Help:      "Set to 1 if monitoring api `/readyz` endpoint returned 200 or else 0",
 	})
+
+	lockHashGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "cluster",
+		Name:      "lock_hash",
+		Help:      "Constant gauge with label set to current cluster lock hash",
+	}, []string{"lock_hash"})
+
+	thresholdGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "cluster",
+		Name:      "threshold_number",
+		Help:      "Aggregation threshold for the cluster",
+	})
+
+	operatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "cluster",
+		Name:      "operators_number",
+		Help:      "Number of operators in the cluster",
+	})
+
+	validatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "cluster",
+		Name:      "validators_number",
+		Help:      "Number of validators",
+	})
 )
 
-func initStartupMetrics(lockHash, peerName string, threshold, numOperators int) {
+func initStartupMetrics(lockHash, peerName string, threshold, numOperators, numValidators int) {
 	versionGauge.WithLabelValues(version.Version).Set(1)
 	startGauge.SetToCurrentTime()
 
@@ -81,6 +87,7 @@ func initStartupMetrics(lockHash, peerName string, threshold, numOperators int) 
 	gitGauge.WithLabelValues(hash).Set(1)
 	lockHashGauge.WithLabelValues(lockHash).Set(1)
 	thresholdGauge.Set(float64(threshold))
-	numOperatorsGauge.Set(float64(numOperators))
+	operatorsGauge.Set(float64(numOperators))
+	validatorsGauge.Set(float64(numValidators))
 	peerNameGauge.WithLabelValues(peerName).Set(1)
 }

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -43,6 +43,12 @@ var (
 		Help:      "Constant gauge with label set to the number of operators in the cluster",
 	}, []string{"num_operators"})
 
+	numValidatorsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Name:      "num_validators",
+		Help:      "Constant gauge with label set to the number of validators in the cluster",
+	}, []string{"num_validators"})
+
 	peerNameGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "app",
 		Name:      "peer_name",
@@ -75,7 +81,7 @@ var (
 	})
 )
 
-func initStartupMetrics(lockHash, peerName string, threshold, numOperators int) {
+func initStartupMetrics(lockHash, peerName string, threshold, numOperators int, numValidators int) {
 	versionGauge.WithLabelValues(version.Version).Set(1)
 	startGauge.SetToCurrentTime()
 
@@ -84,5 +90,6 @@ func initStartupMetrics(lockHash, peerName string, threshold, numOperators int) 
 	lockHashGauge.WithLabelValues(lockHash).Set(1)
 	thresholdGauge.WithLabelValues(fmt.Sprintf("%d", threshold)).Set(1)
 	numOperatorsGauge.WithLabelValues(fmt.Sprintf("%d", numOperators)).Set(1)
+	numValidatorsGauge.WithLabelValues(fmt.Sprintf("%d", numValidators)).Set(1)
 	peerNameGauge.WithLabelValues(peerName).Set(1)
 }

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -63,19 +63,19 @@ var (
 	thresholdGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",
 		Name:      "threshold_number",
-		Help:      "Aggregation threshold for the cluster",
+		Help:      "Aggregation threshold in the cluster lock",
 	})
 
 	operatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",
 		Name:      "operators_number",
-		Help:      "Number of operators in the cluster",
+		Help:      "Number of operators in the cluster lock",
 	})
 
 	validatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",
 		Name:      "validators_number",
-		Help:      "Number of validators",
+		Help:      "Number of validators in the cluster lock",
 	})
 )
 

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -16,8 +16,6 @@
 package app
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 
@@ -31,23 +29,17 @@ var (
 		Help:      "Constant gauge with label set to current app version",
 	}, []string{"version"})
 
-	thresholdGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	thresholdGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "app",
 		Name:      "threshold",
-		Help:      "Constant gauge with label set to cluster threshold",
-	}, []string{"threshold"})
+		Help:      "Threshold for the cluster",
+	})
 
-	numOperatorsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	numOperatorsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "app",
 		Name:      "num_operators",
-		Help:      "Constant gauge with label set to the number of operators in the cluster",
-	}, []string{"num_operators"})
-
-	numValidatorsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: "app",
-		Name:      "num_validators",
-		Help:      "Constant gauge with label set to the number of validators in the cluster",
-	}, []string{"num_validators"})
+		Help:      "Number of operators in the cluster",
+	})
 
 	peerNameGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "app",
@@ -81,15 +73,14 @@ var (
 	})
 )
 
-func initStartupMetrics(lockHash, peerName string, threshold, numOperators int, numValidators int) {
+func initStartupMetrics(lockHash, peerName string, threshold, numOperators int) {
 	versionGauge.WithLabelValues(version.Version).Set(1)
 	startGauge.SetToCurrentTime()
 
 	hash, _ := version.GitCommit()
 	gitGauge.WithLabelValues(hash).Set(1)
 	lockHashGauge.WithLabelValues(lockHash).Set(1)
-	thresholdGauge.WithLabelValues(fmt.Sprintf("%d", threshold)).Set(1)
-	numOperatorsGauge.WithLabelValues(fmt.Sprintf("%d", numOperators)).Set(1)
-	numValidatorsGauge.WithLabelValues(fmt.Sprintf("%d", numValidators)).Set(1)
+	thresholdGauge.Set(float64(threshold))
+	numOperatorsGauge.Set(float64(numOperators))
 	peerNameGauge.WithLabelValues(peerName).Set(1)
 }

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -52,13 +52,6 @@ var (
 		Help:      "Number of active validators",
 	})
 
-	totalValsGauge = promauto.NewGauge(prometheus.GaugeOpts{ //nolint:promlinter
-		Namespace: "core",
-		Subsystem: "scheduler",
-		Name:      "validators_total",
-		Help:      "Total number of validators (this is constant)",
-	})
-
 	balanceGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "core",
 		Subsystem: "scheduler",

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -45,11 +45,18 @@ var (
 		Help:      "The total count of duties scheduled by type",
 	}, []string{"duty"})
 
-	activeGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	activeValsGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "core",
 		Subsystem: "scheduler",
 		Name:      "validators_active",
 		Help:      "Number of active validators",
+	})
+
+	numValsGauge = promauto.NewGauge(prometheus.GaugeOpts{ //nolint:promlinter
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "validators_total",
+		Help:      "Total number of validators (this is constant)",
 	})
 
 	balanceGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -52,7 +52,7 @@ var (
 		Help:      "Number of active validators",
 	})
 
-	numValsGauge = promauto.NewGauge(prometheus.GaugeOpts{ //nolint:promlinter
+	totalValsGauge = promauto.NewGauge(prometheus.GaugeOpts{ //nolint:promlinter
 		Namespace: "core",
 		Subsystem: "scheduler",
 		Name:      "validators_total",

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -53,8 +53,6 @@ func NewForT(t *testing.T, clock clockwork.Clock, delayFunc delayFunc, pubkeys [
 
 // New returns a new scheduler.
 func New(pubkeys []core.PubKey, eth2Cl eth2wrap.Client, builderAPI bool) (*Scheduler, error) {
-	totalValsGauge.Set(float64(len(pubkeys)))
-
 	return &Scheduler{
 		eth2Cl:  eth2Cl,
 		pubkeys: pubkeys,

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -53,6 +53,8 @@ func NewForT(t *testing.T, clock clockwork.Clock, delayFunc delayFunc, pubkeys [
 
 // New returns a new scheduler.
 func New(pubkeys []core.PubKey, eth2Cl eth2wrap.Client, builderAPI bool) (*Scheduler, error) {
+	numValsGauge.Set(float64(len(pubkeys)))
+
 	return &Scheduler{
 		eth2Cl:  eth2Cl,
 		pubkeys: pubkeys,
@@ -246,7 +248,7 @@ func (s *Scheduler) resolveDuties(ctx context.Context, slot core.Slot) error {
 		return err
 	}
 
-	activeGauge.Set(float64(len(vals)))
+	activeValsGauge.Set(float64(len(vals)))
 
 	if len(vals) == 0 {
 		log.Info(ctx, "No active DVs for slot", z.I64("slot", slot.Slot))

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -53,7 +53,7 @@ func NewForT(t *testing.T, clock clockwork.Clock, delayFunc delayFunc, pubkeys [
 
 // New returns a new scheduler.
 func New(pubkeys []core.PubKey, eth2Cl eth2wrap.Client, builderAPI bool) (*Scheduler, error) {
-	numValsGauge.Set(float64(len(pubkeys)))
+	totalValsGauge.Set(float64(len(pubkeys)))
 
 	return &Scheduler{
 		eth2Cl:  eth2Cl,


### PR DESCRIPTION
Add metric for `num_validators`. This will be used in aggregate dashboard to show the total number of validators across all charon clusters.

category: feature
ticket: none 
