### PR TITLE
app/promauto: workaround to wrap promauto registerer

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,7 +53,11 @@ linters-settings:
 
       # Some configured revive rules
       - name: imports-blacklist
-        arguments: ["errors", "github.com/pkg/errors","github.com/golang/protobuf"] # Prefer ./app/errors
+        arguments:
+         - "errors" # Prefer ./app/errors
+         - "github.com/pkg/errors" # Prefer ./app/errors
+         - "github.com/golang/protobuf" # Prefer google.golang.org/protobuf
+         - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
     go: "1.19"
     checks:

--- a/app/app.go
+++ b/app/app.go
@@ -105,8 +105,6 @@ type TestConfig struct {
 	SimnetBMockOpts []beaconmock.Option
 	// BroadcastCallback is called when a duty is completed and sent to the broadcast component.
 	BroadcastCallback func(context.Context, core.Duty, core.PubKey, core.SignedData) error
-	// DisablePromWrap disables wrapping prometheus metrics with cluster identifiers.
-	DisablePromWrap bool
 	// BuilderRegistration provides a channel for tests to trigger builder registration by the validator mock,
 	BuilderRegistration <-chan *eth2api.VersionedValidatorRegistration
 }
@@ -190,15 +188,11 @@ func Run(ctx context.Context, conf Config) (err error) {
 		z.Str("enr", localEnode.Node().String()))
 
 	// Instrument prometheus metrics with cluster and node identifiers.
-	if conf.TestConfig.DisablePromWrap {
-		promauto.WrapAndRegister(nil)
-	} else {
-		promauto.WrapAndRegister(prometheus.Labels{
-			"cluster_hash":      lockHashHex,
-			"cluster_name":      lock.Name,
-			"cluster_peer_name": p2p.PeerName(tcpNode.ID()),
-		})
-	}
+	promauto.WrapAndRegister(prometheus.Labels{
+		"cluster_hash": lockHashHex,
+		"cluster_name": lock.Name,
+		"cluster_peer": p2p.PeerName(tcpNode.ID()),
+	})
 
 	initStartupMetrics(
 		lockHashHex,

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -179,9 +179,8 @@ func pingCluster(t *testing.T, test pingTest) {
 					Callback:   asserter.Callback(t, i),
 					MaxBackoff: time.Second,
 				},
-				Lock:            &lock,
-				P2PKey:          p2pKeys[i],
-				DisablePromWrap: true,
+				Lock:   &lock,
+				P2PKey: p2pKeys[i],
 				SimnetBMockOpts: []beaconmock.Option{
 					beaconmock.WithNoAttesterDuties(),
 					beaconmock.WithNoProposerDuties(),

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -22,10 +22,10 @@ import (
 
 	eth2http "github.com/attestantio/go-eth2-client/http"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/forkjoin"
+	"github.com/obolnetwork/charon/app/promauto"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 

--- a/app/log/metrics.go
+++ b/app/log/metrics.go
@@ -19,7 +19,8 @@ import (
 	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/app/promauto"
 )
 
 var (

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -17,8 +17,8 @@ package app
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/obolnetwork/charon/app/promauto"
 	"github.com/obolnetwork/charon/app/version"
 )
 

--- a/app/promauto/promauto.go
+++ b/app/promauto/promauto.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto" //nolint:revive // Only this package may import the original promauto.
 )
 
 // defaultRegisterer wraps the original prometheus.defaultRegisterer.
@@ -80,25 +79,43 @@ func (*wrappingRegisterer) Unregister(prometheus.Collector) bool {
 }
 
 func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
-	return promauto.With(defaultRegisterer).NewGaugeVec(opts, labelNames)
+	c := prometheus.NewGaugeVec(opts, labelNames)
+	defaultRegisterer.MustRegister(c)
+
+	return c
 }
 
 func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
-	return promauto.With(defaultRegisterer).NewGauge(opts)
+	c := prometheus.NewGauge(opts)
+	defaultRegisterer.MustRegister(c)
+
+	return c
 }
 
 func NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
-	return promauto.With(defaultRegisterer).NewHistogramVec(opts, labelNames)
+	c := prometheus.NewHistogramVec(opts, labelNames)
+	defaultRegisterer.MustRegister(c)
+
+	return c
 }
 
 func NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
-	return promauto.With(defaultRegisterer).NewHistogram(opts)
+	c := prometheus.NewHistogram(opts)
+	defaultRegisterer.MustRegister(c)
+
+	return c
 }
 
 func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
-	return promauto.With(defaultRegisterer).NewCounterVec(opts, labelNames)
+	c := prometheus.NewCounterVec(opts, labelNames)
+	defaultRegisterer.MustRegister(c)
+
+	return c
 }
 
 func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
-	return promauto.With(defaultRegisterer).NewCounter(opts)
+	c := prometheus.NewCounter(opts)
+	defaultRegisterer.MustRegister(c)
+
+	return c
 }

--- a/app/promauto/promauto.go
+++ b/app/promauto/promauto.go
@@ -33,11 +33,10 @@ func WrapAndRegister(labels prometheus.Labels) {
 }
 
 type wrappingRegisterer struct {
-	target  prometheus.Registerer
-	wrapped bool
 	mu      sync.Mutex
-
+	target  prometheus.Registerer
 	pending []prometheus.Collector
+	wrapped bool
 }
 
 // WrapAndRegister wraps the default register with the provided labels and registers all pending collectors.
@@ -58,6 +57,7 @@ func (r *wrappingRegisterer) WrapAndRegister(labels prometheus.Labels) {
 	r.wrapped = true
 }
 
+// MustRegister implements prometheus.Registerer.
 func (r *wrappingRegisterer) MustRegister(collector ...prometheus.Collector) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -69,10 +69,12 @@ func (r *wrappingRegisterer) MustRegister(collector ...prometheus.Collector) {
 	r.pending = append(r.pending, collector...)
 }
 
+// Register implements prometheus.Registerer.
 func (*wrappingRegisterer) Register(prometheus.Collector) error {
 	panic("wrappingRegisterer.Register not supported")
 }
 
+// Unregister implements prometheus.Registerer.
 func (*wrappingRegisterer) Unregister(prometheus.Collector) bool {
 	panic("wrappingRegisterer.Unregister not supported")
 }

--- a/app/promauto/promauto.go
+++ b/app/promauto/promauto.go
@@ -1,0 +1,102 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package promauto aliases github.com/prometheus/client_golang/prometheus/promauto in order
+// to wrap the prometheus.DefaultRegister with runtime labels.
+package promauto
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto" //nolint:revive // Only this package may import the original promauto.
+)
+
+// defaultRegisterer wraps the original prometheus.defaultRegisterer.
+var defaultRegisterer = &wrappingRegisterer{target: prometheus.DefaultRegisterer}
+
+// WrapAndRegister wraps the default register with the provided labels and registers all pending collectors.
+func WrapAndRegister(labels prometheus.Labels) {
+	defaultRegisterer.WrapAndRegister(labels)
+}
+
+type wrappingRegisterer struct {
+	target  prometheus.Registerer
+	wrapped bool
+	mu      sync.Mutex
+
+	pending []prometheus.Collector
+}
+
+// WrapAndRegister wraps the default register with the provided labels and registers all pending collectors.
+func (r *wrappingRegisterer) WrapAndRegister(labels prometheus.Labels) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Only register once. This is required for testing.
+	if r.wrapped {
+		return
+	}
+
+	if len(labels) > 0 {
+		r.target = prometheus.WrapRegistererWith(labels, r.target)
+	}
+
+	r.target.MustRegister(r.pending...)
+	r.wrapped = true
+}
+
+func (r *wrappingRegisterer) MustRegister(collector ...prometheus.Collector) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.wrapped {
+		panic("wrappingRegisterer already wrapped")
+	}
+
+	r.pending = append(r.pending, collector...)
+}
+
+func (*wrappingRegisterer) Register(prometheus.Collector) error {
+	panic("wrappingRegisterer.Register not supported")
+}
+
+func (*wrappingRegisterer) Unregister(prometheus.Collector) bool {
+	panic("wrappingRegisterer.Unregister not supported")
+}
+
+func NewGaugeVec(opts prometheus.GaugeOpts, labelNames []string) *prometheus.GaugeVec {
+	return promauto.With(defaultRegisterer).NewGaugeVec(opts, labelNames)
+}
+
+func NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+	return promauto.With(defaultRegisterer).NewGauge(opts)
+}
+
+func NewHistogramVec(opts prometheus.HistogramOpts, labelNames []string) *prometheus.HistogramVec {
+	return promauto.With(defaultRegisterer).NewHistogramVec(opts, labelNames)
+}
+
+func NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+	return promauto.With(defaultRegisterer).NewHistogram(opts)
+}
+
+func NewCounterVec(opts prometheus.CounterOpts, labelNames []string) *prometheus.CounterVec {
+	return promauto.With(defaultRegisterer).NewCounterVec(opts, labelNames)
+}
+
+func NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+	return promauto.With(defaultRegisterer).NewCounter(opts)
+}

--- a/app/promauto/promauto_test.go
+++ b/app/promauto/promauto_test.go
@@ -1,0 +1,58 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package promauto_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/promauto"
+)
+
+func TestWrapRegisterer(t *testing.T) {
+	simpleGge := promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "sample_gge",
+		Help: "helpSampleGge",
+	}, []string{"prom"})
+	simpleGge.WithLabelValues("obol-prom").Set(1)
+
+	promauto.WrapAndRegister(prometheus.Labels{
+		"cluster_hash":      "lockHash",
+		"cluster_name":      "test-cluster",
+		"cluster_peer_name": "charon",
+	})
+
+	expected := map[string]string{
+		"cluster_hash":      "lockHash",
+		"cluster_name":      "test-cluster",
+		"cluster_peer_name": "charon",
+		"prom":              "obol-prom",
+	}
+
+	got, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	actual := make(map[string]string)
+	labels := got[len(got)-1].Metric[0].Label
+	for _, l := range labels {
+		actual[*l.Name] = *l.Value
+	}
+
+	require.True(t, reflect.DeepEqual(expected, actual))
+}

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -274,7 +274,6 @@ func testSimnet(t *testing.T, args simnetArgs, expect simnetExpect) {
 			TestConfig: app.TestConfig{
 				Lock:               &args.Lock,
 				P2PKey:             args.P2PKeys[i],
-				DisablePromWrap:    true,
 				TestPingConfig:     p2p.TestPingConfig{Disable: true},
 				SimnetKeys:         []*bls_sig.SecretKey{args.SimnetKeys[i]},
 				ParSigExFunc:       parSigExFunc,

--- a/core/bcast/metrics.go
+++ b/core/bcast/metrics.go
@@ -19,8 +19,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/obolnetwork/charon/app/promauto"
 	"github.com/obolnetwork/charon/core"
 )
 

--- a/core/parsigdb/metrics.go
+++ b/core/parsigdb/metrics.go
@@ -17,7 +17,8 @@ package parsigdb
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/app/promauto"
 )
 
 var exitCounter = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -18,8 +18,8 @@ package scheduler
 import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
+	"github.com/obolnetwork/charon/app/promauto"
 	"github.com/obolnetwork/charon/core"
 )
 

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -17,7 +17,8 @@ package tracker
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/app/promauto"
 )
 
 var (

--- a/core/validatorapi/metrics.go
+++ b/core/validatorapi/metrics.go
@@ -20,7 +20,8 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/app/promauto"
 )
 
 var (

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -20,7 +20,8 @@ import (
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+
+	"github.com/obolnetwork/charon/app/promauto"
 )
 
 var (


### PR DESCRIPTION
Workaround the problem of wrapping the `prometheus.DefaultRegisterer` with runtime labels while `promauto` references it during package initialisation.

category: bug
ticket: #1142
