### PR TITLE
app: remove cluster_name from labels

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -190,7 +190,6 @@ func Run(ctx context.Context, conf Config) (err error) {
 	// Instrument prometheus metrics with cluster and node identifiers.
 	promauto.WrapAndRegister(prometheus.Labels{
 		"cluster_hash": lockHashHex,
-		"cluster_name": lock.Name,
 		"cluster_peer": p2p.PeerName(tcpNode.ID()),
 	})
 


### PR DESCRIPTION
Remove `cluster_name` from default labels as we already have a unique identifier for cluster (`cluster_hash`). Moreover, `cluster_name` values are not supposed to be unique as they are user picked.

category: misc
ticket: none 