### PR TITLE
tracker: improve participation logging

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
@@ -168,8 +169,10 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot int64, defSet co
 
 		// This validator isn't an aggregator for this slot.
 		if !res.IsAggregator {
+			log.Debug(ctx, "Not selected for attester aggregation duty", z.Any("pubkey", pubkey))
 			continue
 		}
+		log.Info(ctx, "Resolved attester aggregation duty", z.Any("pubkey", pubkey))
 
 		// Query DutyDB for Attestation data to get attestation data root.
 		attData, err := f.awaitAttDataFunc(ctx, slot, int64(res.CommitteeIndex))

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -406,8 +406,8 @@ func isParSigEventExpected(duty core.Duty, pubkey core.PubKey, allEvents map[cor
 // newParticipationReporter returns a new participation reporter function which logs and instruments peer participation
 // and unexpectedPeers.
 func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty, map[int]bool, map[int]bool) {
-	// prevAbsent is the set of peers who didn't participate in the last duty.
-	var prevAbsent []string
+	// prevAbsent is the set of peers who didn't participate in the last duty per type.
+	prevAbsent := make(map[core.DutyType][]string)
 
 	return func(ctx context.Context, duty core.Duty, participatedShares map[int]bool, unexpectedShares map[int]bool) {
 		var absentPeers []string
@@ -424,7 +424,7 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 			}
 		}
 
-		if fmt.Sprint(prevAbsent) != fmt.Sprint(absentPeers) {
+		if fmt.Sprint(prevAbsent[duty.Type]) != fmt.Sprint(absentPeers) {
 			if len(absentPeers) == 0 {
 				log.Info(ctx, "All peers participated in duty")
 			} else if len(absentPeers) == len(peers) {
@@ -434,7 +434,7 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 			}
 		}
 
-		prevAbsent = absentPeers
+		prevAbsent[duty.Type] = absentPeers
 	}
 }
 


### PR DESCRIPTION
Improve tracker participation logging to only log changes to each duty type.

Also log when attester aggregation resolved.

category: misc
ticket: none

