### PR TITLE
dkg: verify private key before p2p setup

### DIFF
--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -17,15 +17,12 @@ package app
 
 import (
 	"context"
-	"crypto/ecdsa"
 	"encoding/json"
-	"math/rand"
 	"os"
 	"path"
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/cluster"
@@ -53,18 +50,6 @@ func TestLoadLock(t *testing.T) {
 	b2, err := json.Marshal(actual)
 	require.NoError(t, err)
 	require.JSONEq(t, string(b), string(b2))
-}
-
-func TestVerifyP2PKey(t *testing.T) {
-	lock, keys, _ := cluster.NewForT(t, 1, 3, 4, 0)
-
-	for _, key := range keys {
-		require.NoError(t, verifyP2PKey(lock, key))
-	}
-
-	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(time.Now().Unix())))
-	require.NoError(t, err)
-	require.Error(t, verifyP2PKey(lock, key))
 }
 
 func TestCalculateTrackerDelay(t *testing.T) {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -215,6 +215,10 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 // setupP2P returns a started libp2p tcp node and a shutdown function.
 func setupP2P(ctx context.Context, key *ecdsa.PrivateKey, p2pConf p2p.Config, peers []p2p.Peer, lockHashHex string) (host.Host, func(), error) {
+	if err := p2p.VerifyP2PKey(peers, key); err != nil {
+		return nil, nil, err
+	}
+
 	localEnode, db, err := p2p.NewLocalEnode(p2pConf, key)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to open enode")

--- a/p2p/peer.go
+++ b/p2p/peer.go
@@ -161,5 +161,5 @@ func VerifyP2PKey(peers []Peer, key *ecdsa.PrivateKey) error {
 		}
 	}
 
-	return errors.New("private key not matching any operator ENR") // This message seems to know something about the context in which it is used :(
+	return errors.New("unknown private key provided, it doesn't match any public key encoded inside the operator ENRs") // This message seems to know something about the context in which it is used :(
 }

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -19,12 +19,14 @@ import (
 	"crypto/ecdsa"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/p2p"
 )
 
@@ -50,4 +52,19 @@ func TestNewHost(t *testing.T) {
 
 	_, err = p2p.NewTCPNode(p2p.Config{}, privKey, p2p.NewOpenGater(), nil, nil, nil)
 	require.NoError(t, err)
+}
+
+func TestVerifyP2PKey(t *testing.T) {
+	lock, keys, _ := cluster.NewForT(t, 1, 3, 4, 0)
+
+	peers, err := lock.Peers()
+	require.NoError(t, err)
+
+	for _, key := range keys {
+		require.NoError(t, p2p.VerifyP2PKey(peers, key))
+	}
+
+	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(time.Now().Unix())))
+	require.NoError(t, err)
+	require.Error(t, p2p.VerifyP2PKey(peers, key))
 }


### PR DESCRIPTION
This was only added to `charon run`, also doing this in dkg now.

category: feature
ticket: #937
