### PR TITLE
core/fetcher: support aggregate attestation not found

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -63,8 +63,8 @@ func Instrument(clients ...Client) (Client, error) {
 }
 
 // AdaptEth2HTTP returns a Client wrapping an eth2http service by adding experimental endpoints.
-func AdaptEth2HTTP(eth2Svc *eth2http.Service) Client {
-	return httpAdapter{Service: eth2Svc}
+func AdaptEth2HTTP(eth2Svc *eth2http.Service, timeout time.Duration) Client {
+	return httpAdapter{Service: eth2Svc, timeout: timeout}
 }
 
 // NewMultiHTTP returns a new instrumented multi eth2 http client.
@@ -84,7 +84,7 @@ func NewMultiHTTP(ctx context.Context, timeout time.Duration, addresses ...strin
 			return nil, errors.New("invalid eth2 http service")
 		}
 
-		clients = append(clients, AdaptEth2HTTP(eth2Http))
+		clients = append(clients, AdaptEth2HTTP(eth2Http, timeout))
 	}
 
 	return Instrument(clients...)

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -193,7 +193,7 @@ func (m multi) AggregateAttestation(ctx context.Context, slot phase0.Slot, attes
 		func(ctx context.Context, cl Client) (*phase0.Attestation, error) {
 			return cl.AggregateAttestation(ctx, slot, attestationDataRoot)
 		},
-		nil,
+		isAggregateAttestationOk,
 	)
 
 	if err != nil {

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -125,7 +125,8 @@ type Client interface {
 
 	// successFuncs indicates which endpoints have custom success functions.
 	successFuncs = map[string]string{
-		"NodeSyncing": "isSyncStateOk",
+		"NodeSyncing":          "isSyncStateOk",
+		"AggregateAttestation": "isAggregateAttestationOk",
 	}
 
 	skipImport = map[string]bool{

--- a/app/eth2wrap/success.go
+++ b/app/eth2wrap/success.go
@@ -25,7 +25,7 @@ func isSyncStateOk(s *apiv1.SyncState) bool {
 	return !s.IsSyncing
 }
 
-// isAggregateAttestationOk returns tue if the aggregate attestation is not nil (which can happen if the subscription wasn't done).
+// isAggregateAttestationOk returns true if the aggregate attestation is not nil (which can happen if the subscription wasn't successful).
 func isAggregateAttestationOk(att *phase0.Attestation) bool {
 	return att != nil
 }

--- a/app/eth2wrap/success.go
+++ b/app/eth2wrap/success.go
@@ -15,9 +15,17 @@
 
 package eth2wrap
 
-import apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+import (
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/phase0"
+)
 
 // isSyncStateOk returns tue if the sync state is not syncing.
 func isSyncStateOk(s *apiv1.SyncState) bool {
 	return !s.IsSyncing
+}
+
+// isAggregateAttestationOk returns tue if the aggregate attestation is not nil (which can happen if the subscription wasn't done).
+func isAggregateAttestationOk(att *phase0.Attestation) bool {
+	return att != nil
 }

--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -228,6 +228,10 @@ func isTemporaryBeaconErr(err error) bool {
 		return true
 	}
 
+	if strings.Contains(err.Error(), "retryable") {
+		return true
+	}
+
 	// TODO(corver): Add more checks here.
 
 	return false

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -189,6 +189,10 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot int64, defSet co
 		aggAtt, err := f.eth2Cl.AggregateAttestation(ctx, eth2p0.Slot(slot), dataRoot)
 		if err != nil {
 			return core.UnsignedDataSet{}, err
+		} else if aggAtt == nil {
+			// Some beacon nodes return nil if the root is not found, return retryable error.
+			// This could happen if the beacon node didn't subscribe to the correct subnet.
+			return core.UnsignedDataSet{}, errors.New("aggregate attestation not found by root (retryable)", z.Hex("root", dataRoot[:]))
 		}
 
 		resp[pubkey] = core.AggregatedAttestation{

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -27,6 +27,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -616,7 +617,7 @@ func TestBeaconCommitteeSubscriptionsV2(t *testing.T) {
 		},
 	}
 
-	eth2Cl := eth2wrap.AdaptEth2HTTP(eth2Svc.(*eth2http.Service))
+	eth2Cl := eth2wrap.AdaptEth2HTTP(eth2Svc.(*eth2http.Service), time.Second)
 	actual, err := eth2Cl.SubmitBeaconCommitteeSubscriptionsV2(ctx, subs)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
@@ -657,7 +658,7 @@ func TestSubmitAggregateAttestations(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	eth2Cl := eth2wrap.AdaptEth2HTTP(eth2Svc.(*eth2http.Service))
+	eth2Cl := eth2wrap.AdaptEth2HTTP(eth2Svc.(*eth2http.Service), time.Second)
 	err = eth2Cl.SubmitAggregateAttestations(ctx, []*eth2p0.SignedAggregateAndProof{agg})
 	require.NoError(t, err)
 }

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -315,7 +315,7 @@ func attest(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, slot
 }
 
 // aggregate does attestation aggregation for the provided validators, selections and attestation datas and returns true.
-// It returns false if the no aggregation is required.
+// It returns false if aggregation is not required.
 func aggregate(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, slot eth2p0.Slot,
 	vals validators, selections selections, datas datas,
 ) (bool, error) {

--- a/testutil/validatormock/validatormock_test.go
+++ b/testutil/validatormock/validatormock_test.go
@@ -94,7 +94,9 @@ func TestAttest(t *testing.T) {
 
 			require.NoError(t, attester.Prepare(ctx))
 			require.NoError(t, attester.Attest(ctx))
-			require.NoError(t, attester.Aggregate(ctx))
+			ok, err := attester.Aggregate(ctx)
+			require.NoError(t, err)
+			require.Equal(t, test.ExpectAggregations > 0, ok)
 
 			// Assert length and expected attestations
 			require.Len(t, atts, test.ExpectAttestations)


### PR DESCRIPTION
Fixes panic in fetcher when `AggregateAttestation` isn't found and go-eth2-client returns `nil,nil`. This can happen when using infura and the `SubmitBeaconCommitteeSubscription` was processed by a different node. Just retry in that case.

Also use proper timeout for eth2exp calls (2s is too short).

category: bug
ticket: none
