### PR TITLE
core: add signed and unsigned types for sync duties

### DIFF
--- a/core/dutydefinition.go
+++ b/core/dutydefinition.go
@@ -91,3 +91,25 @@ func (EmptyDefinition) Clone() (DutyDefinition, error) {
 func (EmptyDefinition) MarshalJSON() ([]byte, error) {
 	return nil, nil
 }
+
+func NewSyncCommitteDefinition(duty *eth2v1.SyncCommitteeDuty) DutyDefinition {
+	return SyncCommitteeDefinition{SyncCommitteeDuty: *duty}
+}
+
+type SyncCommitteeDefinition struct {
+	eth2v1.SyncCommitteeDuty
+}
+
+func (s SyncCommitteeDefinition) Clone() (DutyDefinition, error) {
+	duty := new(eth2v1.SyncCommitteeDuty)
+	err := cloneJSONMarshaler(&s.SyncCommitteeDuty, duty)
+	if err != nil {
+		return nil, errors.Wrap(err, "clone sync committee definition")
+	}
+
+	return NewSyncCommitteDefinition(duty), nil
+}
+
+func (s SyncCommitteeDefinition) MarshalJSON() ([]byte, error) {
+	return s.SyncCommitteeDuty.MarshalJSON()
+}

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -805,6 +805,90 @@ func (s *SignedAggregateAndProof) UnmarshalJSON(input []byte) error {
 	return s.SignedAggregateAndProof.UnmarshalJSON(input)
 }
 
+// SignedSyncMessage wraps altair.SyncCommitteeMessage and implements SignedData.
+type SignedSyncMessage struct {
+	altair.SyncCommitteeMessage
+}
+
+func (s SignedSyncMessage) Signature() Signature {
+	return SigFromETH2(s.SyncCommitteeMessage.Signature)
+}
+
+func (s SignedSyncMessage) SetSignature(sig Signature) (SignedData, error) {
+	resp, err := s.clone()
+	if err != nil {
+		return nil, err
+	}
+
+	resp.SyncCommitteeMessage.Signature = sig.ToETH2()
+
+	return resp, nil
+}
+
+func (s SignedSyncMessage) Clone() (SignedData, error) {
+	return s.clone()
+}
+
+func (s SignedSyncMessage) clone() (SignedSyncMessage, error) {
+	var resp SignedSyncMessage
+	err := cloneJSONMarshaler(s, &resp)
+	if err != nil {
+		return SignedSyncMessage{}, errors.Wrap(err, "clone signed sync message")
+	}
+
+	return resp, nil
+}
+
+func (s SignedSyncMessage) MarshalJSON() ([]byte, error) {
+	return s.SyncCommitteeMessage.MarshalJSON()
+}
+
+func (s *SignedSyncMessage) UnmarshalJSON(input []byte) error {
+	return s.SyncCommitteeMessage.UnmarshalJSON(input)
+}
+
+// SignedSyncContribution wraps altair.SignedContributionAndProof and implements SignedData.
+type SignedSyncContribution struct {
+	altair.SignedContributionAndProof
+}
+
+func (s SignedSyncContribution) Signature() Signature {
+	return SigFromETH2(s.SignedContributionAndProof.Signature)
+}
+
+func (s SignedSyncContribution) SetSignature(sig Signature) (SignedData, error) {
+	resp, err := s.clone()
+	if err != nil {
+		return nil, err
+	}
+
+	resp.SignedContributionAndProof.Signature = sig.ToETH2()
+
+	return resp, err
+}
+
+func (s SignedSyncContribution) Clone() (SignedData, error) {
+	return s.clone()
+}
+
+func (s SignedSyncContribution) clone() (SignedSyncContribution, error) {
+	var resp SignedSyncContribution
+	err := cloneJSONMarshaler(s, &resp)
+	if err != nil {
+		return SignedSyncContribution{}, errors.Wrap(err, "clone signed sync contribution")
+	}
+
+	return resp, nil
+}
+
+func (s SignedSyncContribution) MarshalJSON() ([]byte, error) {
+	return s.SignedContributionAndProof.MarshalJSON()
+}
+
+func (s *SignedSyncContribution) UnmarshalJSON(input []byte) error {
+	return s.SignedContributionAndProof.UnmarshalJSON(input)
+}
+
 // cloneJSONMarshaler clones the marshaler by serialising to-from json
 // since eth2 types contain pointers. The result is stored in the value pointed to by v.
 func cloneJSONMarshaler(data json.Marshaler, v any) error {

--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -21,6 +21,7 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
@@ -84,6 +85,23 @@ func TestSignedDataSetSignature(t *testing.T) {
 					},
 					Signature: testutil.RandomEth2Signature(),
 				},
+			},
+		},
+		{
+			name: "signed sync committee message",
+			data: core.SignedSyncMessage{
+				SyncCommitteeMessage: altair.SyncCommitteeMessage{
+					Slot:            testutil.RandomSlot(),
+					BeaconBlockRoot: testutil.RandomRoot(),
+					ValidatorIndex:  testutil.RandomVIdx(),
+					Signature:       testutil.RandomEth2Signature(),
+				},
+			},
+		},
+		{
+			name: "signed sync contribution",
+			data: core.SignedSyncContribution{
+				SignedContributionAndProof: testutil.RandomSignedSyncContributionAndProof(),
 			},
 		},
 	}

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -295,6 +295,28 @@ func (b *VersionedBlindedBeaconBlock) UnmarshalJSON(input []byte) error {
 	return nil
 }
 
+type SyncContribution struct {
+	altair.SyncCommitteeContribution
+}
+
+func (s SyncContribution) Clone() (UnsignedData, error) {
+	var resp SyncContribution
+	err := cloneJSONMarshaler(s, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "clone sync contribution")
+	}
+
+	return resp, err
+}
+
+func (s SyncContribution) MarshalJSON() ([]byte, error) {
+	return s.SyncCommitteeContribution.MarshalJSON()
+}
+
+func (s *SyncContribution) UnmarshalJSON(input []byte) error {
+	return s.SyncCommitteeContribution.UnmarshalJSON(input)
+}
+
 // UnmarshalUnsignedData returns an instantiated unsigned data based on the duty type.
 // TODO(corver): Unexport once leadercast is removed or uses protobufs.
 func UnmarshalUnsignedData(typ DutyType, data []byte) (UnsignedData, error) {

--- a/core/unsigneddata_test.go
+++ b/core/unsigneddata_test.go
@@ -45,6 +45,10 @@ func TestUnsignedDataClone(t *testing.T) {
 			name: "aggregated attestation",
 			data: core.NewAggregatedAttestation(testutil.RandomAttestation()),
 		},
+		{
+			name: "sync contribution",
+			data: testutil.RandomCoreSyncContribution(),
+		},
 	}
 
 	for _, test := range tests {

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -388,7 +388,7 @@ func RandomCoreSyncContribution() core.SyncContribution {
 
 func RandomSyncContributionAndProof() *altair.ContributionAndProof {
 	return &altair.ContributionAndProof{
-		AggregatorIndex: 0,
+		AggregatorIndex: RandomVIdx(),
 		Contribution:    RandomSyncCommitteeContribution(),
 		SelectionProof:  RandomEth2Signature(),
 	}
@@ -398,7 +398,7 @@ func RandomSyncCommitteeContribution() *altair.SyncCommitteeContribution {
 	return &altair.SyncCommitteeContribution{
 		Slot:              RandomSlot(),
 		BeaconBlockRoot:   RandomRoot(),
-		SubcommitteeIndex: 0,
+		SubcommitteeIndex: rand.Uint64(),
 		AggregationBits:   RandomBitVec(),
 		Signature:         RandomEth2Signature(),
 	}

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -375,6 +375,35 @@ func RandomAggregateAndProof() *eth2p0.AggregateAndProof {
 	}
 }
 
+func RandomSignedSyncContributionAndProof() altair.SignedContributionAndProof {
+	return altair.SignedContributionAndProof{
+		Message:   RandomSyncContributionAndProof(),
+		Signature: eth2p0.BLSSignature{},
+	}
+}
+
+func RandomCoreSyncContribution() core.SyncContribution {
+	return core.SyncContribution{SyncCommitteeContribution: *RandomSyncCommitteeContribution()}
+}
+
+func RandomSyncContributionAndProof() *altair.ContributionAndProof {
+	return &altair.ContributionAndProof{
+		AggregatorIndex: 0,
+		Contribution:    RandomSyncCommitteeContribution(),
+		SelectionProof:  RandomEth2Signature(),
+	}
+}
+
+func RandomSyncCommitteeContribution() *altair.SyncCommitteeContribution {
+	return &altair.SyncCommitteeContribution{
+		Slot:              RandomSlot(),
+		BeaconBlockRoot:   RandomRoot(),
+		SubcommitteeIndex: 0,
+		AggregationBits:   RandomBitVec(),
+		Signature:         RandomEth2Signature(),
+	}
+}
+
 func RandomSyncAggregate(t *testing.T) *altair.SyncAggregate {
 	t.Helper()
 
@@ -517,6 +546,15 @@ func RandomBitList() bitfield.Bitlist {
 	size := 256
 	index := rand.Intn(size)
 	resp := bitfield.NewBitlist(uint64(size))
+	resp.SetBitAt(uint64(index), true)
+
+	return resp
+}
+
+func RandomBitVec() bitfield.Bitvector128 {
+	size := 128
+	index := rand.Intn(size)
+	resp := bitfield.NewBitvector128()
 	resp.SetBitAt(uint64(index), true)
 
 	return resp


### PR DESCRIPTION
Adds signed and unsigned types for sync committee duties.

category: feature
ticket: #1177 
