### PR TITLE
github: add GITHUB_TOKEN env var to genchangelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: Publish Release
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2


### PR DESCRIPTION
Add the GUTHUB_TOKEN env var so `genchangelog` uses authenticated API to avoid rate limits.

category: misc
ticket: #1039 
