### PR TITLE
github: disable shallow checkout for release action

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 0 # Disable shallow checkout
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v2
       with:
         go-version: '1.19'


### PR DESCRIPTION
Disables shallow checkout for the release action so `genchangelog` can fetch the git commit history.

category: misc
ticket: #1039 
