### PR TITLE
cluster: skip sig verification for versions earlier than v1.3.0

### DIFF
--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -106,12 +106,7 @@ func TestDefinitionVerify(t *testing.T) {
 		definition.Version = v1_2
 		definition.Operators[0].ENRSignature = testutil.RandomSecp256k1Signature()
 
-		b1, err := json.Marshal(definition)
-		testutil.RequireNoError(t, err)
-
-		var definition2 Definition
-		err = json.Unmarshal(b1, &definition2)
-		require.Error(t, err)
+		_, err := json.Marshal(definition)
 		require.ErrorContains(t, err, "older version signatures not supported")
 	})
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -34,7 +34,7 @@ import (
 //go:generate go test . -v -update -clean
 
 func TestEncode(t *testing.T) {
-	for _, version := range cluster.SupportedVersionsForT(t) {
+	for _, version := range cluster.SupportedVersionsForT() {
 		t.Run(version, func(t *testing.T) {
 			vStr := strings.ReplaceAll(version, ".", "_")
 			rand.Seed(1)
@@ -64,6 +64,14 @@ func TestEncode(t *testing.T) {
 			)
 			require.NoError(t, err)
 			definition.Version = version
+
+			if version == "v1.0.0" || version == "v1.1.0" || version == "v1.2.0" {
+				for i := range definition.Operators {
+					definition.Operators[i].ConfigSignature = []byte{}
+					definition.Operators[i].ENRSignature = []byte{}
+				}
+			}
+
 			definition.Timestamp = "2022-07-19T18:19:58+02:00" // Make deterministic
 
 			t.Run("definition_json_"+vStr, func(t *testing.T) {

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -34,7 +34,7 @@ import (
 //go:generate go test . -v -update -clean
 
 func TestEncode(t *testing.T) {
-	for _, version := range cluster.SupportedVersionsForT() {
+	for _, version := range cluster.SupportedVersionsForT(t) {
 		t.Run(version, func(t *testing.T) {
 			vStr := strings.ReplaceAll(version, ".", "_")
 			rand.Seed(1)
@@ -65,6 +65,7 @@ func TestEncode(t *testing.T) {
 			require.NoError(t, err)
 			definition.Version = version
 
+			// Definition version prior to v1.3.0 don't support EIP712 signatures.
 			if version == "v1.0.0" || version == "v1.1.0" || version == "v1.2.0" {
 				for i := range definition.Operators {
 					definition.Operators[i].ConfigSignature = []byte{}

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -141,8 +141,8 @@ func (d Definition) NodeIdx(pID peer.ID) (NodeIdx, error) {
 // VerifySignatures returns true if all config signatures are fully populated and valid. A verified definition is ready for use in DKG.
 func (d Definition) VerifySignatures() error {
 	// Skip signature verification for definition versions earlier than v1.3 since there are no EIP712 signatures before v1.3.0.
-
 	if !supportEIP712Sigs(d.Version) {
+		// TODO(dhruv): maybe error if signatures present
 		return nil
 	}
 

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -141,6 +141,7 @@ func (d Definition) NodeIdx(pID peer.ID) (NodeIdx, error) {
 // VerifySignatures returns true if all config signatures are fully populated and valid. A verified definition is ready for use in DKG.
 func (d Definition) VerifySignatures() error {
 	// Skip signature verification for definition versions earlier than v1.3 since there are no EIP712 signatures before v1.3.0.
+
 	if !supportEIP712Sigs(d.Version) {
 		return nil
 	}
@@ -451,6 +452,8 @@ func unmarshalDefinitionV1x2or3(data []byte) (def Definition, err error) {
 	return def, nil
 }
 
+// supportEIP712Sigs returns true if version is earlier than v1.3.0.
+// Note: Definition version prior to v1.3.0 don't support EIP712 signatures.
 func supportEIP712Sigs(version string) bool {
 	return !isJSONv1x0(version) && !isJSONv1x1(version) && !isJSONv1x2(version)
 }

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -79,7 +79,7 @@ type Definition struct {
 	// UUID is a human-readable random unique identifier. Max 64 chars.
 	UUID string `json:"uuid" ssz:"ByteList[64]" config_hash:"0" definition_hash:"0"`
 
-	// Name is an human-readable cosmetic identifier. Max 256 chars.
+	// Name is a human-readable cosmetic identifier. Max 256 chars.
 	Name string `json:"name" ssz:"ByteList[256]" config_hash:"1" definition_hash:"1"`
 
 	// Version is the schema version of this definition. Max 16 chars.
@@ -140,6 +140,11 @@ func (d Definition) NodeIdx(pID peer.ID) (NodeIdx, error) {
 
 // VerifySignatures returns true if all config signatures are fully populated and valid. A verified definition is ready for use in DKG.
 func (d Definition) VerifySignatures() error {
+	// Skip signature verification for definition versions earlier than v1.3 since there are no EIP712 signatures before v1.3.0.
+	if !supportEIP712Sigs(d.Version) {
+		return nil
+	}
+
 	configHash, err := hashDefinition(d, true)
 	if err != nil {
 		return errors.Wrap(err, "config hash")
@@ -192,7 +197,7 @@ func (d Definition) VerifySignatures() error {
 	}
 
 	if noSigs > 0 && noSigs != len(d.Operators) {
-		return errors.New("some operators signed others not")
+		return errors.New("some operators signed while others didn't")
 	}
 
 	return nil
@@ -304,6 +309,15 @@ func (d *Definition) UnmarshalJSON(data []byte) error {
 	}
 
 	*d = def
+
+	// For definition versions earlier than v1.3.0, error if either config signature or enr signature for any operator is present.
+	if !supportEIP712Sigs(def.Version) {
+		for _, o := range def.Operators {
+			if len(o.ENRSignature) > 0 || len(o.ConfigSignature) > 0 {
+				return errors.New("older version signatures not supported")
+			}
+		}
+	}
 
 	return nil
 }
@@ -435,6 +449,10 @@ func unmarshalDefinitionV1x2or3(data []byte) (def Definition, err error) {
 	}
 
 	return def, nil
+}
+
+func supportEIP712Sigs(version string) bool {
+	return !isJSONv1x0(version) && !isJSONv1x1(version) && !isJSONv1x2(version)
 }
 
 // definitionJSONv1x0or1 is the json formatter of Definition for versions v1.0.0 and v1.1.1.

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/testutil"
@@ -118,6 +119,25 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 
 	for _, opt := range opts {
 		opt(&def)
+	}
+
+	// Definition version prior to v1.3.0 don't support EIP712 signatures.
+	if def.Version == "v1.0.0" || def.Version == "v1.1.0" || def.Version == "v1.2.0" {
+		for i := range def.Operators {
+			def.Operators[i].ConfigSignature = []byte{}
+			def.Operators[i].ENRSignature = []byte{}
+		}
+	} else {
+		confHash, err := hashDefinition(def, true)
+		require.NoError(t, err)
+
+		chainID, err := eth2util.ForkVersionToChainID(def.ForkVersion)
+		require.NoError(t, err)
+
+		for i := 0; i < n; i++ {
+			def.Operators[i], err = signOperator(p2pKeys[i], def.Operators[i], confHash, chainID)
+			require.NoError(t, err)
+		}
 	}
 
 	def, err = def.SetDefinitionHashes()

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -29,7 +29,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/stretchr/testify/require"
 
-	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/testutil"
@@ -119,16 +118,6 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 
 	for _, opt := range opts {
 		opt(&def)
-	}
-	confHash, err := hashDefinition(def, true)
-	require.NoError(t, err)
-
-	chainID, err := eth2util.ForkVersionToChainID(def.ForkVersion)
-	require.NoError(t, err)
-
-	for i := 0; i < n; i++ {
-		def.Operators[i], err = signOperator(p2pKeys[i], def.Operators[i], confHash, chainID)
-		require.NoError(t, err)
 	}
 
 	def, err = def.SetDefinitionHashes()

--- a/cluster/testdata/cluster_definition_v1_0_0.json
+++ b/cluster/testdata/cluster_definition_v1_0_0.json
@@ -5,15 +5,15 @@
    "address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
    "enr": "enr://5fb90badb37c5821b6d95526a41a9504680b4e7c8b763a1b1d49d4955c848621",
    "nonce": 0,
-   "config_signature": "YyUlP+xzjdep4ov5IRGcFg8HAkSGFbvaCDE/ao62aNIL9QWYdZIeZopb3yx/xIRFktJXK80GaNLWxS9QVOLQgxw=",
-   "enr_signature": "+ExxdMt0djZMw9vZaLD3Fy7YV5S7NYsMO1JdoXhvn/8JQnnbGUTr16GdD3u6y+AlWqW31EvsQPhMiSub/9Q2KQA="
+   "config_signature": "",
+   "enr_signature": ""
   },
   {
    "address": "0x223beea5f4f74391f445d15afd4294040374f692",
    "enr": "enr://9192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea",
    "nonce": 0,
-   "config_signature": "b1s69t4DdDZsRxnkOhsGfYm8fwHx9XOYFlmkT/F6THIVo7U56x5YScYHfbtXIvVxeiiaJm+XZHmBmY6+qJwLSxw=",
-   "enr_signature": "OXARXoLtb0ElyPpzEeTX3vqSLarneGZn9+k2zU8kq/ffhmuqVgODZ61hRd4e6PSosJk+vfiIOgrYvpw5eLBIgwE="
+   "config_signature": "",
+   "enr_signature": ""
   }
  ],
  "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
@@ -26,5 +26,5 @@
  "dkg_algorithm": "default",
  "fork_version": "0x90000069",
  "config_hash": "oQzZWiCuJFXV9CWz2PPiZYzwJLTbjC1ok803pY+JLqk=",
- "definition_hash": "ZCmdSsnrFsERpjqawE868PtWzzI4sdQS/oN2PxRi62o="
+ "definition_hash": "EiYv1m3CT2iRKY5m9DBQzDrqRRC5kD/LBculhrmVcjs="
 }

--- a/cluster/testdata/cluster_definition_v1_1_0.json
+++ b/cluster/testdata/cluster_definition_v1_1_0.json
@@ -5,15 +5,15 @@
    "address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
    "enr": "enr://5fb90badb37c5821b6d95526a41a9504680b4e7c8b763a1b1d49d4955c848621",
    "nonce": 0,
-   "config_signature": "YyUlP+xzjdep4ov5IRGcFg8HAkSGFbvaCDE/ao62aNIL9QWYdZIeZopb3yx/xIRFktJXK80GaNLWxS9QVOLQgxw=",
-   "enr_signature": "+ExxdMt0djZMw9vZaLD3Fy7YV5S7NYsMO1JdoXhvn/8JQnnbGUTr16GdD3u6y+AlWqW31EvsQPhMiSub/9Q2KQA="
+   "config_signature": "",
+   "enr_signature": ""
   },
   {
    "address": "0x223beea5f4f74391f445d15afd4294040374f692",
    "enr": "enr://9192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea",
    "nonce": 0,
-   "config_signature": "b1s69t4DdDZsRxnkOhsGfYm8fwHx9XOYFlmkT/F6THIVo7U56x5YScYHfbtXIvVxeiiaJm+XZHmBmY6+qJwLSxw=",
-   "enr_signature": "OXARXoLtb0ElyPpzEeTX3vqSLarneGZn9+k2zU8kq/ffhmuqVgODZ61hRd4e6PSosJk+vfiIOgrYvpw5eLBIgwE="
+   "config_signature": "",
+   "enr_signature": ""
   }
  ],
  "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
@@ -26,5 +26,5 @@
  "dkg_algorithm": "default",
  "fork_version": "0x90000069",
  "config_hash": "CmxY06oRxEw1UMCOLGRb5jSNeG9890x1BuRnTUKEloc=",
- "definition_hash": "8hQPjFhtWeQfJCVPs65DIzn2/19I+cdDfFPylGcWLe4="
+ "definition_hash": "SIqlUaZH0Q2hcpUDG8GUT9Ld8FdJiXX9XJgQkiMbWMk="
 }

--- a/cluster/testdata/cluster_definition_v1_2_0.json
+++ b/cluster/testdata/cluster_definition_v1_2_0.json
@@ -4,14 +4,14 @@
   {
    "address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
    "enr": "enr://5fb90badb37c5821b6d95526a41a9504680b4e7c8b763a1b1d49d4955c848621",
-   "config_signature": "0x6325253fec738dd7a9e28bf921119c160f0702448615bbda08313f6a8eb668d20bf5059875921e668a5bdf2c7fc4844592d2572bcd0668d2d6c52f5054e2d0831c",
-   "enr_signature": "0xf84c7174cb7476364cc3dbd968b0f7172ed85794bb358b0c3b525da1786f9fff094279db1944ebd7a19d0f7bbacbe0255aa5b7d44bec40f84c892b9bffd4362900"
+   "config_signature": "",
+   "enr_signature": ""
   },
   {
    "address": "0x223beea5f4f74391f445d15afd4294040374f692",
    "enr": "enr://9192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea",
-   "config_signature": "0x6f5b3af6de0374366c4719e43a1b067d89bc7f01f1f573981659a44ff17a4c7215a3b539eb1e5849c6077dbb5722f5717a289a266f97647981998ebea89c0b4b1c",
-   "enr_signature": "0x3970115e82ed6f4125c8fa7311e4d7defa922daae7786667f7e936cd4f24abf7df866baa56038367ad6145de1ee8f4a8b0993ebdf8883a0ad8be9c3978b0488301"
+   "config_signature": "",
+   "enr_signature": ""
   }
  ],
  "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
@@ -24,5 +24,5 @@
  "dkg_algorithm": "default",
  "fork_version": "0x90000069",
  "config_hash": "0xf0577c776b42d97418eec0988de901acda5d270e4b44441e73e65c146058832a",
- "definition_hash": "0x86f04bb5aa4f04f342e165535e293e51a4d1f455b2fabd3c953269288e283227"
+ "definition_hash": "0x4ecfd2e92ec91dc0c0533d0783779e47d3bb0a9d9141773d1bd32d0570048a0b"
 }

--- a/cluster/testdata/cluster_lock_v1_0_0.json
+++ b/cluster/testdata/cluster_lock_v1_0_0.json
@@ -6,15 +6,15 @@
     "address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
     "enr": "enr://5fb90badb37c5821b6d95526a41a9504680b4e7c8b763a1b1d49d4955c848621",
     "nonce": 0,
-    "config_signature": "YyUlP+xzjdep4ov5IRGcFg8HAkSGFbvaCDE/ao62aNIL9QWYdZIeZopb3yx/xIRFktJXK80GaNLWxS9QVOLQgxw=",
-    "enr_signature": "+ExxdMt0djZMw9vZaLD3Fy7YV5S7NYsMO1JdoXhvn/8JQnnbGUTr16GdD3u6y+AlWqW31EvsQPhMiSub/9Q2KQA="
+    "config_signature": "",
+    "enr_signature": ""
    },
    {
     "address": "0x223beea5f4f74391f445d15afd4294040374f692",
     "enr": "enr://9192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea",
     "nonce": 0,
-    "config_signature": "b1s69t4DdDZsRxnkOhsGfYm8fwHx9XOYFlmkT/F6THIVo7U56x5YScYHfbtXIvVxeiiaJm+XZHmBmY6+qJwLSxw=",
-    "enr_signature": "OXARXoLtb0ElyPpzEeTX3vqSLarneGZn9+k2zU8kq/ffhmuqVgODZ61hRd4e6PSosJk+vfiIOgrYvpw5eLBIgwE="
+    "config_signature": "",
+    "enr_signature": ""
    }
   ],
   "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
@@ -27,7 +27,7 @@
   "dkg_algorithm": "default",
   "fork_version": "0x90000069",
   "config_hash": "oQzZWiCuJFXV9CWz2PPiZYzwJLTbjC1ok803pY+JLqk=",
-  "definition_hash": "ZCmdSsnrFsERpjqawE868PtWzzI4sdQS/oN2PxRi62o="
+  "definition_hash": "EiYv1m3CT2iRKY5m9DBQzDrqRRC5kD/LBculhrmVcjs="
  },
  "distributed_validators": [
   {
@@ -46,5 +46,5 @@
   }
  ],
  "signature_aggregate": "ahVqjeVjr6Rn1J3sakDpodAH8DPCgjBhvdDqpZ+OTaY=",
- "lock_hash": "6stxh2iYnGSqK7o+lZqLFMalR4ENKTI9E4+Fz3sF8I0="
+ "lock_hash": "TFn4FCR0tVxp9HsdjiMhPQgglpt+o9CAxtYIg4hVOkc="
 }

--- a/cluster/testdata/cluster_lock_v1_1_0.json
+++ b/cluster/testdata/cluster_lock_v1_1_0.json
@@ -6,15 +6,15 @@
     "address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
     "enr": "enr://5fb90badb37c5821b6d95526a41a9504680b4e7c8b763a1b1d49d4955c848621",
     "nonce": 0,
-    "config_signature": "YyUlP+xzjdep4ov5IRGcFg8HAkSGFbvaCDE/ao62aNIL9QWYdZIeZopb3yx/xIRFktJXK80GaNLWxS9QVOLQgxw=",
-    "enr_signature": "+ExxdMt0djZMw9vZaLD3Fy7YV5S7NYsMO1JdoXhvn/8JQnnbGUTr16GdD3u6y+AlWqW31EvsQPhMiSub/9Q2KQA="
+    "config_signature": "",
+    "enr_signature": ""
    },
    {
     "address": "0x223beea5f4f74391f445d15afd4294040374f692",
     "enr": "enr://9192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea",
     "nonce": 0,
-    "config_signature": "b1s69t4DdDZsRxnkOhsGfYm8fwHx9XOYFlmkT/F6THIVo7U56x5YScYHfbtXIvVxeiiaJm+XZHmBmY6+qJwLSxw=",
-    "enr_signature": "OXARXoLtb0ElyPpzEeTX3vqSLarneGZn9+k2zU8kq/ffhmuqVgODZ61hRd4e6PSosJk+vfiIOgrYvpw5eLBIgwE="
+    "config_signature": "",
+    "enr_signature": ""
    }
   ],
   "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
@@ -27,7 +27,7 @@
   "dkg_algorithm": "default",
   "fork_version": "0x90000069",
   "config_hash": "CmxY06oRxEw1UMCOLGRb5jSNeG9890x1BuRnTUKEloc=",
-  "definition_hash": "8hQPjFhtWeQfJCVPs65DIzn2/19I+cdDfFPylGcWLe4="
+  "definition_hash": "SIqlUaZH0Q2hcpUDG8GUT9Ld8FdJiXX9XJgQkiMbWMk="
  },
  "distributed_validators": [
   {
@@ -46,5 +46,5 @@
   }
  ],
  "signature_aggregate": "ahVqjeVjr6Rn1J3sakDpodAH8DPCgjBhvdDqpZ+OTaY=",
- "lock_hash": "G2MTFzak85gjQWpnEgL4BPvrvrPKKNIAdApWBLyxXCI="
+ "lock_hash": "i24Ml+Cd/lwMp5nhmrnciV5/PQHQ8Jv6W4BI8YlPGE4="
 }

--- a/cluster/testdata/cluster_lock_v1_2_0.json
+++ b/cluster/testdata/cluster_lock_v1_2_0.json
@@ -5,14 +5,14 @@
    {
     "address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
     "enr": "enr://5fb90badb37c5821b6d95526a41a9504680b4e7c8b763a1b1d49d4955c848621",
-    "config_signature": "0x6325253fec738dd7a9e28bf921119c160f0702448615bbda08313f6a8eb668d20bf5059875921e668a5bdf2c7fc4844592d2572bcd0668d2d6c52f5054e2d0831c",
-    "enr_signature": "0xf84c7174cb7476364cc3dbd968b0f7172ed85794bb358b0c3b525da1786f9fff094279db1944ebd7a19d0f7bbacbe0255aa5b7d44bec40f84c892b9bffd4362900"
+    "config_signature": "",
+    "enr_signature": ""
    },
    {
     "address": "0x223beea5f4f74391f445d15afd4294040374f692",
     "enr": "enr://9192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea",
-    "config_signature": "0x6f5b3af6de0374366c4719e43a1b067d89bc7f01f1f573981659a44ff17a4c7215a3b539eb1e5849c6077dbb5722f5717a289a266f97647981998ebea89c0b4b1c",
-    "enr_signature": "0x3970115e82ed6f4125c8fa7311e4d7defa922daae7786667f7e936cd4f24abf7df866baa56038367ad6145de1ee8f4a8b0993ebdf8883a0ad8be9c3978b0488301"
+    "config_signature": "",
+    "enr_signature": ""
    }
   ],
   "uuid": "0194FDC2-FA2F-FCC0-41D3-FF12045B73C8",
@@ -25,7 +25,7 @@
   "dkg_algorithm": "default",
   "fork_version": "0x90000069",
   "config_hash": "0xf0577c776b42d97418eec0988de901acda5d270e4b44441e73e65c146058832a",
-  "definition_hash": "0x86f04bb5aa4f04f342e165535e293e51a4d1f455b2fabd3c953269288e283227"
+  "definition_hash": "0x4ecfd2e92ec91dc0c0533d0783779e47d3bb0a9d9141773d1bd32d0570048a0b"
  },
  "distributed_validators": [
   {
@@ -44,5 +44,5 @@
   }
  ],
  "signature_aggregate": "0x6a156a8de563afa467d49dec6a40e9a1d007f033c2823061bdd0eaa59f8e4da6",
- "lock_hash": "0x175d225118fe9486ebca4d7cf63b0928de0b56a91bb83cd1a6fa0146196937b2"
+ "lock_hash": "0x2a7e16d321dfd9792b6e2818642838590099928a6e13d234e4b7e65223e12d0e"
 }

--- a/cluster/version.go
+++ b/cluster/version.go
@@ -15,6 +15,8 @@
 
 package cluster
 
+import "testing"
+
 const (
 	currentVersion = v1_2
 	dkgAlgo        = "default"
@@ -51,7 +53,7 @@ func isJSONv1x3(version string) bool {
 }
 
 // SupportedVersionsForT returns the supported definition versions for testing purposes only.
-func SupportedVersionsForT() []string {
+func SupportedVersionsForT(*testing.T) []string {
 	var resp []string
 	for version := range supportedVersions {
 		resp = append(resp, version)

--- a/cluster/version.go
+++ b/cluster/version.go
@@ -15,8 +15,6 @@
 
 package cluster
 
-import "testing"
-
 const (
 	currentVersion = v1_2
 	dkgAlgo        = "default"
@@ -53,7 +51,7 @@ func isJSONv1x3(version string) bool {
 }
 
 // SupportedVersionsForT returns the supported definition versions for testing purposes only.
-func SupportedVersionsForT(*testing.T) []string {
+func SupportedVersionsForT() []string {
 	var resp []string
 	for version := range supportedVersions {
 		resp = append(resp, version)


### PR DESCRIPTION
Skip EIP712 signature verification for versions earlier than v1.3.0.

category: feature
ticket: #1203 
