### PR TITLE
cluster: fix bug when hashing byte lists

### DIFF
--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -230,7 +230,7 @@ func putByteList(h ssz.HashWalker, b []byte, limit int, field string) error {
 	if byteLen > limit {
 		return errors.Wrap(ssz.ErrIncorrectListSize, "put byte list", z.Str("field", field))
 	}
-	h.PutBytes(b)
+	h.AppendBytes32(b)
 	h.MerkleizeWithMixin(elemIndx, uint64(byteLen), uint64(limit+31)/32)
 
 	return nil

--- a/cluster/testdata/cluster_definition_v1_3_0.json
+++ b/cluster/testdata/cluster_definition_v1_3_0.json
@@ -23,6 +23,6 @@
  "withdrawal_address": "0x81855ad8681d0d86d1e91e00167939cb6694d2c4",
  "dkg_algorithm": "default",
  "fork_version": "0x90000069",
- "config_hash": "0xa3bdacf0139039bd4da641c02e257872e945c8f86b186cd488399123f3e81dfa",
- "definition_hash": "0xa3269c76fca5c3ab25e6e90ee24b972e6aab5bb00f682e66a73223d86c34888b"
+ "config_hash": "0x22011585e8c3aa0abc2bd4954cc272d580f32fd049be314e5f3300aaefbe209b",
+ "definition_hash": "0xc799e77e5f328eb59436fb218e5bbcc6c9acb1debf6e3826dbeebc36f5c23bb1"
 }

--- a/cluster/testdata/cluster_lock_v1_3_0.json
+++ b/cluster/testdata/cluster_lock_v1_3_0.json
@@ -24,8 +24,8 @@
   "withdrawal_address": "0x81855ad8681d0d86d1e91e00167939cb6694d2c4",
   "dkg_algorithm": "default",
   "fork_version": "0x90000069",
-  "config_hash": "0xa3bdacf0139039bd4da641c02e257872e945c8f86b186cd488399123f3e81dfa",
-  "definition_hash": "0xa3269c76fca5c3ab25e6e90ee24b972e6aab5bb00f682e66a73223d86c34888b"
+  "config_hash": "0x22011585e8c3aa0abc2bd4954cc272d580f32fd049be314e5f3300aaefbe209b",
+  "definition_hash": "0xc799e77e5f328eb59436fb218e5bbcc6c9acb1debf6e3826dbeebc36f5c23bb1"
  },
  "distributed_validators": [
   {
@@ -44,5 +44,5 @@
   }
  ],
  "signature_aggregate": "0x6a156a8de563afa467d49dec6a40e9a1d007f033c2823061bdd0eaa59f8e4da6",
- "lock_hash": "0xa082b8d0a9007eae142b2380845250a07e32349d3d17d2c2e37f4e0965e438f8"
+ "lock_hash": "0x4204983266be0e641d7cf90f6ce4b36b54a44463c0c50efbdb116cd1dea1141c"
 }


### PR DESCRIPTION
Fixes copy/paste bug when copying pattern from external reference. See https://github.com/attestantio/go-eth2-client/blob/master/spec/bellatrix/executionpayload_encoding.go#L277-L284.

category: bug 
ticket: none

