### PR TITLE
cluster: add support for old definition signature using noverify

### DIFF
--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -17,7 +17,6 @@ package cluster
 
 import (
 	"crypto/ecdsa"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -89,15 +88,6 @@ func TestDefinitionVerify(t *testing.T) {
 		err = definition.VerifySignatures()
 		require.Error(t, err)
 		require.ErrorContains(t, err, "some operators signed while others didn't")
-	})
-
-	t.Run("older version signatures not supported", func(t *testing.T) {
-		definition := randomDefinition(t, op0, op1)
-		definition.Version = v1_2
-		definition.Operators[0].ENRSignature = testutil.RandomSecp256k1Signature()
-
-		_, err := json.Marshal(definition)
-		require.ErrorContains(t, err, "older version signatures not supported")
 	})
 }
 

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -255,11 +255,6 @@ func (d Definition) SetDefinitionHashes() (Definition, error) {
 }
 
 func (d Definition) MarshalJSON() ([]byte, error) {
-	// For definition versions earlier than v1.3.0, error if either config signature or enr signature for any operator is present.
-	if !supportEIP712Sigs(d.Version) && eip712SigsPresent(d.Operators) {
-		return nil, errors.New("older version signatures not supported")
-	}
-
 	d, err := d.SetDefinitionHashes()
 	if err != nil {
 		return nil, err
@@ -310,11 +305,6 @@ func (d *Definition) UnmarshalJSON(data []byte) error {
 	}
 
 	*d = def
-
-	// For definition versions earlier than v1.3.0, error if either config signature or enr signature for any operator is present.
-	if !supportEIP712Sigs(def.Version) && eip712SigsPresent(def.Operators) {
-		return errors.New("older version signatures not supported")
-	}
 
 	return nil
 }


### PR DESCRIPTION
Re-adds support for definition signatures for older versions (v1.0-v1.2) using `--no-verify`. 

In other words:
 - GIVEN: Users with a launchpad generated cluster definition or lock (version is v1.2 and contains signatures) 
 - WHEN: They run either `charon dkg` or `charon run`
 - THEN: They MUST use `--no-verify` or the programs will crash.
 
 
The bug is that it crashed even if `--no-verify` was used as we decided to drop support for these old signatures all-together since we assumed incorrectly that there were no users with these launchpad generated definitions.

category: bug 
ticket: none
