### PR TITLE
testutil/compose: add loki log panels to simnet dashboard

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -283,6 +283,7 @@ func newNewCmd() *cobra.Command {
 	featureSet := cmd.Flags().String("feature-set", conf.FeatureSet, "Minimum feature set to enable: alpha, beta, stable")
 	numVals := cmd.Flags().Int("num-validators", conf.NumValidators, "Number of distributed validators.")
 	vcTypes := cmd.Flags().StringSlice("validator-types", conf.VCStrings(), "Validator types to include.")
+	loki := cmd.Flags().Bool("loki", false, "Enables loki logging driver with json logs.")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		conf.KeyGen = compose.KeyGen(*keygen)
@@ -292,6 +293,7 @@ func newNewCmd() *cobra.Command {
 		conf.FeatureSet = *featureSet
 		conf.ExternalBootnode = *extBootnode
 		conf.NumValidators = *numVals
+		conf.EnableLoki = *loki
 
 		var vcs []compose.VCType
 		for _, vc := range *vcTypes {

--- a/testutil/compose/compose/smoke_internal_test.go
+++ b/testutil/compose/compose/smoke_internal_test.go
@@ -136,7 +136,6 @@ func TestSmoke(t *testing.T) {
 
 			conf := compose.NewDefaultConfig()
 			conf.DisableMonitoringPorts = true
-			conf.DisableLoki = true
 			if *prebuiltBinary != "" {
 				copyPrebuiltBinary(t, dir, *prebuiltBinary)
 				conf.PrebuiltBinary = true

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -115,8 +115,8 @@ type Config struct {
 	// DisableMonitoringPorts defines whether to disable prometheus and jaeger monitoring  port binding.
 	DisableMonitoringPorts bool `json:"disable_monitoring_ports"`
 
-	// DisableLoki defines whether to loki logging driver should be configured.
-	DisableLoki bool `json:"disable_loki"`
+	// EnableLoki defines whether to loki logging driver should be configured.
+	EnableLoki bool `json:"enable_loki"`
 }
 
 // VCStrings returns the VCs field as a slice of strings.

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -117,6 +117,11 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		p2pRelay = "true"
 	}
 
+	logFmt := "console"
+	if conf.EnableLoki {
+		logFmt = "logfmt"
+	}
+
 	// Common config
 	kvs := []kv{
 		{"private-key-file", fmt.Sprintf("/compose/node%d/charon-enr-private-key", index)},
@@ -127,6 +132,7 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		{"p2p-bootnodes", p2pBootnodes},
 		{"p2p-bootnode-relay", fmt.Sprintf(`"%v"`, p2pRelay)},
 		{"log-level", "debug"},
+		{"log-format", logFmt},
 		{"feature-set", conf.FeatureSet},
 	}
 

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -63,7 +63,7 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 		Bootnode:         true,
 		Monitoring:       true,
 		MonitoringPorts:  !conf.DisableMonitoringPorts,
-		Loki:             !conf.DisableLoki,
+		Loki:             conf.EnableLoki,
 		VCs:              vcs,
 	}
 

--- a/testutil/compose/static/grafana/dash_simnet.json
+++ b/testutil/compose/static/grafana/dash_simnet.json
@@ -100,7 +100,7 @@
         "frameIndex": 0,
         "showHeader": false
       },
-      "pluginVersion": "9.0.4",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -217,7 +217,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.4",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -375,7 +375,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.4",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -407,6 +407,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
@@ -542,7 +544,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.4",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -783,7 +785,7 @@
           }
         ]
       },
-      "pluginVersion": "9.0.4",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -995,188 +997,8 @@
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "noValue": "No errors",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 12,
-        "x": 0,
-        "y": 14
-      },
-      "id": 13,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "increase(app_log_error_total{job=\"$node\"}[$__rate_interval])",
-          "interval": "",
-          "legendFormat": "{{topic}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Errors by topic",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "drawStyle": "line",
-            "fillOpacity": 0,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "auto",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "mappings": [],
-          "noValue": "No warnings",
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          }
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 12,
-        "x": 12,
-        "y": 14
-      },
-      "id": 14,
-      "options": {
-        "legend": {
-          "calcs": [],
-          "displayMode": "list",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "single",
-          "sort": "none"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "PBFA97CFB590B2093"
-          },
-          "exemplar": true,
-          "expr": "increase(app_log_warn_total{job=\"$node\"}[$__rate_interval]) ",
-          "interval": "",
-          "legendFormat": "{{topic}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Warnings by topic",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "PBFA97CFB590B2093"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1225,7 +1047,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 19
+        "y": 14
       },
       "id": 7,
       "options": {
@@ -1281,6 +1103,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1331,7 +1155,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 19
+        "y": 14
       },
       "id": 5,
       "options": {
@@ -1366,6 +1190,142 @@
     },
     {
       "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "description": "Top 10 count of errors and warning per minute grouped by message. ",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "noValue": "No warnings",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 21
+      },
+      "id": 62,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "code",
+          "expr": "topk(10,sum(count_over_time({compose_service=\"$node\"} | logfmt | level=~`(warn|error)` | label_format level=\"{{trunc 1 .level | upper}}\"[1m])) by (level,msg,topic))",
+          "legendFormat": "{{level}} [{{topic}}] {{msg}}",
+          "queryType": "range",
+          "refId": "A",
+          "resolution": 10
+        }
+      ],
+      "title": "Top Warnings and Errors",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "description": "Reasons why duties failed prefixed by slot and duty type",
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "id": 66,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": false,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "code",
+          "expr": "{compose_service=\"$node\"} | logfmt | msg=`Duty failed` | line_format `{{.duty}}\t{{.reason}}`",
+          "legendFormat": "{{level}} [{{topic}}] {{msg}}",
+          "queryType": "range",
+          "refId": "A",
+          "resolution": 10
+        }
+      ],
+      "title": "Duty Failed Reasons",
+      "type": "logs"
+    },
+    {
+      "datasource": {
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
@@ -1375,6 +1335,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1407,7 +1369,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1423,7 +1386,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 27
       },
       "id": 17,
       "options": {
@@ -1465,6 +1428,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1497,7 +1462,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1513,7 +1479,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 27
       },
       "id": 18,
       "options": {
@@ -1555,6 +1521,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1587,7 +1555,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1603,7 +1572,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 34
       },
       "id": 15,
       "options": {
@@ -1645,6 +1614,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1677,7 +1648,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1693,7 +1665,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 34
       },
       "id": 24,
       "options": {
@@ -1735,6 +1707,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1768,7 +1742,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1784,7 +1759,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 41
       },
       "id": 50,
       "options": {
@@ -1840,6 +1815,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -1873,7 +1850,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1902,7 +1880,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 41
       },
       "id": 49,
       "options": {
@@ -1968,7 +1946,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue"
+                "color": "light-blue",
+                "value": null
               },
               {
                 "color": "red",
@@ -2060,7 +2039,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 48
       },
       "id": 56,
       "options": {
@@ -2073,7 +2052,7 @@
         },
         "showHeader": true
       },
-      "pluginVersion": "9.0.0",
+      "pluginVersion": "9.1.6",
       "targets": [
         {
           "datasource": {
@@ -2136,6 +2115,8 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
@@ -2168,7 +2149,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2184,7 +2166,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 48
       },
       "id": 52,
       "links": [],
@@ -2219,10 +2201,48 @@
       ],
       "title": "CPU",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "loki",
+        "uid": "P8E80F9AEF21F6940"
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 55
+      },
+      "id": 65,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": false
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "P8E80F9AEF21F6940"
+          },
+          "editorMode": "code",
+          "expr": "{compose_service=\"$node\"} | logfmt | line_format \"{{upper .level | trunc 4 }} {{.topic}}\t{{.msg}}\t\t{{if .slot}}slot={{.slot}}{{end}}{{if .duty}}duty={{.duty}}{{end}}\"",
+          "queryType": "range",
+          "refId": "A",
+          "resolution": 1
+        }
+      ],
+      "title": "Logs",
+      "type": "logs"
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 36,
+  "schemaVersion": 37,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
@@ -41,6 +41,10 @@
      "Value": "debug"
     },
     {
+     "Key": "log-format",
+     "Value": "console"
+    },
+    {
      "Key": "feature-set",
      "Value": "alpha"
     },
@@ -90,6 +94,10 @@
     {
      "Key": "log-level",
      "Value": "debug"
+    },
+    {
+     "Key": "log-format",
+     "Value": "console"
     },
     {
      "Key": "feature-set",
@@ -143,6 +151,10 @@
      "Value": "debug"
     },
     {
+     "Key": "log-format",
+     "Value": "console"
+    },
+    {
      "Key": "feature-set",
      "Value": "alpha"
     },
@@ -192,6 +204,10 @@
     {
      "Key": "log-level",
      "Value": "debug"
+    },
+    {
+     "Key": "log-format",
+     "Value": "console"
     },
     {
      "Key": "feature-set",

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -29,6 +29,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node0
       CHARON_DEFINITION_FILE: /compose/cluster-definition.json
@@ -46,6 +47,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node1
       CHARON_DEFINITION_FILE: /compose/cluster-definition.json
@@ -63,6 +65,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node2
       CHARON_DEFINITION_FILE: /compose/cluster-definition.json
@@ -80,6 +83,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node3
       CHARON_DEFINITION_FILE: /compose/cluster-definition.json

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -41,6 +41,10 @@
      "Value": "debug"
     },
     {
+     "Key": "log-format",
+     "Value": "console"
+    },
+    {
      "Key": "feature-set",
      "Value": "alpha"
     },
@@ -135,6 +139,10 @@
     {
      "Key": "log-level",
      "Value": "debug"
+    },
+    {
+     "Key": "log-format",
+     "Value": "console"
     },
     {
      "Key": "feature-set",
@@ -233,6 +241,10 @@
      "Value": "debug"
     },
     {
+     "Key": "log-format",
+     "Value": "console"
+    },
+    {
      "Key": "feature-set",
      "Value": "alpha"
     },
@@ -329,6 +341,10 @@
      "Value": "debug"
     },
     {
+     "Key": "log-format",
+     "Value": "console"
+    },
+    {
      "Key": "feature-set",
      "Value": "alpha"
     },
@@ -422,5 +438,5 @@
  "Bootnode": true,
  "Monitoring": true,
  "MonitoringPorts": true,
- "Loki": true
+ "Loki": false
 }

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -12,9 +12,7 @@ x-node-base: &node-base
 x-logging: &logging
   logging:
   
-    driver: loki
-    options:
-      loki-url: http://localhost:3100/loki/api/v1/push
+    driver: json-file
   
 
 services:
@@ -31,6 +29,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node0
       CHARON_JAEGER_SERVICE: node0
@@ -64,6 +63,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node1
       CHARON_JAEGER_SERVICE: node1
@@ -97,6 +97,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node2
       CHARON_JAEGER_SERVICE: node2
@@ -130,6 +131,7 @@ services:
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
       CHARON_P2P_BOOTNODE_RELAY: "false"
       CHARON_LOG_LEVEL: debug
+      CHARON_LOG_FORMAT: console
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node3
       CHARON_JAEGER_SERVICE: node3
@@ -242,15 +244,6 @@ services:
       - "16686:16686"
     
 
-  
-  loki:
-    image: grafana/loki:latest
-    ports:
-      - "3100:3100"
-    networks: [compose]
-    command: -config.file=/etc/loki/loki.yml
-    volumes:
-      - ./loki/loki.yml:/etc/loki/loki.yml
   
 
 

--- a/testutil/compose/testdata/TestNewDefaultConfig.golden
+++ b/testutil/compose/testdata/TestNewDefaultConfig.golden
@@ -18,5 +18,5 @@
  ],
  "feature_set": "alpha",
  "disable_monitoring_ports": false,
- "disable_loki": false
+ "enable_loki": false
 }


### PR DESCRIPTION
Changes compose log format to `logfmt` when running with `-loki` which results in new log panels being populated in the simnet dash.

category: feature
ticket: none
