### PR TITLE
core/parsigex: add support for `DutySyncMessage`

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -213,6 +213,13 @@ func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[
 			}
 
 			return signing.VerifyAggregateAndProof(ctx, eth2Cl, pubshare, &aggAndProof.SignedAggregateAndProof)
+		case core.DutySyncMessage:
+			msg, ok := data.SignedData.(core.SignedSyncMessage)
+			if !ok {
+				return errors.New("invalid sync committee message")
+			}
+
+			return signing.VerifySyncCommitteeMessage(ctx, eth2Cl, pubshare, &msg.SyncCommitteeMessage)
 		default:
 			return errors.New("unknown duty type")
 		}

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -261,4 +261,16 @@ func TestParSigExVerifier(t *testing.T) {
 
 		require.NoError(t, verifyFunc(ctx, core.NewAggregatorDuty(slot), pubkey, data))
 	})
+
+	t.Run("verify sync committee message", func(t *testing.T) {
+		msg := testutil.RandomSyncCommitteeMessage()
+		msg.Slot = slot
+
+		sigData, err := signing.GetDataRoot(ctx, bmock, signing.DomainSyncCommittee, epoch, msg.BeaconBlockRoot)
+		require.NoError(t, err)
+		msg.Signature = sign(sigData[:])
+
+		data := core.NewPartialSignedSyncMessage(msg, shareIdx)
+		require.NoError(t, verifyFunc(ctx, core.NewSyncMessageDuty(slot), pubkey, data))
+	})
 }

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -40,6 +40,8 @@ var (
 	_ SignedData = SignedRandao{}
 	_ SignedData = SignedBeaconCommitteeSubscription{}
 	_ SignedData = SignedAggregateAndProof{}
+	_ SignedData = SignedSyncMessage{}
+	_ SignedData = SignedSyncContribution{}
 )
 
 // SigFromETH2 returns a new signature from eth2 phase0 BLSSignature.


### PR DESCRIPTION
Add support for `DutySyncMessage` to parsigex. Also add tests.

category: feature
ticket: #1191 
