### PR TITLE
cmd: fix `charon enr --verbose` bug

### DIFF
--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -90,7 +90,7 @@ func writeExpandedEnr(w io.Writer, sig []byte, seq uint64, pubkey string) {
 	var sb strings.Builder
 	_, _ = sb.WriteString("\n")
 	_, _ = sb.WriteString("***************** Decoded ENR (see https://enr-viewer.com/ for additional fields) **********************\n")
-	_, _ = sb.WriteString(fmt.Sprintf("secp256k1 pubkey: %#x\n", pubkey))
+	_, _ = sb.WriteString(fmt.Sprintf("secp256k1 pubkey: %s\n", pubkey))
 	_, _ = sb.WriteString(fmt.Sprintf("signature: %#x\n", sig))
 	_, _ = sb.WriteString(fmt.Sprintf("seq: %d\n", seq))
 	_, _ = sb.WriteString("********************************************************************************************************\n")
@@ -99,7 +99,7 @@ func writeExpandedEnr(w io.Writer, sig []byte, seq uint64, pubkey string) {
 	_, _ = w.Write([]byte(sb.String()))
 }
 
-// pubkeyHex returns compressed public key bytes.
+// pubkeyHex compresses the provided public key and returns the 0x hex encoded string.
 func pubkeyHex(pubkey ecdsa.PublicKey) string {
 	b := crypto.CompressPubkey(&pubkey)
 

--- a/cmd/enr_internal_test.go
+++ b/cmd/enr_internal_test.go
@@ -16,15 +16,25 @@
 package cmd
 
 import (
+	"crypto/ecdsa"
+	"encoding/hex"
 	"io"
+	"math/rand"
 	"os"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/p2p"
+)
+
+const (
+	compressedK1PubkeyLen = 33
 )
 
 func TestRunNewEnr(t *testing.T) {
@@ -34,4 +44,14 @@ func TestRunNewEnr(t *testing.T) {
 	got := runNewENR(io.Discard, p2p.Config{}, temp, false)
 	expected := errors.New("private key not found. If this is your first time running this client, create one with `charon create enr`.", z.Str("enr_path", p2p.KeyPath(temp)))
 	require.Equal(t, expected.Error(), got.Error())
+}
+
+func TestPubkeyHex(t *testing.T) {
+	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(time.Now().Unix())))
+	require.NoError(t, err)
+
+	pk := pubkeyHex(key.PublicKey)
+	bytes, err := hex.DecodeString(strings.TrimPrefix(pk, "0x"))
+	require.NoError(t, err)
+	require.Equal(t, len(bytes), compressedK1PubkeyLen)
 }


### PR DESCRIPTION
`charon enr --verbose` reports wrong value for decoded k1 public key. This PR fixes it.

category: bug 
ticket: none 
