### PR TITLE
cmd: remove default values for `p2p-tcp-address` and `p2p-udp-address`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -265,6 +265,12 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
+	// Start discv5 UDP node.
+	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, bootnodes)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	relays := p2p.NewRelays(conf.P2P, bootnodes)
 
 	connGater, err := p2p.NewConnGater(peerIDs, relays)
@@ -273,13 +279,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	// Start libp2p TCP node.
-	tcpNode, err := p2p.NewTCPNode(conf.P2P, p2pKey, connGater)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Start discv5 UDP node.
-	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, bootnodes)
+	tcpNode, err := p2p.NewTCPNode(ctx, conf.P2P, p2pKey, connGater)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -254,17 +254,13 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
+	// Start libp2p TCP node.
 	localEnode, peerDB, err := p2p.NewLocalEnode(conf.P2P, p2pKey)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	bootnodes, err := p2p.NewUDPBootnodes(ctx, conf.P2P, peers, localEnode.ID(), lockHashHex)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, bootnodes)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -281,9 +277,17 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
+	// Start discv5 UDP node.
+	udpNode, ok, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, bootnodes)
+	if err != nil {
+		return nil, nil, err
+	} else if ok {
+		life.RegisterStop(lifecycle.StopP2PUDPNode, lifecycle.HookFuncMin(udpNode.Close))
+		life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewDiscoveryRouter(tcpNode, udpNode, peers))
+	}
+
 	life.RegisterStop(lifecycle.StopP2PPeerDB, lifecycle.HookFuncMin(peerDB.Close))
 	life.RegisterStop(lifecycle.StopP2PTCPNode, lifecycle.HookFuncErr(tcpNode.Close))
-	life.RegisterStop(lifecycle.StopP2PUDPNode, lifecycle.HookFuncMin(udpNode.Close))
 
 	for _, relay := range relays {
 		life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartRelay, p2p.NewRelayReserver(tcpNode, relay))
@@ -291,7 +295,6 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PPing, p2p.NewPingService(tcpNode, peerIDs, conf.TestConfig.TestPingConfig))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PEventCollector, p2p.NewEventCollector(tcpNode))
-	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewDiscoveryRouter(tcpNode, udpNode, peers))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewRelayRouter(tcpNode, peers, relays))
 
 	return tcpNode, localEnode, nil

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -117,11 +117,9 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 	}
 	defer db.Close()
 
-	udpNode, discv5Enabled, err := p2p.NewUDPNode(ctx, config.P2PConfig, localEnode, key, nil)
+	udpNode, err := p2p.NewUDPNode(ctx, config.P2PConfig, localEnode, key, nil)
 	if err != nil {
 		return err
-	} else if discv5Enabled {
-		defer udpNode.Close()
 	}
 
 	// Setup p2p tcp relay (async for snappy startup)
@@ -221,10 +219,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 		case err := <-p2pErr:
 			return err
 		case <-ticker.C:
-			if discv5Enabled {
-				log.Info(ctx, "Discv5 UDP discovered peers", z.Int("peers", len(udpNode.AllNodes())))
-			}
-
+			log.Info(ctx, "Discv5 UDP discovered peers", z.Int("peers", len(udpNode.AllNodes())))
 			logP2P()
 		case <-ctx.Done():
 			log.Info(ctx, "Shutting down")

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -66,7 +66,7 @@ func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
 	bindBootnodeFlag(cmd.Flags(), &config)
-	bindP2PFlags(cmd.Flags(), &config.P2PConfig)
+	bindP2PFlags(cmd, &config.P2PConfig)
 	bindLogFlags(cmd.Flags(), &config.LogConfig)
 
 	return cmd

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -121,6 +121,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 	if err != nil {
 		return err
 	}
+	defer udpNode.Close()
 
 	// Setup p2p tcp relay (async for snappy startup)
 	var (
@@ -151,7 +152,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 			p2pErr <- errors.Wrap(err, "new resource manager")
 		}
 
-		tcpNode, err := p2p.NewTCPNode(config.P2PConfig, key, p2p.NewOpenGater(), libp2p.ResourceManager(mgr))
+		tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(), libp2p.ResourceManager(mgr))
 		if err != nil {
 			p2pErr <- errors.Wrap(err, "new tcp node")
 			return

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -110,18 +110,19 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 		return err
 	}
 
-	// Setup p2p udp discovery
+	// Setup p2p udp discovery.
 	localEnode, db, err := p2p.NewLocalEnode(config.P2PConfig, key)
 	if err != nil {
 		return errors.Wrap(err, "failed to open enode")
 	}
 	defer db.Close()
 
-	udpNode, err := p2p.NewUDPNode(ctx, config.P2PConfig, localEnode, key, nil)
+	udpNode, discv5Enabled, err := p2p.NewUDPNode(ctx, config.P2PConfig, localEnode, key, nil)
 	if err != nil {
-		return errors.Wrap(err, "")
+		return err
+	} else if discv5Enabled {
+		defer udpNode.Close()
 	}
-	defer udpNode.Close()
 
 	// Setup p2p tcp relay (async for snappy startup)
 	var (
@@ -220,7 +221,10 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 		case err := <-p2pErr:
 			return err
 		case <-ticker.C:
-			log.Info(ctx, "Discv5 UDP discovered peers", z.Int("peers", len(udpNode.AllNodes())))
+			if discv5Enabled {
+				log.Info(ctx, "Discv5 UDP discovered peers", z.Int("peers", len(udpNode.AllNodes())))
+			}
+
 			logP2P()
 		case <-ctx.Done():
 			log.Info(ctx, "Shutting down")

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -74,9 +74,9 @@ func TestCmdFlags(t *testing.T) {
 				P2P: p2p.Config{
 					UDPBootnodes: []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
 					UDPAddr:      "",
-					// TCPAddrs:     []string{"127.0.0.1:3610"},
-					Allowlist: "",
-					Denylist:  "",
+					TCPAddrs:     nil,
+					Allowlist:    "",
+					Denylist:     "",
 				},
 				Feature: featureset.Config{
 					MinStatus: "stable",
@@ -100,9 +100,9 @@ func TestCmdFlags(t *testing.T) {
 			P2PConfig: &p2p.Config{
 				UDPBootnodes: []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
 				UDPAddr:      "",
-				// TCPAddrs:     []string{"127.0.0.1:3610"},
-				Allowlist: "",
-				Denylist:  "",
+				TCPAddrs:     nil,
+				Allowlist:    "",
+				Denylist:     "",
 			},
 		},
 		{

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -119,7 +119,7 @@ func TestCmdFlags(t *testing.T) {
 				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
 				"CHARON_P2P_BOOTNODE_RELAY":    "false",
 			},
-			ErrorMsg: "node undiscoverable with the provided settings, please enable any one of `p2p-udp-address`, `p2p-bootnode-relay` or `p2p-bootnodes-from-lockfile`",
+			ErrorMsg: "node undiscoverable with the provided settings, please configure any one of `p2p-udp-address`, `p2p-bootnode-relay` or `p2p-bootnodes-from-lockfile`",
 		},
 	}
 

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -73,10 +73,10 @@ func TestCmdFlags(t *testing.T) {
 				},
 				P2P: p2p.Config{
 					UDPBootnodes: []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
-					UDPAddr:      "127.0.0.1:3630",
-					TCPAddrs:     []string{"127.0.0.1:3610"},
-					Allowlist:    "",
-					Denylist:     "",
+					UDPAddr:      "",
+					// TCPAddrs:     []string{"127.0.0.1:3610"},
+					Allowlist: "",
+					Denylist:  "",
 				},
 				Feature: featureset.Config{
 					MinStatus: "stable",
@@ -99,10 +99,10 @@ func TestCmdFlags(t *testing.T) {
 			Datadir: ".charon",
 			P2PConfig: &p2p.Config{
 				UDPBootnodes: []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
-				UDPAddr:      "127.0.0.1:3630",
-				TCPAddrs:     []string{"127.0.0.1:3610"},
-				Allowlist:    "",
-				Denylist:     "",
+				UDPAddr:      "",
+				// TCPAddrs:     []string{"127.0.0.1:3610"},
+				Allowlist: "",
+				Denylist:  "",
 			},
 		},
 		{

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -72,11 +72,12 @@ func TestCmdFlags(t *testing.T) {
 					Format: "console",
 				},
 				P2P: p2p.Config{
-					UDPBootnodes: []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
-					UDPAddr:      "",
-					TCPAddrs:     nil,
-					Allowlist:    "",
-					Denylist:     "",
+					UDPBootnodes:  []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
+					UDPAddr:       "",
+					TCPAddrs:      nil,
+					Allowlist:     "",
+					Denylist:      "",
+					BootnodeRelay: true,
 				},
 				Feature: featureset.Config{
 					MinStatus: "stable",
@@ -98,17 +99,27 @@ func TestCmdFlags(t *testing.T) {
 			Args:    slice("create", "enr"),
 			Datadir: ".charon",
 			P2PConfig: &p2p.Config{
-				UDPBootnodes: []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
-				UDPAddr:      "",
-				TCPAddrs:     nil,
-				Allowlist:    "",
-				Denylist:     "",
+				UDPBootnodes:  []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"},
+				UDPAddr:       "",
+				TCPAddrs:      nil,
+				Allowlist:     "",
+				Denylist:      "",
+				BootnodeRelay: true,
 			},
 		},
 		{
 			Name:     "run require beacon addrs",
 			Args:     slice("run"),
 			ErrorMsg: "either flag 'beacon-node-endpoints' or flag 'simnet-beacon-mock=true' must be specified",
+		},
+		{
+			Name: "run requires node discoverability",
+			Args: slice("run"),
+			Envs: map[string]string{
+				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
+				"CHARON_P2P_BOOTNODE_RELAY":    "false",
+			},
+			ErrorMsg: "node undiscoverable with the provided settings, please enable any one of `p2p-udp-address`, `p2p-bootnode-relay` or `p2p-bootnodes-from-lockfile`",
 		},
 	}
 

--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -46,7 +46,7 @@ func newCreateEnrCmd(runFunc func(io.Writer, p2p.Config, string) error) *cobra.C
 	}
 
 	bindDataDirFlag(cmd.Flags(), &dataDir)
-	bindP2PFlags(cmd.Flags(), &config)
+	bindP2PFlags(cmd, &config)
 
 	return cmd
 }

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -44,7 +44,7 @@ this command at the same time.`,
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
 	bindDefDirFlag(cmd.Flags(), &config.DefFile)
 	bindNoVerifyFlag(cmd.Flags(), &config.NoVerify)
-	bindP2PFlags(cmd.Flags(), &config.P2P)
+	bindP2PFlags(cmd, &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
 
 	return cmd

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -49,7 +49,7 @@ func newEnrCmd(runFunc func(io.Writer, p2p.Config, string, bool) error) *cobra.C
 	}
 
 	bindDataDirFlag(cmd.Flags(), &dataDir)
-	bindP2PFlags(cmd.Flags(), &config)
+	bindP2PFlags(cmd, &config)
 	bindEnrFlags(cmd.Flags(), &verbose)
 
 	return cmd

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -20,9 +20,11 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -80,19 +82,21 @@ func runNewENR(w io.Writer, config p2p.Config, dataDir string, verbose bool) err
 		return nil
 	}
 
-	writeExpandedEnr(w, r.Signature(), r.Seq(), pubkeyHex(key.PublicKey))
+	writeExpandedEnr(w, r, key)
 
 	return nil
 }
 
 // writeExpandedEnr writes the expanded form of ENR to the terminal.
-func writeExpandedEnr(w io.Writer, sig []byte, seq uint64, pubkey string) {
+func writeExpandedEnr(w io.Writer, r enr.Record, privKey *ecdsa.PrivateKey) {
 	var sb strings.Builder
 	_, _ = sb.WriteString("\n")
 	_, _ = sb.WriteString("***************** Decoded ENR (see https://enr-viewer.com/ for additional fields) **********************\n")
-	_, _ = sb.WriteString(fmt.Sprintf("secp256k1 pubkey: %s\n", pubkey))
-	_, _ = sb.WriteString(fmt.Sprintf("signature: %#x\n", sig))
-	_, _ = sb.WriteString(fmt.Sprintf("seq: %d\n", seq))
+	_, _ = sb.WriteString(fmt.Sprintf("secp256k1 pubkey: %#x\n", pubkeyHex(privKey.PublicKey)))
+	_, _ = sb.WriteString(fmt.Sprintf("signature: %#x\n", r.Signature()))
+	_, _ = sb.WriteString(fmt.Sprintf("seq: %d\n", r.Seq()))
+	_, _ = sb.WriteString(fmt.Sprintf("id: %s\n", r.IdentityScheme()))
+	_, _ = sb.WriteString(enrNetworkingKeys(r))
 	_, _ = sb.WriteString("********************************************************************************************************\n")
 	_, _ = sb.WriteString("\n")
 
@@ -108,4 +112,43 @@ func pubkeyHex(pubkey ecdsa.PublicKey) string {
 
 func bindEnrFlags(flags *pflag.FlagSet, verbose *bool) {
 	flags.BoolVar(verbose, "verbose", false, "Prints the expanded form of ENR.")
+}
+
+// enrNetworkingKeys returns a string containing the non-empty networking keys (ips and ports) present in the ENR record.
+func enrNetworkingKeys(r enr.Record) string {
+	var (
+		sb   strings.Builder
+		ip   enr.IPv4
+		ip6  enr.IPv6
+		tcp  enr.TCP
+		tcp6 enr.TCP6
+		udp  enr.UDP
+		udp6 enr.UDP6
+	)
+
+	if err := r.Load(&ip); err == nil {
+		_, _ = sb.WriteString(fmt.Sprintf("%s: %s\n", ip.ENRKey(), net.IP(ip).String()))
+	}
+
+	if err := r.Load(&ip6); err == nil {
+		_, _ = sb.WriteString(fmt.Sprintf("%s: %s\n", ip6.ENRKey(), net.IP(ip6).String()))
+	}
+
+	if err := r.Load(&tcp); err == nil {
+		_, _ = sb.WriteString(fmt.Sprintf("%s: %d\n", tcp.ENRKey(), tcp))
+	}
+
+	if err := r.Load(&tcp6); err == nil {
+		_, _ = sb.WriteString(fmt.Sprintf("%s: %d\n", tcp6.ENRKey(), tcp6))
+	}
+
+	if err := r.Load(&udp); err == nil {
+		_, _ = sb.WriteString(fmt.Sprintf("%s: %d\n", udp.ENRKey(), udp))
+	}
+
+	if err := r.Load(&udp6); err == nil {
+		_, _ = sb.WriteString(fmt.Sprintf("%s: %d\n", udp6.ENRKey(), udp6))
+	}
+
+	return sb.String()
 }

--- a/cmd/enr_internal_test.go
+++ b/cmd/enr_internal_test.go
@@ -20,17 +20,20 @@ import (
 	"encoding/hex"
 	"io"
 	"math/rand"
+	"net"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 const (
@@ -54,4 +57,27 @@ func TestPubkeyHex(t *testing.T) {
 	bytes, err := hex.DecodeString(strings.TrimPrefix(pk, "0x"))
 	require.NoError(t, err)
 	require.Equal(t, len(bytes), compressedK1PubkeyLen)
+}
+
+func TestEnrNetworkingKeys(t *testing.T) {
+	var (
+		ip       = enr.IPv4(net.ParseIP("192.168.3.45"))
+		ip6      = enr.IPv6(net.ParseIP("192.123.87.12"))
+		tcp      = enr.TCP(4987)
+		tcp6     = enr.TCP6(9844)
+		udp      = enr.UDP(1344)
+		udp6     = enr.UDP6(5198)
+		expected = "ip: 192.168.3.45\nip6: 192.123.87.12\ntcp: 4987\ntcp6: 9844\nudp: 1344\nudp6: 5198\n"
+	)
+
+	_, r := testutil.RandomENR(t, rand.New(rand.NewSource(time.Now().Unix())))
+	r.Set(ip)
+	r.Set(ip6)
+	r.Set(tcp)
+	r.Set(tcp6)
+	r.Set(udp)
+	r.Set(udp6)
+
+	got := enrNetworkingKeys(r)
+	require.Equal(t, expected, got)
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -136,17 +136,17 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
 	cmd.Flags().BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", true, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible.")
 	cmd.Flags().BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
-	cmd.Flags().StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery.")
+	cmd.Flags().StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery.")
 	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	cmd.Flags().StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
-	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.")
+	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")
 	cmd.Flags().StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
 	cmd.Flags().StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
 
 	preRunE := cmd.PreRunE // Allow multiple wraps of PreRunE.
 	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
 		if config.UDPAddr == "" && !config.BootnodeRelay && !config.UDPBootLock {
-			return errors.New("node undiscoverable with the provided settings, please enable any one of `p2p-udp-address`, `p2p-bootnode-relay` or `p2p-bootnodes-from-lockfile`")
+			return errors.New("node undiscoverable with the provided settings, please configure any one of `p2p-udp-address`, `p2p-bootnode-relay` or `p2p-bootnodes-from-lockfile`")
 		}
 
 		if preRunE != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -51,7 +51,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 	bindPrivKeyFlag(cmd, &conf.PrivKeyFile)
 	bindRunFlags(cmd, &conf)
 	bindNoVerifyFlag(cmd.Flags(), &conf.NoVerify)
-	bindP2PFlags(cmd.Flags(), &conf.P2P)
+	bindP2PFlags(cmd, &conf.P2P)
 	bindLogFlags(cmd.Flags(), &conf.Log)
 	bindFeatureFlags(cmd.Flags(), &conf.Feature)
 
@@ -132,16 +132,29 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 	flags.StringVar(&config.Level, "log-level", "info", "Log level; debug, info, warn or error")
 }
 
-func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
-	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
-	flags.BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", false, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.")
-	flags.BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
-	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery.")
-	flags.StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
-	flags.StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
-	flags.StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.")
-	flags.StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
-	flags.StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
+func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
+	cmd.Flags().StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
+	cmd.Flags().BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", true, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible.")
+	cmd.Flags().BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
+	cmd.Flags().StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery.")
+	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
+	cmd.Flags().StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
+	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.")
+	cmd.Flags().StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
+	cmd.Flags().StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
+
+	preRunE := cmd.PreRunE // Allow multiple wraps of PreRunE.
+	cmd.PreRunE = func(cmd *cobra.Command, args []string) error {
+		if config.UDPAddr == "" && !config.BootnodeRelay && !config.UDPBootLock {
+			return errors.New("node undiscoverable with the provided settings, please enable any one of `p2p-udp-address`, `p2p-bootnode-relay` or `p2p-bootnodes-from-lockfile`")
+		}
+
+		if preRunE != nil {
+			return preRunE(cmd, args)
+		}
+
+		return nil
+	}
 }
 
 func bindFeatureFlags(flags *pflag.FlagSet, config *featureset.Config) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -136,10 +136,10 @@ func bindP2PFlags(flags *pflag.FlagSet, config *p2p.Config) {
 	flags.StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
 	flags.BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", false, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.")
 	flags.BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.")
-	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "127.0.0.1:3630", "Listening UDP address (ip and port) for discv5 discovery.")
+	flags.StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery.")
 	flags.StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	flags.StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
-	flags.StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", []string{"127.0.0.1:3610"}, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.")
+	flags.StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.")
 	flags.StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
 	flags.StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -228,9 +228,11 @@ func setupP2P(ctx context.Context, key *ecdsa.PrivateKey, p2pConf p2p.Config, pe
 		return nil, nil, errors.Wrap(err, "new bootnodes")
 	}
 
-	udpNode, err := p2p.NewUDPNode(ctx, p2pConf, localEnode, key, bootnodes)
+	udpNode, ok, err := p2p.NewUDPNode(ctx, p2pConf, localEnode, key, bootnodes)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "")
+	} else if !ok {
+		udpNode = new(p2p.MutableUDPNode)
 	}
 
 	relays := p2p.NewRelays(p2pConf, bootnodes)

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -228,11 +228,9 @@ func setupP2P(ctx context.Context, key *ecdsa.PrivateKey, p2pConf p2p.Config, pe
 		return nil, nil, errors.Wrap(err, "new bootnodes")
 	}
 
-	udpNode, ok, err := p2p.NewUDPNode(ctx, p2pConf, localEnode, key, bootnodes)
+	udpNode, err := p2p.NewUDPNode(ctx, p2pConf, localEnode, key, bootnodes)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "")
-	} else if !ok {
-		udpNode = new(p2p.MutableUDPNode)
 	}
 
 	relays := p2p.NewRelays(p2pConf, bootnodes)

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -235,7 +235,7 @@ func setupP2P(ctx context.Context, key *ecdsa.PrivateKey, p2pConf p2p.Config, pe
 
 	relays := p2p.NewRelays(p2pConf, bootnodes)
 
-	tcpNode, err := p2p.NewTCPNode(p2pConf, key, p2p.NewOpenGater())
+	tcpNode, err := p2p.NewTCPNode(ctx, p2pConf, key, p2p.NewOpenGater())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "")
 	}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,8 +134,8 @@ Flags:
       --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.
-      --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. (default [127.0.0.1:3610])
-      --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery. (default "127.0.0.1:3630")
+      --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.
+      --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,8 +134,8 @@ Flags:
       --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.
-      --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic.
-      --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery.
+      --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
+      --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ Flags:
       --monitoring-address string          Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
       --no-verify                          Disables cluster definition and lock file verification.
       --p2p-allowlist string               Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-bootnode-relay                 Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not have publicly accessible.
+      --p2p-bootnode-relay                 Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. (default true)
       --p2p-bootnodes strings              Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.lb.gcp.obol.tech:3640/enr])
       --p2p-bootnodes-from-lockfile        Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
       --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -131,26 +131,26 @@ func (n *MutableUDPNode) AllNodes() []*enode.Node {
 	return n.udpNode.AllNodes()
 }
 
-// NewUDPNode starts and returns a discv5 UDP provider. It returns false if the udp node is not started.
+// NewUDPNode starts and returns a discv5 UDP provider.
 func NewUDPNode(ctx context.Context, config Config, ln *enode.LocalNode,
 	key *ecdsa.PrivateKey, bootnodes []*MutablePeer,
-) (*MutableUDPNode, bool, error) {
-	if config.UDPAddr == "" { // Do not start a discv5 UDPNode if p2p-udp-address is not defined.
-		log.Debug(ctx, "Not starting discv5 UDP node since p2p-udp-address not defined, only relying on libp2p relays for discovery")
+) (*MutableUDPNode, error) {
+	if config.UDPAddr == "" {
+		log.Info(ctx, "Discv5 UDP peer discovery disabled since --p2p-udp-address empty.")
 
-		return nil, false, nil
+		return new(MutableUDPNode), nil
 	}
 
 	udpAddr, err := net.ResolveUDPAddr("udp", config.UDPAddr)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "resolve udp address")
+		return nil, errors.Wrap(err, "resolve udp address")
 	}
 
 	var allowList *netutil.Netlist
 	if config.Allowlist != "" {
 		allowList, err = netutil.ParseNetlist(config.Allowlist) // Note empty string would result in "none allowed".
 		if err != nil {
-			return nil, false, errors.Wrap(err, "parse allow list")
+			return nil, errors.Wrap(err, "parse allow list")
 		}
 	}
 
@@ -187,7 +187,7 @@ func NewUDPNode(ctx context.Context, config Config, ln *enode.LocalNode,
 	}
 
 	// Return a refreshed mutable udp node
-	return mutable, true, mutable.maybeRefresh(bootnodes)
+	return mutable, mutable.maybeRefresh(bootnodes)
 }
 
 // NewLocalEnode returns a local enode and a peer DB or an error.

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -256,7 +256,7 @@ func NewLocalEnode(config Config, key *ecdsa.PrivateKey) (*enode.LocalNode, *eno
 }
 
 // NewDiscoveryRouter returns a life cycle hook that links discv5 to libp2p by
-// continuously polling discv5 for latest peer ENRs and adding them to libp2p peer store.
+// continuously polling discv5 for latest peer ENRs and adding them to the libp2p peer store.
 func NewDiscoveryRouter(tcpNode host.Host, udpNode *MutableUDPNode, peers []Peer) lifecycle.HookFuncCtx {
 	return func(ctx context.Context) {
 		ctx = log.WithTopic(ctx, "p2p")

--- a/p2p/discovery_test.go
+++ b/p2p/discovery_test.go
@@ -46,8 +46,9 @@ func TestExternalHost(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	udpNode, err := p2p.NewUDPNode(context.Background(), config, localNode, p2pKey, nil)
+	udpNode, ok, err := p2p.NewUDPNode(context.Background(), config, localNode, p2pKey, nil)
 	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
+	require.True(t, ok)
 	defer udpNode.Close()
 }

--- a/p2p/discovery_test.go
+++ b/p2p/discovery_test.go
@@ -46,9 +46,9 @@ func TestExternalHost(t *testing.T) {
 	require.NoError(t, err)
 	defer db.Close()
 
-	udpNode, ok, err := p2p.NewUDPNode(context.Background(), config, localNode, p2pKey, nil)
+	udpNode, err := p2p.NewUDPNode(context.Background(), config, localNode, p2pKey, nil)
 	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
-	require.True(t, ok)
+
 	defer udpNode.Close()
 }

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -54,8 +54,6 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater, opts ...
 	defaultOpts := []libp2p.Option{
 		// Set P2P identity key.
 		libp2p.Identity(priv),
-		// Set listen addresses.
-		libp2p.ListenAddrs(addrs...),
 		// Set up user-agent.
 		libp2p.UserAgent("obolnetwork-charon/" + version.Version),
 		// Limit connections to DV peers.
@@ -65,6 +63,11 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater, opts ...
 		// Define p2pcfg.AddrsFactory that does not advertise
 		// addresses via libp2p, since we use discv5 for peer discovery.
 		libp2p.AddrsFactory(func([]ma.Multiaddr) []ma.Multiaddr { return nil }),
+	}
+
+	// Set TCP listen addresses.
+	if len(addrs) > 0 {
+		defaultOpts = append(defaultOpts, libp2p.ListenAddrs(addrs...))
 	}
 
 	defaultOpts = append(defaultOpts, opts...)

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -38,11 +38,15 @@ import (
 )
 
 // NewTCPNode returns a started tcp-based libp2p host.
-func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater, opts ...libp2p.Option,
+func NewTCPNode(ctx context.Context, cfg Config, key *ecdsa.PrivateKey, connGater ConnGater, opts ...libp2p.Option,
 ) (host.Host, error) {
 	addrs, err := cfg.Multiaddrs()
 	if err != nil {
 		return nil, err
+	}
+
+	if len(addrs) == 0 {
+		log.Info(ctx, "LibP2P not accepting incoming connections since --p2p-tcp-addresses empty.")
 	}
 
 	priv, err := libp2pcrypto.UnmarshalSecp256k1PrivateKey(crypto.FromECDSA(key))

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -54,6 +54,8 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater, opts ...
 	defaultOpts := []libp2p.Option{
 		// Set P2P identity key.
 		libp2p.Identity(priv),
+		// Set TCP listen addresses.
+		libp2p.ListenAddrs(addrs...),
 		// Set up user-agent.
 		libp2p.UserAgent("obolnetwork-charon/" + version.Version),
 		// Limit connections to DV peers.
@@ -63,11 +65,6 @@ func NewTCPNode(cfg Config, key *ecdsa.PrivateKey, connGater ConnGater, opts ...
 		// Define p2pcfg.AddrsFactory that does not advertise
 		// addresses via libp2p, since we use discv5 for peer discovery.
 		libp2p.AddrsFactory(func([]ma.Multiaddr) []ma.Multiaddr { return nil }),
-	}
-
-	// Set TCP listen addresses.
-	if len(addrs) > 0 {
-		defaultOpts = append(defaultOpts, libp2p.ListenAddrs(addrs...))
 	}
 
 	defaultOpts = append(defaultOpts, opts...)

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -16,6 +16,7 @@
 package p2p_test
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"math/rand"
 	"testing"
@@ -50,7 +51,7 @@ func TestNewHost(t *testing.T) {
 	privKey, err := crypto.GenerateKey()
 	require.NoError(t, err)
 
-	_, err = p2p.NewTCPNode(p2p.Config{}, privKey, p2p.NewOpenGater(), nil, nil, nil)
+	_, err = p2p.NewTCPNode(context.Background(), p2p.Config{}, privKey, p2p.NewOpenGater(), nil, nil, nil)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
* Removes default values for `p2p-tcp-address` and `p2p-udp-address`. 
* Errors if `--p2p-udp-address==""` and `--p2p-bootnode-relay=false` and `--p2p-bootnodes-from-lockfile==false`.
* Sets`--p2p-bootnode-relay` default value to true.
* Output all information pertaining to a decoded ENR for `charon enr --verbose`.

category: feature
ticket: #998 
