### PR TITLE
cmd: add init logger in printFlags

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -123,9 +123,6 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}()
 
 	_, _ = maxprocs.Set()
-	if err := log.InitLogger(conf.Log); err != nil {
-		return err
-	}
 
 	if err := featureset.Init(ctx, conf.Feature); err != nil {
 		return err

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -58,9 +58,11 @@ func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.
 		Long:  `Starts a discv5 bootnode that charon nodes can use to bootstrap their p2p cluster`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := printFlags(cmd.Context(), cmd.Flags()); err != nil {
+			if err := initLogger(cmd.Flags()); err != nil {
 				return err
 			}
+
+			printFlags(cmd.Context(), cmd.Flags())
 
 			return runFunc(cmd.Context(), config)
 		},

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/p2p"
 )
@@ -93,6 +94,8 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 	defer cancel()
 
 	ctx = log.WithTopic(ctx, "bootnode")
+
+	version.LogInfo(ctx, "Charon bootnode starting")
 
 	key, err := p2p.LoadPrivKey(config.DataDir)
 	if errors.Is(err, os.ErrNotExist) {

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -32,7 +32,6 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
-	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/p2p"
 )
@@ -59,7 +58,9 @@ func newBootnodeCmd(runFunc func(context.Context, BootnodeConfig) error) *cobra.
 		Long:  `Starts a discv5 bootnode that charon nodes can use to bootstrap their p2p cluster`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			printFlags(cmd.Context(), cmd.Flags())
+			if err := printFlags(cmd.Context(), cmd.Flags()); err != nil {
+				return err
+			}
 
 			return runFunc(cmd.Context(), config)
 		},
@@ -90,12 +91,6 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 	defer cancel()
 
 	ctx = log.WithTopic(ctx, "bootnode")
-
-	if err := log.InitLogger(config.LogConfig); err != nil {
-		return err
-	}
-
-	version.LogInfo(ctx, "Charon bootnode starting")
 
 	key, err := p2p.LoadPrivKey(config.DataDir)
 	if errors.Is(err, os.ErrNotExist) {

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -146,9 +146,19 @@ func titledHelp(cmd *cobra.Command) {
 }
 
 // printFlags INFO logs all the given flags in alphabetical order.
-func printFlags(ctx context.Context, flags *pflag.FlagSet) error {
+func printFlags(ctx context.Context, flags *pflag.FlagSet) {
 	ctx = log.WithTopic(ctx, "cmd")
 
+	var zStrs []z.Field
+	flags.VisitAll(func(flag *pflag.Flag) {
+		zStrs = append(zStrs, z.Str(flag.Name, flag.Value.String()))
+	})
+
+	log.Info(ctx, "Parsed config", zStrs...)
+}
+
+// initLogger initialises logger based on provided log config flags.
+func initLogger(flags *pflag.FlagSet) error {
 	logLevel := flags.Lookup("log-level")
 	logFmt := flags.Lookup("log-format")
 
@@ -161,13 +171,6 @@ func printFlags(ctx context.Context, flags *pflag.FlagSet) error {
 			return err
 		}
 	}
-
-	var zStrs []z.Field
-	flags.VisitAll(func(flag *pflag.Flag) {
-		zStrs = append(zStrs, z.Str(flag.Name, flag.Value.String()))
-	})
-
-	log.Info(ctx, "Parsed config", zStrs...)
 
 	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -146,8 +146,21 @@ func titledHelp(cmd *cobra.Command) {
 }
 
 // printFlags INFO logs all the given flags in alphabetical order.
-func printFlags(ctx context.Context, flags *pflag.FlagSet) {
+func printFlags(ctx context.Context, flags *pflag.FlagSet) error {
 	ctx = log.WithTopic(ctx, "cmd")
+
+	logLevel := flags.Lookup("log-level")
+	logFmt := flags.Lookup("log-format")
+
+	if logLevel != nil && logFmt != nil {
+		err := log.InitLogger(log.Config{
+			Level:  logLevel.Value.String(),
+			Format: logFmt.Value.String(),
+		})
+		if err != nil {
+			return err
+		}
+	}
 
 	var zStrs []z.Field
 	flags.VisitAll(func(flag *pflag.Flag) {
@@ -155,4 +168,6 @@ func printFlags(ctx context.Context, flags *pflag.FlagSet) {
 	})
 
 	log.Info(ctx, "Parsed config", zStrs...)
+
+	return nil
 }

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -35,7 +35,9 @@ distributed validator key shares and a final cluster lock configuration. Note th
 this command at the same time.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			printFlags(cmd.Context(), cmd.Flags())
+			if err := printFlags(cmd.Context(), cmd.Flags()); err != nil {
+				return err
+			}
 
 			return runFunc(cmd.Context(), config)
 		},

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -35,9 +35,11 @@ distributed validator key shares and a final cluster lock configuration. Note th
 this command at the same time.`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if err := printFlags(cmd.Context(), cmd.Flags()); err != nil {
+			if err := initLogger(cmd.Flags()); err != nil {
 				return err
 			}
+
+			printFlags(cmd.Context(), cmd.Flags())
 
 			return runFunc(cmd.Context(), config)
 		},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,9 +41,11 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			defer cancel()
 
-			if err := printFlags(ctx, cmd.Flags()); err != nil {
+			if err := initLogger(cmd.Flags()); err != nil {
 				return err
 			}
+
+			printFlags(ctx, cmd.Flags())
 
 			return runFunc(ctx, conf)
 		},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -41,7 +41,9 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 			ctx, cancel := signal.NotifyContext(cmd.Context(), os.Interrupt)
 			defer cancel()
 
-			printFlags(ctx, cmd.Flags())
+			if err := printFlags(ctx, cmd.Flags()); err != nil {
+				return err
+			}
 
 			return runFunc(ctx, conf)
 		},

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/core"
@@ -63,6 +64,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 			log.Error(ctx, "Fatal error", err)
 		}
 	}()
+
+	version.LogInfo(ctx, "Charon DKG starting")
 
 	def, err := loadDefinition(ctx, conf)
 	if err != nil {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
-	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/core"
@@ -64,12 +63,6 @@ func Run(ctx context.Context, conf Config) (err error) {
 			log.Error(ctx, "Fatal error", err)
 		}
 	}()
-
-	if err := log.InitLogger(conf.Log); err != nil {
-		return err
-	}
-
-	version.LogInfo(ctx, "Charon DKG starting")
 
 	def, err := loadDefinition(ctx, conf)
 	if err != nil {


### PR DESCRIPTION
Inits logging as soon as log flags are parsed in printFlags function.

category: bug
ticket: #1272 
