### PR TITLE
dkg: remove reconnected logs

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -102,8 +102,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 
-	log.Info(ctx, "Starting local DKG peer: ",
-		z.Str("local_peer", p2p.PeerName(pID)))
+	log.Info(ctx, "Starting local P2P networking peer", z.Str("local_peer", p2p.PeerName(pID)))
 
 	tcpNode, shutdown, err := setupP2P(ctx, key, conf.P2P, peers, clusterID)
 	if err != nil {

--- a/dkg/sync/server.go
+++ b/dkg/sync/server.go
@@ -174,8 +174,6 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 		return errors.Wrap(err, "extract pubkey")
 	}
 
-	defer s.clearConnected(pID)
-
 	for {
 		// Read next sync message
 		msg := new(pb.MsgSync)

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -136,8 +136,7 @@ func NewUDPNode(ctx context.Context, config Config, ln *enode.LocalNode,
 	key *ecdsa.PrivateKey, bootnodes []*MutablePeer,
 ) (*MutableUDPNode, error) {
 	if config.UDPAddr == "" {
-		log.Info(ctx, "Discv5 UDP peer discovery disabled since --p2p-udp-address empty.")
-
+		log.Info(ctx, "Discv5 UDP peer discovery disabled since --p2p-udp-address empty")
 		return new(MutableUDPNode), nil
 	}
 

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -46,7 +46,7 @@ func NewTCPNode(ctx context.Context, cfg Config, key *ecdsa.PrivateKey, connGate
 	}
 
 	if len(addrs) == 0 {
-		log.Info(ctx, "LibP2P not accepting incoming connections since --p2p-tcp-addresses empty.")
+		log.Info(ctx, "LibP2P not accepting incoming connections since --p2p-tcp-addresses empty")
 	}
 
 	priv, err := libp2pcrypto.UnmarshalSecp256k1PrivateKey(crypto.FromECDSA(key))


### PR DESCRIPTION
Removes duplicate `Connected to peer 3 of 4` logs when relay circuits reconnect.
Also removes colons and periods from other logs.

category: misc
ticket: none
