### PR TITLE
core/validatorapi: cache commitee length with committee subscriptions

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -44,7 +44,6 @@ type Client interface {
 	eth2client.BeaconBlockProposalProvider
 	eth2client.BeaconBlockSubmitter
 	eth2client.BeaconCommitteeSubscriptionsSubmitter
-	eth2client.BeaconCommitteesProvider
 	eth2client.BlindedBeaconBlockProposalProvider
 	eth2client.BlindedBeaconBlockSubmitter
 	eth2client.DepositContractProvider
@@ -139,46 +138,6 @@ func (m multi) DepositContract(ctx context.Context) (*apiv1.DepositContract, err
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*apiv1.DepositContract, error) {
 			return cl.DepositContract(ctx)
-		},
-		nil,
-	)
-
-	if err != nil {
-		incError(label)
-		err = errors.Wrap(err, "eth2wrap")
-	}
-
-	return res0, err
-}
-
-// BeaconCommittees fetches all beacon committees for the epoch at the given state.
-func (m multi) BeaconCommittees(ctx context.Context, stateID string) ([]*apiv1.BeaconCommittee, error) {
-	const label = "beacon_committees"
-	defer latency(label)()
-
-	res0, err := provide(ctx, m.clients,
-		func(ctx context.Context, cl Client) ([]*apiv1.BeaconCommittee, error) {
-			return cl.BeaconCommittees(ctx, stateID)
-		},
-		nil,
-	)
-
-	if err != nil {
-		incError(label)
-		err = errors.Wrap(err, "eth2wrap")
-	}
-
-	return res0, err
-}
-
-// BeaconCommitteesAtEpoch fetches all beacon committees for the given epoch at the given state.
-func (m multi) BeaconCommitteesAtEpoch(ctx context.Context, stateID string, epoch phase0.Epoch) ([]*apiv1.BeaconCommittee, error) {
-	const label = "beacon_committees_at_epoch"
-	defer latency(label)()
-
-	res0, err := provide(ctx, m.clients,
-		func(ctx context.Context, cl Client) ([]*apiv1.BeaconCommittee, error) {
-			return cl.BeaconCommitteesAtEpoch(ctx, stateID, epoch)
 		},
 		nil,
 	)

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -96,7 +96,6 @@ type Client interface {
 		"AttesterDutiesProvider":                true,
 		"BeaconBlockProposalProvider":           true,
 		"BeaconBlockSubmitter":                  true,
-		"BeaconCommitteesProvider":              true,
 		"BeaconCommitteeSubscriptionsSubmitter": true,
 		"BlindedBeaconBlockProposalProvider":    true,
 		"BlindedBeaconBlockSubmitter":           true,

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -159,7 +159,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, pubkey core.
 		// Ignore error as beacon node probably doesn't support v2 SubmitBeaconCommitteeSubscriptions
 		// endpoint (yet). Just try again with v1.
 
-		res, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, b.eth2Cl, &sub.BeaconCommitteeSubscription)
+		res, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, b.eth2Cl, &sub.BeaconCommitteeSubscription, sub.CommitteeLength)
 		if err != nil {
 			return err
 		}

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -165,7 +165,7 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot int64, defSet co
 			return core.UnsignedDataSet{}, errors.New("invalid beacon committee subscription")
 		}
 
-		res, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, f.eth2Cl, &sub.BeaconCommitteeSubscription)
+		res, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, f.eth2Cl, &sub.BeaconCommitteeSubscription, sub.CommitteeLength)
 		if err != nil {
 			return core.UnsignedDataSet{}, err
 		}

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -238,7 +238,7 @@ func TestParSigExVerifier(t *testing.T) {
 		sigData, err := signing.GetDataRoot(ctx, bmock, signing.DomainSelectionProof, epoch, sigRoot)
 		require.NoError(t, err)
 		sub.SlotSignature = sign(sigData[:])
-		data := core.NewPartialSignedBeaconCommitteeSubscription(sub, shareIdx)
+		data := core.NewPartialSignedBeaconCommitteeSubscription(sub, 0, shareIdx)
 
 		require.NoError(t, verifyFunc(ctx, core.NewPrepareAggregatorDuty(slot), pubkey, data))
 	})

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -698,14 +698,17 @@ func (s SignedRandao) clone() (SignedRandao, error) {
 }
 
 // NewBeaconCommitteeSubscription is a convenience function which returns new signed BeaconCommitteeSubscription.
-func NewBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSubscription) SignedBeaconCommitteeSubscription {
-	return SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *sub}
+func NewBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSubscription, committeeLength uint64) SignedBeaconCommitteeSubscription {
+	return SignedBeaconCommitteeSubscription{
+		BeaconCommitteeSubscription: *sub,
+		CommitteeLength:             committeeLength,
+	}
 }
 
 // NewPartialSignedBeaconCommitteeSubscription is a convenience function which returns new partially signed BeaconCommitteeSubscription.
-func NewPartialSignedBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSubscription, shareIdx int) ParSignedData {
+func NewPartialSignedBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSubscription, committeeLength uint64, shareIdx int) ParSignedData {
 	return ParSignedData{
-		SignedData: NewBeaconCommitteeSubscription(sub),
+		SignedData: NewBeaconCommitteeSubscription(sub, committeeLength),
 		ShareIdx:   shareIdx,
 	}
 }
@@ -713,6 +716,7 @@ func NewPartialSignedBeaconCommitteeSubscription(sub *eth2exp.BeaconCommitteeSub
 // SignedBeaconCommitteeSubscription is a Signed BeaconCommitteeSubscription which implements SignedData.
 type SignedBeaconCommitteeSubscription struct {
 	eth2exp.BeaconCommitteeSubscription
+	CommitteeLength uint64
 }
 
 func (s SignedBeaconCommitteeSubscription) Signature() Signature {

--- a/core/types.go
+++ b/core/types.go
@@ -229,6 +229,11 @@ const (
 	sigLen = 96
 )
 
+// PubKeyFrom48Bytes returns a new public key from raw bytes.
+func PubKeyFrom48Bytes(bytes [48]byte) PubKey {
+	return PubKey(fmt.Sprintf("%#x", bytes))
+}
+
 // PubKeyFromBytes returns a new public key from raw bytes.
 func PubKeyFromBytes(bytes []byte) (PubKey, error) {
 	pk := PubKey(fmt.Sprintf("%#x", bytes))

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1250,7 +1250,8 @@ func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
 		commLen = 43
 	)
 
-	eth2Cl, err := beaconmock.New(beaconmock.WithValidatorSet(beaconmock.ValidatorSetA))
+	valSet := beaconmock.ValidatorSetA
+	eth2Cl, err := beaconmock.New(beaconmock.WithValidatorSet(valSet))
 	require.NoError(t, err)
 
 	_, secret, err := tbls.KeygenWithSeed(mrand.New(mrand.NewSource(1)))
@@ -1268,24 +1269,6 @@ func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
 	sig, _ := tbls.Sign(secret, sigData[:])
 	blssig := tblsconv.SigToETH2(sig)
 
-	eth2Cl.BeaconCommitteesAtEpochFunc = func(_ context.Context, stateID string, epoch eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
-		require.Equal(t, "head", stateID)
-		require.Equal(t, eth2p0.Epoch(uint64(slot)/slotsPerEpoch), epoch)
-
-		var vals []eth2p0.ValidatorIndex
-		for idx := 1; idx <= commLen; idx++ {
-			vals = append(vals, eth2p0.ValidatorIndex(idx))
-		}
-
-		return []*eth2v1.BeaconCommittee{
-			{
-				Slot:       slot,
-				Index:      commIdx,
-				Validators: vals,
-			},
-		}, nil
-	}
-
 	vapi, err := validatorapi.NewComponentInsecure(t, eth2Cl, 0)
 	require.NoError(t, err)
 
@@ -1298,10 +1281,27 @@ func TestComponent_SubmitBeaconCommitteeSubscriptionsV2(t *testing.T) {
 		},
 	}
 
+	vapi.RegisterGetDutyDefinition(func(_ context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+		require.Equal(t, core.NewAttesterDuty(slot), duty)
+		resp := make(core.DutyDefinitionSet)
+		for _, val := range valSet {
+			resp[core.PubKeyFrom48Bytes(val.Validator.PublicKey)] = core.AttesterDefinition{
+				AttesterDuty: eth2v1.AttesterDuty{
+					CommitteeLength: commLen,
+				},
+			}
+		}
+
+		return resp, nil
+	})
+
 	vapi.RegisterAwaitAggSigDB(func(_ context.Context, duty core.Duty, _ core.PubKey) (core.SignedData, error) {
 		require.Equal(t, core.NewPrepareAggregatorDuty(slot), duty)
 
-		return core.SignedBeaconCommitteeSubscription{BeaconCommitteeSubscription: *subs[0]}, nil
+		return core.SignedBeaconCommitteeSubscription{
+			BeaconCommitteeSubscription: *subs[0],
+			CommitteeLength:             commLen,
+		}, nil
 	})
 
 	expected := []*eth2exp.BeaconCommitteeSubscriptionResponse{

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1349,7 +1349,9 @@ func TestComponent_SubmitAggregateAttestations(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, eth2Pubkey, pubkey)
 
-		return core.NewBeaconCommitteeSubscription(&eth2exp.BeaconCommitteeSubscription{SlotSignature: agg.Message.SelectionProof}), nil
+		return core.NewBeaconCommitteeSubscription(
+			&eth2exp.BeaconCommitteeSubscription{SlotSignature: agg.Message.SelectionProof},
+			0), nil
 	})
 
 	vapi.Subscribe(func(_ context.Context, duty core.Duty, set core.ParSignedDataSet) error {

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -32,10 +32,7 @@ import (
 )
 
 type eth2Provider interface {
-	eth2client.BeaconCommitteesProvider
-	eth2client.SlotsPerEpochProvider
 	eth2client.SpecProvider
-	eth2client.AttesterDutiesProvider
 }
 
 // BeaconCommitteeSubscriptionsSubmitterV2 is the interface for submitting beacon committee subnet subscription requests.

--- a/eth2util/eth2exp/attagg_test.go
+++ b/eth2util/eth2exp/attagg_test.go
@@ -69,24 +69,17 @@ func TestCalculateCommitteeSubscriptionResponse(t *testing.T) {
 	}
 
 	t.Run("aggregator", func(t *testing.T) {
-		commLen := 43
-		bmock.BeaconCommitteesAtEpochFunc = func(_ context.Context, _ string, _ eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
-			return []*eth2v1.BeaconCommittee{beaconCommittee(commLen)}, nil
-		}
-
-		resp, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, bmock, &subscription)
+		const commLen uint64 = 43
+		resp, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, bmock, &subscription, commLen)
 		require.NoError(t, err)
 		require.Equal(t, resp.ValidatorIndex, subscription.ValidatorIndex)
 		require.True(t, resp.IsAggregator)
 	})
 
 	t.Run("not an aggregator", func(t *testing.T) {
-		commLen := 61
-		bmock.BeaconCommitteesAtEpochFunc = func(_ context.Context, _ string, _ eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
-			return []*eth2v1.BeaconCommittee{beaconCommittee(commLen)}, nil
-		}
+		const commLen uint64 = 61
 
-		resp, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, bmock, &subscription)
+		resp, err := eth2exp.CalculateCommitteeSubscriptionResponse(ctx, bmock, &subscription, commLen)
 		require.NoError(t, err)
 		require.Equal(t, resp.ValidatorIndex, subscription.ValidatorIndex)
 		require.False(t, resp.IsAggregator)

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -126,7 +126,6 @@ type Mock struct {
 	AttesterDutiesFunc                       func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
 	BlindedBeaconBlockProposalFunc           func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
 	BeaconCommitteesFunc                     func(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error)
-	BeaconCommitteesAtEpochFunc              func(ctx context.Context, stateID string, epoch eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error)
 	BeaconBlockProposalFunc                  func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
 	ProposerDutiesFunc                       func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
 	SubmitAttestationsFunc                   func(context.Context, []*eth2p0.Attestation) error
@@ -182,10 +181,6 @@ func (m Mock) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, randaoR
 
 func (m Mock) BeaconCommittees(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error) {
 	return m.BeaconCommitteesFunc(ctx, stateID)
-}
-
-func (m Mock) BeaconCommitteesAtEpoch(ctx context.Context, stateID string, epoch eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
-	return m.BeaconCommitteesAtEpochFunc(ctx, stateID, epoch)
 }
 
 func (m Mock) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -276,25 +276,6 @@ func WithDeterministicAttesterDuties(factor int) Option {
 
 			return resp, nil
 		}
-
-		mock.BeaconCommitteesAtEpochFunc = func(ctx context.Context, stateID string, epoch eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
-			// Duties above uses this number of committees
-			slotsPerEpoch, err := mock.SlotsPerEpoch(ctx)
-			if err != nil {
-				return nil, err
-			}
-
-			var resp []*eth2v1.BeaconCommittee
-			for i := 0; i < int(slotsPerEpoch); i++ {
-				resp = append(resp, &eth2v1.BeaconCommittee{
-					Slot:       0, // TODO(corver): Beacon mock might need to be stateful at some point.
-					Index:      eth2p0.CommitteeIndex(i),
-					Validators: []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(i)},
-				})
-			}
-
-			return resp, nil
-		}
 	}
 }
 
@@ -457,9 +438,6 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 			return []*eth2v1.ProposerDuty{}, nil
 		},
 		BeaconCommitteesFunc: func(context.Context, string) ([]*eth2v1.BeaconCommittee, error) {
-			return []*eth2v1.BeaconCommittee{}, nil
-		},
-		BeaconCommitteesAtEpochFunc: func(context.Context, string, eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error) {
 			return []*eth2v1.BeaconCommittee{}, nil
 		},
 		AttesterDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -348,7 +348,7 @@ func RandomBeaconCommitteeSubscription() *eth2exp.BeaconCommitteeSubscription {
 }
 
 // RandomSignedBeaconCommitteeSubscription returns a SignedBeaconCommitteeSubscription with the inputs and a random slot signature.
-func RandomSignedBeaconCommitteeSubscription(vIdx, slot, commIdx int) core.SignedBeaconCommitteeSubscription {
+func RandomSignedBeaconCommitteeSubscription(vIdx, slot, commIdx, commLen int) core.SignedBeaconCommitteeSubscription {
 	return core.SignedBeaconCommitteeSubscription{
 		BeaconCommitteeSubscription: eth2exp.BeaconCommitteeSubscription{
 			ValidatorIndex:   eth2p0.ValidatorIndex(vIdx),
@@ -357,6 +357,7 @@ func RandomSignedBeaconCommitteeSubscription(vIdx, slot, commIdx int) core.Signe
 			CommitteesAtSlot: rand.Uint64(),
 			SlotSignature:    RandomEth2Signature(),
 		},
+		CommitteeLength: uint64(commLen),
 	}
 }
 


### PR DESCRIPTION
Optimisation to remove usage of `/eth/v1/beacon/states/head/committees` when calculating `is_aggregator` since it downloads 3.3MB on prater and probably more on mainnet. Rather use the in-memory available attester duty field and cache it.

category: refactor
ticket: none
