### PR TITLE
p2p: fix connection metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -270,6 +270,8 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
+	p2p.RegisterConnectionLogger(tcpNode, peerIDs)
+
 	life.RegisterStop(lifecycle.StopP2PPeerDB, lifecycle.HookFuncMin(peerDB.Close))
 	life.RegisterStop(lifecycle.StopP2PTCPNode, lifecycle.HookFuncErr(tcpNode.Close))
 	life.RegisterStop(lifecycle.StopP2PUDPNode, lifecycle.HookFuncMin(udpNode.Close))

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -161,6 +161,8 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 			return
 		}
 
+		p2p.RegisterConnectionLogger(tcpNode, nil)
+
 		// Reservations are valid for 30min (github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay/constraints.go:14)
 		relayResources := relay.DefaultResources()
 		relayResources.MaxReservationsPerPeer = config.MaxResPerPeer


### PR DESCRIPTION
Exclude relays from `p2p_peer_connection_types` since relays are not peers and this resulted in relays appearing on the peer dashboard. 

Had to jump through some nasty hoops :(

category: refactor
ticket: none
