### PR TITLE
app/retryer: cancel async context on shutdown

### DIFF
--- a/app/retry/retry_test.go
+++ b/app/retry/retry_test.go
@@ -133,11 +133,12 @@ func TestShutdown(t *testing.T) {
 
 	// Start 3 long-running functions
 	for i := 0; i < 3; i++ {
-		go retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", func(_ context.Context) error {
+		go retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", func(ctx context.Context) error {
 			waiting <- struct{}{}
 			<-stop
+			<-ctx.Done()
 
-			return context.Canceled
+			return ctx.Err()
 		})
 	}
 


### PR DESCRIPTION
This attempts to fix the flapping `app` tests due to shutdown timeout by cancelling the async contexts on shutdown.

category: bug
ticket: none
