### PR TITLE
testutil/validatormock: integrate DutySyncMessage

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -558,7 +558,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 	}
 
 	if conf.SimnetBMock { // Configure the beacon mock.
-		const dutyFactor = 100 // Duty factor spreads duties deterministicly in an epoch.
+		const dutyFactor = 100 // Duty factor spreads duties deterministically in an epoch.
 		opts := []beaconmock.Option{
 			beaconmock.WithSlotDuration(time.Second),
 			beaconmock.WithDeterministicAttesterDuties(dutyFactor),

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -42,6 +42,7 @@ type Client interface {
 	eth2client.AttestationsSubmitter
 	eth2client.AttesterDutiesProvider
 	eth2client.BeaconBlockProposalProvider
+	eth2client.BeaconBlockRootProvider
 	eth2client.BeaconBlockSubmitter
 	eth2client.BeaconCommitteeSubscriptionsSubmitter
 	eth2client.BeaconCommitteesProvider
@@ -396,6 +397,26 @@ func (m multi) BeaconBlockProposal(ctx context.Context, slot phase0.Slot, randao
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*spec.VersionedBeaconBlock, error) {
 			return cl.BeaconBlockProposal(ctx, slot, randaoReveal, graffiti)
+		},
+		nil,
+	)
+
+	if err != nil {
+		incError(label)
+		err = errors.Wrap(err, "eth2wrap")
+	}
+
+	return res0, err
+}
+
+// BeaconBlockRoot fetches a block's root given a block ID.
+// Note this endpoint is cached in go-eth2-client.
+func (m multi) BeaconBlockRoot(ctx context.Context, blockID string) (*phase0.Root, error) {
+	const label = "beacon_block_root"
+
+	res0, err := provide(ctx, m.clients,
+		func(ctx context.Context, cl Client) (*phase0.Root, error) {
+			return cl.BeaconBlockRoot(ctx, blockID)
 		},
 		nil,
 	)

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -95,6 +95,7 @@ type Client interface {
 		"AttestationsSubmitter":                 true,
 		"AttesterDutiesProvider":                true,
 		"BeaconBlockProposalProvider":           true,
+		"BeaconBlockRootProvider":               false,
 		"BeaconBlockSubmitter":                  true,
 		"BeaconCommitteesProvider":              true,
 		"BeaconCommitteeSubscriptionsSubmitter": true,

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -155,6 +155,15 @@ func TestSimnetNoNetwork_WithBuilderRegistrationMockVCs(t *testing.T) {
 	testSimnet(t, args, expect)
 }
 
+func TestSimnetNoNetwork_WithSyncCommitteeMockVCs(t *testing.T) {
+	args := newSimnetArgs(t)
+	args.BMockOpts = append(args.BMockOpts, beaconmock.WithSyncCommitteeDuties())
+	args.BMockOpts = append(args.BMockOpts, beaconmock.WithNoAttesterDuties())
+	args.BMockOpts = append(args.BMockOpts, beaconmock.WithNoProposerDuties())
+	expect := newSimnetExpect(args.N, core.DutySyncMessage)
+	testSimnet(t, args, expect)
+}
+
 type simnetArgs struct {
 	N                   int
 	VMocks              []bool

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -60,6 +60,8 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 			})
 		}
 
+		onStartup = false
+
 		// Prepare sync committee selections when slots tick.
 		vMockWrap(ctx, slot.Slot, slot.Epoch(), func(ctx context.Context, state vMockState) error {
 			// Either call if it is first slot in epoch or on charon startup.
@@ -111,7 +113,7 @@ type vMockState struct {
 	SyncCommMember *validatormock.SyncCommMember
 }
 
-// vMockCallback is a validator mock callback function that has access to latest state.
+// vMockCallback is a validator mock callback function that has access to the latest state.
 type vMockCallback func(context.Context, vMockState) error
 
 // newVMockWrapper returns a stateful validator mock wrapper function.
@@ -164,7 +166,7 @@ func newVMockWrapper(conf Config, pubshares []eth2p0.BLSPubKey) (func(ctx contex
 			defer cancel()
 
 			err := fn(ctx2, state)
-			if err != nil && ctx.Err() == nil { // Only log if parrent context wasn't closed.
+			if err != nil && ctx.Err() == nil { // Only log if parent context wasn't closed.
 				log.Error(ctx, "Validator mock error", err)
 				return
 			}

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -45,35 +45,38 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 		return err
 	}
 
-	// Prepare attestations when slots tick.
+	onStartup := true
 	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
-		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {
+		// Prepare attestations when slots tick.
+		vMockWrap(ctx, slot.Slot, slot.Epoch(), func(ctx context.Context, state vMockState) error {
 			return state.Attester.Prepare(ctx)
 		})
 
-		return nil
-	})
-
-	// Prepare for sync committee duties and SyncCommitteeMessage.
-	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
-		onStartup := true
-
-		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {
-			if onStartup || slot.FirstInEpoch() {
+		// Prepare sync committee message when epoch tick.
+		if onStartup || slot.FirstInEpoch() {
+			vMockWrap(ctx, slot.Slot, slot.Epoch(), func(ctx context.Context, state vMockState) error {
 				// Either call if it is first slot in epoch or on charon startup.
-				err := state.SyncCommMember.PrepareEpoch(ctx, state.Eth2Cl, eth2p0.Epoch(slot.Epoch()))
-				if err != nil {
-					return err
-				}
-			}
-			onStartup = false
+				return state.SyncCommMember.PrepareEpoch(ctx)
+			})
+		}
 
-			err := state.SyncCommMember.IsAggregator(ctx)
-			if err != nil {
-				return err
-			}
+		// Prepare sync committee selections when slots tick.
+		vMockWrap(ctx, slot.Slot, slot.Epoch(), func(ctx context.Context, state vMockState) error {
+			// Either call if it is first slot in epoch or on charon startup.
+			return state.SyncCommMember.PrepareSlot(ctx, eth2p0.Slot(slot.Slot))
+		})
 
-			return state.SyncCommMember.Message(ctx, state.Eth2Cl, eth2p0.Slot(slot.Slot), slot.Time, slot.SlotDuration)
+		// Submit sync committee message 1/3 into the slot.
+		vMockWrap(ctx, slot.Slot, slot.Epoch(), func(ctx context.Context, state vMockState) error {
+			thirdDuration := slot.SlotDuration / 3
+			thirdTime := slot.Time.Add(thirdDuration)
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Until(thirdTime)):
+				return state.SyncCommMember.Message(ctx, eth2p0.Slot(slot.Slot))
+			}
 		})
 
 		return nil
@@ -81,7 +84,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 
 	// Handle duties when triggered.
 	sched.SubscribeDuties(func(ctx context.Context, duty core.Duty, _ core.DutyDefinitionSet) error {
-		vMockWrap(ctx, duty.Slot, func(ctx context.Context, state vMockState) error {
+		vMockWrap(ctx, duty.Slot, 0, func(ctx context.Context, state vMockState) error {
 			return handleVMockDuty(ctx, duty, state.Eth2Cl, state.SignFunc, pubshares, state.Attester, state.SyncCommMember)
 		})
 
@@ -91,7 +94,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 	go func() {
 		// TODO(corver): Improve registrations to use lock file and trigger on epoch transitions.
 		for registration := range conf.TestConfig.BuilderRegistration {
-			vMockWrap(context.Background(), 0, func(ctx context.Context, state vMockState) error {
+			vMockWrap(context.Background(), 0, 0, func(ctx context.Context, state vMockState) error {
 				return validatormock.Register(ctx, state.Eth2Cl, state.SignFunc, registration, pubshares[0])
 			})
 		}
@@ -112,7 +115,7 @@ type vMockState struct {
 type vMockCallback func(context.Context, vMockState) error
 
 // newVMockWrapper returns a stateful validator mock wrapper function.
-func newVMockWrapper(conf Config, pubshares []eth2p0.BLSPubKey) (func(context.Context, int64, vMockCallback), error) {
+func newVMockWrapper(conf Config, pubshares []eth2p0.BLSPubKey) (func(ctx context.Context, slot int64, epoch int64, callback vMockCallback), error) {
 	// Immutable state and providers.
 	signFunc, err := newVMockSigner(conf, pubshares)
 	if err != nil {
@@ -125,10 +128,10 @@ func newVMockWrapper(conf Config, pubshares []eth2p0.BLSPubKey) (func(context.Co
 	var (
 		mu          sync.Mutex
 		attester    = new(validatormock.SlotAttester)
-		syncCommMem = validatormock.NewSyncCommMember(signFunc, pubshares)
+		syncCommMem = new(validatormock.SyncCommMember)
 	)
 
-	return func(ctx context.Context, slot int64, fn vMockCallback) {
+	return func(ctx context.Context, slot, epoch int64, fn vMockCallback) {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -143,6 +146,9 @@ func newVMockWrapper(conf Config, pubshares []eth2p0.BLSPubKey) (func(context.Co
 		// Create new slot attester on new slots
 		if slot != 0 && attester.Slot() != eth2p0.Slot(slot) {
 			attester = validatormock.NewSlotAttester(eth2Cl, eth2p0.Slot(slot), signFunc, pubshares)
+		}
+		if epoch != 0 && syncCommMem.Epoch() != eth2p0.Epoch(epoch) {
+			syncCommMem = validatormock.NewSyncCommMember(eth2Cl, eth2p0.Epoch(epoch), signFunc, pubshares)
 		}
 
 		state := vMockState{
@@ -269,7 +275,7 @@ func handleVMockDuty(ctx context.Context, duty core.Duty, eth2Cl eth2wrap.Client
 		}
 		log.Info(ctx, "Mock blinded block proposal submitted to validatorapi", z.I64("slot", duty.Slot))
 	case core.DutySyncContribution:
-		err := syncCommMember.SubmitContribution(ctx)
+		err := syncCommMember.Aggregate(ctx, eth2p0.Slot(duty.Slot))
 		if err != nil {
 			return errors.Wrap(err, "mock sync contribution failed")
 		}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -350,6 +350,11 @@ func proposerDuties(p eth2client.ProposerDutiesProvider) handlerFunc {
 			return nil, err
 		}
 
+		// response.data cannot be nil, it leads to NullPointerException in teku.
+		if len(data) == 0 {
+			data = []*eth2v1.ProposerDuty{}
+		}
+
 		return proposerDutiesResponse{
 			DependentRoot: stubRoot(epoch), // TODO(corver): Fill this properly
 			Data:          data,
@@ -375,6 +380,11 @@ func attesterDuties(p eth2client.AttesterDutiesProvider) handlerFunc {
 			return nil, err
 		}
 
+		// response.data cannot be nil, it leads to NullPointerException in teku.
+		if len(data) == 0 {
+			data = []*eth2v1.AttesterDuty{}
+		}
+
 		return attesterDutiesResponse{
 			DependentRoot: stubRoot(epoch), // TODO(corver): Fill this properly
 			Data:          data,
@@ -398,6 +408,11 @@ func syncCommitteeDuties(p eth2client.SyncCommitteeDutiesProvider) handlerFunc {
 		data, err := p.SyncCommitteeDuties(ctx, eth2p0.Epoch(epoch), req)
 		if err != nil {
 			return nil, err
+		}
+
+		// response.data cannot be nil, it leads to NullPointerException in teku.
+		if len(data) == 0 {
+			data = []*eth2v1.SyncCommitteeDuty{}
 		}
 
 		return syncCommitteeDutiesResponse{Data: data}, nil

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -128,6 +128,7 @@ type Mock struct {
 	BeaconCommitteesFunc                     func(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error)
 	BeaconCommitteesAtEpochFunc              func(ctx context.Context, stateID string, epoch eth2p0.Epoch) ([]*eth2v1.BeaconCommittee, error)
 	BeaconBlockProposalFunc                  func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
+	BeaconBlockRootFunc                      func(ctx context.Context, blockID string) (*eth2p0.Root, error)
 	ProposerDutiesFunc                       func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
 	SubmitAttestationsFunc                   func(context.Context, []*eth2p0.Attestation) error
 	SubmitBeaconBlockFunc                    func(context.Context, *spec.VersionedSignedBeaconBlock) error
@@ -178,6 +179,10 @@ func (m Mock) BlindedBeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, 
 
 func (m Mock) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error) {
 	return m.BeaconBlockProposalFunc(ctx, slot, randaoReveal, graffiti)
+}
+
+func (m Mock) BeaconBlockRoot(ctx context.Context, blockID string) (*eth2p0.Root, error) {
+	return m.BeaconBlockRootFunc(ctx, blockID)
 }
 
 func (m Mock) BeaconCommittees(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -372,10 +372,6 @@ func WithNoAttesterDuties() Option {
 func WithSyncCommitteeDuties() Option {
 	return func(mock *Mock) {
 		mock.SyncCommitteeDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
-			if epoch%3 != 0 {
-				return nil, nil
-			}
-
 			vals, err := mock.Validators(ctx, "", indices)
 			if err != nil {
 				return nil, err

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -367,6 +367,8 @@ func WithNoAttesterDuties() Option {
 	}
 }
 
+// WithSyncCommitteeDuties configures the mock to override SyncCommitteeDutiesFunc to return sync committee
+// duties for epochs not divisible by 3.
 func WithSyncCommitteeDuties() Option {
 	return func(mock *Mock) {
 		mock.SyncCommitteeDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -367,6 +367,37 @@ func WithNoAttesterDuties() Option {
 	}
 }
 
+func WithSyncCommitteeDuties() Option {
+	return func(mock *Mock) {
+		mock.SyncCommitteeDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
+			if epoch%3 != 0 {
+				return nil, nil
+			}
+
+			vals, err := mock.Validators(ctx, "", indices)
+			if err != nil {
+				return nil, err
+			}
+
+			var resp []*eth2v1.SyncCommitteeDuty
+			for i, index := range indices {
+				val, ok := vals[index]
+				if !ok {
+					continue
+				}
+
+				resp = append(resp, &eth2v1.SyncCommitteeDuty{
+					PubKey:                        val.Validator.PublicKey,
+					ValidatorIndex:                index,
+					ValidatorSyncCommitteeIndices: []eth2p0.CommitteeIndex{eth2p0.CommitteeIndex(i)},
+				})
+			}
+
+			return resp, nil
+		}
+	}
+}
+
 // WithClock configures the mock with the provided clock.
 func WithClock(clock clockwork.Clock) Option {
 	return func(mock *Mock) {
@@ -479,22 +510,22 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 				Data:            attData,
 			}, nil
 		},
-		ValidatorsFunc: func(ctx context.Context, stateID string, indices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+		ValidatorsFunc: func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 			return nil, nil
 		},
-		ValidatorsByPubKeyFunc: func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+		ValidatorsByPubKeyFunc: func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 			return nil, nil
 		},
-		SubmitAttestationsFunc: func(ctx context.Context, atts []*eth2p0.Attestation) error {
+		SubmitAttestationsFunc: func(context.Context, []*eth2p0.Attestation) error {
 			return nil
 		},
-		SubmitBeaconBlockFunc: func(ctx context.Context, block *spec.VersionedSignedBeaconBlock) error {
+		SubmitBeaconBlockFunc: func(context.Context, *spec.VersionedSignedBeaconBlock) error {
 			return nil
 		},
-		SubmitBlindedBeaconBlockFunc: func(ctx context.Context, block *eth2api.VersionedSignedBlindedBeaconBlock) error {
+		SubmitBlindedBeaconBlockFunc: func(context.Context, *eth2api.VersionedSignedBlindedBeaconBlock) error {
 			return nil
 		},
-		SubmitVoluntaryExitFunc: func(ctx context.Context, exit *eth2p0.SignedVoluntaryExit) error {
+		SubmitVoluntaryExitFunc: func(context.Context, *eth2p0.SignedVoluntaryExit) error {
 			return nil
 		},
 		GenesisTimeFunc: func(ctx context.Context) (time.Time, error) {
@@ -530,11 +561,14 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		SlotsPerEpochFunc: func(ctx context.Context) (uint64, error) {
 			return httpMock.SlotsPerEpoch(ctx)
 		},
-		SubmitProposalPreparationsFunc: func(_ context.Context, _ []*eth2v1.ProposalPreparation) error {
+		SubmitProposalPreparationsFunc: func(context.Context, []*eth2v1.ProposalPreparation) error {
 			return nil
 		},
-		SyncCommitteeDutiesFunc: func(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
+		SyncCommitteeDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
 			return []*eth2v1.SyncCommitteeDuty{}, nil
+		},
+		SubmitSyncCommitteeMessagesFunc: func(context.Context, []*altair.SyncCommitteeMessage) error {
+			return nil
 		},
 	}
 }

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -40,6 +40,7 @@ var staticJSON []byte
 // It serves all proxied endpoints not handled by charon's validatorapi.
 // Endpoints include static endpoints defined in static.json and a few stubbed paths.
 type HTTPMock interface {
+	eth2client.BeaconBlockRootProvider
 	eth2client.DepositContractProvider
 	eth2client.DomainProvider
 	eth2client.ForkProvider
@@ -51,7 +52,7 @@ type HTTPMock interface {
 	eth2client.SlotDurationProvider
 	eth2client.SlotsPerEpochProvider
 	eth2client.SpecProvider
-	eth2client.SyncCommitteeDutiesProvider
+	eth2client.SyncCommitteeSubscriptionsSubmitter
 }
 
 // staticOverride defines a http server static override for a endpoint response value.
@@ -75,9 +76,15 @@ func newHTTPServer(addr string, overrides ...staticOverride) (*http.Server, erro
 			Handler: func(w http.ResponseWriter, r *http.Request) {},
 		},
 		{
-			Path: "/eth/v1/validator/duties/sync/{epoch}",
+			Path: "/eth/v1/validator/sync_committee_subscriptions",
 			Handler: func(w http.ResponseWriter, r *http.Request) {
-				_, _ = w.Write([]byte(`{"data":[]}`))
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		{
+			Path: "/eth/v1/beacon/blocks/head/root",
+			Handler: func(w http.ResponseWriter, r *http.Request) {
+				_, _ = w.Write([]byte(`{"data": {"root": "0xcf8e0d4e9587369b2301d0790347320302cc0943d5a1884560367e8208d920f2"}}`))
 			},
 		},
 		{

--- a/testutil/validatormock/synccomm.go
+++ b/testutil/validatormock/synccomm.go
@@ -1,0 +1,149 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package validatormock
+
+import (
+	"context"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/eth2util/signing"
+)
+
+func NewSyncCommMember(signFunc SignFunc, pubkeys []eth2p0.BLSPubKey) *SyncCommMember {
+	return &SyncCommMember{
+		pubkeys:  pubkeys,
+		signFunc: signFunc,
+	}
+}
+
+// SyncCommMember is a stateful structure providing sync committee message and contribution APIs.
+type SyncCommMember struct {
+	pubkeys  []eth2p0.BLSPubKey
+	duties   []*eth2v1.SyncCommitteeDuty
+	signFunc SignFunc
+}
+
+// PrepareEpoch does store sync committee duties and submits sync committee subscriptions at the start of an epoch.
+func (s *SyncCommMember) PrepareEpoch(ctx context.Context, eth2Cl eth2wrap.Client, epoch eth2p0.Epoch) error {
+	vals, err := activeValidators(ctx, eth2Cl, s.pubkeys)
+	if err != nil {
+		return err
+	}
+
+	var vIdxs []eth2p0.ValidatorIndex
+	for idx := range vals {
+		vIdxs = append(vIdxs, idx)
+	}
+
+	s.duties, err = eth2Cl.SyncCommitteeDuties(ctx, epoch, vIdxs)
+	if err != nil {
+		return err
+	}
+
+	// Don't proceed if we have no duties.
+	if len(s.duties) == 0 {
+		return nil
+	}
+
+	var subs []*eth2v1.SyncCommitteeSubscription
+	for _, duty := range s.duties {
+		subs = append(subs, &eth2v1.SyncCommitteeSubscription{
+			ValidatorIndex:       duty.ValidatorIndex,
+			SyncCommitteeIndices: duty.ValidatorSyncCommitteeIndices,
+			UntilEpoch:           epoch + 1,
+		})
+	}
+
+	err = eth2Cl.SubmitSyncCommitteeSubscriptions(ctx, subs)
+	if err != nil {
+		return err
+	}
+
+	log.Info(ctx, "Mock sync committee subscription submitted")
+
+	return nil
+}
+
+// Message submits Sync committee messages at desired i.e., 1/3rd into the slot.
+func (s *SyncCommMember) Message(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.Slot, slotStartTime time.Time, slotDuration time.Duration) error {
+	if len(s.duties) == 0 {
+		return nil
+	}
+
+	// Schedule DutySyncMessage 1/3rd into the slot.
+	offset := slotDuration / 3
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(time.Until(slotStartTime.Add(offset))):
+		return submitSyncMessage(ctx, eth2Cl, slot, s.signFunc, s.duties)
+	}
+}
+
+// submitSyncMessage submits signed sync committee messages for desired slot.
+func submitSyncMessage(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.Slot, signFunc SignFunc, duties []*eth2v1.SyncCommitteeDuty) error {
+	blockRoot, err := eth2Cl.BeaconBlockRoot(ctx, "head")
+	if err != nil {
+		return err
+	}
+
+	epoch, err := epochFromSlot(ctx, eth2Cl, slot)
+	if err != nil {
+		return err
+	}
+
+	sigData, err := signing.GetDataRoot(ctx, eth2Cl, signing.DomainSyncCommittee, epoch, *blockRoot)
+	if err != nil {
+		return err
+	}
+
+	var msgs []*altair.SyncCommitteeMessage
+	for _, duty := range duties {
+		sig, err := signFunc(duty.PubKey, sigData[:])
+		if err != nil {
+			return err
+		}
+
+		msgs = append(msgs, &altair.SyncCommitteeMessage{
+			Slot:            slot,
+			BeaconBlockRoot: *blockRoot,
+			ValidatorIndex:  duty.ValidatorIndex,
+			Signature:       sig,
+		})
+	}
+
+	return eth2Cl.SubmitSyncCommitteeMessages(ctx, msgs)
+}
+
+// IsAggregator submits selection proof POST /eth/v1/validator/sync_committee_selections
+// and stores the boolean result and selection proof to further generate ContributionAndProof.
+// TODO(dhruv): Implement this method as part of https://github.com/ObolNetwork/charon/issues/1268.
+func (*SyncCommMember) IsAggregator(context.Context) error {
+	return nil
+}
+
+// SubmitContribution submits sync committee contributions if chosen as an aggregator based on selection proof.
+// TODO(dhruv): Implement this method as part of https://github.com/ObolNetwork/charon/issues/1268.
+func (*SyncCommMember) SubmitContribution(context.Context) error {
+	return nil
+}

--- a/testutil/validatormock/synccomm.go
+++ b/testutil/validatormock/synccomm.go
@@ -17,7 +17,7 @@ package validatormock
 
 import (
 	"context"
-	"time"
+	"sync"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec/altair"
@@ -28,44 +28,135 @@ import (
 	"github.com/obolnetwork/charon/eth2util/signing"
 )
 
-func NewSyncCommMember(signFunc SignFunc, pubkeys []eth2p0.BLSPubKey) *SyncCommMember {
+type (
+	syncDuties     []*eth2v1.SyncCommitteeDuty
+	syncSelections []any
+)
+
+func NewSyncCommMember(eth2Cl eth2wrap.Client, epoch eth2p0.Epoch, signFunc SignFunc, pubkeys []eth2p0.BLSPubKey) *SyncCommMember {
 	return &SyncCommMember{
-		pubkeys:  pubkeys,
-		signFunc: signFunc,
+		eth2Cl:       eth2Cl,
+		epoch:        epoch,
+		pubkeys:      pubkeys,
+		signFunc:     signFunc,
+		dutiesOK:     make(chan struct{}),
+		selections:   make(map[eth2p0.Slot]syncSelections),
+		selectionsOK: make(map[eth2p0.Slot]chan struct{}),
 	}
 }
 
 // SyncCommMember is a stateful structure providing sync committee message and contribution APIs.
 type SyncCommMember struct {
+	// Immutable state
+	eth2Cl   eth2wrap.Client
+	epoch    eth2p0.Epoch
 	pubkeys  []eth2p0.BLSPubKey
-	duties   []*eth2v1.SyncCommitteeDuty
 	signFunc SignFunc
+
+	// Mutable state
+	mu           sync.Mutex
+	vals         validators
+	duties       syncDuties
+	dutiesOK     chan struct{}
+	selections   map[eth2p0.Slot]syncSelections
+	selectionsOK map[eth2p0.Slot]chan struct{}
 }
 
-// PrepareEpoch does store sync committee duties and submits sync committee subscriptions at the start of an epoch.
-func (s *SyncCommMember) PrepareEpoch(ctx context.Context, eth2Cl eth2wrap.Client, epoch eth2p0.Epoch) error {
-	vals, err := activeValidators(ctx, eth2Cl, s.pubkeys)
+func (s *SyncCommMember) Epoch() eth2p0.Epoch {
+	return s.epoch
+}
+
+func (s *SyncCommMember) setSelections(slot eth2p0.Slot, selections syncSelections) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.selections[slot] = selections
+
+	// Mark selections as done
+	ch, ok := s.selectionsOK[slot]
+	if !ok {
+		ch = make(chan struct{})
+		s.selectionsOK[slot] = ch
+	}
+	close(ch)
+}
+
+//nolint:unused
+func (s *SyncCommMember) getSelections(slot eth2p0.Slot) syncSelections {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.selections[slot]
+}
+
+func (s *SyncCommMember) getSelectionsOK(slot eth2p0.Slot) chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	ch, ok := s.selectionsOK[slot]
+	if !ok {
+		ch = make(chan struct{})
+		s.selectionsOK[slot] = ch
+	}
+
+	return ch
+}
+
+// PrepareEpoch does store sync committee attDuties and submits sync committee subscriptions at the start of an epoch.
+func (s *SyncCommMember) PrepareEpoch(ctx context.Context) error {
+	var err error
+	s.vals, err = activeValidators(ctx, s.eth2Cl, s.pubkeys)
 	if err != nil {
 		return err
 	}
 
-	var vIdxs []eth2p0.ValidatorIndex
-	for idx := range vals {
-		vIdxs = append(vIdxs, idx)
-	}
-
-	s.duties, err = eth2Cl.SyncCommitteeDuties(ctx, epoch, vIdxs)
+	s.duties, err = prepareSyncCommDuties(ctx, s.eth2Cl, s.vals, s.epoch)
 	if err != nil {
 		return err
 	}
 
-	// Don't proceed if we have no duties.
-	if len(s.duties) == 0 {
-		return nil
+	err = subscribeSyncCommSubnets(ctx, s.eth2Cl, s.epoch, s.duties)
+	if err != nil {
+		return err
 	}
+	close(s.dutiesOK)
 
+	return nil
+}
+
+// PrepareSlot .
+func (s *SyncCommMember) PrepareSlot(ctx context.Context, slot eth2p0.Slot) error {
+	wait(ctx, s.dutiesOK)
+	selections, err := prepareSyncContributions(ctx, s.eth2Cl, s.signFunc, s.vals, s.duties, slot)
+	if err != nil {
+		return err
+	}
+	s.setSelections(slot, selections)
+
+	return nil
+}
+
+// Message submits Sync committee messages at desired i.e., 1/3rd into the slot.
+func (s *SyncCommMember) Message(ctx context.Context, slot eth2p0.Slot) error {
+	wait(ctx, s.dutiesOK)
+	return submitSyncMessage(ctx, s.eth2Cl, slot, s.signFunc, s.duties)
+}
+
+// Aggregate submits Sync committee messages at desired i.e., 1/3rd into the slot.
+func (s *SyncCommMember) Aggregate(ctx context.Context, slot eth2p0.Slot) error {
+	wait(ctx, s.getSelectionsOK(slot))
+	return nil
+}
+
+func prepareSyncContributions(context.Context, eth2wrap.Client, SignFunc,
+	validators, syncDuties, eth2p0.Slot,
+) (syncSelections, error) {
+	return nil, nil
+}
+
+func subscribeSyncCommSubnets(ctx context.Context, eth2Cl eth2wrap.Client, epoch eth2p0.Epoch, duties syncDuties) error {
 	var subs []*eth2v1.SyncCommitteeSubscription
-	for _, duty := range s.duties {
+	for _, duty := range duties {
 		subs = append(subs, &eth2v1.SyncCommitteeSubscription{
 			ValidatorIndex:       duty.ValidatorIndex,
 			SyncCommitteeIndices: duty.ValidatorSyncCommitteeIndices,
@@ -73,7 +164,7 @@ func (s *SyncCommMember) PrepareEpoch(ctx context.Context, eth2Cl eth2wrap.Clien
 		})
 	}
 
-	err = eth2Cl.SubmitSyncCommitteeSubscriptions(ctx, subs)
+	err := eth2Cl.SubmitSyncCommitteeSubscriptions(ctx, subs)
 	if err != nil {
 		return err
 	}
@@ -83,25 +174,25 @@ func (s *SyncCommMember) PrepareEpoch(ctx context.Context, eth2Cl eth2wrap.Clien
 	return nil
 }
 
-// Message submits Sync committee messages at desired i.e., 1/3rd into the slot.
-func (s *SyncCommMember) Message(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.Slot, slotStartTime time.Time, slotDuration time.Duration) error {
-	if len(s.duties) == 0 {
-		return nil
+func prepareSyncCommDuties(ctx context.Context, eth2Cl eth2wrap.Client, vals validators, epoch eth2p0.Epoch) (syncDuties, error) {
+	if len(vals) == 0 {
+		return nil, nil
 	}
 
-	// Schedule DutySyncMessage 1/3rd into the slot.
-	offset := slotDuration / 3
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(time.Until(slotStartTime.Add(offset))):
-		return submitSyncMessage(ctx, eth2Cl, slot, s.signFunc, s.duties)
+	var vIdxs []eth2p0.ValidatorIndex
+	for idx := range vals {
+		vIdxs = append(vIdxs, idx)
 	}
+
+	return eth2Cl.SyncCommitteeDuties(ctx, epoch, vIdxs)
 }
 
 // submitSyncMessage submits signed sync committee messages for desired slot.
-func submitSyncMessage(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.Slot, signFunc SignFunc, duties []*eth2v1.SyncCommitteeDuty) error {
+func submitSyncMessage(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.Slot, signFunc SignFunc, duties syncDuties) error {
+	if len(duties) == 0 {
+		return nil
+	}
+
 	blockRoot, err := eth2Cl.BeaconBlockRoot(ctx, "head")
 	if err != nil {
 		return err
@@ -133,17 +224,4 @@ func submitSyncMessage(ctx context.Context, eth2Cl eth2wrap.Client, slot eth2p0.
 	}
 
 	return eth2Cl.SubmitSyncCommitteeMessages(ctx, msgs)
-}
-
-// IsAggregator submits selection proof POST /eth/v1/validator/sync_committee_selections
-// and stores the boolean result and selection proof to further generate ContributionAndProof.
-// TODO(dhruv): Implement this method as part of https://github.com/ObolNetwork/charon/issues/1268.
-func (*SyncCommMember) IsAggregator(context.Context) error {
-	return nil
-}
-
-// SubmitContribution submits sync committee contributions if chosen as an aggregator based on selection proof.
-// TODO(dhruv): Implement this method as part of https://github.com/ObolNetwork/charon/issues/1268.
-func (*SyncCommMember) SubmitContribution(context.Context) error {
-	return nil
 }

--- a/testutil/validatormock/synccomm.go
+++ b/testutil/validatormock/synccomm.go
@@ -102,7 +102,7 @@ func (s *SyncCommMember) getSelectionsOK(slot eth2p0.Slot) chan struct{} {
 	return ch
 }
 
-// PrepareEpoch does store sync committee attDuties and submits sync committee subscriptions at the start of an epoch.
+// PrepareEpoch stores sync committee attDuties and submits sync committee subscriptions at the start of an epoch.
 func (s *SyncCommMember) PrepareEpoch(ctx context.Context) error {
 	var err error
 	s.vals, err = activeValidators(ctx, s.eth2Cl, s.pubkeys)
@@ -124,7 +124,7 @@ func (s *SyncCommMember) PrepareEpoch(ctx context.Context) error {
 	return nil
 }
 
-// PrepareSlot .
+// PrepareSlot prepares selection proofs at the start of a slot.
 func (s *SyncCommMember) PrepareSlot(ctx context.Context, slot eth2p0.Slot) error {
 	wait(ctx, s.dutiesOK)
 	selections, err := prepareSyncContributions(ctx, s.eth2Cl, s.signFunc, s.vals, s.duties, slot)
@@ -142,7 +142,7 @@ func (s *SyncCommMember) Message(ctx context.Context, slot eth2p0.Slot) error {
 	return submitSyncMessage(ctx, s.eth2Cl, slot, s.signFunc, s.duties)
 }
 
-// Aggregate submits Sync committee messages at desired i.e., 1/3rd into the slot.
+// Aggregate submits Sync committee messages at desired i.e., 2/3rd into the slot.
 func (s *SyncCommMember) Aggregate(ctx context.Context, slot eth2p0.Slot) error {
 	wait(ctx, s.getSelectionsOK(slot))
 	return nil
@@ -154,6 +154,7 @@ func prepareSyncContributions(context.Context, eth2wrap.Client, SignFunc,
 	return nil, nil
 }
 
+// subscribeSyncCommSubnets submits sync committee subscriptions at the start of an epoch until next epoch.
 func subscribeSyncCommSubnets(ctx context.Context, eth2Cl eth2wrap.Client, epoch eth2p0.Epoch, duties syncDuties) error {
 	var subs []*eth2v1.SyncCommitteeSubscription
 	for _, duty := range duties {
@@ -174,6 +175,7 @@ func subscribeSyncCommSubnets(ctx context.Context, eth2Cl eth2wrap.Client, epoch
 	return nil
 }
 
+// prepareSyncCommDuties returns sync committee duties for the epoch.
 func prepareSyncCommDuties(ctx context.Context, eth2Cl eth2wrap.Client, vals validators, epoch eth2p0.Epoch) (syncDuties, error) {
 	if len(vals) == 0 {
 		return nil, nil

--- a/testutil/validatormock/synccontributionflow_test.go
+++ b/testutil/validatormock/synccontributionflow_test.go
@@ -54,9 +54,9 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 	startEpoch := (epoch / period) * period
 	endEpoch := startEpoch + period
 
-	// Get the sync committee duties for this epoch.
+	// Get the sync committee attDuties for this epoch.
 
-	// One option is to fetch the sync committee duties for a subset of validators
+	// One option is to fetch the sync committee attDuties for a subset of validators
 	duties, _ := eth2Cl.SyncCommitteeDuties(ctx, epoch, valIdxs)
 	for _, duty := range duties {
 		// Note SyncCommitteeDuty contains a public key which charon needs to intercept/swap.
@@ -114,7 +114,7 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 	_ = eth2Cl.SubmitSyncCommitteeMessages(ctx, msgs)
 
 	// For each slot, some validators are also aggregators and need to submit contributions.
-	// This can be calculated at any time in the sync committee period after the duties have been fetched.
+	// This can be calculated at any time in the sync committee period after the attDuties have been fetched.
 
 	syncCommSize, _ := spec["SYNC_COMMITTEE_SIZE"].(uint64)
 	subnetCount, _ := spec["SYNC_COMMITTEE_SUBNET_COUNT"].(uint64)
@@ -148,7 +148,7 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 					continue
 				}
 
-				// Add aggregator duties per slot.
+				// Add aggregator attDuties per slot.
 				aggsPerSubComm[subcommittee] = append(aggsPerSubComm[subcommittee], aggregator{
 					ValidatorIndex: duty.ValidatorIndex,
 					Pubkey:         duty.PubKey,
@@ -180,7 +180,7 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 			// Fetch cached pubkey from selection.ValidatorIndex
 			var pubkey eth2p0.BLSPubKey
 
-			// Add aggregator duties per slot.
+			// Add aggregator attDuties per slot.
 			aggsPerSubComm[selection.Data.SubcommitteeIndex] = append(aggsPerSubComm[selection.Data.SubcommitteeIndex], aggregator{
 				ValidatorIndex: selection.ValidatorIndex,
 				Pubkey:         pubkey,
@@ -257,8 +257,8 @@ type SyncCommitteeSelection struct {
 	IsAggregator   bool
 }
 
-// SyncCommitteeSelections is the new proposed endpoint that returns aggregated sync committee selections
-// for the provided partial selections.
+// SyncCommitteeSelections is the new proposed endpoint that returns aggregated sync committee attSelections
+// for the provided partial attSelections.
 //
 // Note endpoint MUST be called at the start of the slot, since all VCs in the cluster need to do it at the same time.
 // This is by convention, to ensure timely successful aggregation.


### PR DESCRIPTION
Integrates DutySyncMessage by adding support to validatormock and adds a simnet_test.

category: feature
ticket: #1261 
