### PR TITLE
core: fix beacon committee subscription marshalling

### DIFF
--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -30,10 +30,9 @@ import (
 
 func TestCalculateOutput(t *testing.T) {
 	tests := []struct {
-		name     string
-		input    []int
-		output   []int
-		provider int
+		name   string
+		input  []int
+		output []int
 	}{
 		{
 			name:   "empty",

--- a/core/proto.go
+++ b/core/proto.go
@@ -40,6 +40,10 @@ func DutyFromProto(duty *pbv1.Duty) Duty {
 
 // ParSignedDataFromProto returns the data from a protobuf.
 func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (ParSignedData, error) {
+	// TODO(corver): This can panic due to json unmarshalling unexpected data.
+	//  For now, it is a good way to catch compatibility issues. But we should
+	//  recover panics and return an error before launching mainnet.
+
 	var signedData SignedData
 	switch typ {
 	case DutyAttester:

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -749,11 +749,33 @@ func (s SignedBeaconCommitteeSubscription) clone() (SignedBeaconCommitteeSubscri
 }
 
 func (s SignedBeaconCommitteeSubscription) MarshalJSON() ([]byte, error) {
-	return s.BeaconCommitteeSubscription.MarshalJSON()
+	resp, err := json.Marshal(subscriptionJSON{
+		Subscription:    &s.BeaconCommitteeSubscription,
+		CommitteeLength: s.CommitteeLength,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal subscription")
+	}
+
+	return resp, nil
 }
 
 func (s *SignedBeaconCommitteeSubscription) UnmarshalJSON(input []byte) error {
-	return s.BeaconCommitteeSubscription.UnmarshalJSON(input)
+	var subJSON subscriptionJSON
+	err := json.Unmarshal(input, &subJSON)
+	if err != nil {
+		return errors.Wrap(err, "unmarshal subscription")
+	}
+
+	s.BeaconCommitteeSubscription = *subJSON.Subscription
+	s.CommitteeLength = subJSON.CommitteeLength
+
+	return nil
+}
+
+type subscriptionJSON struct {
+	Subscription    *eth2exp.BeaconCommitteeSubscription `json:"subscription"`
+	CommitteeLength uint64                               `json:"committee_length"`
 }
 
 // NewSignedAggregateAndProof is a convenience function which returns a new signed SignedAggregateAndProof.

--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -16,6 +16,7 @@
 package core_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -114,4 +115,15 @@ func TestSignedDataSetSignature(t *testing.T) {
 			require.NotEmpty(t, clone.Signature())
 		})
 	}
+}
+
+func TestMarshalSubscription(t *testing.T) {
+	sub := testutil.RandomSignedBeaconCommitteeSubscription(1, 2, 3, 4)
+	b, err := json.Marshal(sub)
+	require.NoError(t, err)
+
+	var sub2 core.SignedBeaconCommitteeSubscription
+	err = json.Unmarshal(b, &sub2)
+	require.NoError(t, err)
+	require.Equal(t, sub2, sub)
 }


### PR DESCRIPTION
Fixes bug in beacon committee subscription json marshalling that didn't include committee length.

category: bug
ticket: none
