### PR TITLE
app/peerinfo: reset peer info metrics

### DIFF
--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -237,7 +237,7 @@ func newMetricsSubmitter() metricSubmitter {
 		peerVersion.WithLabelValues(peerName, version).Set(1)
 		peerGitHash.WithLabelValues(peerName, gitHash).Set(1)
 
-		// Clear previous metrics of changed
+		// Clear previous metrics if changed
 		if prev, ok := prevVersions[peerName]; ok && version != prev {
 			peerVersion.WithLabelValues(peerName, prev).Set(0)
 		}


### PR DESCRIPTION
Reset previous peerinfo metrics when peer githash or version changes.
Also do basic sanity check on values (since peers can send arbitrary values). 

category: bug
ticket: none
