### PR TITLE
eth2util/eth2exp: spec new proposal aggregate endpoint

### DIFF
--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -32,6 +32,7 @@ import (
 // TODO(dhruv): Should be removed once it is supported by go-eth2-client.
 type BeaconCommitteeSelectionAggregator interface {
 	// AggregateBeaconCommitteeSelections returns DVT aggregated beacon committee selection proofs.
+	// This would call a new BN API endpoint: POST /eth/v1/aggregate/beacon_committee_selections
 	AggregateBeaconCommitteeSelections(ctx context.Context, partialSelections []*BeaconCommitteeSelection) ([]*BeaconCommitteeSelection, error)
 }
 

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -17,200 +17,102 @@ package eth2exp
 
 import (
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
-	eth2client "github.com/attestantio/go-eth2-client"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/minio/sha256-simd"
 
 	"github.com/obolnetwork/charon/app/errors"
 )
 
-type eth2Provider interface {
-	eth2client.SpecProvider
-}
-
-// BeaconCommitteeSubscriptionsSubmitterV2 is the interface for submitting beacon committee subnet subscription requests.
+// BeaconCommitteeSelectionAggregator is the interface for aggregating beacon committee selection proofs in a DVT cluster.
 // TODO(dhruv): Should be removed once it is supported by go-eth2-client.
-type BeaconCommitteeSubscriptionsSubmitterV2 interface {
-	// SubmitBeaconCommitteeSubscriptionsV2 subscribes to beacon committees.
-	SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*BeaconCommitteeSubscription) ([]*BeaconCommitteeSubscriptionResponse, error)
+type BeaconCommitteeSelectionAggregator interface {
+	// AggregateBeaconCommitteeSelections returns DVT aggregated beacon committee selection proofs.
+	AggregateBeaconCommitteeSelections(ctx context.Context, partialSelections []*BeaconCommitteeSelection) ([]*BeaconCommitteeSelection, error)
 }
 
-// BeaconCommitteeSubscription is the data required for a beacon committee subscription.
-type BeaconCommitteeSubscription struct {
-	// ValidatorIdex is the index of the validator making the subscription request.
+// BeaconCommitteeSelection is the data required for a beacon committee subscription.
+type BeaconCommitteeSelection struct {
+	// ValidatorIdex is the index of the validator making the aggregate request.
 	ValidatorIndex eth2p0.ValidatorIndex
-	// Slot is the slot for which the validator is attesting.
+	// Slot is the slot for which the validator is possibly aggregating.
 	Slot eth2p0.Slot
-	// CommitteeIndex is the index of the committee of which the validator is a member at the given slot.
-	CommitteeIndex eth2p0.CommitteeIndex
-	// CommitteesAtSlot is the number of committees at the given slot.
-	CommitteesAtSlot uint64
-	// SlotSignature is the slot signature required to calculate whether the validator is an aggregator.
-	SlotSignature eth2p0.BLSSignature
+	// SelectionProof is the slot signature required to calculate whether the validator is an aggregator.
+	SelectionProof eth2p0.BLSSignature
 }
 
-// beaconCommitteeSubscriptionJSON is the spec representation of the struct.
-type beaconCommitteeSubscriptionJSON struct {
-	ValidatorIndex   string `json:"validator_index"`
-	Slot             string `json:"slot"`
-	CommitteeIndex   string `json:"committee_index"`
-	CommitteesAtSlot string `json:"committees_at_slot"`
-	SlotSignature    string `json:"slot_signature"`
+// beaconCommitteeSelectionJSON is the spec representation of the struct.
+type beaconCommitteeSelectionJSON struct {
+	ValidatorIndex string `json:"validator_index"`
+	Slot           string `json:"slot"`
+	SelectionProof string `json:"selection_proof"`
 }
 
 // MarshalJSON implements json.Marshaler.
-func (b *BeaconCommitteeSubscription) MarshalJSON() ([]byte, error) {
-	resp, err := json.Marshal(&beaconCommitteeSubscriptionJSON{
-		ValidatorIndex:   fmt.Sprintf("%d", b.ValidatorIndex),
-		Slot:             fmt.Sprintf("%d", b.Slot),
-		CommitteeIndex:   fmt.Sprintf("%d", b.CommitteeIndex),
-		CommitteesAtSlot: fmt.Sprintf("%d", b.CommitteesAtSlot),
-		SlotSignature:    fmt.Sprintf("%#x", b.SlotSignature),
+func (b *BeaconCommitteeSelection) MarshalJSON() ([]byte, error) {
+	resp, err := json.Marshal(&beaconCommitteeSelectionJSON{
+		ValidatorIndex: fmt.Sprintf("%d", b.ValidatorIndex),
+		Slot:           fmt.Sprintf("%d", b.Slot),
+		SelectionProof: fmt.Sprintf("%#x", b.SelectionProof),
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "marshal beacon committee subscriptions v2")
+		return nil, errors.Wrap(err, "marshal beacon committee subscription")
 	}
 
 	return resp, nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (b *BeaconCommitteeSubscription) UnmarshalJSON(input []byte) error {
+func (b *BeaconCommitteeSelection) UnmarshalJSON(input []byte) error {
 	var err error
 
-	var beaconCommitteeSubscriptionJSON beaconCommitteeSubscriptionJSON
-	if err = json.Unmarshal(input, &beaconCommitteeSubscriptionJSON); err != nil {
+	var beaconCommitteeSelectionJSON beaconCommitteeSelectionJSON
+	if err = json.Unmarshal(input, &beaconCommitteeSelectionJSON); err != nil {
 		return errors.Wrap(err, "invalid JSON")
 	}
-	if beaconCommitteeSubscriptionJSON.ValidatorIndex == "" {
+	if beaconCommitteeSelectionJSON.ValidatorIndex == "" {
 		return errors.New("validator index missing")
 	}
-	validatorIndex, err := strconv.ParseUint(beaconCommitteeSubscriptionJSON.ValidatorIndex, 10, 64)
+	validatorIndex, err := strconv.ParseUint(beaconCommitteeSelectionJSON.ValidatorIndex, 10, 64)
 	if err != nil {
 		return errors.Wrap(err, "invalid value for validator index")
 	}
 	b.ValidatorIndex = eth2p0.ValidatorIndex(validatorIndex)
-	if beaconCommitteeSubscriptionJSON.Slot == "" {
+	if beaconCommitteeSelectionJSON.Slot == "" {
 		return errors.New("slot missing")
 	}
-	slot, err := strconv.ParseUint(beaconCommitteeSubscriptionJSON.Slot, 10, 64)
+	slot, err := strconv.ParseUint(beaconCommitteeSelectionJSON.Slot, 10, 64)
 	if err != nil {
 		return errors.Wrap(err, "invalid value for slot")
 	}
 	b.Slot = eth2p0.Slot(slot)
-	if beaconCommitteeSubscriptionJSON.CommitteeIndex == "" {
-		return errors.New("committee index missing")
-	}
-	committeeIndex, err := strconv.ParseUint(beaconCommitteeSubscriptionJSON.CommitteeIndex, 10, 64)
-	if err != nil {
-		return errors.Wrap(err, "invalid value for committee index")
-	}
-	b.CommitteeIndex = eth2p0.CommitteeIndex(committeeIndex)
-	if beaconCommitteeSubscriptionJSON.CommitteesAtSlot == "" {
-		return errors.New("committees at slot missing")
-	}
-	if b.CommitteesAtSlot, err = strconv.ParseUint(beaconCommitteeSubscriptionJSON.CommitteesAtSlot, 10, 64); err != nil {
-		return errors.Wrap(err, "invalid value for committees at slot")
-	}
-	if b.CommitteesAtSlot == 0 {
-		return errors.New("committees at slot cannot be 0")
+
+	if beaconCommitteeSelectionJSON.SelectionProof == "" {
+		return errors.New("selection proof missing")
 	}
 
-	if beaconCommitteeSubscriptionJSON.SlotSignature == "" {
-		return errors.New("slot signature missing")
-	}
-
-	signature, err := hex.DecodeString(strings.TrimPrefix(beaconCommitteeSubscriptionJSON.SlotSignature, "0x"))
+	signature, err := hex.DecodeString(strings.TrimPrefix(beaconCommitteeSelectionJSON.SelectionProof, "0x"))
 	if err != nil {
 		return errors.Wrap(err, "invalid value for signature")
 	}
 	if len(signature) != eth2p0.SignatureLength {
 		return errors.New("incorrect length for signature")
 	}
-	copy(b.SlotSignature[:], signature)
+	copy(b.SelectionProof[:], signature)
 
 	return nil
 }
 
 // String returns a string version of the structure.
-func (b *BeaconCommitteeSubscription) String() (string, error) {
+func (b *BeaconCommitteeSelection) String() (string, error) {
 	data, err := json.Marshal(b)
 	if err != nil {
-		return "", errors.Wrap(err, "marshal BeaconCommitteeSubscription")
+		return "", errors.Wrap(err, "marshal BeaconCommitteeSelection")
 	}
 
 	return string(data), nil
-}
-
-// BeaconCommitteeSubscriptionResponse is the response from beacon node after submitting BeaconCommitteeSubscription.
-type BeaconCommitteeSubscriptionResponse struct {
-	// ValidatorIndex is the index of the validator the made the subscription request.
-	ValidatorIndex eth2p0.ValidatorIndex
-	// Slot is the slot for which the validator is attesting.
-	Slot eth2p0.Slot
-	// CommitteeIndex is the index of the committee of which the validator is a member at the given slot.
-	CommitteeIndex eth2p0.CommitteeIndex
-	// CommitteesAtSlot is the number of committees at the given slot.
-	CommitteesAtSlot uint64
-	// IsAggregator indicates whether the validator is an attestation aggregator.
-	IsAggregator bool
-	// SelectionProof is the slot signature proving the validator is an aggregator for this slot and committee.
-	SelectionProof eth2p0.BLSSignature
-}
-
-// CalculateCommitteeSubscriptionResponse returns a BeaconCommitteeSubscriptionResponse with isAggregator field set to true if the validator is an aggregator.
-func CalculateCommitteeSubscriptionResponse(ctx context.Context, eth2Cl eth2Provider, sub *BeaconCommitteeSubscription,
-	committeeLength uint64,
-) (*BeaconCommitteeSubscriptionResponse, error) {
-	isAgg, err := isAggregator(ctx, eth2Cl, committeeLength, sub.SlotSignature)
-	if err != nil {
-		return nil, err
-	}
-
-	return &BeaconCommitteeSubscriptionResponse{
-		ValidatorIndex:   sub.ValidatorIndex,
-		Slot:             sub.Slot,
-		CommitteeIndex:   sub.CommitteeIndex,
-		CommitteesAtSlot: sub.CommitteesAtSlot,
-		SelectionProof:   sub.SlotSignature,
-		IsAggregator:     isAgg,
-	}, nil
-}
-
-// isAggregator returns true if the validator is the attestation aggregator for the given committee.
-// Refer: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#aggregation-selection
-func isAggregator(ctx context.Context, eth2Cl eth2Provider, commLen uint64, slotSig eth2p0.BLSSignature) (bool, error) {
-	spec, err := eth2Cl.Spec(ctx)
-	if err != nil {
-		return false, errors.Wrap(err, "get eth2 spec")
-	}
-
-	aggsPerComm, ok := spec["TARGET_AGGREGATORS_PER_COMMITTEE"].(uint64)
-	if !ok {
-		return false, errors.New("invalid TARGET_AGGREGATORS_PER_COMMITTEE")
-	}
-
-	modulo := commLen / aggsPerComm
-	if modulo < 1 {
-		modulo = 1
-	}
-
-	h := sha256.New()
-	_, err = h.Write(slotSig[:])
-	if err != nil {
-		return false, errors.Wrap(err, "calculate sha256")
-	}
-
-	hash := h.Sum(nil)
-	lowest8bytes := hash[0:8]
-	asUint64 := binary.LittleEndian.Uint64(lowest8bytes)
-
-	return asUint64%modulo == 0, nil
 }

--- a/eth2util/eth2exp/attagg_old.go
+++ b/eth2util/eth2exp/attagg_old.go
@@ -1,0 +1,217 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2exp
+
+import (
+	"context"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/minio/sha256-simd"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+type eth2Provider interface {
+	eth2client.SpecProvider
+}
+
+// BeaconCommitteeSubscriptionsSubmitterV2 is the interface for submitting beacon committee subnet subscription requests.
+// TODO(dhruv): Should be removed once it is supported by go-eth2-client.
+type BeaconCommitteeSubscriptionsSubmitterV2 interface {
+	// SubmitBeaconCommitteeSubscriptionsV2 subscribes to beacon committees.
+	// This would call a new BN API endpoint: POST /eth/v1/aggregate/beacon_committee_selections
+	SubmitBeaconCommitteeSubscriptionsV2(ctx context.Context, subscriptions []*BeaconCommitteeSubscription) ([]*BeaconCommitteeSubscriptionResponse, error)
+}
+
+// BeaconCommitteeSubscription is the data required for a beacon committee subscription.
+type BeaconCommitteeSubscription struct {
+	// ValidatorIdex is the index of the validator making the subscription request.
+	ValidatorIndex eth2p0.ValidatorIndex
+	// Slot is the slot for which the validator is attesting.
+	Slot eth2p0.Slot
+	// CommitteeIndex is the index of the committee of which the validator is a member at the given slot.
+	CommitteeIndex eth2p0.CommitteeIndex
+	// CommitteesAtSlot is the number of committees at the given slot.
+	CommitteesAtSlot uint64
+	// SlotSignature is the slot signature required to calculate whether the validator is an aggregator.
+	SlotSignature eth2p0.BLSSignature
+}
+
+// beaconCommitteeSubscriptionJSON is the spec representation of the struct.
+type beaconCommitteeSubscriptionJSON struct {
+	ValidatorIndex   string `json:"validator_index"`
+	Slot             string `json:"slot"`
+	CommitteeIndex   string `json:"committee_index"`
+	CommitteesAtSlot string `json:"committees_at_slot"`
+	SlotSignature    string `json:"slot_signature"`
+}
+
+// MarshalJSON implements json.Marshaler.
+func (b *BeaconCommitteeSubscription) MarshalJSON() ([]byte, error) {
+	resp, err := json.Marshal(&beaconCommitteeSubscriptionJSON{
+		ValidatorIndex:   fmt.Sprintf("%d", b.ValidatorIndex),
+		Slot:             fmt.Sprintf("%d", b.Slot),
+		CommitteeIndex:   fmt.Sprintf("%d", b.CommitteeIndex),
+		CommitteesAtSlot: fmt.Sprintf("%d", b.CommitteesAtSlot),
+		SlotSignature:    fmt.Sprintf("%#x", b.SlotSignature),
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal beacon committee subscriptions v2")
+	}
+
+	return resp, nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (b *BeaconCommitteeSubscription) UnmarshalJSON(input []byte) error {
+	var err error
+
+	var beaconCommitteeSubscriptionJSON beaconCommitteeSubscriptionJSON
+	if err = json.Unmarshal(input, &beaconCommitteeSubscriptionJSON); err != nil {
+		return errors.Wrap(err, "invalid JSON")
+	}
+	if beaconCommitteeSubscriptionJSON.ValidatorIndex == "" {
+		return errors.New("validator index missing")
+	}
+	validatorIndex, err := strconv.ParseUint(beaconCommitteeSubscriptionJSON.ValidatorIndex, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for validator index")
+	}
+	b.ValidatorIndex = eth2p0.ValidatorIndex(validatorIndex)
+	if beaconCommitteeSubscriptionJSON.Slot == "" {
+		return errors.New("slot missing")
+	}
+	slot, err := strconv.ParseUint(beaconCommitteeSubscriptionJSON.Slot, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for slot")
+	}
+	b.Slot = eth2p0.Slot(slot)
+	if beaconCommitteeSubscriptionJSON.CommitteeIndex == "" {
+		return errors.New("committee index missing")
+	}
+	committeeIndex, err := strconv.ParseUint(beaconCommitteeSubscriptionJSON.CommitteeIndex, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "invalid value for committee index")
+	}
+	b.CommitteeIndex = eth2p0.CommitteeIndex(committeeIndex)
+	if beaconCommitteeSubscriptionJSON.CommitteesAtSlot == "" {
+		return errors.New("committees at slot missing")
+	}
+	if b.CommitteesAtSlot, err = strconv.ParseUint(beaconCommitteeSubscriptionJSON.CommitteesAtSlot, 10, 64); err != nil {
+		return errors.Wrap(err, "invalid value for committees at slot")
+	}
+	if b.CommitteesAtSlot == 0 {
+		return errors.New("committees at slot cannot be 0")
+	}
+
+	if beaconCommitteeSubscriptionJSON.SlotSignature == "" {
+		return errors.New("slot signature missing")
+	}
+
+	signature, err := hex.DecodeString(strings.TrimPrefix(beaconCommitteeSubscriptionJSON.SlotSignature, "0x"))
+	if err != nil {
+		return errors.Wrap(err, "invalid value for signature")
+	}
+	if len(signature) != eth2p0.SignatureLength {
+		return errors.New("incorrect length for signature")
+	}
+	copy(b.SlotSignature[:], signature)
+
+	return nil
+}
+
+// String returns a string version of the structure.
+func (b *BeaconCommitteeSubscription) String() (string, error) {
+	data, err := json.Marshal(b)
+	if err != nil {
+		return "", errors.Wrap(err, "marshal BeaconCommitteeSubscription")
+	}
+
+	return string(data), nil
+}
+
+// BeaconCommitteeSubscriptionResponse is the response from beacon node after submitting BeaconCommitteeSubscription.
+type BeaconCommitteeSubscriptionResponse struct {
+	// ValidatorIndex is the index of the validator the made the subscription request.
+	ValidatorIndex eth2p0.ValidatorIndex
+	// Slot is the slot for which the validator is attesting.
+	Slot eth2p0.Slot
+	// CommitteeIndex is the index of the committee of which the validator is a member at the given slot.
+	CommitteeIndex eth2p0.CommitteeIndex
+	// CommitteesAtSlot is the number of committees at the given slot.
+	CommitteesAtSlot uint64
+	// IsAggregator indicates whether the validator is an attestation aggregator.
+	IsAggregator bool
+	// SelectionProof is the slot signature proving the validator is an aggregator for this slot and committee.
+	SelectionProof eth2p0.BLSSignature
+}
+
+// CalculateCommitteeSubscriptionResponse returns a BeaconCommitteeSubscriptionResponse with isAggregator field set to true if the validator is an aggregator.
+func CalculateCommitteeSubscriptionResponse(ctx context.Context, eth2Cl eth2Provider, sub *BeaconCommitteeSubscription,
+	committeeLength uint64,
+) (*BeaconCommitteeSubscriptionResponse, error) {
+	isAgg, err := isAggregator(ctx, eth2Cl, committeeLength, sub.SlotSignature)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BeaconCommitteeSubscriptionResponse{
+		ValidatorIndex:   sub.ValidatorIndex,
+		Slot:             sub.Slot,
+		CommitteeIndex:   sub.CommitteeIndex,
+		CommitteesAtSlot: sub.CommitteesAtSlot,
+		SelectionProof:   sub.SlotSignature,
+		IsAggregator:     isAgg,
+	}, nil
+}
+
+// isAggregator returns true if the validator is the attestation aggregator for the given committee.
+// Refer: https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#aggregation-selection
+func isAggregator(ctx context.Context, eth2Cl eth2Provider, commLen uint64, slotSig eth2p0.BLSSignature) (bool, error) {
+	spec, err := eth2Cl.Spec(ctx)
+	if err != nil {
+		return false, errors.Wrap(err, "get eth2 spec")
+	}
+
+	aggsPerComm, ok := spec["TARGET_AGGREGATORS_PER_COMMITTEE"].(uint64)
+	if !ok {
+		return false, errors.New("invalid TARGET_AGGREGATORS_PER_COMMITTEE")
+	}
+
+	modulo := commLen / aggsPerComm
+	if modulo < 1 {
+		modulo = 1
+	}
+
+	h := sha256.New()
+	_, err = h.Write(slotSig[:])
+	if err != nil {
+		return false, errors.Wrap(err, "calculate sha256")
+	}
+
+	hash := h.Sum(nil)
+	lowest8bytes := hash[0:8]
+	asUint64 := binary.LittleEndian.Uint64(lowest8bytes)
+
+	return asUint64%modulo == 0, nil
+}

--- a/testutil/validatormock/synccontributionflow_test.go
+++ b/testutil/validatormock/synccontributionflow_test.go
@@ -246,6 +246,7 @@ func isSyncCommAggregator(ctx context.Context, t *testing.T, eth2Cl *mock.Servic
 // SyncCommitteeSelectionAggregator is the interface for aggregating sync committee selection proofs in a DVT cluster.
 type SyncCommitteeSelectionAggregator interface {
 	// AggregateSyncCommitteeSelections returns DVT aggregated sync committee selection proofs.
+	// This would call a new BN API endpoint: POST /eth/v1/aggregate/sync_committee_selections
 	AggregateSyncCommitteeSelections(ctx context.Context, partialSelections []*SyncCommitteeSelection) ([]*SyncCommitteeSelection, error)
 }
 

--- a/testutil/validatormock/synccontributionflow_test.go
+++ b/testutil/validatormock/synccontributionflow_test.go
@@ -125,7 +125,7 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 		SelectionProof eth2p0.BLSSignature
 	}
 	aggsPerSubComm := make(map[uint64][]aggregator)
-	var selectionReqs []*SyncCommitteeSelectionRequest // Only used if supporting DVT
+	var partialSelections []*SyncCommitteeSelection // Only used if supporting DVT
 	for _, duty := range duties {
 		// Each validator can be part of multiple subcommittees.
 		for _, syncCommitteeIdx := range duty.ValidatorSyncCommitteeIndices {
@@ -159,10 +159,11 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 			// For DVT a new endpoint needs to be introduced to calculate and provide aggregated selection proofs.
 			// This is a batch endpoint that much be called at roughly the same time by all VCs in the cluster,
 			// so cache all the requests until the start of the slot.
-			selectionReqs = append(selectionReqs, &SyncCommitteeSelectionRequest{
-				ValidatorIndex: duty.ValidatorIndex,
-				Data:           data,
-				SelectionProof: sig,
+			partialSelections = append(partialSelections, &SyncCommitteeSelection{
+				ValidatorIndex:    duty.ValidatorIndex,
+				Slot:              data.Slot,
+				SubcommitteeIndex: data.SubcommitteeIndex,
+				SelectionProof:    sig,
 			})
 		}
 	}
@@ -170,10 +171,10 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 	// Instead of calculating aggregator locally, VCs supporting DVT need to request this from the upstream middleware DVT client.
 	// By convention, this MUST happen at the start of the slot, since all VCs need to do this at the same.
 	if supportDVT {
-		selections, _ := SyncCommitteeSelections(ctx, selectionReqs) // This is the new proposed endpoint!
+		aggregateSelections, _ := AggregateSyncCommitteeSelections(ctx, partialSelections) // This is the new proposed endpoint!
 
-		for _, selection := range selections {
-			if !selection.IsAggregator {
+		for _, selection := range aggregateSelections {
+			if !isSyncCommAggregator(ctx, t, eth2Cl, selection.SelectionProof) {
 				continue
 			}
 
@@ -181,7 +182,7 @@ func PseudoSyncCommContributionFlow(t *testing.T, supportDVT bool) {
 			var pubkey eth2p0.BLSPubKey
 
 			// Add aggregator attDuties per slot.
-			aggsPerSubComm[selection.Data.SubcommitteeIndex] = append(aggsPerSubComm[selection.Data.SubcommitteeIndex], aggregator{
+			aggsPerSubComm[selection.SubcommitteeIndex] = append(aggsPerSubComm[selection.SubcommitteeIndex], aggregator{
 				ValidatorIndex: selection.ValidatorIndex,
 				Pubkey:         pubkey,
 				SelectionProof: selection.SelectionProof,
@@ -242,30 +243,29 @@ func isSyncCommAggregator(ctx context.Context, t *testing.T, eth2Cl *mock.Servic
 	return binary.LittleEndian.Uint64(hash[:8])%modulo == 0
 }
 
-// SyncCommitteeSelectionRequest is the new proposed endpoint request type.
-type SyncCommitteeSelectionRequest struct {
-	ValidatorIndex eth2p0.ValidatorIndex               // ValidatorIndex required to aggregate the signature.
-	Data           *altair.SyncAggregatorSelectionData // Data required to verify the signature.
-	SelectionProof eth2p0.BLSSignature                 // SelectionProof is a partial signature
+// SyncCommitteeSelectionAggregator is the interface for aggregating sync committee selection proofs in a DVT cluster.
+type SyncCommitteeSelectionAggregator interface {
+	// AggregateSyncCommitteeSelections returns DVT aggregated sync committee selection proofs.
+	AggregateSyncCommitteeSelections(ctx context.Context, partialSelections []*SyncCommitteeSelection) ([]*SyncCommitteeSelection, error)
 }
 
-// SyncCommitteeSelection is the new proposed endpoint response type.
+// SyncCommitteeSelectionRequest is the new proposed endpoint request and response types.
 type SyncCommitteeSelection struct {
-	ValidatorIndex eth2p0.ValidatorIndex
-	Data           *altair.SyncAggregatorSelectionData
-	SelectionProof eth2p0.BLSSignature
-	IsAggregator   bool
+	ValidatorIndex    eth2p0.ValidatorIndex // ValidatorIndex required to aggregate the signature.
+	Slot              eth2p0.Slot           // Slot required to verify the signature
+	SubcommitteeIndex uint64                // SubcommitteeIndex required to verify the signature
+	SelectionProof    eth2p0.BLSSignature   // SelectionProof is a partial signature
 }
 
-// SyncCommitteeSelections is the new proposed endpoint that returns aggregated sync committee attSelections
+// AggregateSyncCommitteeSelections is the new proposed endpoint that returns aggregated sync committee attSelections
 // for the provided partial attSelections.
 //
 // Note endpoint MUST be called at the start of the slot, since all VCs in the cluster need to do it at the same time.
 // This is by convention, to ensure timely successful aggregation.
 //
 // Note this is a completely new endpoint, there is no v1 equivalent.
-func SyncCommitteeSelections(ctx context.Context, partials []*SyncCommitteeSelectionRequest) ([]*SyncCommitteeSelection, error) {
-	// This would call a new v2 BN API endpoint: POST /eth/v2/validator/sync_committee_selections
+func AggregateSyncCommitteeSelections(ctx context.Context, partials []*SyncCommitteeSelection) ([]*SyncCommitteeSelection, error) {
+	// This would call a new BN API endpoint: POST /eth/v1/aggregate/sync_committee_selections
 
 	// The charon middleware would do the following (error handling omitted):
 
@@ -279,26 +279,26 @@ func SyncCommitteeSelections(ctx context.Context, partials []*SyncCommitteeSelec
 		// Store partial selection
 		storePrepareDutySyncContributionPartialSig(selection)
 
-		aggregatedReq := awaitAggregatedDutySyncContribution(selection.Data.Slot)
-
-		// Calculate isAggregator
-		isAggregator := isSyncCommAggregator(ctx, nil, nil, aggregatedReq.SelectionProof)
+		aggregatedReq := awaitAggregatedDutySyncContribution(selection.Slot)
 
 		resp = append(resp, &SyncCommitteeSelection{
-			ValidatorIndex: selection.ValidatorIndex,
-			Data:           selection.Data,
-			SelectionProof: aggregatedReq.SelectionProof,
-			IsAggregator:   isAggregator,
+			ValidatorIndex:    selection.ValidatorIndex,
+			Slot:              selection.Slot,
+			SubcommitteeIndex: selection.SubcommitteeIndex,
+			SelectionProof:    aggregatedReq.SelectionProof,
 		})
 	}
 
 	return resp, nil
 }
 
-func verifySelectionProof(ctx context.Context, partial *SyncCommitteeSelectionRequest) error {
-	root, _ := partial.Data.HashTreeRoot()
+func verifySelectionProof(ctx context.Context, partial *SyncCommitteeSelection) error {
+	root, _ := (&altair.SyncAggregatorSelectionData{
+		Slot:              partial.Slot,
+		SubcommitteeIndex: partial.SubcommitteeIndex,
+	}).HashTreeRoot()
 
-	epoch, _ := epochFromSlot(ctx, nil, partial.Data.Slot)
+	epoch, _ := epochFromSlot(ctx, nil, partial.Slot)
 
 	signingRoot, _ := signing.GetDataRoot(ctx, nil, signing.DomainSyncCommitteeSelectionProof, epoch, root)
 
@@ -309,11 +309,11 @@ func verifySelectionProof(ctx context.Context, partial *SyncCommitteeSelectionRe
 }
 
 // storePrepareDutySyncContributionPartialSig stores the partial sync committee selection proof for aggregation when possible.
-func storePrepareDutySyncContributionPartialSig(*SyncCommitteeSelectionRequest) {}
+func storePrepareDutySyncContributionPartialSig(*SyncCommitteeSelection) {}
 
 // awaitAggregatedDutySyncContribution blocks and returns a cluster aggregated SyncCommitteeSelection.
-func awaitAggregatedDutySyncContribution(eth2p0.Slot) *SyncCommitteeSelectionRequest {
-	return &SyncCommitteeSelectionRequest{}
+func awaitAggregatedDutySyncContribution(eth2p0.Slot) *SyncCommitteeSelection {
+	return &SyncCommitteeSelection{}
 }
 
 func verifySignature(eth2p0.BLSSignature, eth2p0.BLSPubKey, []byte) error {


### PR DESCRIPTION
Specs the 2 new "aggregate selection" endpoints to support aggregations in middleware DVT clusters.
- `POST /eth/v1/aggregate/beacon_committee_selections`
- `POST /eth/v1/aggregate/sync_committee_selections`

VCs should call these at the start of the slot to fetch a DVT aggregate selection proof for use in committee aggregator duties (both beacon committee and sync committee).

```
// BeaconCommitteeSelectionAggregator is the interface for aggregating beacon committee selection proofs in a DVT cluster.
type BeaconCommitteeSelectionAggregator interface {
	// AggregateBeaconCommitteeSelections returns DVT aggregated beacon committee selection proofs.
	// This would call a new BN API endpoint: POST /eth/v1/aggregate/beacon_committee_selections
	AggregateBeaconCommitteeSelections(ctx context.Context, partialSelections []*BeaconCommitteeSelection) ([]*BeaconCommitteeSelection, error)
}

// BeaconCommitteeSelection is the data required for a beacon committee subscription.
type BeaconCommitteeSelection struct {
	// ValidatorIdex is the index of the validator making the aggregate request.
	ValidatorIndex eth2p0.ValidatorIndex
	// Slot is the slot for which the validator is possibly aggregating.
	Slot eth2p0.Slot
	// SelectionProof is the slot signature required to calculate whether the validator is an aggregator.
	SelectionProof eth2p0.BLSSignature
}

// SyncCommitteeSelectionAggregator is the interface for aggregating sync committee selection proofs in a DVT cluster.
type SyncCommitteeSelectionAggregator interface {
	// AggregateSyncCommitteeSelections returns DVT aggregated sync committee selection proofs.
	// This would call a new BN API endpoint: POST /eth/v1/aggregate/sync_committee_selections
	AggregateSyncCommitteeSelections(ctx context.Context, partialSelections []*SyncCommitteeSelection) ([]*SyncCommitteeSelection, error)
}

// SyncCommitteeSelection is the data required for a sync committee subscription.
type SyncCommitteeSelection struct {
	ValidatorIndex    eth2p0.ValidatorIndex // ValidatorIndex required to aggregate the signature.
	Slot              eth2p0.Slot           // Slot required to verify the signature
	SubcommitteeIndex uint64                // SubcommitteeIndex required to verify the signature
	SelectionProof       eth2p0.BLSSignature   // SelectionProof is a partial signature
}
```

category: misc
ticket: none
