### PR TITLE
dkg: fix flapper due to bind error

### DIFF
--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -102,7 +102,12 @@ func testDKG(t *testing.T, def cluster.Definition, p2pKeys []*ecdsa.PrivateKey) 
 		require.NoError(t, err)
 
 		eg.Go(func() error {
-			return dkg.Run(ctx, conf)
+			err := dkg.Run(ctx, conf)
+			if err != nil {
+				cancel()
+			}
+
+			return err
 		})
 		if i == 0 {
 			// Allow node0 some time to startup, this just mitigates startup races and backoffs but isn't required.


### PR DESCRIPTION
Fixes flapping test due to bind errors by cancelling the context so all nodes exit. Previously, the test timed out on bind errors.

category: test
ticket: none
