### PR TITLE
testutil/validatormock: only subscribe contributions if duties

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -66,6 +66,7 @@ func Instrument(clients ...Client) (Client, error) {
 }
 
 // AdaptEth2HTTP returns a Client wrapping an eth2http service by adding experimental endpoints.
+// Note that the returned client doesn't wrap errors, so they are unstructured without stacktraces.
 func AdaptEth2HTTP(eth2Svc *eth2http.Service, timeout time.Duration) Client {
 	return httpAdapter{Service: eth2Svc, timeout: timeout}
 }

--- a/testutil/validatormock/synccomm.go
+++ b/testutil/validatormock/synccomm.go
@@ -157,6 +157,10 @@ func prepareSyncContributions(context.Context, eth2wrap.Client, SignFunc,
 
 // subscribeSyncCommSubnets submits sync committee subscriptions at the start of an epoch until next epoch.
 func subscribeSyncCommSubnets(ctx context.Context, eth2Cl eth2wrap.Client, epoch eth2p0.Epoch, duties syncDuties) error {
+	if len(duties) == 0 {
+		return nil
+	}
+
 	var subs []*eth2v1.SyncCommitteeSubscription
 	for _, duty := range duties {
 		subs = append(subs, &eth2v1.SyncCommitteeSubscription{


### PR DESCRIPTION
Fixes on issue in validatormock that subscribes to sync committee subnets even if no duties are present.

category: bug
ticket: none
