### PR TITLE
app: fix test shutdown timeout

### DIFF
--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -308,7 +308,7 @@ func testSimnet(t *testing.T, args simnetArgs, expect simnetExpect) {
 				SimnetKeys:         []*bls_sig.SecretKey{args.SimnetKeys[i]},
 				ParSigExFunc:       parSigExFunc,
 				LcastTransportFunc: lcastTransportFunc,
-				BroadcastCallback: func(ctx context.Context, duty core.Duty, key core.PubKey, data core.SignedData) error {
+				BroadcastCallback: func(_ context.Context, duty core.Duty, key core.PubKey, data core.SignedData) error {
 					select {
 					case <-ctx.Done():
 						return ctx.Err()


### PR DESCRIPTION
Attempts to fix the flapping test due to shutdown timeout. The problem is that the http request context is not closed when the server is shutdown. So rather use the external test context in the select.

category: test
ticket: none
