### PR TITLE
app: add memory monitor

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -217,6 +217,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 
+	wireMemoryMonitor(life, conf)
+
 	// Run life cycle manager
 	return life.Run(ctx)
 }

--- a/app/heap.go
+++ b/app/heap.go
@@ -86,7 +86,7 @@ func monitorMemory(ctx context.Context, dir string) {
 				return
 			}
 
-			log.Info(ctx, "Inuse memory crossed threshold, dumped heap to file",
+			log.Warn(ctx, "Inuse memory crossed threshold, dumped heap to file", nil,
 				z.U64("memory_mb", stats.HeapInuse>>20),
 				z.U64("threshold_mb", threshold>>20),
 				z.Str("file", filename),

--- a/app/heap.go
+++ b/app/heap.go
@@ -1,0 +1,86 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"runtime"
+	"runtime/pprof"
+	"time"
+
+	"github.com/obolnetwork/charon/app/lifecycle"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+// wireMemoryMonitor wires a memory monitor that write heap dumps to disk when memory increases.
+func wireMemoryMonitor(life *lifecycle.Manager, conf Config) {
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartRest,
+		lifecycle.HookFuncCtx(func(ctx context.Context) {
+			dir := path.Join(path.Dir(conf.LockFile), "heapdumps")
+			monitorMemory(ctx, dir)
+		}),
+	)
+}
+
+// monitorMemory blocks until the context is closed.
+//   - It reads the inuse memory every second,
+//   - if it crosses the threshold,
+//   - it writes a pprof heap dump to the dir,
+//   - and doubles the threshold.
+func monitorMemory(ctx context.Context, dir string) {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	const mb uint64 = 1 << 20
+	threshold := 100 * mb
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			var stats runtime.MemStats
+			runtime.ReadMemStats(&stats)
+			if stats.HeapInuse < threshold {
+				continue
+			}
+
+			filename := fmt.Sprintf("heap_dump_%s", time.Now().Format("20060102150405"))
+			filename = path.Join(dir, filename)
+
+			file, err := os.Open(filename)
+			if err != nil {
+				log.Warn(ctx, "Failed opening heap dump file", err)
+				return
+			}
+
+			err = pprof.Lookup("heap").WriteTo(file, 0)
+			if err != nil {
+				log.Warn(ctx, "Failed writing heap dump file", err)
+				return
+			}
+
+			log.Info(ctx, "Inuse memory crossed threshold, dumped heap to file",
+				z.U64("threhsold", threshold), z.Str("file", filename))
+
+			threshold *= 2
+		}
+	}
+}

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -38,6 +38,7 @@ const (
 	StartScheduler
 	StartP2PEventCollector
 	StartPeerInfo
+	StartRest
 )
 
 // Global ordering of stop hooks; follows dependency tree from root to leaves.

--- a/app/lifecycle/orderstart_string.go
+++ b/app/lifecycle/orderstart_string.go
@@ -35,11 +35,12 @@ func _() {
 	_ = x[StartScheduler-9]
 	_ = x[StartP2PEventCollector-10]
 	_ = x[StartPeerInfo-11]
+	_ = x[StartRest-12]
 }
 
-const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersP2PConsensusSimulatorSchedulerP2PEventCollectorPeerInfo"
+const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersP2PConsensusSimulatorSchedulerP2PEventCollectorPeerInfoRest"
 
-var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 62, 74, 83, 92, 109, 117}
+var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 62, 74, 83, 92, 109, 117, 121}
 
 func (i OrderStart) String() string {
 	if i < 0 || i >= OrderStart(len(_OrderStart_index)-1) {


### PR DESCRIPTION
Adds a memory monitor that writes heap dumps to disk when memory increases. This aims to catch suspicious spikes seen in the wild.

category: misc
ticket: none
