### PR TITLE
main: don't handle kill signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,19 +16,11 @@
 package main
 
 import (
-	"context"
-	"os"
-	"os/signal"
-	"syscall"
-
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/cmd"
 )
 
 func main() {
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
-
-	cobra.CheckErr(cmd.New().ExecuteContext(ctx))
+	cobra.CheckErr(cmd.New().Execute())
 }

--- a/main.go
+++ b/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
@@ -28,15 +27,7 @@ import (
 )
 
 func main() {
-	killCtx, killCancel := signal.NotifyContext(context.Background(), syscall.SIGKILL)
-	defer killCancel()
-	go func() {
-		<-killCtx.Done()
-		_, _ = fmt.Fprintln(os.Stderr, "Kill signal received")
-		os.Exit(1)
-	}()
-
-	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	cobra.CheckErr(cmd.New().ExecuteContext(ctx))


### PR DESCRIPTION
Don't handle any signals (specifically SigTERM) as it causes docker containers to hang if stopped.

category: bug 
ticket: none
