### PR TITLE
core/scheduler: adds support for sync committee duties

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -560,7 +560,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 			beaconmock.WithSlotDuration(time.Second),
 			beaconmock.WithDeterministicAttesterDuties(dutyFactor),
 			beaconmock.WithDeterministicProposerDuties(dutyFactor),
-			beaconmock.WithSyncCommitteeDuties(),
+			beaconmock.WithDeterministicSyncCommDuties(),
 			beaconmock.WithValidatorSet(createMockValidators(pubkeys)),
 		}
 		opts = append(opts, conf.TestConfig.SimnetBMockOpts...)

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -127,6 +127,23 @@ func (m multi) AggregateBeaconCommitteeSelections(ctx context.Context, selection
 	return res0, err
 }
 
+func (m multi) AggregateSyncCommitteeSelections(ctx context.Context, selections []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error) {
+	const label = "aggregate_sync_committee_selections"
+
+	res, err := provide(ctx, m.clients,
+		func(ctx context.Context, cl Client) ([]*eth2exp.SyncCommitteeSelection, error) {
+			return cl.AggregateSyncCommitteeSelections(ctx, selections)
+		},
+		nil,
+	)
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return res, err
+}
+
 // provide calls the work function with each client in parallel, returning the
 // first successful result or first error.
 func provide[O any](ctx context.Context, clients []Client,

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -34,6 +34,7 @@ import (
 type Client interface {
 	eth2client.Service
 	eth2exp.BeaconCommitteeSelectionAggregator
+	eth2exp.SyncCommitteeSelectionAggregator
 
 	eth2client.AggregateAttestationProvider
 	eth2client.AggregateAttestationsSubmitter

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -56,6 +56,7 @@ import (
 type Client interface {
     eth2client.Service
     eth2exp.BeaconCommitteeSelectionAggregator
+	eth2exp.SyncCommitteeSelectionAggregator
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
@@ -118,6 +119,7 @@ type Client interface {
 		"SyncCommitteeContributionProvider":     true,
 		"SyncCommitteeContributionsSubmitter":   true,
 		"SyncCommitteeMessagesSubmitter":        true,
+		"SyncCommitteeSelectionAggregator":      true,
 		"SyncCommitteeSubscriptionsSubmitter":   true,
 		"ValidatorsProvider":                    true,
 		"ValidatorRegistrationsSubmitter":       true,

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -56,7 +56,7 @@ import (
 type Client interface {
     eth2client.Service
     eth2exp.BeaconCommitteeSelectionAggregator
-	eth2exp.SyncCommitteeSelectionAggregator
+    eth2exp.SyncCommitteeSelectionAggregator
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
@@ -119,7 +119,6 @@ type Client interface {
 		"SyncCommitteeContributionProvider":     true,
 		"SyncCommitteeContributionsSubmitter":   true,
 		"SyncCommitteeMessagesSubmitter":        true,
-		"SyncCommitteeSelectionAggregator":      true,
 		"SyncCommitteeSubscriptionsSubmitter":   true,
 		"ValidatorsProvider":                    true,
 		"ValidatorRegistrationsSubmitter":       true,

--- a/core/dutydefinition.go
+++ b/core/dutydefinition.go
@@ -76,10 +76,13 @@ func (d ProposerDefinition) MarshalJSON() ([]byte, error) {
 	return d.ProposerDuty.MarshalJSON()
 }
 
-func NewSyncCommitteDefinition(duty *eth2v1.SyncCommitteeDuty) DutyDefinition {
+// NewSyncCommitteeDefinition is a convenience function that returns a new SyncCommitteeDefinition.
+func NewSyncCommitteeDefinition(duty *eth2v1.SyncCommitteeDuty) DutyDefinition {
 	return SyncCommitteeDefinition{SyncCommitteeDuty: *duty}
 }
 
+// SyncCommitteeDefinition defines a sync committee duty. It implements DutyDefinition.
+// Note the slight rename from Duty to Definition to avoid overloading the term Duty.
 type SyncCommitteeDefinition struct {
 	eth2v1.SyncCommitteeDuty
 }
@@ -91,7 +94,7 @@ func (s SyncCommitteeDefinition) Clone() (DutyDefinition, error) {
 		return nil, errors.Wrap(err, "clone sync committee definition")
 	}
 
-	return NewSyncCommitteDefinition(duty), nil
+	return NewSyncCommitteeDefinition(duty), nil
 }
 
 func (s SyncCommitteeDefinition) MarshalJSON() ([]byte, error) {

--- a/core/scheduler/offset.go
+++ b/core/scheduler/offset.go
@@ -23,8 +23,9 @@ import (
 
 // slotOffsets defines the offsets at which the duties should be triggered.
 var slotOffsets = map[core.DutyType]func(time.Duration) time.Duration{
-	core.DutyAttester:   fraction(1, 3), // 1/3 slot duration
-	core.DutyAggregator: fraction(2, 3), // 2/3 slot duration
+	core.DutyAttester:         fraction(1, 3), // 1/3 slot duration
+	core.DutyAggregator:       fraction(2, 3), // 2/3 slot duration
+	core.DutySyncContribution: fraction(2, 3), // 2/3 slot duration
 	// TODO(corver): Add more duties
 }
 

--- a/core/scheduler/offset.go
+++ b/core/scheduler/offset.go
@@ -25,8 +25,7 @@ import (
 var slotOffsets = map[core.DutyType]func(time.Duration) time.Duration{
 	core.DutyAttester:         fraction(1, 3), // 1/3 slot duration
 	core.DutyAggregator:       fraction(2, 3), // 2/3 slot duration
-	core.DutySyncContribution: fraction(2, 3), // 2/3 slot duration
-	// TODO(corver): Add more duties
+	core.DutySyncContribution: fraction(2, 3),
 }
 
 // fraction returns a function that calculates slot offset based on the fraction x/y of total slot duration.

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -387,20 +387,19 @@ func (s *Scheduler) resolveSyncCommDuties(ctx context.Context, slot core.Slot, v
 	}
 
 	for _, syncCommDuty := range duties {
-		var (
-			startSlot = slot
-			currEpoch = slot.Epoch()
-			vIdx      = syncCommDuty.ValidatorIndex
-		)
-
+		vIdx := syncCommDuty.ValidatorIndex
 		pubkey, ok := vals.PubKeyFromIndex(vIdx)
 		if !ok {
-			log.Warn(ctx, "Ignoring unexpected sync committee duty", nil, z.U64("vidx", uint64(syncCommDuty.ValidatorIndex)), z.I64("slot", slot.Slot))
+			log.Warn(ctx, "Ignoring unexpected sync committee duty", nil, z.U64("vidx", uint64(vIdx)), z.I64("slot", slot.Slot))
 			continue
 		}
 
 		// TODO(xenowits): sync committee duties start in the slot before the sync committee period.
 		// Refer: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#sync-committee
+		var (
+			startSlot = slot
+			currEpoch = slot.Epoch()
+		)
 
 		for sl := startSlot; sl.Epoch() == currEpoch; sl = sl.Next() {
 			// Schedule sync committee contribution aggregation.
@@ -409,7 +408,7 @@ func (s *Scheduler) resolveSyncCommDuties(ctx context.Context, slot core.Slot, v
 		}
 
 		log.Info(ctx, "Resolved sync committee duty",
-			z.U64("vidx", uint64(syncCommDuty.ValidatorIndex)),
+			z.U64("vidx", uint64(vIdx)),
 			z.Any("pubkey", pubkey),
 			z.U64("epoch", uint64(slot.Epoch())),
 		)

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -298,7 +298,7 @@ func TestSchedulerDuties(t *testing.T) {
 func TestScheduler_GetDuty(t *testing.T) {
 	var (
 		t0     time.Time
-		slot   = int64(0)
+		slot   = int64(1)
 		valSet = beaconmock.ValidatorSetA
 	)
 
@@ -308,6 +308,7 @@ func TestScheduler_GetDuty(t *testing.T) {
 		beaconmock.WithGenesisTime(t0),
 		beaconmock.WithDeterministicAttesterDuties(0),
 		beaconmock.WithDeterministicSyncCommDuties(),
+		beaconmock.WithSlotsPerEpoch(1),
 	)
 	require.NoError(t, err)
 

--- a/core/types.go
+++ b/core/types.go
@@ -436,16 +436,6 @@ func (s Slot) Next() Slot {
 	}
 }
 
-// Previous returns the previous slot.
-func (s Slot) Previous() Slot {
-	return Slot{
-		Slot:          s.Slot - 1,
-		Time:          s.Time.Add(-1 * s.SlotDuration),
-		SlotsPerEpoch: s.SlotsPerEpoch,
-		SlotDuration:  s.SlotDuration,
-	}
-}
-
 // Epoch returns the epoch of the slot.
 func (s Slot) Epoch() int64 {
 	return s.Slot / s.SlotsPerEpoch

--- a/core/types.go
+++ b/core/types.go
@@ -451,24 +451,6 @@ func (s Slot) Epoch() int64 {
 	return s.Slot / s.SlotsPerEpoch
 }
 
-// NextEpoch returns the next epoch of the slot.
-func (s Slot) NextEpoch() int64 {
-	return s.Epoch() + 1
-}
-
-// LastSlotInEpoch returns the last slot in the epoch.
-func (s Slot) LastSlotInEpoch() Slot {
-	lastSlot := s.SlotsPerEpoch*s.NextEpoch() - 1
-	slotDistance := lastSlot - s.Slot
-
-	return Slot{
-		Slot:          lastSlot,
-		Time:          s.Time.Add(time.Duration(slotDistance) * s.SlotDuration),
-		SlotsPerEpoch: s.SlotsPerEpoch,
-		SlotDuration:  s.SlotDuration,
-	}
-}
-
 // LastInEpoch returns true if this is the last slot in the epoch.
 func (s Slot) LastInEpoch() bool {
 	return s.Slot%s.SlotsPerEpoch == s.SlotsPerEpoch-1

--- a/core/types.go
+++ b/core/types.go
@@ -436,9 +436,37 @@ func (s Slot) Next() Slot {
 	}
 }
 
+// Previous returns the previous slot.
+func (s Slot) Previous() Slot {
+	return Slot{
+		Slot:          s.Slot - 1,
+		Time:          s.Time.Add(-1 * s.SlotDuration),
+		SlotsPerEpoch: s.SlotsPerEpoch,
+		SlotDuration:  s.SlotDuration,
+	}
+}
+
 // Epoch returns the epoch of the slot.
 func (s Slot) Epoch() int64 {
 	return s.Slot / s.SlotsPerEpoch
+}
+
+// NextEpoch returns the next epoch of the slot.
+func (s Slot) NextEpoch() int64 {
+	return s.Epoch() + 1
+}
+
+// LastSlotInEpoch returns the last slot in the epoch.
+func (s Slot) LastSlotInEpoch() Slot {
+	lastSlot := s.SlotsPerEpoch*s.NextEpoch() - 1
+	slotDistance := lastSlot - s.Slot
+
+	return Slot{
+		Slot:          lastSlot,
+		Time:          s.Time.Add(time.Duration(slotDistance) * s.SlotDuration),
+		SlotsPerEpoch: s.SlotsPerEpoch,
+		SlotDuration:  s.SlotDuration,
+	}
 }
 
 // LastInEpoch returns true if this is the last slot in the epoch.

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -149,6 +149,7 @@ type Mock struct {
 	SubmitValidatorRegistrationsFunc          func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error
 	SlotsPerEpochFunc                         func(context.Context) (uint64, error)
 	AggregateBeaconCommitteeSubscriptionsFunc func(context.Context, []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error)
+	AggregateSyncCommitteeSelectionsFunc      func(context.Context, []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error)
 	SubmitBeaconCommitteeSubscriptionsFunc    func(ctx context.Context, subscriptions []*eth2v1.BeaconCommitteeSubscription) error
 	AggregateAttestationFunc                  func(ctx context.Context, slot eth2p0.Slot, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error)
 	SubmitAggregateAttestationsFunc           func(ctx context.Context, aggregateAndProofs []*eth2p0.SignedAggregateAndProof) error
@@ -230,6 +231,10 @@ func (m Mock) SubmitValidatorRegistrations(ctx context.Context, registrations []
 
 func (m Mock) AggregateBeaconCommitteeSelections(ctx context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
 	return m.AggregateBeaconCommitteeSubscriptionsFunc(ctx, selections)
+}
+
+func (m Mock) AggregateSyncCommitteeSelections(ctx context.Context, selections []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error) {
+	return m.AggregateSyncCommitteeSelectionsFunc(ctx, selections)
 }
 
 func (m Mock) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*eth2v1.BeaconCommitteeSubscription) error {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -268,6 +268,39 @@ func WithDeterministicAttesterDuties(factor int) Option {
 	}
 }
 
+// WithDeterministicSyncCommDuties configures the mock to provide deterministic sync committee duties based on provided arguments and config.
+// Note that it depends on ValidatorsFunc being populated, e.g. via WithValidatorSet.
+func WithDeterministicSyncCommDuties() Option {
+	return func(mock *Mock) {
+		mock.SyncCommitteeDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
+			vals, err := mock.Validators(ctx, "", indices)
+			if err != nil {
+				return nil, err
+			}
+
+			sort.Slice(indices, func(i, j int) bool {
+				return indices[i] < indices[j]
+			})
+
+			var resp []*eth2v1.SyncCommitteeDuty
+			for _, index := range indices {
+				val, ok := vals[index]
+				if !ok {
+					continue
+				}
+
+				resp = append(resp, &eth2v1.SyncCommitteeDuty{
+					PubKey:                        val.Validator.PublicKey,
+					ValidatorIndex:                index,
+					ValidatorSyncCommitteeIndices: []eth2p0.CommitteeIndex{1, 2, 3},
+				})
+			}
+
+			return resp, nil
+		}
+	}
+}
+
 // WithDeterministicProposerDuties configures the mock to provide deterministic duties based on provided arguments and config.
 // Note it depends on ValidatorsFunc being populated, e.g. via WithValidatorSet.
 func WithDeterministicProposerDuties(factor int) Option {
@@ -521,6 +554,9 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 			return []*eth2v1.SyncCommitteeDuty{}, nil
 		},
 		SubmitSyncCommitteeMessagesFunc: func(context.Context, []*altair.SyncCommitteeMessage) error {
+			return nil
+		},
+		SubmitSyncCommitteeSubscriptionsFunc: func(context.Context, []*eth2v1.SyncCommitteeSubscription) error {
 			return nil
 		},
 	}

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -268,39 +268,6 @@ func WithDeterministicAttesterDuties(factor int) Option {
 	}
 }
 
-// WithDeterministicSyncCommDuties configures the mock to provide deterministic sync committee duties based on provided arguments and config.
-// Note that it depends on ValidatorsFunc being populated, e.g. via WithValidatorSet.
-func WithDeterministicSyncCommDuties() Option {
-	return func(mock *Mock) {
-		mock.SyncCommitteeDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
-			vals, err := mock.Validators(ctx, "", indices)
-			if err != nil {
-				return nil, err
-			}
-
-			sort.Slice(indices, func(i, j int) bool {
-				return indices[i] < indices[j]
-			})
-
-			var resp []*eth2v1.SyncCommitteeDuty
-			for _, index := range indices {
-				val, ok := vals[index]
-				if !ok {
-					continue
-				}
-
-				resp = append(resp, &eth2v1.SyncCommitteeDuty{
-					PubKey:                        val.Validator.PublicKey,
-					ValidatorIndex:                index,
-					ValidatorSyncCommitteeIndices: []eth2p0.CommitteeIndex{1, 2, 3},
-				})
-			}
-
-			return resp, nil
-		}
-	}
-}
-
 // WithDeterministicProposerDuties configures the mock to provide deterministic duties based on provided arguments and config.
 // Note it depends on ValidatorsFunc being populated, e.g. via WithValidatorSet.
 func WithDeterministicProposerDuties(factor int) Option {
@@ -379,9 +346,9 @@ func WithNoSyncCommitteeDuties() Option {
 	}
 }
 
-// WithSyncCommitteeDuties configures the mock to override SyncCommitteeDutiesFunc to return sync committee
+// WithDeterministicSyncCommDuties configures the mock to override SyncCommitteeDutiesFunc to return sync committee
 // duties for all validators with epoch number not divisible by 3.
-func WithSyncCommitteeDuties() Option {
+func WithDeterministicSyncCommDuties() Option {
 	return func(mock *Mock) {
 		mock.SyncCommitteeDutiesFunc = func(ctx context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
 			if epoch%3 == 0 {


### PR DESCRIPTION
Adds support for sync committee duties to the `scheduler` component.

category: feature
ticket: https://github.com/ObolNetwork/charon/issues/1265
