### PR TITLE
app/eth2wrap: decompose eth2client http errors

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -195,5 +196,17 @@ func TestErrors(t *testing.T) {
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: caller cancelled http request: context canceled")
+	})
+
+	t.Run("go-eth2-client http error", func(t *testing.T) {
+		bmock, err := beaconmock.New()
+		require.NoError(t, err)
+		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, bmock.Address())
+		require.NoError(t, err)
+
+		_, err = eth2Cl.AggregateAttestation(ctx, 0, eth2p0.Root{})
+		log.Error(ctx, "See this error log for fields", err)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "beacon api aggregate_attestation: nok http response")
 	})
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/obolnetwork/charon
 go 1.19
 
 require (
-	github.com/attestantio/go-eth2-client v0.14.0
+	github.com/attestantio/go-eth2-client v0.14.1
 	github.com/bufbuild/buf v1.9.0
 	github.com/coinbase/kryptology v1.5.6-0.20220316191335-269410e1b06b
 	github.com/ethereum/go-ethereum v1.10.25

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/attestantio/go-eth2-client v0.14.0 h1:usWgI0KIfGWQ8G7XUsMM2bTe+yuJEh4d3HEO1vPD5Go=
-github.com/attestantio/go-eth2-client v0.14.0/go.mod h1:bcg5gfjVcm+MtcaZfzv/uSWNHU4i8hGamVG+9JCZnC0=
+github.com/attestantio/go-eth2-client v0.14.1 h1:RUdwL6RsLuk113DQJEXz2Bx1yqYGgUgV8SWPQzd265I=
+github.com/attestantio/go-eth2-client v0.14.1/go.mod h1:bcg5gfjVcm+MtcaZfzv/uSWNHU4i8hGamVG+9JCZnC0=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=


### PR DESCRIPTION
Upgrade to latest go-eth2-client and handle structured errors.

category: misc
ticket: none
