### PR TITLE
core: add message root to signed data interface

### DIFF
--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -102,6 +102,12 @@ func TestSignedDataSetSignature(t *testing.T) {
 			require.NoError(t, err)
 			require.NotEqual(t, clone.Signature(), test.data.Signature())
 			require.NotEmpty(t, clone.Signature())
+
+			msgRoot, err := test.data.MessageRoot()
+			require.NoError(t, err)
+			cloneRoot, err := test.data.MessageRoot()
+			require.NoError(t, err)
+			require.Equal(t, msgRoot, cloneRoot)
 		})
 	}
 }

--- a/core/types.go
+++ b/core/types.go
@@ -371,6 +371,8 @@ type SignedData interface {
 	Signature() Signature
 	// SetSignature returns a copy of signed duty data with the signature replaced.
 	SetSignature(Signature) (SignedData, error)
+	// MessageRoot returns the unsigned data message root.
+	MessageRoot() ([32]byte, error)
 	// Clone returns a cloned copy of the SignedData. For an immutable core workflow architecture,
 	// remember to clone data when it leaves the current scope (sharing, storing, returning, etc).
 	Clone() (SignedData, error)


### PR DESCRIPTION
Add explicit unsigned data message root function to signed data as a better way to ensure consistent unsigned data in parsigdb. Relying on json serialisation to check for consistent signed data is brittle.

category: refactor
ticket: #1347
