### PR TITLE
core/parsigdb: use message root for consistency check

### DIFF
--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -102,7 +102,7 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 			z.Any("pubkey", pubkey))
 
 		// Check if sufficient matching partial signed data has been received.
-		psigs, ok, err := getThresholdMatching(sigs, db.threshold)
+		psigs, ok, err := getThresholdMatching(duty.Type, sigs, db.threshold)
 		if err != nil {
 			return err
 		} else if !ok {
@@ -166,9 +166,13 @@ func (db *MemDB) store(k key, value core.ParSignedData) ([]core.ParSignedData, b
 }
 
 // getThresholdMatching returns true and threshold number of partial signed data with identical data or false.
-func getThresholdMatching(sigs []core.ParSignedData, threshold int) ([]core.ParSignedData, bool, error) {
+func getThresholdMatching(typ core.DutyType, sigs []core.ParSignedData, threshold int) ([]core.ParSignedData, bool, error) {
 	if len(sigs) < threshold {
 		return nil, false, nil
+	}
+	if typ == core.DutySignature {
+		// Signatures do not support message roots.
+		return sigs, len(sigs) == threshold, nil
 	}
 
 	sigsByMsgRoot := make(map[[32]byte][]core.ParSignedData)

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -18,7 +18,6 @@ package parsigdb
 import (
 	"bytes"
 	"context"
-	"crypto/sha256"
 	"encoding/json"
 	"sync"
 
@@ -172,35 +171,22 @@ func getThresholdMatching(sigs []core.ParSignedData, threshold int) ([]core.ParS
 		return nil, false, nil
 	}
 
-	sigsByDataHash := make(map[[32]byte][]core.ParSignedData)
+	sigsByMsgRoot := make(map[[32]byte][]core.ParSignedData)
 	for _, sig := range sigs {
-		// Clear the signature to get the raw signed data.
-		noSig, err := sig.SetSignature(nil)
+		root, err := sig.MessageRoot()
 		if err != nil {
-			return nil, false, err
+			return nil, false, errors.Wrap(err, "message root")
 		}
 
-		// Convert it to json
-		b, err := json.Marshal(noSig)
-		if err != nil {
-			return nil, false, errors.Wrap(err, "marshal parsig")
-		}
-
-		// Hash it
-		h := sha256.New()
-		h.Write(b)
-		var hash [32]byte
-		copy(hash[:], h.Sum(nil))
-
-		// Find the first identical set of length threshold
-		set := sigsByDataHash[hash]
+		// Find the first set of length threshold
+		set := sigsByMsgRoot[root]
 		set = append(set, sig)
 
 		if len(set) == threshold {
 			return set, true, nil
 		}
 
-		sigsByDataHash[hash] = set
+		sigsByMsgRoot[root] = set
 	}
 
 	return nil, false, nil

--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -95,7 +95,7 @@ func TestGetThresholdMatching(t *testing.T) {
 						datas = append(datas, provider(i))
 					}
 
-					out, ok, err := getThresholdMatching(datas, cluster.Threshold(len(datas)))
+					out, ok, err := getThresholdMatching(1, datas, cluster.Threshold(len(datas)))
 					require.NoError(t, err)
 					require.Equal(t, len(test.output) > 0, ok)
 

--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/obolnetwork/charon/testutil"
 )
 
-func TestCalculateOutput(t *testing.T) {
+func TestGetThresholdMatching(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  []int

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -206,13 +206,18 @@ func TestAnalyseDutyFailed(t *testing.T) {
 		require.Equal(t, step, parSigDBThreshold)
 		require.Equal(t, msg, msgParSigDBInsufficient)
 
-		failed, step, msg = analyseDutyFailed(attDuty, events, parsigsByMsg{"a": nil, "b": nil})
+		inconsistentParsigs := parsigsByMsg{
+			testutil.RandomRoot(): nil,
+			testutil.RandomRoot(): nil,
+		}
+
+		failed, step, msg = analyseDutyFailed(attDuty, events, inconsistentParsigs)
 		require.True(t, failed)
 		require.Equal(t, step, parSigDBThreshold)
 		require.Equal(t, msg, msgParSigDBInconsistent)
 
 		events[syncMsgDuty] = events[attDuty]
-		failed, step, msg = analyseDutyFailed(syncMsgDuty, events, parsigsByMsg{"a": nil, "b": nil})
+		failed, step, msg = analyseDutyFailed(syncMsgDuty, events, inconsistentParsigs)
 		require.True(t, failed)
 		require.Equal(t, step, parSigDBThreshold)
 		require.Equal(t, msg, msgParSigDBInconsistentSync)


### PR DESCRIPTION
Use message root for partial signed data consistency check in parsigdb. Also do the same in tracker.

category: refactor
ticket: #1347 
