### PR TITLE
core/fetcher: monitor inconsistent attestation data

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -149,9 +149,14 @@ func (f *Fetcher) fetchAttesterData(ctx context.Context, slot int64, defSet core
 		resp[pubkey] = attData
 
 		// Store Attestation data root excluding committee index.
-		data := *eth2AttData
-		data.Index = 0
-		root, err := data.HashTreeRoot()
+		clone, err := attData.Clone()
+		if err != nil {
+			return nil, err
+		}
+
+		data := clone.(core.AttestationData)
+		data.Data.Index = 0
+		root, err := data.Data.HashTreeRoot()
 		if err != nil {
 			return nil, err
 		}

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -120,6 +120,7 @@ func (f *Fetcher) fetchAttesterData(ctx context.Context, slot int64, defSet core
 	// We may have multiple validators in the same committee, use the same attestation data in that case.
 	dataByCommIdx := make(map[eth2p0.CommitteeIndex]*eth2p0.AttestationData)
 
+	attDataRoots := make(map[eth2p0.Root]bool)
 	resp := make(core.UnsignedDataSet)
 	for pubkey, def := range defSet {
 		attDuty, ok := def.(core.AttesterDefinition)
@@ -146,6 +147,19 @@ func (f *Fetcher) fetchAttesterData(ctx context.Context, slot int64, defSet core
 		}
 
 		resp[pubkey] = attData
+
+		// Store Attestation data root excluding committee index.
+		eth2AttData.Index = 0
+		root, err := eth2AttData.HashTreeRoot()
+		if err != nil {
+			return nil, err
+		}
+		attDataRoots[root] = true
+	}
+
+	if len(attDataRoots) > 1 {
+		// Increase inconsistent data counter when different attestation data are found for the same slot.
+		inconsistentAttDataCounter.Inc()
 	}
 
 	return resp, nil

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -149,8 +149,9 @@ func (f *Fetcher) fetchAttesterData(ctx context.Context, slot int64, defSet core
 		resp[pubkey] = attData
 
 		// Store Attestation data root excluding committee index.
-		eth2AttData.Index = 0
-		root, err := eth2AttData.HashTreeRoot()
+		data := *eth2AttData
+		data.Index = 0
+		root, err := data.HashTreeRoot()
 		if err != nil {
 			return nil, err
 		}

--- a/core/fetcher/metrics.go
+++ b/core/fetcher/metrics.go
@@ -25,5 +25,5 @@ var inconsistentAttDataCounter = promauto.NewCounter(prometheus.CounterOpts{
 	Namespace: "core",
 	Subsystem: "fetcher",
 	Name:      "inconsistent_att_data_total",
-	Help:      "Total number of times attestation data found different for the same slot excluding committee_index.",
+	Help:      "Total number of inconsistent attestation data detected. Note this is expected.",
 })

--- a/core/fetcher/metrics.go
+++ b/core/fetcher/metrics.go
@@ -21,6 +21,7 @@ import (
 	"github.com/obolnetwork/charon/app/promauto"
 )
 
+// TODO(dhruv): Remove the inconsistent counter code after the data has been collected.
 var inconsistentAttDataCounter = promauto.NewCounter(prometheus.CounterOpts{
 	Namespace: "core",
 	Subsystem: "fetcher",

--- a/core/fetcher/metrics.go
+++ b/core/fetcher/metrics.go
@@ -1,0 +1,29 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package fetcher
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/obolnetwork/charon/app/promauto"
+)
+
+var inconsistentAttDataCounter = promauto.NewCounter(prometheus.CounterOpts{
+	Namespace: "core",
+	Subsystem: "fetcher",
+	Name:      "inconsistent_att_data_total",
+	Help:      "Total number of times attestation data found different for the same slot excluding committee_index.",
+})


### PR DESCRIPTION
Adds a counter metric to monitor inconsistent attestation data obtained from beacon node for the same slot.

category: misc
ticket: none
