### PR TITLE
core/validatorapi: verify attestation aggregation selection proof

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -685,7 +685,19 @@ func (c Component) SubmitAggregateAttestations(ctx context.Context, aggregateAnd
 			return err
 		}
 
-		// Verify Signature.
+		// Verify inner selection proof (outcome of DutyPrepareAggregator).
+		if !c.insecureTest {
+			blsPubkey, err := tblsconv.KeyFromETH2(eth2Pubkey) // Use group pubkey, not pubshare.
+			if err != nil {
+				return err
+			}
+			err = signing.VerifyAggregateAndProofSelection(ctx, c.eth2Cl, blsPubkey, agg.Message)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Verify outer partial signature.
 		err = c.verifyPartialSig(pk, func(pubshare *bls_sig.PublicKey) error {
 			return signing.VerifyAggregateAndProof(ctx, c.eth2Cl, pubshare, agg)
 		})

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -201,6 +201,20 @@ func VerifyBeaconCommitteeSelection(ctx context.Context, eth2Cl eth2wrap.Client,
 	return verify(ctx, eth2Cl, DomainSelectionProof, epoch, sigRoot, selection.SelectionProof, pubkey)
 }
 
+func VerifyAggregateAndProofSelection(ctx context.Context, eth2Cl eth2wrap.Client, pubkey *bls_sig.PublicKey, agg *eth2p0.AggregateAndProof) error {
+	epoch, err := epochFromSlot(ctx, eth2Cl, agg.Aggregate.Data.Slot)
+	if err != nil {
+		return err
+	}
+
+	sigRoot, err := eth2util.SlotHashRoot(agg.Aggregate.Data.Slot)
+	if err != nil {
+		return err
+	}
+
+	return verify(ctx, eth2Cl, DomainSelectionProof, epoch, sigRoot, agg.SelectionProof, pubkey)
+}
+
 func VerifyAggregateAndProof(ctx context.Context, eth2Cl eth2wrap.Client, pubkey *bls_sig.PublicKey, agg *eth2p0.SignedAggregateAndProof) error {
 	epoch, err := epochFromSlot(ctx, eth2Cl, agg.Message.Aggregate.Data.Slot)
 	if err != nil {

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -76,6 +76,26 @@ func RandomEth2PubKey(t *testing.T) eth2p0.BLSPubKey {
 	return resp
 }
 
+func RandomValidator(t *testing.T) *eth2v1.Validator {
+	t.Helper()
+
+	return &eth2v1.Validator{
+		Index:   eth2p0.ValidatorIndex(rand.Uint64()),
+		Balance: eth2p0.Gwei(rand.Uint64()),
+		Status:  eth2v1.ValidatorStateActiveOngoing,
+		Validator: &eth2p0.Validator{
+			PublicKey:                  RandomEth2PubKey(t),
+			WithdrawalCredentials:      RandomBytes32(),
+			EffectiveBalance:           eth2p0.Gwei(rand.Uint64()),
+			Slashed:                    false,
+			ActivationEligibilityEpoch: 1,
+			ActivationEpoch:            2,
+			ExitEpoch:                  0,
+			WithdrawableEpoch:          3,
+		},
+	}
+}
+
 func RandomAttestation() *eth2p0.Attestation {
 	return &eth2p0.Attestation{
 		AggregationBits: RandomBitList(),


### PR DESCRIPTION
Verify inner attestation aggregation selection proof, not just the aggregation signature. This should fix the sporadic aggregation failures which I suspect is due to the cluster running both validatormock and teku, and that teku is per-chance submitting aggregation using legacy selection proofs in the same slot. It is also good practice to verify all signatures.

category: bug
ticket: #1343 
