### PR TITLE
core/scheduler: skip missed slots

### DIFF
--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -58,6 +58,13 @@ var (
 		Name:      "validator_balance_gwei",
 		Help:      "Total balance of a validator by public key",
 	}, []string{"pubkey_full", "pubkey"})
+
+	skipCounter = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: "core",
+		Subsystem: "scheduler",
+		Name:      "skipped_slots_total",
+		Help:      "The total number times that slots were skipped",
+	})
 )
 
 // instrumentSlot sets the current slot and epoch metrics.

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -63,7 +63,7 @@ var (
 		Namespace: "core",
 		Subsystem: "scheduler",
 		Name:      "skipped_slots_total",
-		Help:      "The total number times that slots were skipped",
+		Help:      "Total number times slots were skipped",
 	})
 )
 

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -520,7 +520,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.
 			case <-clock.After(slot.Time.Sub(clock.Now())):
 			}
 
-			// Recalculate slot to avoid thundering-heard by skipping slots if missed due
+			// Recalculate slot to avoid "thundering herd" problem by skipping slots if missed due
 			// to pause-the-world events (i.e. resources are already constrained).
 			actual := currentSlot()
 			if actual.Slot != slot.Slot {

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -525,6 +525,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.
 			actual := currentSlot()
 			if actual.Slot != slot.Slot {
 				log.Warn(ctx, "Slot(s) skipped", nil, z.I64("actual_slot", actual.Slot), z.I64("expect_slot", slot.Slot))
+				skipCounter.Inc()
 			}
 
 			select {


### PR DESCRIPTION
Skip missed slots in scheduler to avoid thundering heard due to pause-the-world-events.

category: misc
ticket: none
