### PR TITLE
core: add verification for sync selection

### DIFF
--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -151,3 +151,13 @@ func (SignedSyncContributionAndProof) DomainName() signing.DomainName {
 func (s SignedSyncContributionAndProof) Epoch(ctx context.Context, eth2Cl eth2wrap.Client) (eth2p0.Epoch, error) {
 	return eth2util.EpochFromSlot(ctx, eth2Cl, s.Message.Contribution.Slot)
 }
+
+// Implement Eth2SignedData for SyncCommitteeSelection.
+
+func (SyncCommitteeSelection) DomainName() signing.DomainName {
+	return signing.DomainSyncCommitteeSelectionProof
+}
+
+func (s SyncCommitteeSelection) Epoch(ctx context.Context, eth2Cl eth2wrap.Client) (eth2p0.Epoch, error) {
+	return eth2util.EpochFromSlot(ctx, eth2Cl, s.Slot)
+}

--- a/core/eth2signeddata_test.go
+++ b/core/eth2signeddata_test.go
@@ -80,6 +80,10 @@ func TestVerifyEth2SignedData(t *testing.T) {
 			name: "verify sync committee contribution and proof",
 			data: core.NewSignedSyncContributionAndProof(testutil.RandomSignedSyncContributionAndProof()),
 		},
+		{
+			name: "verify sync committee selection",
+			data: core.NewSyncCommitteeSelection(testutil.RandomSyncCommitteeSelection()),
+		},
 	}
 
 	for _, test := range tests {

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -995,6 +995,13 @@ func NewSignedSyncContributionAndProof(proof *altair.SignedContributionAndProof)
 	return SignedSyncContributionAndProof{SignedContributionAndProof: *proof}
 }
 
+func NewPartialSignedSyncContributionAndProof(proof *altair.SignedContributionAndProof, shareIdx int) ParSignedData {
+	return ParSignedData{
+		SignedData: NewSignedSyncContributionAndProof(proof),
+		ShareIdx:   shareIdx,
+	}
+}
+
 // SignedSyncContributionAndProof wraps altair.SignedContributionAndProof and implements SignedData.
 type SignedSyncContributionAndProof struct {
 	altair.SignedContributionAndProof

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -423,6 +423,15 @@ func RandomSyncCommitteeMessage() *altair.SyncCommitteeMessage {
 	}
 }
 
+func RandomSyncCommitteeSelection() *eth2exp.SyncCommitteeSelection {
+	return &eth2exp.SyncCommitteeSelection{
+		ValidatorIndex:    RandomVIdx(),
+		Slot:              RandomSlot(),
+		SubcommitteeIndex: RandomCommIdx(),
+		SelectionProof:    RandomEth2Signature(),
+	}
+}
+
 func RandomSyncCommitteeDuty(t *testing.T) *eth2v1.SyncCommitteeDuty {
 	t.Helper()
 


### PR DESCRIPTION
Implement core.Eth2SignedData for SyncCommitteeSelection to support signature verification.

category: feature
ticket: #1264
