### PR TITLE
core/infosync: implement infosync priority protocol use case

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -23,9 +23,22 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 )
 
-// Version is the release version of the codebase.
-// Usually overridden by tag names when building binaries.
-const Version = "v0.11.0"
+const (
+	// Version is the release version of the codebase.
+	// Usually overridden by tag names when building binaries.
+	Version = v11
+
+	v11 = "v0.11.0"
+	v10 = "v0.10.0"
+)
+
+// Supported returns the supported versions in order of precedence.
+func Supported() []string {
+	return []string{
+		v11,
+		v10,
+	}
+}
 
 // GitCommit returns the git commit hash and timestamp from build info.
 func GitCommit() (hash string, timestamp string) {

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -26,17 +26,14 @@ import (
 const (
 	// Version is the release version of the codebase.
 	// Usually overridden by tag names when building binaries.
-	Version = v11
-
-	v11 = "v0.11.0"
-	v10 = "v0.10.0"
+	Version = "v0.11.0"
 )
 
 // Supported returns the supported versions in order of precedence.
 func Supported() []string {
 	return []string{
-		v11,
-		v10,
+		"v0.11",
+		"v0.10",
 	}
 }
 

--- a/core/infosync/infosync.go
+++ b/core/infosync/infosync.go
@@ -25,7 +25,7 @@ import (
 	"github.com/obolnetwork/charon/core/priority"
 )
 
-// New return a new infosync component.
+// New returns a new infosync component.
 func New(prioritiser *priority.Component, versions []string) *Component {
 	prioritiser.Subscribe(func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
 		for _, result := range results {

--- a/core/infosync/infosync.go
+++ b/core/infosync/infosync.go
@@ -1,0 +1,54 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package infosync provides a simple use-case of the priority protocol that prioritises cluster supported versions.
+package infosync
+
+import (
+	"context"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/priority"
+)
+
+// New return a new infosync component.
+func New(prioritiser *priority.Component, versions []string) *Component {
+	prioritiser.Subscribe(func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
+		for _, result := range results {
+			log.Debug(ctx, "Infosync completed", z.Any(result.Topic, result.Priorities))
+		}
+
+		return nil
+	})
+
+	return &Component{
+		prioritiser: prioritiser,
+		versions:    versions,
+	}
+}
+
+type Component struct {
+	prioritiser *priority.Component
+	versions    []string
+}
+
+func (c *Component) Trigger(ctx context.Context, slot int64) error {
+	return c.prioritiser.Prioritise(ctx, core.NewInfoSyncDuty(slot), priority.TopicProposal{
+		Topic:      "version",
+		Priorities: c.versions,
+	})
+}

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -1,0 +1,292 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package priority
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/core"
+	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
+	"github.com/obolnetwork/charon/p2p"
+)
+
+// TopicProposal defines the proposed priorities of a single prioritise topic.
+type TopicProposal struct {
+	Topic      string
+	Priorities []string
+}
+
+// TopicResult defines the resulting cluster-agreed upon priorities of a single prioritise topic.
+type TopicResult struct {
+	Topic      string
+	Priorities []ScoredPriority
+}
+
+// ScoredPriority defines a resulting cluster-agreed priority including its score.
+type ScoredPriority struct {
+	Priority string
+	Score    int
+}
+
+// coreConsensus is an interface for the core/consensus.Component.
+type coreConsensus interface {
+	ProposePriority(context.Context, core.Duty, *pbv1.PriorityResult) error
+	SubscribePriority(func(context.Context, core.Duty, *pbv1.PriorityResult) error)
+}
+
+// NewComponent returns a new priority component.
+func NewComponent(tcpNode host.Host, peers []peer.ID, minRequired int, sendFunc p2p.SendReceiveFunc,
+	registerHandlerFunc p2p.RegisterHandlerFunc, consensus coreConsensus,
+	slotDuration time.Duration, privkey *ecdsa.PrivateKey,
+) (*Component, error) {
+	verifier, err := newMsgVerifier(peers)
+	if err != nil {
+		return nil, err
+	}
+
+	tickerProvider := func() (<-chan time.Time, func()) {
+		ticker := time.NewTicker(slotDuration / 10)
+		return ticker.C, ticker.Stop
+	}
+
+	prioritiser := newInternal(tcpNode, peers, minRequired, sendFunc, registerHandlerFunc,
+		consensusWrapper{consensus}, verifier, slotDuration, tickerProvider)
+
+	return &Component{
+		prioritiser: prioritiser,
+		privkey:     privkey,
+	}, nil
+}
+
+// Component wraps a prioritise protocol instance providing a friendly API (hiding the underlying protobuf types) and does signing.
+type Component struct {
+	peerID      peer.ID
+	privkey     *ecdsa.PrivateKey
+	prioritiser *Prioritiser
+}
+
+// Subscribe registers a prioritiser output subscriber function.
+func (c *Component) Subscribe(fn func(context.Context, core.Duty, []TopicResult) error) {
+	c.prioritiser.Subscribe(func(ctx context.Context, instance Instance, result *pbv1.PriorityResult) error {
+		dutypb, ok := instance.(*pbv1.Duty)
+		if !ok {
+			return errors.New("invalid duty instance")
+		}
+
+		var results []TopicResult
+		for _, topic := range result.Topics {
+			result, err := topicResultFromProto(topic)
+			if err != nil {
+				return err
+			}
+
+			results = append(results, result)
+		}
+
+		return fn(ctx, core.DutyFromProto(dutypb), results)
+	})
+}
+
+// Prioritise starts a new prioritisation instance for the provided duty and proposals or returns an error.
+func (c *Component) Prioritise(ctx context.Context, duty core.Duty, proposals ...TopicProposal) error {
+	instance, err := anypb.New(core.DutyToProto(duty))
+	if err != nil {
+		return errors.Wrap(err, "any proto duty")
+	}
+
+	var topics []*pbv1.PriorityTopicProposal
+	for _, proposal := range proposals {
+		proposalPB, err := topicProposalToProto(proposal)
+		if err != nil {
+			return err
+		}
+
+		topics = append(topics, proposalPB)
+	}
+
+	msg := &pbv1.PriorityMsg{
+		Instance: instance,
+		PeerId:   c.peerID.String(),
+		Topics:   topics,
+	}
+
+	msg, err = signMsg(msg, c.privkey)
+	if err != nil {
+		return err
+	}
+
+	return c.prioritiser.Prioritise(ctx, msg)
+}
+
+// signMsg returns a copy of the proto message with a populated signature signed by the provided private key.
+func signMsg(msg *pbv1.PriorityMsg, privkey *ecdsa.PrivateKey) (*pbv1.PriorityMsg, error) {
+	clone := proto.Clone(msg).(*pbv1.PriorityMsg)
+	clone.Signature = nil
+
+	hash, err := hashProto(clone)
+	if err != nil {
+		return nil, err
+	}
+
+	clone.Signature, err = crypto.Sign(hash[:], privkey)
+	if err != nil {
+		return nil, errors.Wrap(err, "sign")
+	}
+
+	return clone, nil
+}
+
+// verifyMsgSig returns true if the message was signed by pubkey.
+func verifyMsgSig(msg *pbv1.PriorityMsg, pubkey *ecdsa.PublicKey) (bool, error) {
+	if msg.Signature == nil {
+		return false, errors.New("empty signature")
+	}
+
+	clone := proto.Clone(msg).(*pbv1.QBFTMsg)
+	clone.Signature = nil
+	hash, err := hashProto(clone)
+	if err != nil {
+		return false, err
+	}
+
+	actual, err := crypto.SigToPub(hash[:], msg.Signature)
+	if err != nil {
+		return false, errors.Wrap(err, "sig to pub")
+	}
+
+	if !pubkey.Equal(actual) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// newMsgVerifier returns a function that verifies message signatures using peer public keys.
+func newMsgVerifier(peers []peer.ID) (func(msg *pbv1.PriorityMsg) error, error) {
+	// Extract peer pubkeys.
+	keys := make(map[string]*ecdsa.PublicKey)
+	for _, p := range peers {
+		pk, err := p2p.PeerIDToKey(p)
+		if err != nil {
+			return nil, err
+		}
+		keys[p.String()] = pk
+	}
+
+	return func(msg *pbv1.PriorityMsg) error {
+		key, ok := keys[msg.PeerId]
+		if !ok {
+			return errors.New("unknown peer id")
+		}
+
+		ok, err := verifyMsgSig(msg, key)
+		if err != nil {
+			return err
+		} else if !ok {
+			return errors.New("invalid signature")
+		}
+
+		return nil
+	}, nil
+}
+
+type consensusWrapper struct {
+	consensus coreConsensus
+}
+
+func (c consensusWrapper) ProposePriority(ctx context.Context, instance Instance, result *pbv1.PriorityResult) error {
+	duty, ok := instance.(*pbv1.Duty)
+	if !ok {
+		return errors.New("invalid instance duty")
+	}
+
+	return c.consensus.ProposePriority(ctx, core.DutyFromProto(duty), result)
+}
+
+func (c consensusWrapper) SubscribePriority(fn func(context.Context, Instance, *pbv1.PriorityResult) error) {
+	c.consensus.SubscribePriority(func(ctx context.Context, duty core.Duty, result *pbv1.PriorityResult) error {
+		return fn(ctx, core.DutyToProto(duty), result)
+	})
+}
+
+// topicProposalToProto returns the proto version of the topic proposal.
+func topicProposalToProto(p TopicProposal) (*pbv1.PriorityTopicProposal, error) {
+	topic, err := anypb.New(structpb.NewStringValue(p.Topic))
+	if err != nil {
+		return nil, errors.Wrap(err, "anypb topic")
+	}
+
+	var priorities []*anypb.Any
+	for _, priority := range p.Priorities {
+		pb, err := anypb.New(structpb.NewStringValue(priority))
+		if err != nil {
+			return nil, errors.Wrap(err, "anypb priority")
+		}
+
+		priorities = append(priorities, pb)
+	}
+
+	return &pbv1.PriorityTopicProposal{
+		Topic:      topic,
+		Priorities: priorities,
+	}, nil
+}
+
+// topicProposalToProto returns a topic proposal from the proto version.
+func topicResultFromProto(p *pbv1.PriorityTopicResult) (TopicResult, error) {
+	var topicVal *structpb.Value
+	if err := p.Topic.UnmarshalTo(topicVal); err != nil {
+		return TopicResult{}, errors.Wrap(err, "anypb topic")
+	}
+
+	topic, ok := topicVal.AsInterface().(string)
+	if !ok {
+		return TopicResult{}, errors.New("topic value not a string")
+	}
+
+	var priorities []ScoredPriority
+	for _, scored := range p.Priorities {
+		var prioVal *structpb.Value
+		if err := scored.Priority.UnmarshalTo(prioVal); err != nil {
+			return TopicResult{}, errors.Wrap(err, "anypb priority")
+		}
+
+		prio, ok := prioVal.AsInterface().(string)
+		if !ok {
+			return TopicResult{}, errors.New("topic value not a string")
+		}
+
+		priorities = append(priorities, ScoredPriority{
+			Priority: prio,
+			Score:    int(scored.Score),
+		})
+	}
+
+	return TopicResult{
+		Topic:      topic,
+		Priorities: priorities,
+	}, nil
+}

--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -18,6 +18,7 @@ package priority
 
 import (
 	"context"
+	"testing"
 	"time"
 
 	ssz "github.com/ferranbt/fastssz"
@@ -71,7 +72,16 @@ type received struct {
 	Response chan<- *pbv1.PriorityMsg
 }
 
-func NewForT(tcpNode host.Host, peers []peer.ID, minRequired int, sendFunc p2p.SendReceiveFunc, registerHandlerFunc p2p.RegisterHandlerFunc,
+// NewForT exports newInternal for testing and returns a new prioritiser.
+func NewForT(_ *testing.T, tcpNode host.Host, peers []peer.ID, minRequired int, sendFunc p2p.SendReceiveFunc, registerHandlerFunc p2p.RegisterHandlerFunc,
+	consensus Consensus, msgValidator msgValidator,
+	consensusTimeout time.Duration, tickerProvider tickerProvider,
+) *Prioritiser {
+	return newInternal(tcpNode, peers, minRequired, sendFunc, registerHandlerFunc, consensus, msgValidator, consensusTimeout, tickerProvider)
+}
+
+// newInternal returns a new prioritiser, it is the constructor.
+func newInternal(tcpNode host.Host, peers []peer.ID, minRequired int, sendFunc p2p.SendReceiveFunc, registerHandlerFunc p2p.RegisterHandlerFunc,
 	consensus Consensus, msgValidator msgValidator,
 	consensusTimeout time.Duration, tickerProvider tickerProvider,
 ) *Prioritiser {

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -71,7 +71,7 @@ func TestPrioritiser(t *testing.T) {
 			priorities = append(priorities, prioToAny(j))
 		}
 
-		prio := priority.NewForT(tcpNode, peers, n, p2p.SendReceive, p2p.RegisterHandler, consensus, msgValidator, time.Hour, noTicks)
+		prio := priority.NewForT(t, tcpNode, peers, n, p2p.SendReceive, p2p.RegisterHandler, consensus, msgValidator, time.Hour, noTicks)
 
 		prio.Subscribe(func(_ context.Context, resInstance priority.Instance, result *pbv1.PriorityResult) error {
 			require.Len(t, result.Topics, 1)

--- a/core/types.go
+++ b/core/types.go
@@ -48,9 +48,10 @@ const (
 	DutySyncMessage             DutyType = 10
 	DutyPrepareSyncContribution DutyType = 11
 	DutySyncContribution        DutyType = 12
+	DutyInfoSync                DutyType = 13
 	// Only ever append new types here...
 
-	dutySentinel DutyType = 13 // Must always be last
+	dutySentinel DutyType = 14 // Must always be last
 )
 
 func (d DutyType) Valid() bool {
@@ -72,13 +73,14 @@ func (d DutyType) String() string {
 		DutySyncMessage:             "sync_message",
 		DutyPrepareSyncContribution: "prepare_sync_contribution",
 		DutySyncContribution:        "sync_contribution",
+		DutyInfoSync:                "info_sync",
 	}[d]
 }
 
 // AllDutyTypes returns a list of all valid duty types.
 func AllDutyTypes() []DutyType {
 	var resp []DutyType
-	for i := DutyUnknown + 1; i.Valid(); i++ {
+	for i := DutyUnknown + 1; i < dutySentinel; i++ {
 		resp = append(resp, i)
 	}
 
@@ -250,6 +252,15 @@ func NewSyncContributionDuty(slot int64) Duty {
 	return Duty{
 		Slot: slot,
 		Type: DutySyncContribution,
+	}
+}
+
+// NewInfoSyncDuty returns a new info sync duty. It is a convenience function that is
+// slightly more readable and concise than the struct literal equivalent.
+func NewInfoSyncDuty(slot int64) Duty {
+	return Duty{
+		Slot: slot,
+		Type: DutyInfoSync,
 	}
 }
 

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -40,9 +40,10 @@ func TestBackwardsCompatability(t *testing.T) {
 	require.EqualValues(t, 10, core.DutySyncMessage)
 	require.EqualValues(t, 11, core.DutyPrepareSyncContribution)
 	require.EqualValues(t, 12, core.DutySyncContribution)
+	require.EqualValues(t, 13, core.DutyInfoSync)
 	// Add more types here.
 
-	const sentinel = core.DutyType(13)
+	const sentinel = core.DutyType(14)
 	for i := core.DutyUnknown; i <= sentinel; i++ {
 		if i == core.DutyUnknown {
 			require.False(t, i.Valid())

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -69,3 +69,20 @@ func TestVerifyP2PKey(t *testing.T) {
 	require.NoError(t, err)
 	require.Error(t, p2p.VerifyP2PKey(peers, key))
 }
+
+func TestPeerIDKey(t *testing.T) {
+	lock, keys, _ := cluster.NewForT(t, 1, 3, 4, 0)
+
+	peers, err := lock.Peers()
+	require.NoError(t, err)
+
+	for i, p := range peers {
+		pk, err := p2p.PeerIDToKey(p.ID)
+		require.NoError(t, err)
+		require.Equal(t, keys[i].PublicKey, *pk)
+
+		pID, err := p2p.PeerIDFromKey(pk)
+		require.NoError(t, err)
+		require.Equal(t, p.ID, pID)
+	}
+}


### PR DESCRIPTION
Adds the `infosync` component that prioritised cluster supported versions. Also add the `priority.Component` that wraps the prioritiser to hide protobuf types and do signing.

category: feature
ticket: #1380 
