### PR TITLE
core/tracker: mark sync message as unexpected

### DIFF
--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -530,7 +530,7 @@ func analyseParticipation(duty core.Duty, allEvents map[core.Duty][]event) (map[
 // It basically checks if the duty (or an associated duty) was scheduled.
 func isParSigEventExpected(duty core.Duty, pubkey core.PubKey, allEvents map[core.Duty][]event) bool {
 	// Cannot validate validatorAPI triggered duties that are not linked to locally scheduled duties.
-	if duty.Type == core.DutyExit || duty.Type == core.DutyBuilderRegistration || duty.Type == core.DutySyncMessage {
+	if duty.Type == core.DutyExit || duty.Type == core.DutyBuilderRegistration {
 		return true
 	}
 
@@ -556,7 +556,7 @@ func isParSigEventExpected(duty core.Duty, pubkey core.PubKey, allEvents map[cor
 	}
 
 	// For DutyPrepareSyncContribution and DutySyncMessage, check that if DutySyncContribution was scheduled.
-	if duty.Type == core.DutyPrepareSyncContribution { // TODO(corver): Add sync message here once we schedule sync contribution.
+	if duty.Type == core.DutyPrepareSyncContribution || duty.Type == core.DutySyncMessage {
 		return scheduled(core.DutySyncContribution)
 	}
 

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -923,7 +923,7 @@ func TestIsParSigEventExpected(t *testing.T) {
 		{
 			name: "DutySyncMessage unexpected",
 			duty: core.NewSyncMessageDuty(slot),
-			out:  true,
+			out:  false,
 		},
 		{
 			name: "DutySyncMessage expected",


### PR DESCRIPTION
Updates tracker to mark sync message as unexpected as `DutySyncContribution` is scheduled now.

category: misc
ticket: none 
