### PR TITLE
app: ignore failed infosyncs

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -466,6 +466,10 @@ func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Contex
 	t.Helper()
 
 	return func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
+		if len(results) == 0 {
+			// Some but not all peers participated, ignore.
+			return nil
+		}
 		if !assert.Len(t, results, 1) {
 			return errors.New("unexpected number of results")
 		} else if !assert.Equal(t, "version", results[0].Topic) {


### PR DESCRIPTION
When a priority protocol is triggered and not all peers are ready it will complete with an empty result. Just ignore that for now. This fixes the flapping test.

category: test
ticket: none
