### PR TITLE
app/eth2wrap: cache validators by pubkey per epoch

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -373,6 +373,14 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	sched.SubscribeSlots(setFeeRecipient(eth2Cl, eth2Pubkeys, lock.FeeRecipientAddress))
+	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
+		if !slot.FirstInEpoch() {
+			return nil
+		}
+		eth2Cl.ClearCache()
+
+		return nil
+	})
 
 	fetch, err := fetcher.New(eth2Cl, lock.FeeRecipientAddress)
 	if err != nil {

--- a/app/eth2wrap/cache.go
+++ b/app/eth2wrap/cache.go
@@ -1,0 +1,72 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2wrap
+
+import (
+	"sync"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// valCache caches validators by public key.
+type valCache struct {
+	mu   sync.RWMutex
+	vals map[eth2p0.BLSPubKey]*eth2v1.Validator
+}
+
+// Clear the cache.
+func (c *valCache) Clear() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.vals = nil
+}
+
+// Get returns any found validators (hits) and the public keys not found (misses).
+func (c *valCache) Get(pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, []eth2p0.BLSPubKey) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	var (
+		misses []eth2p0.BLSPubKey
+		hits   = make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
+	)
+	for _, pk := range pubkeys {
+		val, ok := c.vals[pk]
+		if !ok {
+			misses = append(misses, pk)
+			continue
+		}
+		hits[val.Index] = val
+	}
+
+	return hits, misses
+}
+
+// Set stores the validators in the cache.
+func (c *valCache) Set(vals map[eth2p0.ValidatorIndex]*eth2v1.Validator) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.vals == nil {
+		c.vals = make(map[eth2p0.BLSPubKey]*eth2v1.Validator)
+	}
+
+	for _, val := range vals {
+		c.vals[val.Validator.PublicKey] = val
+	}
+}

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -65,10 +65,11 @@ func Instrument(clients ...Client) (Client, error) {
 	return multi{clients: clients}, nil
 }
 
-// AdaptEth2HTTP returns a Client wrapping an eth2http service by adding experimental endpoints.
+// AdaptEth2HTTP returns a Client wrapping an eth2http service by adding experimental endpoints
+// and caching.
 // Note that the returned client doesn't wrap errors, so they are unstructured without stacktraces.
 func AdaptEth2HTTP(eth2Svc *eth2http.Service, timeout time.Duration) Client {
-	return httpAdapter{Service: eth2Svc, timeout: timeout}
+	return &httpAdapter{Service: eth2Svc, timeout: timeout}
 }
 
 // NewMultiHTTP returns a new instrumented multi eth2 http client.
@@ -108,6 +109,12 @@ func (multi) Name() string {
 func (m multi) Address() string {
 	// TODO(corver): return "best" address.
 	return m.clients[0].Address()
+}
+
+func (m multi) ClearCache() {
+	for _, client := range m.clients {
+		client.ClearCache()
+	}
 }
 
 func (m multi) AggregateBeaconCommitteeSelections(ctx context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -69,6 +69,8 @@ type Client interface {
 	eth2client.ValidatorRegistrationsSubmitter
 	eth2client.ValidatorsProvider
 	eth2client.VoluntaryExitSubmitter
+	// ClearCache clears the internal "head" valCache.
+	ClearCache()
 }
 
 // NodeVersion returns a free-text string with the node version.

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/core/validatorapi"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
@@ -241,4 +242,46 @@ func TestCtxCancel(t *testing.T) {
 		_, err = eth2Cl.SlotDuration(ctx)
 		require.ErrorIs(t, err, context.Canceled)
 	}
+}
+
+func TestValCache(t *testing.T) {
+	ctx := context.Background()
+
+	set := beaconmock.ValidatorSetA
+
+	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(set))
+	require.NoError(t, err)
+
+	misses := make(map[string]int)
+	cacheFunc := bmock.ValidatorsByPubKeyFunc
+	bmock.ValidatorsByPubKeyFunc = func(ctx context.Context, stateID string, keys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+		misses[stateID]++
+		return cacheFunc(ctx, stateID, keys)
+	}
+
+	router, err := validatorapi.NewRouter(bmock, bmock)
+	require.NoError(t, err)
+
+	// Test http server that returns the validator set
+	srv := httptest.NewServer(router)
+
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, srv.URL)
+	require.NoError(t, err)
+	require.Len(t, misses, 0)
+
+	assert := func(t *testing.T, missed int) {
+		t.Helper()
+
+		resp, err := eth2Cl.ValidatorsByPubKey(ctx, "head", set.PublicKeys())
+		require.NoError(t, err)
+		require.EqualValues(t, set, resp)
+		require.Len(t, misses, 1)
+		require.Equal(t, missed*len(set), misses["head"]) // ValidatorAPI doesn't batch validator calls :(
+	}
+
+	assert(t, 1)
+	assert(t, 1)
+	eth2Cl.ClearCache()
+	assert(t, 2)
+	assert(t, 2)
 }

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -60,6 +60,9 @@ type Client interface {
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
+
+    // ClearCache clears the internal "head" cache.
+	ClearCache()
 }
 
 {{range .Methods}}

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/core/validatorapi"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
@@ -277,6 +278,10 @@ func (m Mock) SlotsPerEpoch(ctx context.Context) (uint64, error) {
 	return m.SlotsPerEpochFunc(ctx)
 }
 
+func (Mock) TekuProposerConfig(context.Context) (validatorapi.TekuProposerConfigResponse, error) {
+	panic("implement me")
+}
+
 func (Mock) Name() string {
 	return "beacon-mock"
 }
@@ -284,6 +289,8 @@ func (Mock) Name() string {
 func (m Mock) Address() string {
 	return "http://" + m.httpServer.Addr
 }
+
+func (Mock) ClearCache() {}
 
 func (m Mock) Close() error {
 	m.headProducer.Close()

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -45,6 +45,16 @@ type Option func(*Mock)
 
 type ValidatorSet map[eth2p0.ValidatorIndex]*eth2v1.Validator
 
+// Validators is a convenience function to return the validators as a slice.
+func (s ValidatorSet) Validators() []*eth2v1.Validator {
+	var resp []*eth2v1.Validator
+	for _, validator := range s {
+		resp = append(resp, validator)
+	}
+
+	return resp
+}
+
 // ByPublicKey is a convenience function to return a validator by its public key.
 func (s ValidatorSet) ByPublicKey(pubkey eth2p0.BLSPubKey) (*eth2v1.Validator, bool) {
 	for _, validator := range s {
@@ -92,6 +102,7 @@ var ValidatorSetA = ValidatorSet{
 			EffectiveBalance:           1,
 			ActivationEligibilityEpoch: 1,
 			ActivationEpoch:            2,
+			WithdrawalCredentials:      []byte("12345678901234567890123456789012"),
 		},
 	},
 	2: {
@@ -103,6 +114,7 @@ var ValidatorSetA = ValidatorSet{
 			EffectiveBalance:           2,
 			ActivationEligibilityEpoch: 2,
 			ActivationEpoch:            3,
+			WithdrawalCredentials:      []byte("12345678901234567890123456789012"),
 		},
 	},
 	3: {
@@ -114,6 +126,7 @@ var ValidatorSetA = ValidatorSet{
 			EffectiveBalance:           3,
 			ActivationEligibilityEpoch: 3,
 			ActivationEpoch:            4,
+			WithdrawalCredentials:      []byte("12345678901234567890123456789012"),
 		},
 	},
 }


### PR DESCRIPTION
Reduce overall latency and eth2client call rates by caching slow changing `validators_by_pubkey` in eth2wrap per epoch.

category: feature 
ticket: #1396 
