### PR TITLE
app: fix flapping info sync test

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -466,14 +466,15 @@ func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Contex
 	t.Helper()
 
 	return func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
-		if len(results) == 0 {
-			// Some but not all peers participated, ignore.
-			return nil
-		}
 		if !assert.Len(t, results, 1) {
 			return errors.New("unexpected number of results")
 		} else if !assert.Equal(t, "version", results[0].Topic) {
 			return errors.New("unexpected topic")
+		}
+
+		if len(results[0].Priorities) == 0 {
+			// Some but not all peers participated, ignore.
+			return nil
 		}
 
 		var actual []string


### PR DESCRIPTION
Fix flapping test, was checking the wrong structure.

category: test 
ticket: none
