### PR TITLE
github: notify on trunk test failures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,7 +85,7 @@ jobs:
           DISCORD_EMBEDS: |
             [{
               "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
-              "description": "Workflows:${{ join(needs.*, ',')\nResults:${{ join(needs.*.result, ',')}}"
+              "description": "Workflows:${{ join(needs.*, ',')}}\nResults:${{ join(needs.*.result, ',')}}"
               "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "color": 10038562
             }]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-go-
     - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m ./...
+    - name: Test
+      run: exit 1
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.1.0
       with:
@@ -44,6 +46,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: docker pull consensys/teku:latest
+      - name: Test
+        run: exit 1
       - run: go test -timeout=5m github.com/obolnetwork/charon/app -integration -slow
 
   compose_tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,6 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out
-    - name: Test
-      run: exit 1
 
   integration_tests:
     runs-on: ubuntu-latest
@@ -64,6 +62,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
+      - name: Test
+        run: exit 1
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m
 
   notify_failure:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,8 +20,6 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - name: Test
-      run: exit 1
     - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.1.0
@@ -46,8 +44,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: docker pull consensys/teku:latest
-      - name: Test
-        run: exit 1
       - run: go test -timeout=5m github.com/obolnetwork/charon/app -integration -slow
 
   compose_tests:
@@ -66,15 +62,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
-      - name: Test
-        run: exit 1
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m
 
   notify_failure:
     runs-on: ubuntu-latest
     needs: [ unit_tests, integration_tests, compose_tests ]
     # Syntax ref: https://github.com/actions/runner/issues/1251
-    if: always() && github.ref != 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
+    if: always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
     steps:
       - name: notify failure
         uses: Ilshidur/action-discord@0.3.2
@@ -85,7 +79,6 @@ jobs:
           DISCORD_EMBEDS: |
             [{
               "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
-              "description": "Workflows:${{ join(needs.*, ',')}}\nResults:${{ join(needs.*.result, ',')}}"
               "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "color": 10038562
             }]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m ./...
     - name: Test
       run: exit 1
+    - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m ./...
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v2.1.0
       with:
@@ -85,7 +85,7 @@ jobs:
           DISCORD_EMBEDS: |
             [{
               "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
-              "description": "${{ toJSON(needs) }}"
+              "description": "Workflows:${{ join(needs.*, ',')\nResults:${{ join(needs.*.result, ',')}}"
               "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "color": 10038562
             }]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,8 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: coverage.out
+    - name: Test
+      run: exit 1
 
   integration_tests:
     runs-on: ubuntu-latest
@@ -63,3 +65,21 @@ jobs:
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/compose # Pre-build current SHA charon binary
       - run: go test github.com/obolnetwork/charon/testutil/compose/compose -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m
+
+  notify_failure:
+    runs-on: ubuntu-latest
+    needs: [ unit_tests, integration_tests, compose_tests ]
+    if: always() && github.ref != 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
+    steps:
+      - name: notify failure
+        uses: Ilshidur/action-discord@0.3.2
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+          DISCORD_USERNAME: GitHub
+          DISCORD_AVATAR: https://avatars.githubusercontent.com/u/583231
+          DISCORD_EMBEDS: |
+            [{
+              "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
+              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
+              "color": 10038562
+            }]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,12 +63,13 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/compose # Pre-build current SHA charon binary
-      - run: go test github.com/obolnetwork/charon/testutil/compose/compose -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m
+      - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
+      - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m
 
   notify_failure:
     runs-on: ubuntu-latest
     needs: [ unit_tests, integration_tests, compose_tests ]
+    # Syntax ref: https://github.com/actions/runner/issues/1251
     if: always() && github.ref != 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
     steps:
       - name: notify failure
@@ -80,6 +81,7 @@ jobs:
           DISCORD_EMBEDS: |
             [{
               "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
+              "description": "${{ toJSON(needs) }}"
               "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
               "color": 10038562
             }]


### PR DESCRIPTION
Send a notification to discord if main branch tests fails. Currently we only send notifications on `pre-commit` failures.

category: misc
ticket: #1412 
