### PR TITLE
p2p: do periodic pings

### DIFF
--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -69,7 +69,7 @@ var (
 	peerConnCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "p2p",
 		Name:      "peer_connection_total",
-		Help:      "Total number of libp2p connection per peer.",
+		Help:      "Total number of libp2p connections per peer.",
 	}, []string{"peer"})
 )
 

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -66,11 +66,10 @@ var (
 		Help:      "Current number of libp2p connections by peer and type ('direct' or 'relay'). Note that peers may have multiple connections.",
 	}, []string{"peer", "type"})
 
-	peerConnDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
+	peerConnCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "p2p",
-		Name:      "peer_connection_duration_secs",
-		Help:      "Libp2p connection duration in seconds per peer.",
-		Buckets:   []float64{1, 5, 10, 30, 60, 300, 600, 1800, 3600, 21600, 43200},
+		Name:      "peer_connection_total",
+		Help:      "Total number of libp2p connection per peer.",
 	}, []string{"peer"})
 )
 

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/libp2p/go-libp2p"
@@ -154,7 +153,6 @@ func RegisterConnectionLogger(tcpNode host.Host, peerIDs []peer.ID) {
 
 	go func() {
 		ctx := log.WithTopic(context.Background(), "p2p")
-		startTimes := make(map[string]time.Time)
 		for e := range events {
 			addr := NamedAddr(e.Addr)
 			name := PeerName(e.Peer)
@@ -179,12 +177,9 @@ func RegisterConnectionLogger(tcpNode host.Host, peerIDs []peer.ID) {
 
 			if e.Connected {
 				peerConnGauge.WithLabelValues(name, addrType(e.Addr)).Inc()
-				startTimes[e.ConnID] = time.Now()
+				peerConnCounter.WithLabelValues(name).Inc()
 			} else if e.Disconnect {
 				peerConnGauge.WithLabelValues(name, addrType(e.Addr)).Dec()
-				if t0, ok := startTimes[e.ConnID]; ok {
-					peerConnDuration.WithLabelValues(name).Observe(time.Since(t0).Seconds())
-				}
 			}
 
 			// Ensure both connection type metrics are initiated

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -112,7 +112,7 @@ func (s *Sender) SendAsync(parent context.Context, tcpNode host.Host, protoID pr
 	go func() {
 		// Clone the context since parent context may be closed soon.
 		ctx := log.CopyFields(context.Background(), parent)
-		err := Send(ctx, tcpNode, protoID, peerID, msg)
+		err := Send(ctx, tcpNode, protoID, peerID, msg) // TODO(corver): Retry once on relay errors.
 		s.addResult(ctx, peerID, err)
 	}()
 


### PR DESCRIPTION
Refactor pings to be periodic (once per second). Currently we ping as fast as we can. In cloud clusters with low latency, this can go up to thousands of pings per second.

Also refactor the connection duration histogram into a connection counter as that is much simpler and easier to use in dashboards.

category: refactor
ticket: none
