### PR TITLE
cmd: increase bootnode connection data limit

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -165,6 +165,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 
 		// Reservations are valid for 30min (github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay/constraints.go:14)
 		relayResources := relay.DefaultResources()
+		relayResources.Limit.Data = 2 * (1 << 20) // 2MB
 		relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
 		relayResources.MaxReservationsPerIP = config.MaxResPerPeer
 		relayResources.MaxReservations = config.MaxConns


### PR DESCRIPTION
Increase bootnode libp2p relay connection limits from default 128kB to 2MB as the default is very small.

category: misc
ticket: #1420
