### PR TITLE
cmd/bootnode: increase relay limit

### DIFF
--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -165,7 +165,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 
 		// Reservations are valid for 30min (github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay/constraints.go:14)
 		relayResources := relay.DefaultResources()
-		relayResources.Limit.Data = 2 * (1 << 20) // 2MB
+		relayResources.Limit.Data = 1 << 25 // 32MB
 		relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
 		relayResources.MaxReservationsPerIP = config.MaxResPerPeer
 		relayResources.MaxReservations = config.MaxConns

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -165,7 +165,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 
 		// Reservations are valid for 30min (github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay/constraints.go:14)
 		relayResources := relay.DefaultResources()
-		relayResources.Limit.Data = 1 << 25 // 32MB
+		relayResources.Limit.Data = 32 * (1 << 20) // 32MB
 		relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
 		relayResources.MaxReservationsPerIP = config.MaxResPerPeer
 		relayResources.MaxReservations = config.MaxConns


### PR DESCRIPTION
Increases relay limit to 32MB. This is to enable relays not dropping connections when load increases. QBFT exchange of beacon block in such a case when each peer exchanges beacon block (~2MB max) 4 times in a single consensus round. 

category: misc
ticket: none 
