### PR TITLE
core/infosync: add metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -486,17 +486,17 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, t
 		return nil
 	}
 
-	// consensusDelay of 6 seconds (half a slot) is a good thumb suck. It is long enough for all peers to share proposals both in prod and in testing.
-	const consensusDelay = time.Second * 6
+	// exchangeTimeout of 6 seconds (half a slot) is a good thumb suck.
+	// It is long enough for all peers to exchange proposals both in prod and in testing.
+	const exchangeTimeout = time.Second * 6
 
-	deadliner := core.NewDeadliner(ctx, "priority", deadlineFunc)
-	prio, err := priority.NewComponent(tcpNode, peers, thresholhd,
-		sendFunc, p2p.RegisterHandler, cons, consensusDelay, p2pKey, deadliner)
+	prio, err := priority.NewComponent(ctx, tcpNode, peers, thresholhd,
+		sendFunc, p2p.RegisterHandler, cons, exchangeTimeout, p2pKey, deadlineFunc)
 	if err != nil {
 		return err
 	}
 
-	sync := infosync.New(prio, version.Supported(), deadlineFunc)
+	sync := infosync.New(prio, version.Supported())
 
 	// Trigger info syncs in last slot of the epoch (for the next epoch).
 	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {

--- a/app/app.go
+++ b/app/app.go
@@ -473,7 +473,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 // wirePrioritise wires the priority protocol which determines cluster wide priorities for the next epoch.
 func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, tcpNode host.Host,
-	peers []peer.ID, thresholhd int, sendFunc p2p.SendReceiveFunc, coreCons core.Consensus,
+	peers []peer.ID, threshold int, sendFunc p2p.SendReceiveFunc, coreCons core.Consensus,
 	sched core.Scheduler, p2pKey *ecdsa.PrivateKey, deadlineFunc func(duty core.Duty) (time.Time, bool),
 ) error {
 	if !featureset.Enabled(featureset.Priority) {
@@ -490,7 +490,7 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, t
 	// It is long enough for all peers to exchange proposals both in prod and in testing.
 	const exchangeTimeout = time.Second * 6
 
-	prio, err := priority.NewComponent(ctx, tcpNode, peers, thresholhd,
+	prio, err := priority.NewComponent(ctx, tcpNode, peers, threshold,
 		sendFunc, p2p.RegisterHandler, cons, exchangeTimeout, p2pKey, deadlineFunc)
 	if err != nil {
 		return err

--- a/core/infosync/infosync.go
+++ b/core/infosync/infosync.go
@@ -18,51 +18,55 @@ package infosync
 
 import (
 	"context"
-	"time"
+	"strings"
 
-	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/priority"
 )
 
+const topicVersion = "version"
+
 // New returns a new infosync component.
-func New(prioritiser *priority.Component, versions []string, deadlineFunc func(duty core.Duty) (time.Time, bool)) *Component {
+func New(prioritiser *priority.Component, versions []string) *Component {
 	prioritiser.Subscribe(func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
+		resultType := resultEmpty
 		for _, result := range results {
 			log.Debug(ctx, "Infosync completed", z.Any(result.Topic, result.Priorities))
+
+			if result.Topic != topicVersion {
+				continue
+			}
+
+			if len(result.Priorities) == 0 {
+				resultType = resultEmpty
+			} else if strings.Join(result.PrioritiesOnly(), ",") == strings.Join(versions, ",") {
+				resultType = resultOwn
+			} else {
+				resultType = resultOther
+			}
 		}
+
+		completeTotal.WithLabelValues(resultType).Inc()
 
 		return nil
 	})
 
 	return &Component{
-		prioritiser:  prioritiser,
-		versions:     versions,
-		deadlineFunc: deadlineFunc,
+		prioritiser: prioritiser,
+		versions:    versions,
 	}
 }
 
 type Component struct {
-	prioritiser  *priority.Component
-	versions     []string
-	deadlineFunc func(duty core.Duty) (time.Time, bool)
+	prioritiser *priority.Component
+	versions    []string
 }
 
 func (c *Component) Trigger(ctx context.Context, slot int64) error {
-	duty := core.NewInfoSyncDuty(slot)
-
-	deadline, ok := c.deadlineFunc(duty)
-	if !ok {
-		return errors.New("no deadline")
-	}
-
-	ctx, cancel := context.WithDeadline(ctx, deadline)
-	defer cancel()
-
-	return c.prioritiser.Prioritise(ctx, duty, priority.TopicProposal{
-		Topic:      "version",
+	return c.prioritiser.Prioritise(ctx, core.NewInfoSyncDuty(slot), priority.TopicProposal{
+		Topic:      topicVersion,
 		Priorities: c.versions,
 	})
 }

--- a/core/infosync/infosync.go
+++ b/core/infosync/infosync.go
@@ -48,7 +48,7 @@ func New(prioritiser *priority.Component, versions []string) *Component {
 			}
 		}
 
-		completeTotal.WithLabelValues(resultType).Inc()
+		completeCounter.WithLabelValues(resultType).Inc()
 
 		return nil
 	})

--- a/core/infosync/metrics.go
+++ b/core/infosync/metrics.go
@@ -27,7 +27,7 @@ const (
 	resultEmpty = "empty"
 	// resultOwn indicates that resulting cluster-wide priorities match this node's own priorities.
 	resultOwn = "own"
-	// resultOther indicates that resulting cluster-wide priorities is different from this node's own priorities.
+	// resultOther indicates that resulting cluster-wide priorities are different from this node's own priorities.
 	resultOther = "other"
 )
 
@@ -35,5 +35,5 @@ var completeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "core",
 	Subsystem: "infosync",
 	Name:      "complete_total",
-	Help:      "Total number of infosync instances completed by result; empty, own, other",
+	Help:      "Total number of infosync instances completed by result: empty, own or other",
 }, []string{"result"})

--- a/core/infosync/metrics.go
+++ b/core/infosync/metrics.go
@@ -31,7 +31,7 @@ const (
 	resultOther = "other"
 )
 
-var completeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+var completeCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 	Namespace: "core",
 	Subsystem: "infosync",
 	Name:      "complete_total",

--- a/core/infosync/metrics.go
+++ b/core/infosync/metrics.go
@@ -1,0 +1,39 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package infosync
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/obolnetwork/charon/app/promauto"
+)
+
+const (
+	// resultEmpty indicates that insufficient peers exchanged the same priorities so cluster-wide priorities
+	// could not be calculated.
+	resultEmpty = "empty"
+	// resultOwn indicates that resulting cluster-wide priorities match this node's own priorities.
+	resultOwn = "own"
+	// resultOther indicates that resulting cluster-wide priorities is different from this node's own priorities.
+	resultOther = "other"
+)
+
+var completeTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Namespace: "core",
+	Subsystem: "infosync",
+	Name:      "complete_total",
+	Help:      "Total number of infosync instances completed by result; empty, own, other",
+}, []string{"result"})


### PR DESCRIPTION
Adds metrics to infosync in order to track results. 

Also refactor duty deadline by moving it to prioritise instead of infosync so users of prioritise do not need to worry about that.

category: refactor
ticket: #1421 
