### PR TITLE
core/priority: skip unsupported peers

### DIFF
--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -28,6 +28,7 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	"github.com/obolnetwork/charon/p2p"
@@ -151,7 +152,14 @@ func (c *Component) Prioritise(ctx context.Context, duty core.Duty, proposals ..
 		return err
 	}
 
-	return c.prioritiser.Prioritise(ctx, msg)
+	err = c.prioritiser.Prioritise(ctx, msg)
+	if ctx.Err() != nil {
+		return nil //nolint:nilerr // Context expiry is expected behaviour, return nil.
+	} else if err != nil {
+		return errors.Wrap(err, "prioritise", z.Any("duty", duty))
+	}
+
+	return nil
 }
 
 // signMsg returns a copy of the proto message with a populated signature signed by the provided private key.

--- a/p2p/receive.go
+++ b/p2p/receive.go
@@ -51,7 +51,10 @@ func RegisterHandler(logTopic string, tcpNode host.Host, protocol protocol.ID,
 	tcpNode.SetStreamHandler(protocol, func(s network.Stream) {
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 		ctx = log.WithTopic(ctx, logTopic)
-		ctx = log.WithCtx(ctx, z.Str("peer", PeerName(s.Conn().RemotePeer())))
+		ctx = log.WithCtx(ctx,
+			z.Str("peer", PeerName(s.Conn().RemotePeer())),
+			z.Str("protocol", string(protocol)),
+		)
 		defer cancel()
 		defer s.Close()
 
@@ -69,7 +72,7 @@ func RegisterHandler(logTopic string, tcpNode host.Host, protocol protocol.ID,
 
 		resp, ok, err := handlerFunc(ctx, s.Conn().RemotePeer(), req)
 		if err != nil {
-			log.Error(ctx, "LibP2P handle stream error", err, z.Str("protocol", string(protocol)))
+			log.Error(ctx, "LibP2P handle stream error", err)
 			return
 		}
 


### PR DESCRIPTION
Skip exchanging messages with peers that do not support the protocol. Add protocol to p2p logging. Do not error on deadline since this is expected.

category: refactor
ticket: #1421 
