### PR TITLE
core/parsigdb: avoid aggregating and submitting again

### DIFF
--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -70,7 +70,7 @@ func TestSimnetDuties(t *testing.T) {
 				beaconmock.WithNoProposerDuties(),
 				beaconmock.WithNoSyncCommitteeDuties(),
 			},
-			duties: []core.DutyType{core.DutyPrepareAggregator, core.DutyAttester, core.DutyAggregator}, // Teku doesn't support beacon committee selection.
+			duties: []core.DutyType{core.DutyPrepareAggregator, core.DutyAttester, core.DutyAggregator},
 		},
 		{
 			name: "attester with teku",
@@ -78,7 +78,7 @@ func TestSimnetDuties(t *testing.T) {
 				beaconmock.WithNoProposerDuties(),
 				beaconmock.WithNoSyncCommitteeDuties(),
 			},
-			duties: []core.DutyType{core.DutyAttester},
+			duties: []core.DutyType{core.DutyAttester}, // Teku doesn't support beacon committee selection.
 			teku:   true,
 		},
 		{

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -87,7 +87,6 @@ func (db *MemDB) StoreInternal(ctx context.Context, duty core.Duty, signedSet co
 
 // StoreExternal stores an externally received partially signed duty data set.
 func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet core.ParSignedDataSet) error {
-	thresholdReached := make(map[core.PubKey]bool)
 	for pubkey, sig := range signedSet {
 		sigs, ok, err := db.store(key{Duty: duty, PubKey: pubkey}, sig)
 		if err != nil {
@@ -106,7 +105,7 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 		psigs, ok, err := getThresholdMatching(duty.Type, sigs, db.threshold)
 		if err != nil {
 			return err
-		} else if !ok || thresholdReached[pubkey] {
+		} else if !ok {
 			continue
 		}
 
@@ -126,8 +125,6 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 				return err
 			}
 		}
-
-		thresholdReached[pubkey] = true
 	}
 
 	return nil

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -87,6 +87,7 @@ func (db *MemDB) StoreInternal(ctx context.Context, duty core.Duty, signedSet co
 
 // StoreExternal stores an externally received partially signed duty data set.
 func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet core.ParSignedDataSet) error {
+	thresholdReached := make(map[core.PubKey]bool)
 	for pubkey, sig := range signedSet {
 		sigs, ok, err := db.store(key{Duty: duty, PubKey: pubkey}, sig)
 		if err != nil {
@@ -105,7 +106,7 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 		psigs, ok, err := getThresholdMatching(duty.Type, sigs, db.threshold)
 		if err != nil {
 			return err
-		} else if !ok {
+		} else if !ok || thresholdReached[pubkey] {
 			continue
 		}
 
@@ -125,6 +126,8 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 				return err
 			}
 		}
+
+		thresholdReached[pubkey] = true
 	}
 
 	return nil

--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -135,5 +135,5 @@ func TestMemDBThreshold(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, timesCalled, n-th+1)
+	require.Equal(t, 1, timesCalled)
 }

--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 func TestGetThresholdMatching(t *testing.T) {
+	const n = 4
+
 	tests := []struct {
 		name   string
 		input  []int
@@ -40,9 +42,14 @@ func TestGetThresholdMatching(t *testing.T) {
 			output: nil,
 		},
 		{
-			name:   "all identical",
-			input:  []int{0, 0, 0, 0},
+			name:   "all identical exact threshold",
+			input:  []int{0, 0, 0},
 			output: []int{0, 1, 2},
+		},
+		{
+			name:   "all identical above threshold",
+			input:  []int{0, 0, 0, 0},
+			output: nil,
 		},
 		{
 			name:   "one odd",
@@ -96,9 +103,11 @@ func TestGetThresholdMatching(t *testing.T) {
 						datas = append(datas, provider(i))
 					}
 
-					out, ok, err := getThresholdMatching(1, datas, cluster.Threshold(len(datas)))
+					th := cluster.Threshold(n)
+
+					out, ok, err := getThresholdMatching(1, datas, th)
 					require.NoError(t, err)
-					require.Equal(t, len(test.output) > 0, ok)
+					require.Equal(t, len(out) == th, ok)
 
 					var expect []core.ParSignedData
 					for _, i := range test.output {


### PR DESCRIPTION
Avoids signature aggregation and broadcast if threshold is already reached.

category: misc
ticket: none
