### PR TITLE
app: handle no active validators better

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -759,6 +759,18 @@ func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeReci
 			return err
 		}
 
+		var activeIdxs []eth2p0.ValidatorIndex
+		for _, validator := range vals {
+			if validator.Status != eth2v1.ValidatorStateActiveOngoing {
+				continue
+			}
+			activeIdxs = append(activeIdxs, validator.Index)
+		}
+
+		if len(activeIdxs) == 0 {
+			return nil // No active validators.
+		}
+
 		var addr bellatrix.ExecutionAddress
 		b, err := hex.DecodeString(strings.TrimPrefix(feeRecipient, "0x"))
 		if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -779,7 +779,7 @@ func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeReci
 		copy(addr[:], b)
 
 		var preps []*eth2v1.ProposalPreparation
-		for vIdx := range vals {
+		for _, vIdx := range activeIdxs {
 			preps = append(preps, &eth2v1.ProposalPreparation{
 				ValidatorIndex: vIdx,
 				FeeRecipient:   addr,

--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -23,9 +23,12 @@ import (
 	"testing"
 	"time"
 
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
@@ -87,5 +90,45 @@ func TestCalculateTrackerDelay(t *testing.T) {
 			require.NoError(t, err)
 			require.EqualValues(t, currentSlot+test.slotDelay, fromSlot)
 		})
+	}
+}
+
+func TestSetFeeRecipient(t *testing.T) {
+	set := beaconmock.ValidatorSetA
+	for i := 0; i < len(set); i++ {
+		clone, err := set.Clone()
+		require.NoError(t, err)
+
+		// Make i+1 validators inactive
+		inactive := i + 1
+		for index, validator := range clone {
+			validator.Status = eth2v1.ValidatorStatePendingQueued
+			clone[index] = validator
+			inactive--
+			if inactive == 0 {
+				break
+			}
+		}
+
+		bmock, err := beaconmock.New(beaconmock.WithValidatorSet(clone))
+		require.NoError(t, err)
+
+		// Only expect preparations for active validators.
+		var active int
+		bmock.SubmitProposalPreparationsFunc = func(ctx context.Context, preparations []*eth2v1.ProposalPreparation) error {
+			if len(preparations) == 0 {
+				return errors.New("empty slice")
+			}
+
+			active = len(preparations)
+
+			return nil
+		}
+
+		fn := setFeeRecipient(bmock, clone.PublicKeys(), "0xdead")
+		err = fn(context.Background(), core.Slot{SlotsPerEpoch: 1})
+		require.NoError(t, err)
+
+		require.Equal(t, active, len(clone)-(i+1))
 	}
 }

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -272,10 +272,7 @@ func getValidators(p eth2client.ValidatorsProvider) handlerFunc {
 		if err != nil {
 			return nil, err
 		} else if len(resp) == 0 {
-			return nil, apiError{
-				StatusCode: http.StatusNotFound,
-				Message:    "NotFound",
-			}
+			resp = []v1Validator{} // Return empty json array instead of null.
 		}
 
 		return validatorsResponse{Data: resp}, nil
@@ -356,10 +353,7 @@ func proposerDuties(p eth2client.ProposerDutiesProvider) handlerFunc {
 		data, err := p.ProposerDuties(ctx, eth2p0.Epoch(epoch), nil)
 		if err != nil {
 			return nil, err
-		}
-
-		// response.data cannot be nil, it leads to NullPointerException in teku.
-		if len(data) == 0 {
+		} else if len(data) == 0 { // Return empty json array instead of null
 			data = []*eth2v1.ProposerDuty{}
 		}
 
@@ -387,10 +381,7 @@ func attesterDuties(p eth2client.AttesterDutiesProvider) handlerFunc {
 		data, err := p.AttesterDuties(ctx, eth2p0.Epoch(epoch), req)
 		if err != nil {
 			return nil, err
-		}
-
-		// response.data cannot be nil, it leads to NullPointerException in teku.
-		if len(data) == 0 {
+		} else if len(data) == 0 { // Return empty json array instead of null
 			data = []*eth2v1.AttesterDuty{}
 		}
 
@@ -418,10 +409,7 @@ func syncCommitteeDuties(p eth2client.SyncCommitteeDutiesProvider) handlerFunc {
 		data, err := p.SyncCommitteeDuties(ctx, eth2p0.Epoch(epoch), req)
 		if err != nil {
 			return nil, err
-		}
-
-		// response.data cannot be nil, it leads to NullPointerException in teku.
-		if len(data) == 0 {
+		} else if len(data) == 0 { // Return empty json array instead of null
 			data = []*eth2v1.SyncCommitteeDuty{}
 		}
 

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -383,6 +383,73 @@ func TestRouter(t *testing.T) {
 		testRouter(t, handler, callback)
 	})
 
+	t.Run("empty_validators", func(t *testing.T) {
+		handler := testHandler{
+			ValidatorsByPubKeyFunc: func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+				return nil, nil //nolint:nilnil
+			},
+		}
+
+		callback := func(ctx context.Context, cl *eth2http.Service) {
+			res, err := cl.ValidatorsByPubKey(ctx, "head", []eth2p0.BLSPubKey{
+				testutil.RandomEth2PubKey(t),
+				testutil.RandomEth2PubKey(t),
+			})
+			require.NoError(t, err)
+			require.Len(t, res, 0)
+		}
+
+		testRouter(t, handler, callback)
+	})
+
+	t.Run("empty_attester_duties", func(t *testing.T) {
+		handler := testHandler{
+			AttesterDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
+				return nil, nil
+			},
+		}
+
+		callback := func(ctx context.Context, cl *eth2http.Service) {
+			res, err := cl.AttesterDuties(ctx, eth2p0.Epoch(1), []eth2p0.ValidatorIndex{1, 2, 3})
+			require.NoError(t, err)
+			require.Len(t, res, 0)
+		}
+
+		testRouter(t, handler, callback)
+	})
+
+	t.Run("empty_synccomm_duties", func(t *testing.T) {
+		handler := testHandler{
+			SyncCommitteeDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
+				return nil, nil
+			},
+		}
+
+		callback := func(ctx context.Context, cl *eth2http.Service) {
+			res, err := cl.SyncCommitteeDuties(ctx, eth2p0.Epoch(1), []eth2p0.ValidatorIndex{1, 2, 3})
+			require.NoError(t, err)
+			require.Len(t, res, 0)
+		}
+
+		testRouter(t, handler, callback)
+	})
+
+	t.Run("empty_proposer_duties", func(t *testing.T) {
+		handler := testHandler{
+			ProposerDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+				return nil, nil
+			},
+		}
+
+		callback := func(ctx context.Context, cl *eth2http.Service) {
+			res, err := cl.ProposerDuties(ctx, eth2p0.Epoch(1), []eth2p0.ValidatorIndex{1, 2, 3})
+			require.NoError(t, err)
+			require.Len(t, res, 0)
+		}
+
+		testRouter(t, handler, callback)
+	})
+
 	t.Run("attestation_data", func(t *testing.T) {
 		handler := testHandler{
 			AttestationDataFunc: func(ctx context.Context, slot eth2p0.Slot, commIdx eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -18,6 +18,7 @@ package beaconmock
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sort"
@@ -89,6 +90,22 @@ func (s ValidatorSet) PublicKeys() []eth2p0.BLSPubKey {
 	}
 
 	return resp
+}
+
+// Clone returns a copy of this validator set.
+func (s ValidatorSet) Clone() (ValidatorSet, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal set")
+	}
+
+	resp := make(ValidatorSet)
+	err = json.Unmarshal(b, &resp)
+	if err != nil {
+		return nil, errors.Wrap(err, "unmarshal set")
+	}
+
+	return resp, nil
 }
 
 // ValidatorSetA defines a set of 3 validators.


### PR DESCRIPTION
- Do not attempt to set fee recipient if no active validators.
- Return empty response instead of 404 for `get_validators` (aligns with beacon node behaviour)

category: refactor
ticket: none
