### PR TITLE
app/eth2wrap: add block attestation endpoint

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -35,6 +35,7 @@ type Client interface {
 	eth2client.Service
 	eth2exp.BeaconCommitteeSelectionAggregator
 	eth2exp.SyncCommitteeSelectionAggregator
+	BlockAttestationsProvider
 
 	eth2client.AggregateAttestationProvider
 	eth2client.AggregateAttestationsSubmitter

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -57,6 +57,7 @@ type Client interface {
     eth2client.Service
     eth2exp.BeaconCommitteeSelectionAggregator
     eth2exp.SyncCommitteeSelectionAggregator
+	BlockAttestationsProvider
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -57,7 +57,7 @@ type Client interface {
     eth2client.Service
     eth2exp.BeaconCommitteeSelectionAggregator
     eth2exp.SyncCommitteeSelectionAggregator
-	BlockAttestationsProvider
+    BlockAttestationsProvider
 
     {{range .Providers}} eth2client.{{.}}
     {{end -}}

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -19,21 +19,40 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"testing"
 	"time"
 
 	eth2http "github.com/attestantio/go-eth2-client/http"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
+// BlockAttestationsProvider is the interface for providing attestations included in blocks.
+// It is a standard beacon API endpoint not implemented by eth2client.
+// See https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockAttestations.
+type BlockAttestationsProvider interface {
+	BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error)
+}
+
+// NewHTTPAdapterForT returns a http adaptor for testing non-eth2service methods as it is nil.
+func NewHTTPAdapterForT(_ *testing.T, address string, timeout time.Duration) *httpAdapter {
+	return &httpAdapter{
+		address: address,
+		timeout: timeout,
+	}
+}
+
 // httpAdapter implements Client by wrapping eth2http.Service adding the experimental interfaces not present in go-eth2-client.
 type httpAdapter struct {
 	*eth2http.Service
+	address string
 	timeout time.Duration
 }
 
@@ -45,6 +64,10 @@ type submitSyncCommitteeSelectionsJSON struct {
 	Data []*eth2exp.SyncCommitteeSelection `json:"data"`
 }
 
+type attestationsJSON struct {
+	Data []*eth2p0.Attestation `json:"data"`
+}
+
 // AggregateBeaconCommitteeSelections implements eth2exp.BeaconCommitteeSelectionAggregator.
 func (h *httpAdapter) AggregateBeaconCommitteeSelections(ctx context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
 	reqBody, err := json.Marshal(selections)
@@ -52,7 +75,7 @@ func (h *httpAdapter) AggregateBeaconCommitteeSelections(ctx context.Context, se
 		return nil, errors.Wrap(err, "marshal submit beacon committee selections")
 	}
 
-	respBody, err := httpPost(ctx, h.Address(), "/eth/v1/validator/beacon_committee_selections", bytes.NewReader(reqBody), h.timeout)
+	respBody, err := httpPost(ctx, h.address, "/eth/v1/validator/beacon_committee_selections", bytes.NewReader(reqBody), h.timeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "submit beacon committee selections")
 	}
@@ -72,7 +95,7 @@ func (h *httpAdapter) AggregateSyncCommitteeSelections(ctx context.Context, sele
 		return nil, errors.Wrap(err, "marshal sync committee selections")
 	}
 
-	respBody, err := httpPost(ctx, h.Address(), "/eth/v1/validator/sync_committee_selections", bytes.NewReader(reqBody), h.timeout)
+	respBody, err := httpPost(ctx, h.address, "/eth/v1/validator/sync_committee_selections", bytes.NewReader(reqBody), h.timeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "submit sync committee selections")
 	}
@@ -80,6 +103,23 @@ func (h *httpAdapter) AggregateSyncCommitteeSelections(ctx context.Context, sele
 	var resp submitSyncCommitteeSelectionsJSON
 	if err := json.Unmarshal(respBody, &resp); err != nil {
 		return nil, errors.Wrap(err, "failed to parse sync committee selections response")
+	}
+
+	return resp.Data, nil
+}
+
+// BlockAttestations returns the attestations included in the requested block.
+// See https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockAttestations.
+func (h *httpAdapter) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
+	path := fmt.Sprintf("/eth/v1/beacon/blocks/%s/attestations", stateID)
+	respBody, err := httpGet(ctx, h.address, path, h.timeout)
+	if err != nil {
+		return nil, errors.Wrap(err, "request block attestations")
+	}
+
+	var resp attestationsJSON
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, errors.Wrap(err, "failed to parse block attestations response")
 	}
 
 	return resp.Data, nil
@@ -107,6 +147,43 @@ func httpPost(ctx context.Context, base string, endpoint string, body io.Reader,
 	res, err := new(http.Client).Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to call POST endpoint")
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to read POST response")
+	}
+
+	if res.StatusCode/100 != 2 {
+		return nil, errors.New("post failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
+	}
+
+	return data, nil
+}
+
+func httpGet(ctx context.Context, base string, endpoint string, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	addr, err := url.JoinPath(base, endpoint)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid address")
+	}
+
+	url, err := url.Parse(addr)
+	if err != nil {
+		return nil, errors.Wrap(err, "invalid endpoint")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "new GET request with ctx")
+	}
+
+	res, err := new(http.Client).Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to call GET endpoint")
 	}
 	defer res.Body.Close()
 

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -133,6 +133,7 @@ type Mock struct {
 
 	AttestationDataFunc                    func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
 	AttesterDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
+	BlockAttestationsFunc                  func(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error)
 	BlindedBeaconBlockProposalFunc         func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
 	BeaconCommitteesFunc                   func(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error)
 	BeaconBlockProposalFunc                func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
@@ -160,6 +161,10 @@ type Mock struct {
 	SyncCommitteeContributionFunc          func(ctx context.Context, slot eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
 	SubmitSyncCommitteeSubscriptionsFunc   func(ctx context.Context, subscriptions []*eth2v1.SyncCommitteeSubscription) error
 	SubmitProposalPreparationsFunc         func(ctx context.Context, preparations []*eth2v1.ProposalPreparation) error
+}
+
+func (m Mock) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
+	return m.BlockAttestationsFunc(ctx, stateID)
 }
 
 func (m Mock) SubmitAttestations(ctx context.Context, attestations []*eth2p0.Attestation) error {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -494,6 +494,9 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		AttesterDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
 			return []*eth2v1.AttesterDuty{}, nil
 		},
+		BlockAttestationsFunc: func(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
+			return []*eth2p0.Attestation{}, nil
+		},
 		AttestationDataFunc: func(ctx context.Context, slot eth2p0.Slot, index eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error) {
 			return attStore.NewAttestationData(ctx, slot, index)
 		},


### PR DESCRIPTION
Add `block_attestation` endpoint to eth2wrap to fetch block attestations to calculate inclusion distance.

category: feature
ticket: #1254 
