### PR TITLE
core/consensus: add missing 'insufficient round changes' reason

### DIFF
--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -410,7 +410,7 @@ func timeoutReason(round int64, msgs []qbft.Msg[core.Duty, [32]byte], peers []p2
 		return incl, excl
 	}
 
-	if round > 0 {
+	if round > 1 {
 		if incl, excl := includedPeers(qbft.MsgRoundChange); len(incl) < threshold {
 			return "insufficient round changes, missing peers=" + fmt.Sprint(excl)
 		}


### PR DESCRIPTION
Adds the missing "insufficient round changes" reason. This happens when quorum peers do not send a round change, then no peer can send their pre-prepare.

category: bug
ticket: none
