### PR TITLE
core/parsigdb: dedicated trimming goroutine

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -464,6 +464,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	life.RegisterStart(lifecycle.AsyncBackground, lifecycle.StartScheduler, lifecycle.HookFuncErr(sched.Run))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PConsensus, startCons)
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartAggSigDB, lifecycle.HookFuncCtx(aggSigDB.Run))
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartParSigDB, lifecycle.HookFuncCtx(parSigDB.Trim))
 	life.RegisterStop(lifecycle.StopScheduler, lifecycle.HookFuncMin(sched.Stop))
 	life.RegisterStop(lifecycle.StopDutyDB, lifecycle.HookFuncMin(dutyDB.Shutdown))
 	life.RegisterStop(lifecycle.StopRetryer, lifecycle.HookFuncCtx(retryer.Shutdown))

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -38,6 +38,7 @@ const (
 	StartScheduler
 	StartP2PEventCollector
 	StartPeerInfo
+	StartParSigDB
 )
 
 // Global ordering of stop hooks; follows dependency tree from root to leaves.

--- a/app/lifecycle/orderstart_string.go
+++ b/app/lifecycle/orderstart_string.go
@@ -35,11 +35,12 @@ func _() {
 	_ = x[StartScheduler-9]
 	_ = x[StartP2PEventCollector-10]
 	_ = x[StartPeerInfo-11]
+	_ = x[StartParSigDB-12]
 }
 
-const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersP2PConsensusSimulatorSchedulerP2PEventCollectorPeerInfo"
+const _OrderStart_name = "TrackerAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersP2PConsensusSimulatorSchedulerP2PEventCollectorPeerInfoParSigDB"
 
-var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 62, 74, 83, 92, 109, 117}
+var _OrderStart_index = [...]uint8{0, 7, 15, 20, 33, 45, 52, 62, 74, 83, 92, 109, 117, 125}
 
 func (i OrderStart) String() string {
 	if i < 0 || i >= OrderStart(len(_OrderStart_index)-1) {

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -144,10 +144,12 @@ func (db *MemDB) Trim(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case duty := <-db.deadliner.C(): // This buffered channel is small, so we need dedicated goroutine to service it.
+			db.mu.Lock()
 			for _, key := range db.keysByDuty[duty] {
 				delete(db.entries, key)
 			}
 			delete(db.keysByDuty, duty)
+			db.mu.Unlock()
 		}
 	}
 }

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -91,7 +91,7 @@ func (db *MemDB) StoreInternal(ctx context.Context, duty core.Duty, signedSet co
 
 // StoreExternal stores an externally received partially signed duty data set.
 func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet core.ParSignedDataSet) error {
-	db.processDeadline(duty)
+	_ = db.deadliner.Add(duty) // TODO(corver): Distinguish between no deadline supported vs already expired.
 
 	for pubkey, sig := range signedSet {
 		sigs, ok, err := db.store(key{Duty: duty, PubKey: pubkey}, sig)
@@ -136,22 +136,18 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 	return nil
 }
 
-// processDeadline adds duties to the deadliner and deletes expired duties.
-func (db *MemDB) processDeadline(duty core.Duty) {
-	db.mu.Lock()
-	defer db.mu.Unlock()
-
-	_ = db.deadliner.Add(duty) // TODO(corver): Distinguish between no deadline supported vs already expired.
-
+// Trim blocks until the context is closed, it deletes state for expired duties.
+// It should only be called once.
+func (db *MemDB) Trim(ctx context.Context) {
 	for {
 		select {
-		case duty := <-db.deadliner.C():
-			for _, k := range db.keysByDuty[duty] {
-				delete(db.entries, k)
+		case <-ctx.Done():
+			return
+		case duty := <-db.deadliner.C(): // This buffered channel is small, so we need dedicated goroutine to service it.
+			for _, key := range db.keysByDuty[duty] {
+				delete(db.entries, key)
 			}
 			delete(db.keysByDuty, duty)
-		default:
-			return
 		}
 	}
 }


### PR DESCRIPTION
Refactor trimming of parsigdb state to a dedicated goroutine since the deadliner's output buffer is small and overflows easily causing `Deadliner output channel full` errors.

category: bug
ticket: none
