### PR TITLE
app/version: bump version

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -26,12 +26,13 @@ import (
 const (
 	// Version is the release version of the codebase.
 	// Usually overridden by tag names when building binaries.
-	Version = "v0.11.0"
+	Version = "v0.12.0"
 )
 
 // Supported returns the supported versions in order of precedence.
 func Supported() []string {
 	return []string{
+		"v0.12",
 		"v0.11",
 		"v0.10",
 	}


### PR DESCRIPTION
Bumps version to `v0.12.0`. 

category: misc
ticket: none
