### PR TITLE
testutil/compose: handle docker-compose build seperately

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           name: smoke-test-logs
           path: testutil/compose/smoke/*.log
+          retention-days: 3
 
   notify_failure:
     runs-on: ubuntu-latest

--- a/testutil/compose/alert.go
+++ b/testutil/compose/alert.go
@@ -41,11 +41,11 @@ func startAlertCollector(ctx context.Context, dir string) chan string {
 		)
 		defer close(resp)
 
+		const iterSleep = time.Second * 2
+
 		// Time required to wait for prometheus container to start.
 		time.Sleep(time.Second * 10)
-		for ctx.Err() == nil {
-			time.Sleep(time.Second * 2)
-
+		for ; ctx.Err() == nil; time.Sleep(iterSleep) { // Sleep for iterSleep before next iteration.
 			cmd := exec.CommandContext(ctx, "docker-compose", "exec", "-T", "curl", "curl", "-s", "http://prometheus:9090/api/v1/rules?type=alert")
 			cmd.Dir = dir
 			out, err := cmd.CombinedOutput()

--- a/testutil/compose/alert.go
+++ b/testutil/compose/alert.go
@@ -40,8 +40,11 @@ func startAlertCollector(ctx context.Context, dir string) chan string {
 			dedup   = make(map[string]bool)
 		)
 		defer close(resp)
+
+		// Time required to wait for prometheus container to start.
+		time.Sleep(time.Second * 10)
 		for ctx.Err() == nil {
-			time.Sleep(time.Second * 5)
+			time.Sleep(time.Second * 2)
 
 			cmd := exec.CommandContext(ctx, "docker-compose", "exec", "-T", "curl", "curl", "-s", "http://prometheus:9090/api/v1/rules?type=alert")
 			cmd.Dir = dir

--- a/testutil/compose/auto.go
+++ b/testutil/compose/auto.go
@@ -119,6 +119,8 @@ func Auto(ctx context.Context, conf AutoConfig) error {
 	// Ensure everything is clean before we start with alert test.
 	_ = execDown(ctx, conf.Dir)
 
+	_, _ = w.Write([]byte("===== run step: docker-compose up --no-start --build =====\n"))
+
 	// Build and create docker-compose services before executing docker-compose up.
 	if err = execBuildAndCreate(ctx, conf.Dir); err != nil {
 		return err

--- a/testutil/compose/compose_internal_test.go
+++ b/testutil/compose/compose_internal_test.go
@@ -110,6 +110,6 @@ func TestParseTemplate(t *testing.T) {
 	_, err := template.New("").Parse(string(tmpl))
 	require.NoError(t, err)
 
-	_, err = getVC(VCTeku, 0, 1)
+	_, err = getVC(VCTeku, 0, 1, false)
 	require.NoError(t, err)
 }

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -38,7 +38,7 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 	)
 	for i := 0; i < conf.NumNodes; i++ {
 		typ := conf.VCs[i%len(conf.VCs)]
-		vc, err := getVC(typ, i, conf.NumValidators)
+		vc, err := getVC(typ, i, conf.NumValidators, conf.InsecureKeys)
 		if err != nil {
 			return TmplData{}, err
 		}
@@ -77,7 +77,7 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 }
 
 // getVC returns the validator client template data for the provided type and index.
-func getVC(typ VCType, nodeIdx int, numVals int) (TmplVC, error) {
+func getVC(typ VCType, nodeIdx int, numVals int, insecure bool) (TmplVC, error) {
 	vcByType := map[VCType]TmplVC{
 		VCLighthouse: {
 			Label: string(VCLighthouse),
@@ -100,7 +100,11 @@ func getVC(typ VCType, nodeIdx int, numVals int) (TmplVC, error) {
 	if typ == VCTeku {
 		var keys []string
 		for i := 0; i < numVals; i++ {
-			keys = append(keys, fmt.Sprintf("/compose/node%d/validator_keys/keystore-%d.json:/compose/node%d/validator_keys/keystore-%d.txt", nodeIdx, i, nodeIdx, i))
+			if insecure {
+				keys = append(keys, fmt.Sprintf("/compose/node%d/validator_keys/keystore-insecure-%d.json:/compose/node%d/validator_keys/keystore-insecure-%d.txt", nodeIdx, i, nodeIdx, i))
+			} else {
+				keys = append(keys, fmt.Sprintf("/compose/node%d/validator_keys/keystore-%d.json:/compose/node%d/validator_keys/keystore-%d.txt", nodeIdx, i, nodeIdx, i))
+			}
 		}
 		data := struct {
 			TekuKeys []string

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -86,14 +86,13 @@ func TestSmoke(t *testing.T) {
 		{
 			Name: "very_large",
 			ConfigFunc: func(conf *compose.Config) {
-				conf.NumNodes = 21
-				conf.Threshold = 14
-				conf.NumValidators = 100
+				conf.NumNodes = 10
+				conf.Threshold = 7
+				conf.NumValidators = 15
 				conf.InsecureKeys = true
 				conf.KeyGen = compose.KeyGenCreate
 			},
-			Timeout:  time.Second * 120,
-			PrintYML: true,
+			Timeout: time.Second * 120,
 		},
 		{
 			Name:     "run_version_matrix_with_dkg",

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -88,11 +88,12 @@ func TestSmoke(t *testing.T) {
 			ConfigFunc: func(conf *compose.Config) {
 				conf.NumNodes = 21
 				conf.Threshold = 14
-				conf.NumValidators = 1000
+				conf.NumValidators = 100
 				conf.InsecureKeys = true
 				conf.KeyGen = compose.KeyGenCreate
 			},
-			Timeout: time.Second * 120,
+			Timeout:  time.Second * 120,
+			PrintYML: true,
 		},
 		{
 			Name:     "run_version_matrix_with_dkg",

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -45,6 +45,8 @@ func TestSmoke(t *testing.T) {
 		t.Skip("Skipping smoke integration test")
 	}
 
+	const defaultTimeout = time.Second * 45
+
 	tests := []struct {
 		Name           string
 		ConfigFunc     func(*compose.Config)
@@ -60,7 +62,6 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 				conf.FeatureSet = "alpha"
 			},
-			Timeout: time.Second * 45,
 		},
 		{
 			Name: "default_beta",
@@ -68,7 +69,6 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 				conf.FeatureSet = "beta"
 			},
-			Timeout: time.Second * 45,
 		},
 		{
 			Name: "default_stable",
@@ -76,14 +76,12 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 				conf.FeatureSet = "stable"
 			},
-			Timeout: time.Second * 45,
 		},
 		{
 			Name: "dkg",
 			ConfigFunc: func(conf *compose.Config) {
 				conf.KeyGen = compose.KeyGenDKG
 			},
-			Timeout: time.Second * 45,
 		},
 		{
 			Name: "very_large",
@@ -94,7 +92,7 @@ func TestSmoke(t *testing.T) {
 				conf.InsecureKeys = true
 				conf.KeyGen = compose.KeyGenCreate
 			},
-			Timeout: time.Second * 60,
+			Timeout: time.Second * 120,
 		},
 		{
 			Name:     "run_version_matrix_with_dkg",
@@ -112,7 +110,6 @@ func TestSmoke(t *testing.T) {
 				pegImageTag(data.Nodes, 2, "v0.10.1")
 				pegImageTag(data.Nodes, 3, "v0.10.0")
 			},
-			Timeout: time.Second * 45,
 		},
 		{
 			Name: "teku_versions", // TODO(corver): Do the same for lighthouse.
@@ -125,7 +122,6 @@ func TestSmoke(t *testing.T) {
 				data.VCs[2].Image = "consensys/teku:22.4"
 				data.VCs[3].Image = "consensys/teku:22.3"
 			},
-			Timeout: time.Second * 45,
 		},
 		{
 			Name: "1_of_4_down",
@@ -137,7 +133,6 @@ func TestSmoke(t *testing.T) {
 					}
 				}
 			},
-			Timeout: time.Second * 45,
 		},
 	}
 
@@ -159,6 +154,10 @@ func TestSmoke(t *testing.T) {
 			require.NoError(t, compose.WriteConfig(dir, conf))
 
 			os.Args = []string{"cobra.test"}
+
+			if test.Timeout == 0 {
+				test.Timeout = defaultTimeout
+			}
 
 			autoConfig := compose.AutoConfig{
 				Dir:            dir,

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -51,6 +51,7 @@ func TestSmoke(t *testing.T) {
 		RunTmplFunc    func(*compose.TmplData)
 		DefineTmplFunc func(*compose.TmplData)
 		PrintYML       bool
+		Timeout        time.Duration
 	}{
 		{
 			Name:     "default_alpha",
@@ -59,6 +60,7 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 				conf.FeatureSet = "alpha"
 			},
+			Timeout: time.Second * 45,
 		},
 		{
 			Name: "default_beta",
@@ -66,6 +68,7 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 				conf.FeatureSet = "beta"
 			},
+			Timeout: time.Second * 45,
 		},
 		{
 			Name: "default_stable",
@@ -73,12 +76,14 @@ func TestSmoke(t *testing.T) {
 				conf.KeyGen = compose.KeyGenCreate
 				conf.FeatureSet = "stable"
 			},
+			Timeout: time.Second * 45,
 		},
 		{
 			Name: "dkg",
 			ConfigFunc: func(conf *compose.Config) {
 				conf.KeyGen = compose.KeyGenDKG
 			},
+			Timeout: time.Second * 45,
 		},
 		{
 			Name: "very_large",
@@ -89,6 +94,7 @@ func TestSmoke(t *testing.T) {
 				conf.InsecureKeys = true
 				conf.KeyGen = compose.KeyGenCreate
 			},
+			Timeout: time.Second * 60,
 		},
 		{
 			Name:     "run_version_matrix_with_dkg",
@@ -106,6 +112,7 @@ func TestSmoke(t *testing.T) {
 				pegImageTag(data.Nodes, 2, "v0.10.1")
 				pegImageTag(data.Nodes, 3, "v0.10.0")
 			},
+			Timeout: time.Second * 45,
 		},
 		{
 			Name: "teku_versions", // TODO(corver): Do the same for lighthouse.
@@ -118,6 +125,7 @@ func TestSmoke(t *testing.T) {
 				data.VCs[2].Image = "consensys/teku:22.4"
 				data.VCs[3].Image = "consensys/teku:22.3"
 			},
+			Timeout: time.Second * 45,
 		},
 		{
 			Name: "1_of_4_down",
@@ -129,6 +137,7 @@ func TestSmoke(t *testing.T) {
 					}
 				}
 			},
+			Timeout: time.Second * 45,
 		},
 	}
 
@@ -153,7 +162,7 @@ func TestSmoke(t *testing.T) {
 
 			autoConfig := compose.AutoConfig{
 				Dir:            dir,
-				AlertTimeout:   time.Second * 45,
+				AlertTimeout:   test.Timeout,
 				SudoPerms:      *sudoPerms,
 				PrintYML:       test.PrintYML,
 				RunTmplFunc:    test.RunTmplFunc,

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -84,7 +84,7 @@ func TestSmoke(t *testing.T) {
 			},
 		},
 		{
-			Name: "very_large",
+			Name: "very_large", // TODO(dhruv): fix consensus issues in this test
 			ConfigFunc: func(conf *compose.Config) {
 				conf.NumNodes = 10
 				conf.Threshold = 7


### PR DESCRIPTION
Handle `docker-compose build` command separately before starting alerts collector. This step takes longer at first and takes almost no time to build again. This might be the reason why `default_alpha` test in smoke tests seldom completes. Also increased alert timeout for `very_large` test.

category: test
ticket: #992 
