### PR TITLE
core/tracker: implement inclusion delay tracker

### DIFF
--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -30,6 +30,7 @@ const epochLag = 1
 // dutiesFunc returns the duty definitions for a given duty.
 type dutiesFunc func(context.Context, core.Duty) (core.DutyDefinitionSet, error)
 
+// NewInclDelayFunc returns a function that calculates this cluster's attestation inclusion delay for a block.
 func NewInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc) func(context.Context, core.Slot) error {
 	return newInclDelayFunc(eth2Cl, dutiesFunc, func(delays []int64) {
 		var sum int64
@@ -42,7 +43,7 @@ func NewInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc) func(contex
 	})
 }
 
-// NewInclDelayFunc returns a function that calculates this cluster's attestation inclusion delay for a block.
+// newInclDelayFunc extends NewInclDelayFunc with abstracted callback.
 func newInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc, callback func([]int64)) func(context.Context, core.Slot) error {
 	var fromSlot int64
 	return func(ctx context.Context, current core.Slot) error {

--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -31,6 +31,10 @@ const epochLag = 1
 type dutiesFunc func(context.Context, core.Duty) (core.DutyDefinitionSet, error)
 
 // NewInclDelayFunc returns a function that calculates this cluster's attestation inclusion delay for a block.
+//
+// Inclusion delay is the average of the distance between the slot a validator’s attestation
+// is expected by the network and the slot the attestation is actually included on-chain.
+// See https://rated.gitbook.io/rated-documentation/rating-methodologies/ethereum-beacon-chain/network-explorer-definitions/top-screener#inclusion-delay.
 func NewInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc) func(context.Context, core.Slot) error {
 	return newInclDelayFunc(eth2Cl, dutiesFunc, func(delays []int64) {
 		var sum int64

--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -31,7 +31,7 @@ const inclDelayLag = 16
 // dutiesFunc returns the duty definitions for a given duty.
 type dutiesFunc func(context.Context, core.Duty) (core.DutyDefinitionSet, error)
 
-// NewInclDelayFunc returns a function that calculates this cluster's attestation inclusion delay for a block.
+// NewInclDelayFunc returns a function that calculates attestation inclusion delay for a block.
 //
 // Inclusion delay is the average of the distance between the slot a validator’s attestation
 // is expected by the network and the slot the attestation is actually included on-chain.
@@ -87,7 +87,7 @@ func newInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc, callback fu
 
 				if !att.AggregationBits.BitAt(duty.ValidatorCommitteeIndex) {
 					continue // We are not included in attestation
-					// Note to track missed attestations, we'd need to keep state of seen attestations.
+					// Note that to track missed attestations, we'd need to keep state of seen attestations.
 				}
 
 				delays = append(delays, blockSlot-int64(attSlot))

--- a/core/tracker/incldelay_internal_test.go
+++ b/core/tracker/incldelay_internal_test.go
@@ -1,0 +1,113 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+func TestInclDelay(t *testing.T) {
+	const (
+		blockSlot     = 10
+		slotsPerEpoch = 16
+		slot          = blockSlot + (epochLag * slotsPerEpoch)
+	)
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	expect := []int64{1, 2, 4, 8}
+
+	var atts []att
+	for i, e := range expect {
+		atts = append(atts, makeAtt(blockSlot-e, int64(i), int64(i)))
+	}
+
+	bmock.BlockAttestationsFunc = func(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
+		require.Equal(t, fmt.Sprint(blockSlot), stateID)
+		var res []*eth2p0.Attestation
+		for _, att := range atts {
+			res = append(res, att.Att)
+		}
+
+		return res, nil
+	}
+
+	dutiesFunc := func(_ context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
+		res := make(core.DutyDefinitionSet)
+		for i, att := range atts {
+			if int64(att.Att.Data.Slot) != duty.Slot {
+				continue
+			}
+			res[core.PubKey(fmt.Sprint(i))] = core.NewAttesterDefinition(att.Duty)
+		}
+
+		return res, nil
+	}
+
+	done := make(chan struct{})
+	fn := newInclDelayFunc(bmock, dutiesFunc, func(delays []int64) {
+		require.EqualValues(t, expect, delays)
+		close(done)
+	})
+
+	err = fn(context.Background(), core.Slot{
+		Slot: 1,
+	})
+	require.NoError(t, err)
+
+	err = fn(context.Background(), core.Slot{
+		Slot:          slot,
+		SlotsPerEpoch: slotsPerEpoch,
+	})
+	require.NoError(t, err)
+
+	<-done
+}
+
+type att struct {
+	Att  *eth2p0.Attestation
+	Duty *eth2v1.AttesterDuty
+}
+
+func makeAtt(slot int64, commIdx int64, valCommIdx int64) att {
+	aggBits := bitfield.NewBitlist(1024)
+	aggBits.SetBitAt(uint64(valCommIdx), true)
+
+	return att{
+		Att: &eth2p0.Attestation{
+			AggregationBits: aggBits,
+			Data: &eth2p0.AttestationData{
+				Slot:  eth2p0.Slot(slot),
+				Index: eth2p0.CommitteeIndex(commIdx),
+			},
+		},
+		Duty: &eth2v1.AttesterDuty{
+			CommitteeIndex:          eth2p0.CommitteeIndex(commIdx),
+			ValidatorCommitteeIndex: uint64(valCommIdx),
+		},
+	}
+}

--- a/core/tracker/incldelay_internal_test.go
+++ b/core/tracker/incldelay_internal_test.go
@@ -33,7 +33,7 @@ func TestInclDelay(t *testing.T) {
 	const (
 		blockSlot     = 10
 		slotsPerEpoch = 16
-		slot          = blockSlot + (epochLag * slotsPerEpoch)
+		slot          = blockSlot + inclDelayLag
 	)
 
 	bmock, err := beaconmock.New()

--- a/core/tracker/inclusiondistance.go
+++ b/core/tracker/inclusiondistance.go
@@ -1,0 +1,88 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tracker
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/core"
+)
+
+// epochLag is the number of epochs to lag when calculating inclusion distance (to ensure finality).
+const epochLag = 2
+
+type dutiesFunc func(context.Context, core.Duty) (core.DutyDefinitionSet, error)
+
+func InclusionDistance(ctx context.Context, eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc) func(ctx context.Context, slot core.Slot) error {
+	var fromSlot int64
+	return func(ctx context.Context, current core.Slot) error {
+		// We have to wait for epochLag since dutiesFunc will not have duties from older epochs.
+		if fromSlot == 0 {
+			fromSlot = current.Slot
+			return nil
+		}
+
+		slot := current.Slot - (epochLag * current.SlotsPerEpoch)
+		if slot < fromSlot {
+			return nil
+		}
+
+		atts, err := eth2Cl.BlockAttestations(ctx, fmt.Sprint(slot))
+		if err != nil {
+			return err
+		}
+
+		maxDist := int64(-1)
+		for _, att := range atts {
+			attSlot := att.Data.Slot
+
+			// Get all our duties for this attestation slot
+			set, err := dutiesFunc(ctx, core.NewAttesterDuty(int64(attSlot)))
+			if err != nil {
+				return err
+			}
+
+			// Get all our validator committee indexes for this attestation.
+			for _, def := range set {
+				duty, ok := def.(core.AttesterDefinition)
+				if !ok {
+					return errors.New("invalid attester definition")
+				}
+
+				if duty.CommitteeIndex != att.Data.Index {
+					continue // This duty is for another committee
+				}
+
+				if !att.AggregationBits.BitAt(duty.ValidatorCommitteeIndex) {
+					continue // We are not included in attestation
+				}
+
+				distance := slot - int64(attSlot)
+
+				if distance > maxDist {
+					maxDist = distance
+				}
+			}
+		}
+
+		// TODO(corver):
+
+		return nil
+	}
+}

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -56,4 +56,11 @@ var (
 		Name:      "inconsistent_parsigs_total",
 		Help:      "Total number of duties that contained inconsistent partial signed data by duty type",
 	}, []string{"duty"})
+
+	inclusionDelay = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: "core",
+		Subsystem: "tracker",
+		Name:      "inclusion_delay",
+		Help:      "Cluster's average attestation inclusion delay in slots",
+	})
 )


### PR DESCRIPTION
Implement a function that calculates the clusters inclusion delay for a specific block.

category: feature 
ticket: #1254 