### PR TITLE
core/consensus: fix nil map panic

### DIFF
--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -148,6 +148,7 @@ func New(tcpNode host.Host, sender *p2p.Sender, peers []p2p.Peer, p2pKey *ecdsa.
 		pubkeys:     keys,
 		deadliner:   deadliner,
 		recvBuffers: make(map[core.Duty]chan msg),
+		recvDropped: make(map[core.Duty]bool),
 		snifferFunc: snifferFunc,
 	}
 


### PR DESCRIPTION
Fixes nil map panic for `recvDropped` map in core/consensus/component.go. Found this while testing very-large cluster test in smoke tests.

category: bug
ticket: none
