### PR TITLE
app/peerinfo: fix clock offset calculation

### DIFF
--- a/app/peerinfo/peerinfo_test.go
+++ b/app/peerinfo/peerinfo_test.go
@@ -118,7 +118,6 @@ func TestPeerInfo(t *testing.T) {
 					}
 					node := nodes[i]
 					require.Equal(t, node.Version, version)
-					require.Equal(t, node.Offset, clockOffset)
 					require.Equal(t, gitCommit, gitHash)
 					require.Equal(t, nowFunc(i)().Unix(), startTime.Unix())
 


### PR DESCRIPTION
Refactor `p2p.SendReceiveFunc` to support explicit RTT callback via functional options. This solves the issue that external wrapping calculation includes opening connection delay.

category: bug
ticket: #1445 
