### PR TITLE
app/eth2wrap: fix block attestation request

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -252,6 +252,7 @@ func TestBlockAttestations(t *testing.T) {
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodGet, r.Method)
 		require.Equal(t, "/eth/v1/beacon/blocks/head/attestations", r.URL.Path)
 		b, err := json.Marshal(struct {
 			Data []*eth2p0.Attestation

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -176,7 +176,7 @@ func httpGet(ctx context.Context, base string, endpoint string, timeout time.Dur
 		return nil, errors.Wrap(err, "invalid endpoint")
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "new GET request with ctx")
 	}


### PR DESCRIPTION
Fixed incorrect http method in block attestation request client.

The error log was:
```
ERRO sched Emit scheduled slot event: beacon api block_attestations: request block attestations: get failed {"slot": 4392784, "label": "block_attestations", "status": 405, "body": "{\"code\":405,\"message\":\"METHOD_NOT_ALLOWED\",\"stacktraces\":[]}"} 
```

category: bug
ticket: none
