### PR TITLE
app/eth2wrap: support synthetic proposers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -655,7 +655,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		return nil, errors.New("beacon node endpoints empty")
 	}
 
-	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, eth2ClientTimeout, conf.BeaconNodeAddrs...)
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, eth2ClientTimeout, conf.BeaconNodeAddrs)
 	if err != nil {
 		return nil, errors.Wrap(err, "new eth2 http client")
 	}

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -66,14 +66,8 @@ func Instrument(clients ...Client) (Client, error) {
 	return multi{clients: clients}, nil
 }
 
-// AdaptEth2HTTP returns a Client wrapping an eth2http service by adding experimental endpoints.
-// Note that the returned client doesn't wrap errors, so they are unstructured without stacktraces.
-func AdaptEth2HTTP(eth2Svc *eth2http.Service, timeout time.Duration) Client {
-	return &httpAdapter{Service: eth2Svc, timeout: timeout, address: eth2Svc.Address()}
-}
-
 // NewMultiHTTP returns a new instrumented multi eth2 http client.
-func NewMultiHTTP(ctx context.Context, timeout time.Duration, addresses ...string) (Client, error) {
+func NewMultiHTTP(ctx context.Context, timeout time.Duration, addresses []string, opts ...Option) (Client, error) {
 	var clients []Client
 	for _, address := range addresses {
 		eth2Svc, err := eth2http.New(ctx,
@@ -89,7 +83,7 @@ func NewMultiHTTP(ctx context.Context, timeout time.Duration, addresses ...strin
 			return nil, errors.New("invalid eth2 http service")
 		}
 
-		clients = append(clients, AdaptEth2HTTP(eth2Http, timeout))
+		clients = append(clients, AdaptEth2HTTP(eth2Http, timeout, opts...))
 	}
 
 	return Instrument(clients...)

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -174,7 +174,7 @@ func TestSyncState(t *testing.T) {
 func TestErrors(t *testing.T) {
 	ctx := context.Background()
 	t.Run("network dial error", func(t *testing.T) {
-		_, err := eth2wrap.NewMultiHTTP(ctx, time.Hour, "localhost:22222")
+		_, err := eth2wrap.NewMultiHTTP(ctx, time.Hour, []string{"localhost:22222"})
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: network operation error: dial: connect: connection refused")
@@ -186,7 +186,7 @@ func TestErrors(t *testing.T) {
 	}))
 
 	t.Run("http timeout", func(t *testing.T) {
-		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, srv.URL)
+		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, []string{srv.URL})
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: http request timeout: context deadline exceeded")
@@ -195,7 +195,7 @@ func TestErrors(t *testing.T) {
 	t.Run("caller cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
-		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, srv.URL)
+		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, []string{srv.URL})
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: caller cancelled http request: context canceled")
@@ -204,7 +204,7 @@ func TestErrors(t *testing.T) {
 	t.Run("go-eth2-client http error", func(t *testing.T) {
 		bmock, err := beaconmock.New()
 		require.NoError(t, err)
-		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, bmock.Address())
+		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, []string{bmock.Address()})
 		require.NoError(t, err)
 
 		_, err = eth2Cl.AggregateAttestation(ctx, 0, eth2p0.Root{})
@@ -235,7 +235,7 @@ func TestCtxCancel(t *testing.T) {
 
 		bmock, err := beaconmock.New()
 		require.NoError(t, err)
-		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, bmock.Address())
+		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, []string{bmock.Address()})
 		require.NoError(t, err)
 
 		cancel() // Cancel context before calling method.

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -51,7 +51,6 @@ type BlockAttestationsProvider interface {
 type Option func(*httpAdapter)
 
 // WithSyntheticDuties returns an option that enables synthetic duties.
-// Note the ordering of pubkeys must be identical for all nodes in the cluster.
 func WithSyntheticDuties(pubkeys []eth2p0.BLSPubKey) Option {
 	return func(a *httpAdapter) {
 		a.syntheticDuties = true

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -26,13 +26,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/attestantio/go-eth2-client/api"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2http "github.com/attestantio/go-eth2-client/http"
+	"github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
+
+// syntheticBlockGraffiti defines the graffiti to identify synthetic blocks.
+const syntheticBlockGraffiti = "SYNTHETIC BLOCK: DO NOT SUBMIT"
 
 // BlockAttestationsProvider is the interface for providing attestations included in blocks.
 // It is a standard beacon API endpoint not implemented by eth2client.
@@ -41,31 +48,140 @@ type BlockAttestationsProvider interface {
 	BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error)
 }
 
-// NewHTTPAdapterForT returns a http adaptor for testing non-eth2service methods as it is nil.
-func NewHTTPAdapterForT(_ *testing.T, address string, timeout time.Duration) *httpAdapter {
-	return &httpAdapter{
-		address: address,
-		timeout: timeout,
+type Option func(*httpAdapter)
+
+// WithSyntheticDuties returns an option that enables synthetic duties.
+// Note the ordering of pubkeys must be identical for all nodes in the cluster.
+func WithSyntheticDuties(pubkeys []eth2p0.BLSPubKey) Option {
+	return func(a *httpAdapter) {
+		a.syntheticDuties = true
+		a.synthProposerCache = newSynthProposerCache(pubkeys)
 	}
 }
 
-// httpAdapter implements Client by wrapping eth2http.Service adding the experimental interfaces not present in go-eth2-client.
+// NewHTTPAdapterForT returns a http adaptor for testing non-eth2service methods as it is nil.
+func NewHTTPAdapterForT(_ *testing.T, address string, timeout time.Duration, opts ...Option) *httpAdapter {
+	return newHTTPAdapter(nil, address, timeout, opts...)
+}
+
+// AdaptEth2HTTP returns a Client wrapping an eth2http service by adding experimental endpoints.
+// Note that the returned client doesn't wrap errors, so they are unstructured without stacktraces.
+func AdaptEth2HTTP(eth2Svc *eth2http.Service, timeout time.Duration, opts ...Option) Client {
+	return newHTTPAdapter(eth2Svc, eth2Svc.Address(), timeout, opts...)
+}
+
+// newHTTPAdapter returns a new http adaptor.
+func newHTTPAdapter(ethSvc *eth2http.Service, address string, timeout time.Duration, opts ...Option) *httpAdapter {
+	a := &httpAdapter{
+		Service: ethSvc,
+		address: address,
+		timeout: timeout,
+	}
+
+	for _, opt := range opts {
+		opt(a)
+	}
+
+	return a
+}
+
+// httpAdapter implements Client by wrapping and adding the following to eth2http.Service:
+//   - experimental interfaces not present in go-eth2-client
+//   - synthetic duties
 type httpAdapter struct {
 	*eth2http.Service
-	address string
-	timeout time.Duration
+	address            string
+	timeout            time.Duration
+	syntheticDuties    bool
+	synthProposerCache *synthProposerCache
 }
 
-type submitBeaconCommitteeSelectionsJSON struct {
-	Data []*eth2exp.BeaconCommitteeSelection `json:"data"`
+// ProposerDuties returns upstream proposer duties for the provided validator indexes or
+// upstream proposer duties and synthetic duties for all cluster validators if enabled.
+func (h *httpAdapter) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, valIdxs []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+	if h.syntheticDuties {
+		return h.synthProposerCache.Duties(ctx, h.Service, epoch)
+	}
+
+	return h.Service.ProposerDuties(ctx, epoch, valIdxs)
 }
 
-type submitSyncCommitteeSelectionsJSON struct {
-	Data []*eth2exp.SyncCommitteeSelection `json:"data"`
+// BeaconBlockProposal returns an unsigned beacon block, possibly marked as synthetic.
+func (h *httpAdapter) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, randao eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error) {
+	if h.syntheticDuties {
+		ok, err := h.synthProposerCache.IsSynthetic(ctx, h.Service, slot)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			graffiti = []byte(syntheticBlockGraffiti)
+		}
+	}
+
+	return h.Service.BeaconBlockProposal(ctx, slot, randao, graffiti)
 }
 
-type attestationsJSON struct {
-	Data []*eth2p0.Attestation `json:"data"`
+// BlindedBeaconBlockProposal returns an unsigned blinded beacon block, possibly marked as synthetic.
+func (h *httpAdapter) BlindedBeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, randao eth2p0.BLSSignature, graffiti []byte) (*api.VersionedBlindedBeaconBlock, error) {
+	if h.syntheticDuties {
+		ok, err := h.synthProposerCache.IsSynthetic(ctx, h.Service, slot)
+		if err != nil {
+			return nil, err
+		}
+
+		if ok {
+			graffiti = []byte(syntheticBlockGraffiti)
+		}
+	}
+
+	return h.Service.BlindedBeaconBlockProposal(ctx, slot, randao, graffiti)
+}
+
+// SubmitBlindedBeaconBlock submits a blinded beacon block or swallows it if marked as synthetic.
+func (h *httpAdapter) SubmitBlindedBeaconBlock(ctx context.Context, block *api.VersionedSignedBlindedBeaconBlock) error {
+	var graffiti [32]byte
+	switch block.Version {
+	case spec.DataVersionBellatrix:
+		graffiti = block.Bellatrix.Message.Body.Graffiti
+	default:
+		return errors.New("unknown block version")
+	}
+
+	var synthGraffiti [32]byte
+	copy(synthGraffiti[:], syntheticBlockGraffiti)
+	if graffiti == synthGraffiti {
+		log.Debug(ctx, "Synthetic blinded beacon block swallowed")
+		return nil
+	}
+
+	return h.Service.SubmitBlindedBeaconBlock(ctx, block)
+}
+
+// SubmitBeaconBlock submits a beacon block or swallows it if marked as synthetic.
+func (h *httpAdapter) SubmitBeaconBlock(ctx context.Context, block *spec.VersionedSignedBeaconBlock) error {
+	var graffiti [32]byte
+	switch block.Version {
+	case spec.DataVersionPhase0:
+		graffiti = block.Phase0.Message.Body.Graffiti
+	case spec.DataVersionAltair:
+		graffiti = block.Altair.Message.Body.Graffiti
+	case spec.DataVersionBellatrix:
+		graffiti = block.Bellatrix.Message.Body.Graffiti
+	case spec.DataVersionCapella:
+		graffiti = block.Capella.Message.Body.Graffiti
+	default:
+		return errors.New("unknown block version")
+	}
+
+	var synthGraffiti [32]byte
+	copy(synthGraffiti[:], syntheticBlockGraffiti)
+	if graffiti == synthGraffiti {
+		log.Debug(ctx, "Synthetic blinded beacon block swallowed")
+		return nil
+	}
+
+	return h.Service.SubmitBeaconBlock(ctx, block)
 }
 
 // AggregateBeaconCommitteeSelections implements eth2exp.BeaconCommitteeSelectionAggregator.
@@ -127,6 +243,18 @@ func (h *httpAdapter) BlockAttestations(ctx context.Context, stateID string) ([]
 	}
 
 	return resp.Data, nil
+}
+
+type submitBeaconCommitteeSelectionsJSON struct {
+	Data []*eth2exp.BeaconCommitteeSelection `json:"data"`
+}
+
+type submitSyncCommitteeSelectionsJSON struct {
+	Data []*eth2exp.SyncCommitteeSelection `json:"data"`
+}
+
+type attestationsJSON struct {
+	Data []*eth2p0.Attestation `json:"data"`
 }
 
 func httpPost(ctx context.Context, base string, endpoint string, body io.Reader, timeout time.Duration) ([]byte, error) {

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -58,7 +58,7 @@ func WithSyntheticDuties(pubkeys []eth2p0.BLSPubKey) Option {
 	}
 }
 
-// NewHTTPAdapterForT returns a http adaptor for testing non-eth2service methods as it is nil.
+// NewHTTPAdapterForT returns a http adapter for testing non-eth2service methods as it is nil.
 func NewHTTPAdapterForT(_ *testing.T, address string, timeout time.Duration, opts ...Option) *httpAdapter {
 	return newHTTPAdapter(nil, address, timeout, opts...)
 }
@@ -69,7 +69,7 @@ func AdaptEth2HTTP(eth2Svc *eth2http.Service, timeout time.Duration, opts ...Opt
 	return newHTTPAdapter(eth2Svc, eth2Svc.Address(), timeout, opts...)
 }
 
-// newHTTPAdapter returns a new http adaptor.
+// newHTTPAdapter returns a new http adapter.
 func newHTTPAdapter(ethSvc *eth2http.Service, address string, timeout time.Duration, opts ...Option) *httpAdapter {
 	a := &httpAdapter{
 		Service: ethSvc,
@@ -176,7 +176,7 @@ func (h *httpAdapter) SubmitBeaconBlock(ctx context.Context, block *spec.Version
 	var synthGraffiti [32]byte
 	copy(synthGraffiti[:], syntheticBlockGraffiti)
 	if graffiti == synthGraffiti {
-		log.Debug(ctx, "Synthetic blinded beacon block swallowed")
+		log.Debug(ctx, "Synthetic beacon block swallowed")
 		return nil
 	}
 

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -62,8 +62,7 @@ type synthProposerCache struct {
 	synths map[eth2p0.Epoch]map[eth2p0.Slot]bool
 }
 
-// Duties returns the upstream and synthetic duties for all pubkeys for the provided epoch
-// via a cache.
+// Duties returns the upstream and synthetic duties for all pubkeys for the provided epoch.
 func (c *synthProposerCache) Duties(ctx context.Context, eth2Cl synthProposerEth2Provider, epoch eth2p0.Epoch) ([]*eth2v1.ProposerDuty, error) {
 	// Check if cache already populated for this epoch using read lock.
 	c.mu.RLock()
@@ -147,7 +146,7 @@ func (c *synthProposerCache) Duties(ctx context.Context, eth2Cl synthProposerEth
 	return duties, nil
 }
 
-// IsSynthetic returns true if the slot is a synthetic proposer duty from via a cache.
+// IsSynthetic returns true if the slot is a synthetic proposer duty.
 func (c *synthProposerCache) IsSynthetic(ctx context.Context, eth2Cl synthProposerEth2Provider, slot eth2p0.Slot) (bool, error) {
 	// Get the epoch.
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
@@ -192,7 +191,8 @@ func eth2Shuffle(epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) []eth2p0.V
 	return resp
 }
 
-// getStandardHashFn returns a standard sha256 hash function as per eth2.
+// getStandardHashFn returns a standard sha256 hash function as per
+// https://github.com/protolambda/eth2-shuffle/blob/master/test_util.go.
 func getStandardHashFn() shuffle.HashFn {
 	hash := sha256.New()
 	hashFn := func(in []byte) []byte {

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -1,0 +1,178 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2wrap
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+)
+
+// fifoEpochMax limits the amount of epochs to cache.
+const fifoEpochMax = 10
+
+type synthProposerEth2Provider interface {
+	eth2client.ValidatorsProvider
+	eth2client.SlotsPerEpochProvider
+	eth2client.ProposerDutiesProvider
+}
+
+// synthProposerCache returns a new cache for synthetic proposer duties.
+func newSynthProposerCache(pubkeys []eth2p0.BLSPubKey) *synthProposerCache {
+	return &synthProposerCache{
+		pubkeys: pubkeys,
+		duties:  make(map[eth2p0.Epoch][]*eth2v1.ProposerDuty),
+		synths:  make(map[eth2p0.Epoch]map[eth2p0.Slot]bool),
+	}
+}
+
+// synthProposerCache caches actual and synthetic proposer duties for the set of public keys.
+//
+// Since only a single validator can be a proposer per slot, we require all
+// validators to calculate the synthetic duties for the whole set.
+type synthProposerCache struct {
+	pubkeys []eth2p0.BLSPubKey
+	// shuffleFunc deterministically shuffles the validator indices for the epoch.
+	shuffleFunc func(eth2p0.Epoch, []eth2p0.ValidatorIndex) []eth2p0.ValidatorIndex
+
+	mu     sync.RWMutex
+	fifo   []eth2p0.Epoch
+	duties map[eth2p0.Epoch][]*eth2v1.ProposerDuty
+	synths map[eth2p0.Epoch]map[eth2p0.Slot]bool
+}
+
+// Duties returns the upstream and synthetic duties for all pubkeys for the provided epoch.
+func (c *synthProposerCache) Duties(ctx context.Context, eth2Cl synthProposerEth2Provider, epoch eth2p0.Epoch) ([]*eth2v1.ProposerDuty, error) {
+	// Check if cache already populated for this epoch using read lock.
+	c.mu.RLock()
+	duties, ok := c.duties[epoch]
+	c.mu.RUnlock()
+	if ok {
+		return duties, nil
+	}
+
+	// Only a single goroutine should resolve and populate the cache (even though it requires slow IO).
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check if populated while waiting for the lock.
+	if duties, ok := c.duties[epoch]; ok {
+		return duties, nil
+	}
+
+	// Get slotsPerEpoch and the starting slot of the epoch.
+	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	epochSlot := eth2p0.Slot(epoch) * eth2p0.Slot(slotsPerEpoch)
+
+	// Get active validators for the epoch
+	vals, err := eth2Cl.ValidatorsByPubKey(ctx, fmt.Sprint(epochSlot), c.pubkeys)
+	if err != nil {
+		return nil, err
+	}
+
+	var activeIdxs []eth2p0.ValidatorIndex
+	for _, val := range vals {
+		if !val.Status.IsActive() {
+			continue
+		}
+		activeIdxs = append(activeIdxs, val.Index)
+	}
+
+	// Get actual duties for all validators for the epoch.
+	duties, err = eth2Cl.ProposerDuties(ctx, epoch, activeIdxs)
+	if err != nil {
+		return nil, err
+	}
+
+	// Mark those not requiring synthetic duties.
+	noSynth := make(map[eth2p0.ValidatorIndex]bool)
+	for _, duty := range duties {
+		noSynth[duty.ValidatorIndex] = true
+	}
+
+	// Deterministic synthetic duties for the rest.
+	synthSlots := make(map[eth2p0.Slot]bool)
+	for _, idx := range c.shuffleFunc(epoch, activeIdxs) {
+		if noSynth[idx] {
+			continue
+		}
+
+		synthSlot := epochSlot + eth2p0.Slot(idx)%eth2p0.Slot(slotsPerEpoch)
+		if _, ok := synthSlots[synthSlot]; ok {
+			// We already have a synth proposer for this slot.
+			continue
+		}
+
+		synthSlots[synthSlot] = true
+		duties = append(duties, &eth2v1.ProposerDuty{
+			PubKey:         vals[idx].Validator.PublicKey,
+			Slot:           synthSlot,
+			ValidatorIndex: idx,
+		})
+	}
+
+	// Cache the values for the epoch
+	c.fifo = append(c.fifo, epoch)
+	c.duties[epoch] = duties
+	c.synths[epoch] = synthSlots
+
+	// Trim the cache
+	if len(c.fifo) > fifoEpochMax {
+		delete(c.duties, c.fifo[0])
+		delete(c.synths, c.fifo[0])
+		c.fifo = c.fifo[1:]
+	}
+
+	return duties, nil
+}
+
+// IsSynthetic returns true if the slot is a synthetic proposer duty.
+func (c *synthProposerCache) IsSynthetic(ctx context.Context, eth2Cl synthProposerEth2Provider, slot eth2p0.Slot) (bool, error) {
+	// Get the epoch.
+	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+	if err != nil {
+		return false, err
+	}
+	epoch := eth2p0.Epoch(slot) / eth2p0.Epoch(slotsPerEpoch)
+
+	// Check if cache already populated for this epoch using read lock.
+	c.mu.RLock()
+	synths, ok := c.synths[epoch]
+	c.mu.RUnlock()
+	if ok {
+		return synths[slot], nil
+	}
+
+	// Otherwise, populate the cache.
+	_, err = c.Duties(ctx, eth2Cl, epoch)
+	if err != nil {
+		return false, err
+	}
+
+	// Try reading again.
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.synths[epoch][slot], nil
+}

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -55,7 +55,7 @@ func TestIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second*2, beaconURL)
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second*2, []string{beaconURL})
 	require.NoError(t, err)
 
 	// Use random actual mainnet validators

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.8.0
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
+	github.com/protolambda/eth2-shuffle v1.1.0
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
 	github.com/r3labs/sse/v2 v2.9.0
 	github.com/shurcooL/githubv4 v0.0.0-20220520033151-0b4e3294ff00

--- a/go.sum
+++ b/go.sum
@@ -573,6 +573,8 @@ github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1
 github.com/prometheus/procfs v0.8.0 h1:ODq8ZFEaYeCaZOJlZZdJA2AbQR98dSHSM1KW/You5mo=
 github.com/prometheus/procfs v0.8.0/go.mod h1:z7EfXMXOkbkqb9IINtpCn86r/to3BnA0uaxHdg830/4=
 github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
+github.com/protolambda/eth2-shuffle v1.1.0 h1:gixIBI84IeugTwwHXm8vej1bSSEhueBCSryA4lAKRLU=
+github.com/protolambda/eth2-shuffle v1.1.0/go.mod h1:FhA2c0tN15LTC+4T9DNVm+55S7uXTTjQ8TQnBuXlkF8=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7 h1:0tVE4tdWQK9ZpYygoV7+vS6QkDvQVySboMVEIxBJmXw=
 github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7/go.mod h1:wmuf/mdK4VMD+jA9ThwcUKjg3a2XWM9cVfFYjDyY4j4=
 github.com/prysmaticlabs/gohashtree v0.0.1-alpha.0.20220714111606-acbb2962fb48 h1:cSo6/vk8YpvkLbk9v3FO97cakNmUoxwi2KMP8hd5WIw=


### PR DESCRIPTION
Adds support for deterministic synthetic proposer duties to eth2wrap package.

TODO: add tests and wire in subsequent PRs.

category: feature
ticket: #1486 
