### PR TITLE
scheduler: clear previous status when validator status changes

### DIFF
--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -99,7 +99,6 @@ func newMetricSubmitter() func(pubkey core.PubKey, totalBal eth2p0.Gwei, status 
 		if prev, ok := prevStatus[pubkey]; ok && prev != status { // Validator status changed
 			statusGauge.WithLabelValues(string(pubkey), pubkey.String(), prev).Set(0)
 		}
-
 		prevStatus[pubkey] = status
 	}
 }

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -90,10 +90,7 @@ func instrumentDuty(duty core.Duty, defSet core.DutyDefinitionSet) {
 
 // newMetricSubmitter returns a function that sets validator balance and status metric.
 func newMetricSubmitter() func(pubkey core.PubKey, totalBal eth2p0.Gwei, status string) {
-	var (
-		prevBal    = make(map[core.PubKey]eth2p0.Gwei)
-		prevStatus = make(map[core.PubKey]string)
-	)
+	prevStatus := make(map[core.PubKey]string)
 
 	return func(pubkey core.PubKey, totalBal eth2p0.Gwei, status string) {
 		balanceGauge.WithLabelValues(string(pubkey), pubkey.String()).Set(float64(totalBal))
@@ -102,11 +99,7 @@ func newMetricSubmitter() func(pubkey core.PubKey, totalBal eth2p0.Gwei, status 
 		if prev, ok := prevStatus[pubkey]; ok && prev != status { // Validator status changed
 			statusGauge.WithLabelValues(string(pubkey), pubkey.String(), prev).Set(0)
 		}
-		if prev, ok := prevBal[pubkey]; ok && prev != totalBal { // Validator balance changed
-			balanceGauge.WithLabelValues(string(pubkey), pubkey.String()).Set(0)
-		}
 
-		prevBal[pubkey] = totalBal
 		prevStatus[pubkey] = status
 	}
 }

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -66,7 +66,7 @@ var (
 		Namespace: "core",
 		Subsystem: "scheduler",
 		Name:      "validator_status",
-		Help:      "Constant gauge with label set to current status of the validator by pubkey",
+		Help:      "Gauge with validator pubkey and status as labels, value=1 is current status, value=0 is previous.",
 	}, []string{"pubkey_full", "pubkey", "status"})
 
 	skipCounter = promauto.NewCounter(prometheus.CounterOpts{

--- a/core/scheduler/metrics.go
+++ b/core/scheduler/metrics.go
@@ -23,6 +23,9 @@ import (
 	"github.com/obolnetwork/charon/core"
 )
 
+// metricSubmitter submits validator balance metric.
+type metricSubmitter func(pubkey core.PubKey, totalBal eth2p0.Gwei, status string)
+
 var (
 	slotGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "core",

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -34,13 +34,8 @@ import (
 	"github.com/obolnetwork/charon/core"
 )
 
-type (
-	// delayFunc abstracts slot offset delaying/sleeping for deterministic tests.
-	delayFunc func(duty core.Duty, deadline time.Time) <-chan time.Time
-
-	// metricSubmitter submits validator balance metric.
-	metricSubmitter func(pubkey core.PubKey, totalBal eth2p0.Gwei, status string)
-)
+// delayFunc abstracts slot offset delaying/sleeping for deterministic tests.
+type delayFunc func(duty core.Duty, deadline time.Time) <-chan time.Time
 
 // NewForT returns a new scheduler for testing using a fake clock.
 func NewForT(t *testing.T, clock clockwork.Clock, delayFunc delayFunc, pubkeys []core.PubKey,

--- a/testutil/compose/static/grafana/dash_charon_overview.json
+++ b/testutil/compose/static/grafana/dash_charon_overview.json
@@ -86,7 +86,7 @@
         "frameIndex": 0,
         "showHeader": false
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
@@ -226,7 +226,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
@@ -424,7 +424,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
@@ -602,7 +602,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
@@ -945,7 +945,7 @@
           }
         ]
       },
-      "pluginVersion": "9.2.4",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
@@ -1521,7 +1521,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1653,7 +1654,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1745,7 +1747,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1837,7 +1840,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -1929,7 +1933,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2022,7 +2027,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2129,7 +2135,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2224,7 +2231,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue"
+                "color": "light-blue",
+                "value": null
               },
               {
                 "color": "red",
@@ -2291,7 +2299,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "Public Key"
+              "options": "pubkey_full"
             },
             "properties": [
               {
@@ -2300,7 +2308,7 @@
                   {
                     "targetBlank": true,
                     "title": "beaconcha.in",
-                    "url": "http://beaconcha.in/validator/${__data.fields[\"Public Key\"]}"
+                    "url": "http://beaconcha.in/validator/${__data.fields[\"Pubkey\"]}"
                   }
                 ]
               },
@@ -2327,9 +2335,15 @@
           ],
           "show": false
         },
-        "showHeader": true
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": true,
+            "displayName": "Balance"
+          }
+        ]
       },
-      "pluginVersion": "9.2.3",
+      "pluginVersion": "9.2.6",
       "targets": [
         {
           "datasource": {
@@ -2342,7 +2356,22 @@
           "format": "table",
           "hide": false,
           "instant": true,
-          "legendFormat": "{{pubkey}}",
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "core_scheduler_validator_status{cluster_name=\"$cluster_name\",cluster_hash=\"$cluster_hash\",cluster_peer=\"$cluster_peer\"}",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
           "range": false,
           "refId": "B"
         }
@@ -2350,35 +2379,43 @@
       "title": "Validators",
       "transformations": [
         {
+          "id": "joinByField",
+          "options": {
+            "byField": "pubkey_full",
+            "mode": "outer"
+          }
+        },
+        {
+          "id": "groupBy",
+          "options": {
+            "fields": {
+              "Value #A": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "pubkey 1": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "pubkey_full": {
+                "aggregations": [],
+                "operation": "groupby"
+              },
+              "status": {
+                "aggregations": [],
+                "operation": "groupby"
+              }
+            }
+          }
+        },
+        {
           "id": "organize",
           "options": {
-            "excludeByName": {
-              "Time": true,
-              "Time 1": true,
-              "Time 2": true,
-              "__name__": true,
-              "__name__ 1": true,
-              "__name__ 2": true,
-              "cluster_hash": true,
-              "cluster_name": true,
-              "cluster_peer": true,
-              "instance": true,
-              "instance 1": true,
-              "instance 2": true,
-              "job": true,
-              "job 1": true,
-              "job 2": true,
-              "pubkey": true,
-              "pubkey_full": false
-            },
+            "excludeByName": {},
             "indexByName": {},
             "renameByName": {
-              "Value": "Balance",
-              "Value #A": "Effectiveness",
-              "Value #B": "Balance",
-              "cluster_network": "Network",
-              "pubkey": "Public Key",
-              "pubkey_full": "Public Key",
+              "Value #A": "Balance",
+              "pubkey_full": "Pubkey",
               "status": "Status"
             }
           }
@@ -2431,7 +2468,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green"
+                "color": "green",
+                "value": null
               },
               {
                 "color": "red",
@@ -2560,8 +2598,8 @@
       {
         "current": {
           "selected": false,
-          "text": "8439eb3",
-          "value": "8439eb3"
+          "text": "cad83ab",
+          "value": "cad83ab"
         },
         "datasource": {
           "type": "prometheus",
@@ -2588,8 +2626,8 @@
       {
         "current": {
           "selected": false,
-          "text": "excited-group",
-          "value": "excited-group"
+          "text": "defiant-name",
+          "value": "defiant-name"
         },
         "datasource": {
           "type": "prometheus",
@@ -2616,8 +2654,8 @@
       {
         "current": {
           "selected": false,
-          "text": "node2",
-          "value": "node2"
+          "text": "node0",
+          "value": "node0"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
Clears previous status when validator status changes. For ex: when a validator progresses from `pending_queued` to `active_ongoing`, we currently see two values, one for each status. This PR fixes this by removing the older statuses. In this example, it removes status `pending_queued`.

category: refactor
ticket: https://github.com/ObolNetwork/charon-distributed-validator-node/issues/139
