### PR TITLE
p2p: add alpha relay discovery feature

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -267,6 +267,12 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
+	if conf.P2P.RelayDiscovery() {
+		log.Info(ctx, "Relay discovery enabled") // TODO(corver): Remove once stable.
+	} else {
+		log.Info(ctx, "Discv5 discovery enabled")
+	}
+
 	// Start discv5 UDP node.
 	udpNode, err := p2p.NewUDPNode(ctx, conf.P2P, localEnode, p2pKey, bootnodes)
 	if err != nil {

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -46,10 +46,10 @@ const (
 	MockAlpha Feature = "mock_alpha"
 
 	// RelayDiscovery enables relay peer discovery and disables discv5:
-	//   - If a direct connection to a peer is not possible then try to connect to it via all the provided bootnodes/relays
+	//   - If a direct connection to a peer is not possible then try to connect to it via all the provided bootnodes/relays.
 	//   - Direct connections are either not possible since no addresses are known or the addresses do not work.
 	//   - When connected via relay, libp2p's identify protocol detects the remote peer's addresses.
-	//   - Those are added to the peer store so will try to use them.
+	//   - Those are added to the peer store so libp2p will try to use them.
 	RelayDiscovery Feature = "relay_discovery"
 )
 

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -44,14 +44,22 @@ const (
 	Priority Feature = "priority"
 	// MockAlpha is a mock feature in alpha status for testing.
 	MockAlpha Feature = "mock_alpha"
+
+	// RelayDiscovery enables relay peer discovery and disables discv5:
+	//   - If a direct connection to a peer is not possible then try to connect to it via all the provided bootnodes/relays
+	//   - Direct connections are either not possible since no addresses are known or the addresses do not work.
+	//   - When connected via relay, libp2p's identify protocol detects the remote peer's addresses.
+	//   - Those are added to the peer store so will try to use them.
+	RelayDiscovery Feature = "relay_discovery"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		QBFTConsensus: statusStable,
-		Priority:      statusStable,
-		MockAlpha:     statusAlpha,
+		QBFTConsensus:  statusStable,
+		Priority:       statusStable,
+		MockAlpha:      statusAlpha,
+		RelayDiscovery: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -22,6 +22,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/featureset"
 )
 
 type Config struct {
@@ -44,6 +45,16 @@ type Config struct {
 	// BootnodeRelay enables circuit relay via bootnodes if direct connections fail.
 	// Only applicable to charon nodes not bootnodes.
 	BootnodeRelay bool
+}
+
+// RelayDiscovery returns true if relay discovery is enabled and discv5 discovery is disabled.
+func (c Config) RelayDiscovery() bool {
+	return len(c.UDPBootnodes) > 0 && c.BootnodeRelay && featureset.Enabled(featureset.RelayDiscovery)
+}
+
+// Discv5Discovery returns true if discv5 discovery is enabled and relay discovery is disabled.
+func (c Config) Discv5Discovery() bool {
+	return !c.RelayDiscovery()
 }
 
 // ParseTCPAddrs returns the configured tcp addresses as typed net tcp addresses.

--- a/p2p/discovery.go
+++ b/p2p/discovery.go
@@ -135,6 +135,10 @@ func (n *MutableUDPNode) AllNodes() []*enode.Node {
 func NewUDPNode(ctx context.Context, config Config, ln *enode.LocalNode,
 	key *ecdsa.PrivateKey, bootnodes []*MutablePeer,
 ) (*MutableUDPNode, error) {
+	if !config.Discv5Discovery() {
+		return &MutableUDPNode{}, nil
+	}
+
 	if config.UDPAddr == "" {
 		log.Info(ctx, "Discv5 UDP peer discovery disabled since --p2p-udp-address empty")
 		return new(MutableUDPNode), nil


### PR DESCRIPTION
Adds a new alpha feature called `relay_discovery` which disables discv5, relying purely on relay connections to be upgraded to direct connections via libp2p Indentify protocol that resolves peer direct addresses.

Facts:
 - We know which peers we want to connect to (from lock file)
 - We know all the nodes in a cluster will use the same bootnode(s)/relay(s) (either Obol-hosted or cluster-hosted).
 - We know all the nodes always reserve circuit relays on all configured bootnode/relays.

Connection logic
 - Use direct connection if possible
 - But if direct connection not possible
     - either because peer address unknown 
     - or because known addresses do not work
 - The try to connect to peer via bootnode relay
 - Once connected, libp2p's identify protocol will detect the peers direct address
 - Rinse and repeat

This doesn't actually require any code, it is mostly about removing code (discv5) and relying on existing code and built-in libp2p magic.

Pros:
 - No new libraries or complex code
 - Removes existing libraries and code (discv5) 
 - No steep learning curve of KAD-DHT.
 - Can always add KAD-DHT later (once we go for the whitelisted bootnode network approach where it is unknown at which relays to find your peers).

Cons:
 - No actual peer discovery.
 - Requires either a cluster-wide known bootnode which must be a relay to connect to peer
 - Or requires known direct address of peer (via lock ENRs or possible new config flag --peer-addrs).
 - So use-case of using a bootnode for peer discovery and then only direct connections not supported anymore.
 - Ie. --bootnode-relay=true flag is required 

category: feature
ticket: #712 
