### PR TITLE
app: wire synthetic block proposals

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -76,21 +76,22 @@ import (
 const eth2ClientTimeout = time.Second * 2
 
 type Config struct {
-	P2P                    p2p.Config
-	Log                    log.Config
-	Feature                featureset.Config
-	LockFile               string
-	NoVerify               bool
-	PrivKeyFile            string
-	MonitoringAddr         string
-	ValidatorAPIAddr       string
-	BeaconNodeAddrs        []string
-	JaegerAddr             string
-	JaegerService          string
-	SimnetBMock            bool
-	SimnetVMock            bool
-	SimnetValidatorKeysDir string
-	BuilderAPI             bool
+	P2P                     p2p.Config
+	Log                     log.Config
+	Feature                 featureset.Config
+	LockFile                string
+	NoVerify                bool
+	PrivKeyFile             string
+	MonitoringAddr          string
+	ValidatorAPIAddr        string
+	BeaconNodeAddrs         []string
+	JaegerAddr              string
+	JaegerService           string
+	SimnetBMock             bool
+	SimnetVMock             bool
+	SimnetValidatorKeysDir  string
+	SyntheticBlockProposals bool
+	BuilderAPI              bool
 
 	TestConfig TestConfig
 }
@@ -637,9 +638,11 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		opts := []beaconmock.Option{
 			beaconmock.WithSlotDuration(time.Second),
 			beaconmock.WithDeterministicAttesterDuties(dutyFactor),
-			beaconmock.WithDeterministicProposerDuties(dutyFactor),
 			beaconmock.WithDeterministicSyncCommDuties(2, 8), // First 2 epochs of every 8
 			beaconmock.WithValidatorSet(createMockValidators(pubkeys)),
+		}
+		if !conf.SyntheticBlockProposals { // Only add deterministic proposals if synthetic duties are disabled.
+			opts = append(opts, beaconmock.WithDeterministicProposerDuties(dutyFactor))
 		}
 		opts = append(opts, conf.TestConfig.SimnetBMockOpts...)
 		bmock, err := beaconmock.New(opts...)
@@ -652,6 +655,11 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 			return nil, err
 		}
 
+		if conf.SyntheticBlockProposals {
+			log.Info(ctx, "Synthetic block proposals enabled")
+			wrap = eth2wrap.WithSyntheticDuties(wrap, pubkeys)
+		}
+
 		life.RegisterStop(lifecycle.StopBeaconMock, lifecycle.HookFuncErr(bmock.Close))
 
 		return wrap, nil
@@ -661,9 +669,14 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		return nil, errors.New("beacon node endpoints empty")
 	}
 
-	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, eth2ClientTimeout, conf.BeaconNodeAddrs)
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, eth2ClientTimeout, conf.BeaconNodeAddrs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "new eth2 http client")
+	}
+
+	if conf.SyntheticBlockProposals {
+		log.Info(ctx, "Synthetic block proposals enabled")
+		eth2Cl = eth2wrap.WithSyntheticDuties(eth2Cl, pubkeys)
 	}
 
 	return eth2Cl, nil

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -174,7 +174,7 @@ func TestSyncState(t *testing.T) {
 func TestErrors(t *testing.T) {
 	ctx := context.Background()
 	t.Run("network dial error", func(t *testing.T) {
-		_, err := eth2wrap.NewMultiHTTP(ctx, time.Hour, []string{"localhost:22222"})
+		_, err := eth2wrap.NewMultiHTTP(ctx, time.Hour, "localhost:22222")
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: network operation error: dial: connect: connection refused")
@@ -186,7 +186,7 @@ func TestErrors(t *testing.T) {
 	}))
 
 	t.Run("http timeout", func(t *testing.T) {
-		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, []string{srv.URL})
+		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, srv.URL)
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: http request timeout: context deadline exceeded")
@@ -195,7 +195,7 @@ func TestErrors(t *testing.T) {
 	t.Run("caller cancelled", func(t *testing.T) {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
-		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, []string{srv.URL})
+		_, err := eth2wrap.NewMultiHTTP(ctx, time.Millisecond, srv.URL)
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "beacon api new eth2 client: caller cancelled http request: context canceled")
@@ -204,7 +204,7 @@ func TestErrors(t *testing.T) {
 	t.Run("go-eth2-client http error", func(t *testing.T) {
 		bmock, err := beaconmock.New()
 		require.NoError(t, err)
-		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, []string{bmock.Address()})
+		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, bmock.Address())
 		require.NoError(t, err)
 
 		_, err = eth2Cl.AggregateAttestation(ctx, 0, eth2p0.Root{})
@@ -235,7 +235,7 @@ func TestCtxCancel(t *testing.T) {
 
 		bmock, err := beaconmock.New()
 		require.NoError(t, err)
-		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, []string{bmock.Address()})
+		eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second, bmock.Address())
 		require.NoError(t, err)
 
 		cancel() // Cancel context before calling method.

--- a/app/eth2wrap/synthproposer_test.go
+++ b/app/eth2wrap/synthproposer_test.go
@@ -73,9 +73,9 @@ func TestSynthProposer(t *testing.T) {
 
 	srv := httptest.NewServer(router)
 
-	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Hour, []string{srv.URL},
-		eth2wrap.WithSyntheticDuties(set.PublicKeys()))
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Hour, srv.URL)
 	require.NoError(t, err)
+	eth2Cl = eth2wrap.WithSyntheticDuties(eth2Cl, set.PublicKeys())
 
 	// Get synthetic duties
 	duties, err := eth2Cl.ProposerDuties(ctx, epoch, nil)

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -57,7 +57,7 @@ var integration = flag.Bool("integration", false, "Enable docker based integrati
 func TestSimnetDuties(t *testing.T) {
 	tests := []struct {
 		name                string
-		bmockOpts           []beaconmock.Option
+		scheduledType       core.DutyType
 		duties              []core.DutyType
 		builderAPI          bool
 		builderRegistration bool
@@ -65,110 +65,72 @@ func TestSimnetDuties(t *testing.T) {
 		teku                bool
 	}{
 		{
-			name: "attester with mock VCs",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties: []core.DutyType{core.DutyPrepareAggregator, core.DutyAttester, core.DutyAggregator},
+			name:          "attester with mock VCs",
+			scheduledType: core.DutyAttester,
+			duties:        []core.DutyType{core.DutyPrepareAggregator, core.DutyAttester, core.DutyAggregator},
 		},
 		{
-			name: "attester with teku",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties: []core.DutyType{core.DutyAttester}, // Teku doesn't support beacon committee selection.
-			teku:   true,
+			name:          "attester with teku",
+			scheduledType: core.DutyAttester,
+			duties:        []core.DutyType{core.DutyAttester}, // Teku doesn't support beacon committee selection.
+			teku:          true,
 		},
 		{
-			name: "proposer with mock VCs",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties: []core.DutyType{core.DutyProposer, core.DutyRandao},
+			name:          "proposer with mock VCs",
+			scheduledType: core.DutyProposer,
+			duties:        []core.DutyType{core.DutyProposer, core.DutyRandao},
 		},
 		{
-			name: "proposer with teku",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties: []core.DutyType{core.DutyProposer, core.DutyRandao},
-			teku:   true,
+			name:          "proposer with teku",
+			scheduledType: core.DutyProposer,
+			duties:        []core.DutyType{core.DutyProposer, core.DutyRandao},
+			teku:          true,
 		},
 		{
-			name: "builder proposer with mock VCs",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties:     []core.DutyType{core.DutyBuilderProposer, core.DutyRandao},
-			builderAPI: true,
+			name:          "builder proposer with mock VCs",
+			scheduledType: core.DutyProposer,
+			duties:        []core.DutyType{core.DutyBuilderProposer, core.DutyRandao},
+			builderAPI:    true,
 		},
 		{
-			name: "builder proposer with teku",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties:     []core.DutyType{core.DutyBuilderProposer, core.DutyRandao},
-			builderAPI: true,
-			teku:       true,
+			name:          "builder proposer with teku",
+			scheduledType: core.DutyProposer,
+			duties:        []core.DutyType{core.DutyBuilderProposer, core.DutyRandao},
+			builderAPI:    true,
+			teku:          true,
 		},
 		{
-			name: "builder registration with mock VCs",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
+			name:                "builder registration with mock VCs",
+			scheduledType:       0,
 			duties:              []core.DutyType{core.DutyBuilderRegistration},
 			builderRegistration: true,
 			builderAPI:          true,
 		},
 		{
-			name: "builder registration with teku",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
+			name:                "builder registration with teku",
+			scheduledType:       0,
 			duties:              []core.DutyType{core.DutyBuilderRegistration},
 			builderRegistration: true,
 			builderAPI:          true,
 			teku:                true,
 		},
 		{
-			name: "sync committee with mock VCs",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithDeterministicSyncCommDuties(2, 2), // Always on
-			},
-			duties: []core.DutyType{core.DutyPrepareSyncContribution, core.DutySyncMessage, core.DutySyncContribution},
+			name:          "sync committee with mock VCs",
+			scheduledType: core.DutySyncMessage,
+			duties:        []core.DutyType{core.DutyPrepareSyncContribution, core.DutySyncMessage, core.DutySyncContribution},
 		},
 		{
-			name: "sync committee with teku",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithDeterministicSyncCommDuties(2, 2), // Always on
-			},
-			duties: []core.DutyType{core.DutySyncMessage}, // Teku doesn't support sync committee selection.
-			teku:   true,
+			name:          "sync committee with teku",
+			scheduledType: core.DutySyncMessage,
+			duties:        []core.DutyType{core.DutySyncMessage}, // Teku doesn't support sync committee selection.
+			teku:          true,
 		},
 		{
-			name: "voluntary exit with teku",
-			bmockOpts: []beaconmock.Option{
-				beaconmock.WithNoAttesterDuties(),
-				beaconmock.WithNoProposerDuties(),
-				beaconmock.WithNoSyncCommitteeDuties(),
-			},
-			duties: []core.DutyType{core.DutyExit},
-			exit:   true,
-			teku:   true,
+			name:          "voluntary exit with teku",
+			scheduledType: 0,
+			duties:        []core.DutyType{core.DutyExit},
+			exit:          true,
+			teku:          true,
 		},
 	}
 
@@ -189,7 +151,25 @@ func TestSimnetDuties(t *testing.T) {
 				}
 			}
 
-			args.BMockOpts = test.bmockOpts
+			if test.scheduledType != core.DutyAttester {
+				// Beaconmock enables attester duties by default.
+				args.BMockOpts = append(args.BMockOpts, beaconmock.WithNoAttesterDuties())
+			}
+			if test.scheduledType != core.DutyProposer {
+				// Beaconmock enables proposer duties by default.
+				args.BMockOpts = append(args.BMockOpts, beaconmock.WithNoProposerDuties())
+			} else {
+				// Use synthetic duties instead of deterministic beaconmock duties.
+				args.SyntheticProposals = true
+			}
+			if test.scheduledType != core.DutySyncMessage {
+				// Beaconmock enables sync committee duties by default.
+				args.BMockOpts = append(args.BMockOpts, beaconmock.WithNoSyncCommitteeDuties())
+			} else {
+				// Enable for all epochs
+				args.BMockOpts = append(args.BMockOpts, beaconmock.WithDeterministicSyncCommDuties(2, 2))
+			}
+
 			expect := newSimnetExpect(args.N, test.duties...)
 			testSimnet(t, args, expect)
 		})
@@ -207,6 +187,7 @@ type simnetArgs struct {
 	ErrChan             chan error
 	BuilderAPI          bool
 	BuilderRegistration bool
+	SyntheticProposals  bool
 	VoluntaryExit       bool
 }
 
@@ -336,8 +317,9 @@ func testSimnet(t *testing.T, args simnetArgs, expect simnetExpect) {
 				}, args.BMockOpts...),
 				BuilderRegistration: registrationFunc(),
 			},
-			P2P:        p2p.Config{},
-			BuilderAPI: args.BuilderAPI,
+			P2P:                     p2p.Config{},
+			BuilderAPI:              args.BuilderAPI,
+			SyntheticBlockProposals: args.SyntheticProposals,
 		}
 
 		eg.Go(func() error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,6 +78,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().BoolVar(&config.SimnetVMock, "simnet-validator-mock", false, "Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.")
 	cmd.Flags().StringVar(&config.SimnetValidatorKeysDir, "simnet-validator-keys-dir", ".charon/validator_keys", "The directory containing the simnet validator key shares.")
 	cmd.Flags().BoolVar(&config.BuilderAPI, "builder-api", false, "Enables the builder api. Will only produce builder blocks. Builder API must also be enabled on the validator client. Beacon node must be connected to a builder-relay to access the builder network.")
+	cmd.Flags().BoolVar(&config.SyntheticBlockProposals, "synthetic-block-proposals", false, "Enables additional synthetic block proposal duties. Used for testing of rare duties. Must be enabled on all nodes in the cluster.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -78,7 +78,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().BoolVar(&config.SimnetVMock, "simnet-validator-mock", false, "Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.")
 	cmd.Flags().StringVar(&config.SimnetValidatorKeysDir, "simnet-validator-keys-dir", ".charon/validator_keys", "The directory containing the simnet validator key shares.")
 	cmd.Flags().BoolVar(&config.BuilderAPI, "builder-api", false, "Enables the builder api. Will only produce builder blocks. Builder API must also be enabled on the validator client. Beacon node must be connected to a builder-relay to access the builder network.")
-	cmd.Flags().BoolVar(&config.SyntheticBlockProposals, "synthetic-block-proposals", false, "Enables additional synthetic block proposal duties. Used for testing of rare duties. Must be enabled on all nodes in the cluster.")
+	cmd.Flags().BoolVar(&config.SyntheticBlockProposals, "synthetic-block-proposals", false, "Enables additional synthetic block proposal duties. Used for testing of rare duties.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -55,7 +55,7 @@ func TestIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second*2, []string{beaconURL})
+	eth2Cl, err := eth2wrap.NewMultiHTTP(ctx, time.Second*2, beaconURL)
 	require.NoError(t, err)
 
 	// Use random actual mainnet validators

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,7 +149,7 @@ Flags:
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")
       --simnet-validator-mock              Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.
-      --synthetic-block-proposals          Enables additional synthetic block proposal duties. Used for testing of rare duties. Must be enabled on all nodes in the cluster.
+      --synthetic-block-proposals          Enables additional synthetic block proposal duties. Used for testing of rare duties.
       --validator-api-address string       Listening address (ip and port) for validator-facing traffic proxying the beacon-node API. (default "127.0.0.1:3600")
 
 ````

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,7 @@ Flags:
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")
       --simnet-validator-mock              Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.
+      --synthetic-block-proposals          Enables additional synthetic block proposal duties. Used for testing of rare duties. Must be enabled on all nodes in the cluster.
       --validator-api-address string       Listening address (ip and port) for validator-facing traffic proxying the beacon-node API. (default "127.0.0.1:3600")
 
 ````

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -153,6 +153,7 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		kv{"simnet-validator-keys-dir", fmt.Sprintf("/compose/node%d/validator_keys", index)},
 		kv{"loki-addresses", "http://loki:3100/loki/api/v1/push"},
 		kv{"loki-service", fmt.Sprintf("node%d", index)},
+		kv{"synthetic-block-proposals", "true"},
 	)
 }
 

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -153,7 +153,7 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		kv{"simnet-validator-keys-dir", fmt.Sprintf("/compose/node%d/validator_keys", index)},
 		kv{"loki-addresses", "http://loki:3100/loki/api/v1/push"},
 		kv{"loki-service", fmt.Sprintf("node%d", index)},
-		kv{"synthetic-block-proposals", "true"},
+		kv{"synthetic-block-proposals", `"true"`},
 	)
 }
 

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -90,7 +90,7 @@
     },
     {
      "Key": "synthetic-block-proposals",
-     "Value": "true"
+     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -198,7 +198,7 @@
     },
     {
      "Key": "synthetic-block-proposals",
-     "Value": "true"
+     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -306,7 +306,7 @@
     },
     {
      "Key": "synthetic-block-proposals",
-     "Value": "true"
+     "Value": "\"true\""
     }
    ],
    "Ports": [
@@ -414,7 +414,7 @@
     },
     {
      "Key": "synthetic-block-proposals",
-     "Value": "true"
+     "Value": "\"true\""
     }
    ],
    "Ports": [

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -87,6 +87,10 @@
     {
      "Key": "loki-service",
      "Value": "node0"
+    },
+    {
+     "Key": "synthetic-block-proposals",
+     "Value": "true"
     }
    ],
    "Ports": [
@@ -191,6 +195,10 @@
     {
      "Key": "loki-service",
      "Value": "node1"
+    },
+    {
+     "Key": "synthetic-block-proposals",
+     "Value": "true"
     }
    ],
    "Ports": [
@@ -295,6 +303,10 @@
     {
      "Key": "loki-service",
      "Value": "node2"
+    },
+    {
+     "Key": "synthetic-block-proposals",
+     "Value": "true"
     }
    ],
    "Ports": [
@@ -399,6 +411,10 @@
     {
      "Key": "loki-service",
      "Value": "node3"
+    },
+    {
+     "Key": "synthetic-block-proposals",
+     "Value": "true"
     }
    ],
    "Ports": [

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -33,6 +33,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node0/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node0
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
     
     ports:
       - "3600:3600"
@@ -67,6 +68,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node1/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node1
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
     
     ports:
       - "13600:3600"
@@ -101,6 +103,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node2/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node2
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
     
     ports:
       - "23600:3600"
@@ -135,6 +138,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node3/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node3
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
     
     ports:
       - "33600:3600"

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -33,7 +33,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node0/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node0
-      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
     
     ports:
       - "3600:3600"
@@ -68,7 +68,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node1/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node1
-      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
     
     ports:
       - "13600:3600"
@@ -103,7 +103,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node2/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node2
-      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
     
     ports:
       - "23600:3600"
@@ -138,7 +138,7 @@ services:
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node3/validator_keys
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node3
-      CHARON_SYNTHETIC_BLOCK_PROPOSALS: true
+      CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
     
     ports:
       - "33600:3600"


### PR DESCRIPTION
Wire synthetic block proposals via the config flag `--synthetic-block-proposals`. Also enable this by default in compose, it replaces beaconmock scheduled deterministic duties.

category: feature
ticket: #1486 
