### PR TITLE
app: fix flapping InfoSync test

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -547,6 +547,11 @@ func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Contex
 		}
 
 		for _, result := range results {
+			if len(result.Priorities) == 0 {
+				// Some but not all peers participated, ignore this result.
+				return nil
+			}
+
 			if !assert.Equal(t, expect[result.Topic], fmt.Sprint(result.PrioritiesOnly())) {
 				return errors.New("unexpected priorities")
 			}


### PR DESCRIPTION
This check was removed in previous refactor so test started flapping again. Re-adding.

category: test
ticket: none
