### PR TITLE
log/loki: lazy loading of cluster labels

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -36,7 +36,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
-	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -195,12 +194,15 @@ func Run(ctx context.Context, conf Config) (err error) {
 		z.Int("peers", len(lock.Operators)),
 		z.Str("enr", localEnode.Node().String()))
 
-	promRegistry, err := promauto.NewRegistry(prometheus.Labels{
+	// Metric and logging labels.
+	labels := map[string]string{
 		"cluster_hash":    lockHashHex,
 		"cluster_name":    lock.Name,
 		"cluster_peer":    p2p.PeerName(tcpNode.ID()),
 		"cluster_network": network,
-	})
+	}
+	log.SetLabels(labels)
+	promRegistry, err := promauto.NewRegistry(labels)
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -201,7 +201,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		"cluster_peer":    p2p.PeerName(tcpNode.ID()),
 		"cluster_network": network,
 	}
-	log.SetLabels(labels)
+	log.SetLokiLabels(labels)
 	promRegistry, err := promauto.NewRegistry(labels)
 	if err != nil {
 		return err

--- a/cmd/bootnode.go
+++ b/cmd/bootnode.go
@@ -135,6 +135,7 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 
 	go func() {
 		if !config.P2PRelay {
+			log.SetLokiLabels(nil)
 			return
 		}
 
@@ -161,6 +162,10 @@ func RunBootnode(ctx context.Context, config BootnodeConfig) error {
 			p2pErr <- errors.Wrap(err, "new tcp node")
 			return
 		}
+
+		log.SetLokiLabels(map[string]string{
+			"bootnode_peer": p2p.PeerName(tcpNode.ID()),
+		})
 
 		p2p.RegisterConnectionLogger(tcpNode, nil)
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -58,6 +58,9 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 	return cmd
 }
 
+// bindLokiFlags binds the loki flags to the config.
+// Note all commands that use this MUST also call log.SetLokiLabels
+// or logs will not be sent to loki.
 func bindLokiFlags(flags *pflag.FlagSet, config *log.Config) {
 	flags.StringSliceVar(&config.LokiAddresses, "loki-addresses", nil, "Enables sending of logfmt structured logs to these Loki log aggregation server addresses. This is in addition to normal stderr logs.")
 	flags.StringVar(&config.LokiService, "loki-service", "charon", "Service label sent with logs to Loki.")


### PR DESCRIPTION
Adds lazy loaded cluster labels when pushing logs to loki so we can filter and query by node/cluster/network. 

category: feature
ticket: #1509 
