### PR TITLE
core/consensus: add QBFT decided round gauge

### DIFF
--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -75,6 +75,8 @@ func newDefinition(nodes int, subs func() []subscriber) qbft.Definition[core.Dut
 				return
 			}
 
+			decidedRoundsGauge.WithLabelValues(duty.Type.String()).Set(float64(qcommit[0].Round()))
+
 			for _, sub := range subs() {
 				if err := sub(ctx, duty, value); err != nil {
 					log.Warn(ctx, "Subscriber error", err)

--- a/core/consensus/metrics.go
+++ b/core/consensus/metrics.go
@@ -1,0 +1,29 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package consensus
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/obolnetwork/charon/app/promauto"
+)
+
+var decidedRoundsGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "core",
+	Subsystem: "consensus",
+	Name:      "decided_rounds",
+	Help:      "Number of rounds it took to decide consensus instances by duty type.",
+}, []string{"duty"}) // Using gauge since the value changes slowly, once per slot.


### PR DESCRIPTION
Adds QBFT rounds to decide consensus per duty type gauge.

category: misc
ticket: none

