### PR TITLE
cluster: add partial definition verification

### DIFF
--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -128,6 +128,36 @@ func TestDefinitionVerify(t *testing.T) {
 		require.Error(t, err)
 		require.ErrorContains(t, err, "empty creator config signature")
 	})
+
+	t.Run("partial definition", func(t *testing.T) {
+		definition := randomDefinition(t, creator, Operator{}, Operator{}, func(def *Definition) {
+			def.Operators = []Operator{}
+		})
+		definition.DefinitionHash = nil
+
+		definition, err = signCreator(secret3, definition)
+		require.NoError(t, err)
+
+		err = definition.VerifyPartialHashes()
+		require.NoError(t, err)
+
+		err = definition.VerifyPartialSignatures()
+		require.NoError(t, err)
+	})
+
+	t.Run("partial definition operators not empty", func(t *testing.T) {
+		definition := randomDefinition(t, creator, Operator{}, Operator{})
+		definition, err = signCreator(secret3, definition)
+		require.NoError(t, err)
+
+		err = definition.VerifyPartialHashes()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "partial definition operators not empty")
+
+		err = definition.VerifyPartialSignatures()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "partial definition operators not empty")
+	})
 }
 
 // randomOperator returns a random ETH1 private key and populated creator struct (excluding config signature).

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -180,7 +180,7 @@ func TestExamples(t *testing.T) {
 		})
 	}
 
-	defFiles, err := filepath.Glob("examples/*definition*")
+	defFiles, err := filepath.Glob("examples/*-definition*")
 	require.NoError(t, err)
 
 	for _, file := range defFiles {
@@ -193,6 +193,22 @@ func TestExamples(t *testing.T) {
 			require.NoError(t, err)
 			require.NoError(t, def.VerifyHashes())
 			require.NoError(t, def.VerifySignatures())
+		})
+	}
+
+	parDefFiles, err := filepath.Glob("examples/*-partialdefinition*")
+	require.NoError(t, err)
+
+	for _, file := range parDefFiles {
+		t.Run(filepath.Base(file), func(t *testing.T) {
+			b, err := os.ReadFile(file)
+			require.NoError(t, err)
+
+			var def cluster.Definition
+			err = json.Unmarshal(b, &def)
+			require.NoError(t, err)
+			require.NoError(t, def.VerifyPartialHashes())
+			require.NoError(t, def.VerifyPartialSignatures())
 		})
 	}
 }

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -158,7 +158,7 @@ func (d Definition) VerifyPartialSignatures() error {
 		return errors.New("partial definition only supported from v1.4.0 onwards")
 	}
 
-	if len(d.Operators) == 0 {
+	if len(d.Operators) != 0 {
 		return errors.New("partial definition operators not empty")
 	}
 
@@ -397,7 +397,7 @@ func (d Definition) VerifyPartialHashes() error {
 		return errors.New("partial definition only supported from v1.4.0 onwards")
 	}
 
-	if len(d.Operators) == 0 {
+	if len(d.Operators) != 0 {
 		return errors.New("partial definition operators not empty")
 	}
 

--- a/cluster/examples/cluster-partialdefinition-000.json
+++ b/cluster/examples/cluster-partialdefinition-000.json
@@ -1,0 +1,17 @@
+{
+  "name": "test definition",
+  "creator": {
+    "address": "0x241c78cb691D30143F91849Ca23b475AE5ED74a4",
+    "config_signature": "0x3a278852059f25e4d891889a6f94d85dd5542d5101db66e8d65e9faf47d09b93317c06db9f9503bfa9643a29f991c076b88dde0583d2081a5fb23057684a84f101"
+  },
+  "operators": [],
+  "uuid": "52FDFC07-2182-654F-163F-5F0F9A621D72",
+  "version": "v1.4.0",
+  "timestamp": "2022-12-06T18:31:51+02:00",
+  "num_validators": 1,
+  "threshold": 2,
+  "dkg_algorithm": "default",
+  "fork_version": "0x90000069",
+  "config_hash": "0x841365735c01f819319c764eedc642cb60adb3a7b508f62d219462b14ec55cce",
+  "definition_hash": ""
+}


### PR DESCRIPTION
Adds partial definition verification functions in order to support launchpad `create cluster` solo flow. 

category: feature 
ticket: #1488

