### PR TITLE
p2p: add option to disable port reuse

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -131,6 +131,7 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")
 	cmd.Flags().StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
 	cmd.Flags().StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
+	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if config.UDPAddr == "" && !config.BootnodeRelay && !config.UDPBootLock {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,7 @@ Flags:
       --p2p-bootnodes strings              Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.lb.gcp.obol.tech:3640/enr])
       --p2p-bootnodes-from-lockfile        Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
       --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
+      --p2p-disable-reuseport              Disables TCP port reuse for outgoing libp2p connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	// BootnodeRelay enables circuit relay via bootnodes if direct connections fail.
 	// Only applicable to charon nodes not bootnodes.
 	BootnodeRelay bool
+	// DisableReuseport disables TCP port reuse for libp2p.
+	DisableReuseport bool
 }
 
 // RelayDiscovery returns true if relay discovery is enabled and discv5 discovery is disabled.

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -29,6 +29,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/routing"
 	"github.com/libp2p/go-libp2p/p2p/protocol/identify"
+	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -64,6 +65,11 @@ func NewTCPNode(ctx context.Context, cfg Config, key *ecdsa.PrivateKey, connGate
 		identify.ActivationThresh = 1
 	}
 
+	var tcpOpts []interface{} // libp2p.Transport requires empty interface options.
+	if cfg.DisableReuseport {
+		tcpOpts = append(tcpOpts, tcp.DisableReuseport())
+	}
+
 	// Init options.
 	defaultOpts := []libp2p.Option{
 		// Set P2P identity key.
@@ -84,6 +90,7 @@ func NewTCPNode(ctx context.Context, cfg Config, key *ecdsa.PrivateKey, connGate
 
 			return append(addrs, externalAddrs...)
 		}),
+		libp2p.Transport(tcp.NewTCPTransport, tcpOpts...),
 	}
 
 	defaultOpts = append(defaultOpts, opts...)


### PR DESCRIPTION
Adds a config option to disable libp2p TCP port reuse to test a network issue we are having in GCP.

category: feature
ticket: none
