### PR TITLE
app: fix failing teku exits

### DIFF
--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -489,7 +489,7 @@ func startTeku(t *testing.T, args simnetArgs, node int) simnetArgs {
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
 		err = c.Run()
-		if ctx.Err() != nil {
+		if err == nil || ctx.Err() != nil {
 			// Expected shutdown
 			return
 		}


### PR DESCRIPTION
Teku exit docker tests started failing in github CI/CD probably due to changes in latest teku versions which resulted in quicker exits which triggered this race condition.

category: test
ticket: none
