### PR TITLE
app/eth2wrap: query previous block for synthetic proposals

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -59,6 +59,7 @@ type Client interface {
 	eth2client.NodeVersionProvider
 	eth2client.ProposalPreparationsSubmitter
 	eth2client.ProposerDutiesProvider
+	eth2client.SignedBeaconBlockProvider
 	eth2client.SlotDurationProvider
 	eth2client.SlotsPerEpochProvider
 	eth2client.SpecProvider
@@ -140,6 +141,26 @@ func (m multi) DepositContract(ctx context.Context) (*apiv1.DepositContract, err
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*apiv1.DepositContract, error) {
 			return cl.DepositContract(ctx)
+		},
+		nil,
+	)
+
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return res0, err
+}
+
+// SignedBeaconBlock fetches a signed beacon block given a block ID.
+func (m multi) SignedBeaconBlock(ctx context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error) {
+	const label = "signed_beacon_block"
+	defer latency(label)()
+
+	res0, err := provide(ctx, m.clients,
+		func(ctx context.Context, cl Client) (*spec.VersionedSignedBeaconBlock, error) {
+			return cl.SignedBeaconBlock(ctx, blockID)
 		},
 		nil,
 	)

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -116,6 +116,7 @@ type Client interface {
 		"SlotDurationProvider":                  false,
 		"SlotsPerEpochProvider":                 false,
 		"SpecProvider":                          false,
+		"SignedBeaconBlockProvider":             true,
 		"SyncCommitteeDutiesProvider":           true,
 		"SyncCommitteeContributionProvider":     true,
 		"SyncCommitteeContributionsSubmitter":   true,

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	shuffle "github.com/protolambda/eth2-shuffle"
 
@@ -33,8 +34,10 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 )
 
-// maxCachedEpochs limits the amount of epochs to cache.
-const maxCachedEpochs = 10
+const (
+	// maxCachedEpochs limits the amount of epochs to cache.
+	maxCachedEpochs = 10
+)
 
 type synthProposerEth2Provider interface {
 	eth2client.ValidatorsProvider
@@ -62,13 +65,11 @@ func (h *synthWrapper) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot
 	ok, err := h.synthProposerCache.IsSynthetic(ctx, h.Client, slot)
 	if err != nil {
 		return nil, err
+	} else if !ok {
+		return h.Client.BeaconBlockProposal(ctx, slot, randao, graffiti)
 	}
 
-	if ok {
-		graffiti = []byte(syntheticBlockGraffiti)
-	}
-
-	return h.Client.BeaconBlockProposal(ctx, slot, randao, graffiti)
+	return h.syntheticBlock(ctx, slot)
 }
 
 // BlindedBeaconBlockProposal returns an unsigned blinded beacon block, possibly marked as synthetic.
@@ -76,13 +77,97 @@ func (h *synthWrapper) BlindedBeaconBlockProposal(ctx context.Context, slot eth2
 	ok, err := h.synthProposerCache.IsSynthetic(ctx, h.Client, slot)
 	if err != nil {
 		return nil, err
+	} else if !ok {
+		return h.Client.BlindedBeaconBlockProposal(ctx, slot, randao, graffiti)
 	}
 
-	if ok {
-		graffiti = []byte(syntheticBlockGraffiti)
+	block, err := h.syntheticBlock(ctx, slot)
+	if err != nil {
+		return nil, err
+	} else if block.Version != spec.DataVersionBellatrix {
+		return nil, errors.New("unsupported blinded block version")
 	}
 
-	return h.Client.BlindedBeaconBlockProposal(ctx, slot, randao, graffiti)
+	// Convert normal block into blinded block.
+	return &api.VersionedBlindedBeaconBlock{
+		Version: block.Version,
+		Bellatrix: &eth2v1.BlindedBeaconBlock{
+			Slot:          block.Bellatrix.Slot,
+			ProposerIndex: block.Bellatrix.ProposerIndex,
+			ParentRoot:    block.Bellatrix.ParentRoot,
+			StateRoot:     block.Bellatrix.StateRoot,
+			Body: &eth2v1.BlindedBeaconBlockBody{
+				RANDAOReveal:      block.Bellatrix.Body.RANDAOReveal,
+				ETH1Data:          block.Bellatrix.Body.ETH1Data,
+				Graffiti:          block.Bellatrix.Body.Graffiti,
+				ProposerSlashings: block.Bellatrix.Body.ProposerSlashings,
+				AttesterSlashings: block.Bellatrix.Body.AttesterSlashings,
+				Attestations:      block.Bellatrix.Body.Attestations,
+				Deposits:          block.Bellatrix.Body.Deposits,
+				VoluntaryExits:    block.Bellatrix.Body.VoluntaryExits,
+				SyncAggregate:     block.Bellatrix.Body.SyncAggregate,
+				ExecutionPayloadHeader: &bellatrix.ExecutionPayloadHeader{
+					ParentHash:       block.Bellatrix.Body.ExecutionPayload.ParentHash,
+					FeeRecipient:     block.Bellatrix.Body.ExecutionPayload.FeeRecipient,
+					StateRoot:        block.Bellatrix.Body.ExecutionPayload.StateRoot,
+					ReceiptsRoot:     block.Bellatrix.Body.ExecutionPayload.ReceiptsRoot,
+					LogsBloom:        block.Bellatrix.Body.ExecutionPayload.LogsBloom,
+					PrevRandao:       block.Bellatrix.Body.ExecutionPayload.PrevRandao,
+					BlockNumber:      block.Bellatrix.Body.ExecutionPayload.BlockNumber,
+					GasLimit:         block.Bellatrix.Body.ExecutionPayload.GasLimit,
+					GasUsed:          block.Bellatrix.Body.ExecutionPayload.GasUsed,
+					Timestamp:        block.Bellatrix.Body.ExecutionPayload.Timestamp,
+					ExtraData:        block.Bellatrix.Body.ExecutionPayload.ExtraData,
+					BaseFeePerGas:    block.Bellatrix.Body.ExecutionPayload.BaseFeePerGas,
+					BlockHash:        block.Bellatrix.Body.ExecutionPayload.BlockHash,
+					TransactionsRoot: eth2p0.Root{}, // Use empty root.
+				},
+			},
+		},
+	}, nil
+}
+
+// syntheticBlock returns a synthetic beacon block to propose.
+func (h *synthWrapper) syntheticBlock(ctx context.Context, slot eth2p0.Slot) (*spec.VersionedBeaconBlock, error) {
+	var (
+		signedBlock *spec.VersionedSignedBeaconBlock
+		blockSlot   = slot - 1 // Start with previous slot.
+	)
+	for {
+		var err error
+		signedBlock, err = h.Client.SignedBeaconBlock(ctx, fmt.Sprint(blockSlot))
+		if err != nil {
+			return nil, err
+		} else if signedBlock == nil {
+			// Try previous slot
+			blockSlot--
+			continue
+		}
+
+		break
+	}
+
+	var synthGraffiti [32]byte
+	copy(synthGraffiti[:], syntheticBlockGraffiti)
+
+	block := &spec.VersionedBeaconBlock{Version: signedBlock.Version}
+
+	switch signedBlock.Version {
+	case spec.DataVersionPhase0:
+		block.Phase0 = signedBlock.Phase0.Message
+		block.Phase0.Body.Graffiti = synthGraffiti
+	case spec.DataVersionAltair:
+		block.Altair = signedBlock.Altair.Message
+		block.Altair.Body.Graffiti = synthGraffiti
+	case spec.DataVersionBellatrix:
+		block.Bellatrix = signedBlock.Bellatrix.Message
+		block.Bellatrix.Body.Graffiti = synthGraffiti
+	case spec.DataVersionCapella:
+		block.Capella = signedBlock.Capella.Message
+		block.Capella.Body.Graffiti = synthGraffiti
+	}
+
+	return block, nil
 }
 
 // SubmitBlindedBeaconBlock submits a blinded beacon block or swallows it if marked as synthetic.

--- a/core/bcast/bcast_test.go
+++ b/core/bcast/bcast_test.go
@@ -154,7 +154,7 @@ func blindedBeaconBlockData(t *testing.T, mock *beaconmock.Mock) test {
 	block1 := eth2api.VersionedSignedBlindedBeaconBlock{
 		Version: spec.DataVersionBellatrix,
 		Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-			Message:   testutil.RandomBellatrixBlindedBeaconBlock(t),
+			Message:   testutil.RandomBellatrixBlindedBeaconBlock(),
 			Signature: testutil.RandomEth2Signature(),
 		},
 	}

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -411,7 +411,7 @@ func TestMemDBBuilderProposer(t *testing.T) {
 	for i := 0; i < queries; i++ {
 		blocks[i] = &eth2api.VersionedBlindedBeaconBlock{
 			Version:   spec.DataVersionBellatrix,
-			Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(t),
+			Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(),
 		}
 		blocks[i].Bellatrix.Slot = eth2p0.Slot(slots[i])
 		blocks[i].Bellatrix.ProposerIndex = eth2p0.ValidatorIndex(i)
@@ -444,12 +444,12 @@ func TestMemDBClashingBlindedBlocks(t *testing.T) {
 	const slot = 123
 	block1 := &eth2api.VersionedBlindedBeaconBlock{
 		Version:   spec.DataVersionBellatrix,
-		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(t),
+		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(),
 	}
 	block1.Bellatrix.Slot = eth2p0.Slot(slot)
 	block2 := &eth2api.VersionedBlindedBeaconBlock{
 		Version:   spec.DataVersionBellatrix,
-		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(t),
+		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(),
 	}
 	block2.Bellatrix.Slot = eth2p0.Slot(slot)
 	pubkey := testutil.RandomCorePubKey(t)
@@ -482,7 +482,7 @@ func TestMemDBClashBuilderProposer(t *testing.T) {
 
 	block := &eth2api.VersionedBlindedBeaconBlock{
 		Version:   spec.DataVersionBellatrix,
-		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(t),
+		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(),
 	}
 	block.Bellatrix.Slot = eth2p0.Slot(slot)
 	pubkey := testutil.RandomCorePubKey(t)
@@ -538,7 +538,7 @@ func TestDutyExpiry(t *testing.T) {
 
 	// Store another duty which deletes expired duties
 	err = db.Store(ctx, core.NewProposerDuty(slot+1), core.UnsignedDataSet{
-		testutil.RandomCorePubKey(t): testutil.RandomCoreVersionBeaconBlock(t),
+		testutil.RandomCorePubKey(t): testutil.RandomCoreVersionBeaconBlock(),
 	})
 	require.NoError(t, err)
 

--- a/core/eth2signeddata_test.go
+++ b/core/eth2signeddata_test.go
@@ -42,11 +42,11 @@ func TestVerifyEth2SignedData(t *testing.T) {
 		},
 		{
 			name: "verify beacon block",
-			data: testutil.RandomCoreVersionSignedBeaconBlock(t),
+			data: testutil.RandomCoreVersionSignedBeaconBlock(),
 		},
 		{
 			name: "verify blinded beacon block",
-			data: testutil.RandomCoreVersionSignedBlindedBeaconBlock(t),
+			data: testutil.RandomCoreVersionSignedBlindedBeaconBlock(),
 		},
 		{
 			name: "verify randao",

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -164,7 +164,7 @@ func TestParSigExVerifier(t *testing.T) {
 	})
 
 	t.Run("Verify block", func(t *testing.T) {
-		block := testutil.RandomVersionSignedBeaconBlock(t)
+		block := testutil.RandomVersionSignedBeaconBlock()
 		block.Bellatrix.Message.Slot = slot
 		sigRoot, err := block.Root()
 		require.NoError(t, err)
@@ -178,7 +178,7 @@ func TestParSigExVerifier(t *testing.T) {
 	})
 
 	t.Run("Verify blinded block", func(t *testing.T) {
-		blindedBlock := testutil.RandomVersionSignedBlindedBeaconBlock(t)
+		blindedBlock := testutil.RandomVersionSignedBlindedBeaconBlock()
 		blindedBlock.Bellatrix.Message.Slot = slot
 		sigRoot, err := blindedBlock.Root()
 		require.NoError(t, err)

--- a/core/proto_test.go
+++ b/core/proto_test.go
@@ -54,11 +54,11 @@ func TestParSignedDataSetProto(t *testing.T) {
 		},
 		{
 			Type: core.DutyProposer,
-			Data: testutil.RandomCoreVersionSignedBeaconBlock(t),
+			Data: testutil.RandomCoreVersionSignedBeaconBlock(),
 		},
 		{
 			Type: core.DutyBuilderProposer,
-			Data: testutil.RandomCoreVersionSignedBlindedBeaconBlock(t),
+			Data: testutil.RandomCoreVersionSignedBlindedBeaconBlock(),
 		},
 		{
 			Type: core.DutyBuilderRegistration,
@@ -128,11 +128,11 @@ func TestUnsignedDataToProto(t *testing.T) {
 		},
 		{
 			Type: core.DutyProposer,
-			Data: testutil.RandomCoreVersionBeaconBlock(t),
+			Data: testutil.RandomCoreVersionBeaconBlock(),
 		},
 		{
 			Type: core.DutyBuilderProposer,
-			Data: testutil.RandomCoreVersionBlindedBeaconBlock(t),
+			Data: testutil.RandomCoreVersionBlindedBeaconBlock(),
 		},
 		{
 			Type: core.DutyAggregator,
@@ -233,8 +233,8 @@ func randomSignedData(t *testing.T) map[core.DutyType]core.SignedData {
 	return map[core.DutyType]core.SignedData{
 		core.DutyAttester:                core.NewAttestation(testutil.RandomAttestation()),
 		core.DutyExit:                    core.NewSignedVoluntaryExit(testutil.RandomExit()),
-		core.DutyRandao:                  core.SignedRandao{eth2util.SignedEpoch{Epoch: testutil.RandomEpoch(), Signature: testutil.RandomEth2Signature()}},
-		core.DutyProposer:                testutil.RandomCoreVersionSignedBeaconBlock(t),
+		core.DutyRandao:                  core.SignedRandao{SignedEpoch: eth2util.SignedEpoch{Epoch: testutil.RandomEpoch(), Signature: testutil.RandomEth2Signature()}},
+		core.DutyProposer:                testutil.RandomCoreVersionSignedBeaconBlock(),
 		core.DutyPrepareAggregator:       testutil.RandomCoreBeaconCommitteeSelection(),
 		core.DutyAggregator:              core.NewSignedAggregateAndProof(testutil.RandomSignedAggregateAndProof()),
 		core.DutyPrepareSyncContribution: core.NewSyncCommitteeSelection(testutil.RandomSyncCommitteeSelection()),

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -242,7 +242,7 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			block: &spec.VersionedSignedBeaconBlock{
 				Version: spec.DataVersionAltair,
 				Altair: &altair.SignedBeaconBlock{
-					Message:   testutil.RandomAltairBeaconBlock(t),
+					Message:   testutil.RandomAltairBeaconBlock(),
 					Signature: testutil.RandomEth2Signature(),
 				},
 			},
@@ -252,7 +252,7 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			block: &spec.VersionedSignedBeaconBlock{
 				Version: spec.DataVersionBellatrix,
 				Bellatrix: &bellatrix.SignedBeaconBlock{
-					Message:   testutil.RandomBellatrixBeaconBlock(t),
+					Message:   testutil.RandomBellatrixBeaconBlock(),
 					Signature: testutil.RandomEth2Signature(),
 				},
 			},
@@ -337,7 +337,7 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			block: &eth2api.VersionedSignedBlindedBeaconBlock{
 				Version: spec.DataVersionBellatrix,
 				Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-					Message:   testutil.RandomBellatrixBlindedBeaconBlock(t),
+					Message:   testutil.RandomBellatrixBlindedBeaconBlock(),
 					Signature: testutil.RandomEth2Signature(),
 				},
 			},

--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -42,7 +42,7 @@ func TestSignedDataSetSignature(t *testing.T) {
 				VersionedSignedBeaconBlock: spec.VersionedSignedBeaconBlock{
 					Version: spec.DataVersionBellatrix,
 					Bellatrix: &bellatrix.SignedBeaconBlock{
-						Message:   testutil.RandomBellatrixBeaconBlock(t),
+						Message:   testutil.RandomBellatrixBeaconBlock(),
 						Signature: testutil.RandomEth2Signature(),
 					},
 				},
@@ -54,7 +54,7 @@ func TestSignedDataSetSignature(t *testing.T) {
 				VersionedSignedBlindedBeaconBlock: eth2api.VersionedSignedBlindedBeaconBlock{
 					Version: spec.DataVersionBellatrix,
 					Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-						Message:   testutil.RandomBellatrixBlindedBeaconBlock(t),
+						Message:   testutil.RandomBellatrixBlindedBeaconBlock(),
 						Signature: testutil.RandomEth2Signature(),
 					},
 				},

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -948,7 +948,7 @@ func TestAnalyseParSigs(t *testing.T) {
 	var events []event
 
 	makeEvents := func(n int, pubkey string) {
-		data := testutil.RandomCoreVersionSignedBeaconBlock(t)
+		data := testutil.RandomCoreVersionSignedBeaconBlock()
 		offset := len(events)
 		for i := 0; i < n; i++ {
 			data, err := data.SetSignature(testutil.RandomCoreSignature())

--- a/core/unsigneddata_test.go
+++ b/core/unsigneddata_test.go
@@ -35,11 +35,11 @@ func TestUnsignedDataClone(t *testing.T) {
 		},
 		{
 			name: "versioned beacon block",
-			data: testutil.RandomCoreVersionBeaconBlock(t),
+			data: testutil.RandomCoreVersionBeaconBlock(),
 		},
 		{
 			name: "versioned blinded beacon block",
-			data: testutil.RandomCoreVersionBlindedBeaconBlock(t),
+			data: testutil.RandomCoreVersionBlindedBeaconBlock(),
 		},
 		{
 			name: "aggregated attestation",

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -150,7 +150,7 @@ func TestRawRouter(t *testing.T) {
 		handler := testHandler{}
 		handler.BeaconBlockProposalFunc = func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error) {
 			require.Empty(t, graffiti)
-			resp := testutil.RandomCoreVersionBeaconBlock(t).VersionedBeaconBlock
+			resp := testutil.RandomCoreVersionBeaconBlock().VersionedBeaconBlock
 
 			return &resp, nil
 		}
@@ -601,7 +601,7 @@ func TestRouter(t *testing.T) {
 		block1 := &spec.VersionedSignedBeaconBlock{
 			Version: spec.DataVersionAltair,
 			Altair: &altair.SignedBeaconBlock{
-				Message:   testutil.RandomAltairBeaconBlock(t),
+				Message:   testutil.RandomAltairBeaconBlock(),
 				Signature: testutil.RandomEth2Signature(),
 			},
 		}
@@ -624,7 +624,7 @@ func TestRouter(t *testing.T) {
 		block1 := &spec.VersionedSignedBeaconBlock{
 			Version: spec.DataVersionBellatrix,
 			Bellatrix: &bellatrix.SignedBeaconBlock{
-				Message:   testutil.RandomBellatrixBeaconBlock(t),
+				Message:   testutil.RandomBellatrixBeaconBlock(),
 				Signature: testutil.RandomEth2Signature(),
 			},
 		}
@@ -647,7 +647,7 @@ func TestRouter(t *testing.T) {
 		block1 := &eth2api.VersionedSignedBlindedBeaconBlock{
 			Version: spec.DataVersionBellatrix,
 			Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-				Message:   testutil.RandomBellatrixBlindedBeaconBlock(t),
+				Message:   testutil.RandomBellatrixBlindedBeaconBlock(),
 				Signature: testutil.RandomEth2Signature(),
 			},
 		}

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -598,7 +598,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 			block: &spec.VersionedSignedBeaconBlock{
 				Version: spec.DataVersionAltair,
 				Altair: &altair.SignedBeaconBlock{
-					Message:   &altair.BeaconBlock{Slot: eth2p0.Slot(123), Body: testutil.RandomAltairBeaconBlockBody(t)},
+					Message:   &altair.BeaconBlock{Slot: eth2p0.Slot(123), Body: testutil.RandomAltairBeaconBlockBody()},
 					Signature: eth2p0.BLSSignature{},
 				},
 			},
@@ -609,7 +609,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 			block: &spec.VersionedSignedBeaconBlock{
 				Version: spec.DataVersionBellatrix,
 				Bellatrix: &bellatrix.SignedBeaconBlock{
-					Message:   &bellatrix.BeaconBlock{Slot: eth2p0.Slot(123), Body: testutil.RandomBellatrixBeaconBlockBody(t)},
+					Message:   &bellatrix.BeaconBlock{Slot: eth2p0.Slot(123), Body: testutil.RandomBellatrixBeaconBlockBody()},
 					Signature: eth2p0.BLSSignature{},
 				},
 			},
@@ -656,7 +656,7 @@ func TestComponent_BlindedBeaconBlockProposal(t *testing.T) {
 
 	block1 := &eth2api.VersionedBlindedBeaconBlock{
 		Version:   spec.DataVersionPhase0,
-		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(t),
+		Bellatrix: testutil.RandomBellatrixBlindedBeaconBlock(),
 	}
 	block1.Bellatrix.Slot = slot
 	block1.Bellatrix.ProposerIndex = vIdx
@@ -715,7 +715,7 @@ func TestComponent_SubmitBlindedBeaconBlock(t *testing.T) {
 	sig, err := tbls.Sign(secret, msg)
 	require.NoError(t, err)
 
-	unsignedBlindedBlock := testutil.RandomBellatrixBlindedBeaconBlock(t)
+	unsignedBlindedBlock := testutil.RandomBellatrixBlindedBeaconBlock()
 	unsignedBlindedBlock.Body.RANDAOReveal = tblsconv.SigToETH2(sig)
 	unsignedBlindedBlock.Slot = slot
 	unsignedBlindedBlock.ProposerIndex = vIdx
@@ -789,7 +789,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	sig, err := tbls.Sign(secret, msg)
 	require.NoError(t, err)
 
-	unsignedBlindedBlock := testutil.RandomBellatrixBlindedBeaconBlock(t)
+	unsignedBlindedBlock := testutil.RandomBellatrixBlindedBeaconBlock()
 	unsignedBlindedBlock.Body.RANDAOReveal = tblsconv.SigToETH2(sig)
 	unsignedBlindedBlock.Slot = slot
 	unsignedBlindedBlock.ProposerIndex = vIdx
@@ -869,7 +869,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidBlock(t *testing.T) {
 			block: &eth2api.VersionedSignedBlindedBeaconBlock{
 				Version: spec.DataVersionBellatrix,
 				Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-					Message:   &eth2v1.BlindedBeaconBlock{Slot: eth2p0.Slot(123), Body: testutil.RandomBellatrixBlindedBeaconBlockBody(t)},
+					Message:   &eth2v1.BlindedBeaconBlock{Slot: eth2p0.Slot(123), Body: testutil.RandomBellatrixBlindedBeaconBlockBody()},
 					Signature: eth2p0.BLSSignature{},
 				},
 			},

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -138,6 +138,7 @@ type Mock struct {
 	BeaconCommitteesFunc                   func(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error)
 	BeaconBlockProposalFunc                func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*spec.VersionedBeaconBlock, error)
 	BeaconBlockRootFunc                    func(ctx context.Context, blockID string) (*eth2p0.Root, error)
+	SignedBeaconBlockFunc                  func(ctx context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error)
 	ProposerDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
 	SubmitAttestationsFunc                 func(context.Context, []*eth2p0.Attestation) error
 	SubmitBeaconBlockFunc                  func(context.Context, *spec.VersionedSignedBeaconBlock) error
@@ -277,6 +278,10 @@ func (m Mock) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscription
 
 func (m Mock) SubmitProposalPreparations(ctx context.Context, preparations []*eth2v1.ProposalPreparation) error {
 	return m.SubmitProposalPreparationsFunc(ctx, preparations)
+}
+
+func (m Mock) SignedBeaconBlock(ctx context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error) {
+	return m.SignedBeaconBlockFunc(ctx, blockID)
 }
 
 func (m Mock) SlotsPerEpoch(ctx context.Context) (uint64, error) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -484,6 +485,15 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 					},
 				},
 			}, nil
+		},
+		SignedBeaconBlockFunc: func(_ context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error) {
+			block := testutil.RandomVersionSignedBeaconBlock()
+
+			if slot, err := strconv.ParseInt(blockID, 10, 64); err == nil {
+				block.Bellatrix.Message.Slot = eth2p0.Slot(slot)
+			}
+
+			return block, nil
 		},
 		ProposerDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
 			return []*eth2v1.ProposerDuty{}, nil

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -142,21 +142,17 @@ func RandomPhase0BeaconBlockBody() *eth2p0.BeaconBlockBody {
 	}
 }
 
-func RandomAltairBeaconBlock(t *testing.T) *altair.BeaconBlock {
-	t.Helper()
-
+func RandomAltairBeaconBlock() *altair.BeaconBlock {
 	return &altair.BeaconBlock{
 		Slot:          RandomSlot(),
 		ProposerIndex: RandomVIdx(),
 		ParentRoot:    RandomRoot(),
 		StateRoot:     RandomRoot(),
-		Body:          RandomAltairBeaconBlockBody(t),
+		Body:          RandomAltairBeaconBlockBody(),
 	}
 }
 
-func RandomAltairBeaconBlockBody(t *testing.T) *altair.BeaconBlockBody {
-	t.Helper()
-
+func RandomAltairBeaconBlockBody() *altair.BeaconBlockBody {
 	return &altair.BeaconBlockBody{
 		RANDAOReveal: RandomEth2Signature(),
 		ETH1Data: &eth2p0.ETH1Data{
@@ -170,25 +166,21 @@ func RandomAltairBeaconBlockBody(t *testing.T) *altair.BeaconBlockBody {
 		Attestations:      []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
 		Deposits:          []*eth2p0.Deposit{},
 		VoluntaryExits:    []*eth2p0.SignedVoluntaryExit{},
-		SyncAggregate:     RandomSyncAggregate(t),
+		SyncAggregate:     RandomSyncAggregate(),
 	}
 }
 
-func RandomBellatrixBeaconBlock(t *testing.T) *bellatrix.BeaconBlock {
-	t.Helper()
-
+func RandomBellatrixBeaconBlock() *bellatrix.BeaconBlock {
 	return &bellatrix.BeaconBlock{
 		Slot:          RandomSlot(),
 		ProposerIndex: RandomVIdx(),
 		ParentRoot:    RandomRoot(),
 		StateRoot:     RandomRoot(),
-		Body:          RandomBellatrixBeaconBlockBody(t),
+		Body:          RandomBellatrixBeaconBlockBody(),
 	}
 }
 
-func RandomBellatrixBeaconBlockBody(t *testing.T) *bellatrix.BeaconBlockBody {
-	t.Helper()
-
+func RandomBellatrixBeaconBlockBody() *bellatrix.BeaconBlockBody {
 	return &bellatrix.BeaconBlockBody{
 		RANDAOReveal: RandomEth2Signature(),
 		ETH1Data: &eth2p0.ETH1Data{
@@ -202,63 +194,53 @@ func RandomBellatrixBeaconBlockBody(t *testing.T) *bellatrix.BeaconBlockBody {
 		Attestations:      []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
 		Deposits:          []*eth2p0.Deposit{},
 		VoluntaryExits:    []*eth2p0.SignedVoluntaryExit{},
-		SyncAggregate:     RandomSyncAggregate(t),
+		SyncAggregate:     RandomSyncAggregate(),
 		ExecutionPayload:  RandomExecutionPayLoad(),
 	}
 }
 
-func RandomCoreVersionBeaconBlock(t *testing.T) core.VersionedBeaconBlock {
-	t.Helper()
-
+func RandomCoreVersionBeaconBlock() core.VersionedBeaconBlock {
 	return core.VersionedBeaconBlock{
 		VersionedBeaconBlock: spec.VersionedBeaconBlock{
 			Version:   spec.DataVersionBellatrix,
-			Bellatrix: RandomBellatrixBeaconBlock(t),
+			Bellatrix: RandomBellatrixBeaconBlock(),
 		},
 	}
 }
 
-func RandomCoreVersionSignedBeaconBlock(t *testing.T) core.VersionedSignedBeaconBlock {
-	t.Helper()
-
+func RandomCoreVersionSignedBeaconBlock() core.VersionedSignedBeaconBlock {
 	return core.VersionedSignedBeaconBlock{
 		VersionedSignedBeaconBlock: spec.VersionedSignedBeaconBlock{
 			Version: spec.DataVersionBellatrix,
 			Bellatrix: &bellatrix.SignedBeaconBlock{
-				Message:   RandomBellatrixBeaconBlock(t),
+				Message:   RandomBellatrixBeaconBlock(),
 				Signature: RandomEth2Signature(),
 			},
 		},
 	}
 }
 
-func RandomVersionSignedBeaconBlock(t *testing.T) *spec.VersionedSignedBeaconBlock {
-	t.Helper()
-
+func RandomVersionSignedBeaconBlock() *spec.VersionedSignedBeaconBlock {
 	return &spec.VersionedSignedBeaconBlock{
 		Version: spec.DataVersionBellatrix,
 		Bellatrix: &bellatrix.SignedBeaconBlock{
-			Message:   RandomBellatrixBeaconBlock(t),
+			Message:   RandomBellatrixBeaconBlock(),
 			Signature: RandomEth2Signature(),
 		},
 	}
 }
 
-func RandomBellatrixBlindedBeaconBlock(t *testing.T) *eth2v1.BlindedBeaconBlock {
-	t.Helper()
-
+func RandomBellatrixBlindedBeaconBlock() *eth2v1.BlindedBeaconBlock {
 	return &eth2v1.BlindedBeaconBlock{
 		Slot:          RandomSlot(),
 		ProposerIndex: RandomVIdx(),
 		ParentRoot:    RandomRoot(),
 		StateRoot:     RandomRoot(),
-		Body:          RandomBellatrixBlindedBeaconBlockBody(t),
+		Body:          RandomBellatrixBlindedBeaconBlockBody(),
 	}
 }
 
-func RandomBellatrixBlindedBeaconBlockBody(t *testing.T) *eth2v1.BlindedBeaconBlockBody {
-	t.Helper()
-
+func RandomBellatrixBlindedBeaconBlockBody() *eth2v1.BlindedBeaconBlockBody {
 	return &eth2v1.BlindedBeaconBlockBody{
 		RANDAOReveal: RandomEth2Signature(),
 		ETH1Data: &eth2p0.ETH1Data{
@@ -272,43 +254,37 @@ func RandomBellatrixBlindedBeaconBlockBody(t *testing.T) *eth2v1.BlindedBeaconBl
 		Attestations:           []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
 		Deposits:               []*eth2p0.Deposit{},
 		VoluntaryExits:         []*eth2p0.SignedVoluntaryExit{},
-		SyncAggregate:          RandomSyncAggregate(t),
+		SyncAggregate:          RandomSyncAggregate(),
 		ExecutionPayloadHeader: RandomExecutionPayloadHeader(),
 	}
 }
 
-func RandomCoreVersionBlindedBeaconBlock(t *testing.T) core.VersionedBlindedBeaconBlock {
-	t.Helper()
-
+func RandomCoreVersionBlindedBeaconBlock() core.VersionedBlindedBeaconBlock {
 	return core.VersionedBlindedBeaconBlock{
 		VersionedBlindedBeaconBlock: eth2api.VersionedBlindedBeaconBlock{
 			Version:   spec.DataVersionBellatrix,
-			Bellatrix: RandomBellatrixBlindedBeaconBlock(t),
+			Bellatrix: RandomBellatrixBlindedBeaconBlock(),
 		},
 	}
 }
 
-func RandomCoreVersionSignedBlindedBeaconBlock(t *testing.T) core.VersionedSignedBlindedBeaconBlock {
-	t.Helper()
-
+func RandomCoreVersionSignedBlindedBeaconBlock() core.VersionedSignedBlindedBeaconBlock {
 	return core.VersionedSignedBlindedBeaconBlock{
 		VersionedSignedBlindedBeaconBlock: eth2api.VersionedSignedBlindedBeaconBlock{
 			Version: spec.DataVersionBellatrix,
 			Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-				Message:   RandomBellatrixBlindedBeaconBlock(t),
+				Message:   RandomBellatrixBlindedBeaconBlock(),
 				Signature: RandomEth2Signature(),
 			},
 		},
 	}
 }
 
-func RandomVersionSignedBlindedBeaconBlock(t *testing.T) *eth2api.VersionedSignedBlindedBeaconBlock {
-	t.Helper()
-
+func RandomVersionSignedBlindedBeaconBlock() *eth2api.VersionedSignedBlindedBeaconBlock {
 	return &eth2api.VersionedSignedBlindedBeaconBlock{
 		Version: spec.DataVersionBellatrix,
 		Bellatrix: &eth2v1.SignedBlindedBeaconBlock{
-			Message:   RandomBellatrixBlindedBeaconBlock(t),
+			Message:   RandomBellatrixBlindedBeaconBlock(),
 			Signature: RandomEth2Signature(),
 		},
 	}
@@ -450,14 +426,14 @@ func RandomSyncCommitteeDuty(t *testing.T) *eth2v1.SyncCommitteeDuty {
 	}
 }
 
-func RandomSyncAggregate(t *testing.T) *altair.SyncAggregate {
-	t.Helper()
-
+func RandomSyncAggregate() *altair.SyncAggregate {
 	var syncSSZ [160]byte
 	_, _ = rand.Read(syncSSZ[:])
 	sync := new(altair.SyncAggregate)
 	err := sync.UnmarshalSSZ(syncSSZ[:])
-	require.NoError(t, err)
+	if err != nil {
+		panic(err) // Should never happen, and this is test code.
+	}
 
 	return sync
 }

--- a/testutil/validatormock/validatormock_test.go
+++ b/testutil/validatormock/validatormock_test.go
@@ -182,7 +182,7 @@ func TestProposeBlindedBlock(t *testing.T) {
 	slotsPerEpoch, err := beaconMock.SlotsPerEpoch(ctx)
 	require.NoError(t, err)
 
-	block := testutil.RandomBellatrixBlindedBeaconBlock(t)
+	block := testutil.RandomBellatrixBlindedBeaconBlock()
 	block.Slot = eth2p0.Slot(slotsPerEpoch)
 
 	mockVAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Query previous blocks to propose as synthetic blocks since only proposers can query the block_proposal endpoint.

category: bug
ticket: #1486 