### PR TITLE
core/priority: fix flapping test

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -840,6 +840,7 @@ func Protocols() []protocol.ID {
 	resp = append(resp, consensus.Protocols()...)
 	resp = append(resp, parsigex.Protocols()...)
 	resp = append(resp, peerinfo.Protocols()...)
+	resp = append(resp, priority.Protocols()...)
 
 	return resp
 }

--- a/app/app.go
+++ b/app/app.go
@@ -34,7 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/automaxprocs/maxprocs"
 
@@ -109,8 +108,6 @@ type TestConfig struct {
 	LcastTransportFunc func() leadercast.Transport
 	// SimnetKeys provides private key shares for the simnet validatormock signer.
 	SimnetKeys []*bls_sig.SecretKey
-	// PeerAddrs contain peer addresses to manually add to the tcp node peer store.
-	PeerAddrs []peer.AddrInfo
 	// SimnetBMockOpts defines additional simnet beacon mock options.
 	SimnetBMockOpts []beaconmock.Option
 	// BroadcastCallback is called when a duty is completed and sent to the broadcast component.
@@ -119,6 +116,8 @@ type TestConfig struct {
 	BuilderRegistration <-chan *eth2api.VersionedValidatorRegistration
 	// PrioritiseCallback is called with priority protocol results.
 	PrioritiseCallback func(context.Context, core.Duty, []priority.TopicResult) error
+	// TCPNodeCallback provides test logic access to the libp2p host.
+	TCPNodeCallback func(host.Host)
 }
 
 // Run is the entrypoint for running a charon DVC instance.
@@ -295,9 +294,8 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return nil, nil, err
 	}
 
-	// Add test peer address
-	for _, pa := range conf.TestConfig.PeerAddrs {
-		tcpNode.Peerstore().AddAddrs(pa.ID, pa.Addrs, peerstore.PermanentAddrTTL)
+	if conf.TestConfig.TCPNodeCallback != nil {
+		conf.TestConfig.TCPNodeCallback(tcpNode)
 	}
 
 	p2p.RegisterConnectionLogger(tcpNode, peerIDs)

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
@@ -59,8 +60,8 @@ func TestPrioritiser(t *testing.T) {
 		for _, other := range tcpNodes {
 			tcpNode.Peerstore().AddAddrs(other.ID(), other.Addrs(), peerstore.PermanentAddrTTL)
 			other.Peerstore().AddAddrs(tcpNode.ID(), tcpNode.Addrs(), peerstore.PermanentAddrTTL)
-			require.NoError(t, tcpNode.Peerstore().AddProtocols(other.ID(), priority.ProtocolID))
-			require.NoError(t, other.Peerstore().AddProtocols(tcpNode.ID(), priority.ProtocolID))
+			require.NoError(t, tcpNode.Peerstore().AddProtocols(other.ID(), toStrs(priority.Protocols())...))
+			require.NoError(t, other.Peerstore().AddProtocols(tcpNode.ID(), toStrs(priority.Protocols())...))
 		}
 		tcpNodes = append(tcpNodes, tcpNode)
 		peers = append(peers, tcpNode.ID())
@@ -196,4 +197,13 @@ func mustResultsToText(msgs []*pbv1.PriorityTopicResult) string {
 func requireProtoEqual(t *testing.T, expect, actual proto.Message) {
 	t.Helper()
 	require.True(t, proto.Equal(expect, actual), "expected: %#v\nactual: %#v\n", expect, actual)
+}
+
+func toStrs(protocols []protocol.ID) []string {
+	var resp []string
+	for _, p := range protocols {
+		resp = append(resp, string(p))
+	}
+
+	return resp
 }


### PR DESCRIPTION
Hardcode peer protocols during infosync test to fix flapping test where one peer didn't think the other peers don't support priority protocol which isn't automatically resolved within the 10s timeout. 

category: test 
ticket: none

