### PR TITLE
cmd/bootnode: instrument peer connections

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: docker pull consensys/teku:latest
-      - run: go test -timeout=5m github.com/obolnetwork/charon/app -integration -slow
+      - run: go test -v -timeout=5m github.com/obolnetwork/charon/app -integration -slow
 
   compose_tests:
     runs-on: ubuntu-latest

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -281,8 +281,7 @@ func pingCluster(t *testing.T, test pingTest) {
 
 	err := eg.Wait()
 	testutil.SkipIfBindErr(t, err)
-
-	require.NoError(t, err)
+	testutil.RequireNoError(t, err)
 }
 
 // startBootnode starts a charon bootnode and returns its http ENR endpoint.

--- a/app/peerinfo/adhoc.go
+++ b/app/peerinfo/adhoc.go
@@ -1,0 +1,50 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package peerinfo
+
+import (
+	"context"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	pbv1 "github.com/obolnetwork/charon/app/peerinfo/peerinfopb/v1"
+	"github.com/obolnetwork/charon/p2p"
+)
+
+// DoOnce returns the peer info and RTT and true of the given peer,
+// or false if the peer doesn't support the protocol,
+// or an error.
+func DoOnce(ctx context.Context, tcpNode host.Host, peerID peer.ID) (*pbv1.PeerInfo, time.Duration, bool, error) {
+	supported, known := p2p.ProtocolSupported(tcpNode, peerID, protocolID)
+	if !known || !supported {
+		return nil, 0, false, nil
+	}
+
+	var rtt time.Duration
+	rttCallback := func(d time.Duration) {
+		rtt = d
+	}
+
+	resp := new(pbv1.PeerInfo)
+	err := p2p.SendReceive(ctx, tcpNode, peerID, &pbv1.PeerInfo{}, resp, protocolID, p2p.WithSendReceiveRTT(rttCallback))
+	if err != nil {
+		return nil, 0, false, err
+	}
+
+	return resp, rtt, true, nil
+}

--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -165,11 +165,11 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			continue // Do not send to self.
 		}
 
-		// Check if peer supports this protocol.
-		if protocols, err := p.tcpNode.Peerstore().GetProtocols(peerID); err != nil || len(protocols) == 0 {
+		supported, known := p2p.ProtocolSupported(p.tcpNode, peerID, protocolID)
+		if !known {
 			// Ignore peer until some protocols detected
 			continue
-		} else if !supported(protocols) {
+		} else if !supported {
 			log.Warn(ctx, "Non-critical peerinfo protocol not supported by peer", nil,
 				z.Str("peer", p2p.PeerName(peerID)),
 				p.noSupportFilters[peerID],
@@ -214,19 +214,6 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			}
 		}(peerID)
 	}
-}
-
-// supported returns true if the peerinfo protocolID is included in the list of protocols.
-func supported(protocols []string) bool {
-	var supported bool
-	for _, p := range protocols {
-		if p == string(protocolID) {
-			supported = true
-			break
-		}
-	}
-
-	return supported
 }
 
 // newMetricsSubmitter returns a prometheus metric submitter.

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -137,8 +137,9 @@ func TestSimnetDuties(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.teku && !*integration {
-				t.Skip("Skipping Teku integration test")
+				t.Skipf("Skipping Teku integration test: %v", t.Name())
 			}
+			t.Logf("Running test: %v", t.Name())
 
 			args := newSimnetArgs(t)
 			args.BuilderRegistration = test.builderRegistration

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -418,6 +418,7 @@ var (
 		"validator-client",
 		"--network=auto",
 		"--log-destination=console",
+		"--beacon-node-ssz-blocks-enabled=false",
 		"--validators-proposer-default-fee-recipient=0x000000000000000000000000000000000000dead",
 	}
 	tekuExit tekuCmd = []string{

--- a/cmd/bootnode/metrics.go
+++ b/cmd/bootnode/metrics.go
@@ -23,33 +23,30 @@ import (
 
 var (
 	newConnsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Namespace:   "bootnode",
-		Subsystem:   "p2p",
-		Name:        "connection_total",
-		Help:        "Total number of connections per peers by cluster",
-		ConstLabels: nil,
-	}, []string{"cluster_hash", "peer"})
+		Namespace: "bootnode",
+		Subsystem: "p2p",
+		Name:      "connection_total",
+		Help:      "Total number of connections by peer and cluster",
+	}, []string{"peer", "peer_cluster"})
 
 	bandwidthInGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:   "bootnode",
-		Subsystem:   "p2p",
-		Name:        "bandwidth_in",
-		Help:        "Bandwidth rate in by peer and cluster",
-		ConstLabels: nil,
-	}, []string{"cluster_hash", "peer"})
+		Namespace: "bootnode",
+		Subsystem: "p2p",
+		Name:      "bandwidth_in",
+		Help:      "Bandwidth rate in by peer and cluster",
+	}, []string{"peer", "peer_cluster"})
 
 	bandwidthOutGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace:   "bootnode",
-		Subsystem:   "p2p",
-		Name:        "bandwidth_out",
-		Help:        "Bandwidth rate out by peer and cluster",
-		ConstLabels: nil,
-	}, []string{"cluster_hash", "peer"})
+		Namespace: "bootnode",
+		Subsystem: "p2p",
+		Name:      "bandwidth_out",
+		Help:      "Bandwidth rate out by peer and cluster",
+	}, []string{"peer", "peer_cluster"})
 
 	peerPingLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "bootnode",
 		Subsystem: "p2p",
 		Name:      "ping_latency",
-		Help:      "Ping latency by peer",
-	}, []string{"cluster_hash", "peer"})
+		Help:      "Ping latency by peer and cluster",
+	}, []string{"peer", "peer_cluster"})
 )

--- a/cmd/bootnode/metrics.go
+++ b/cmd/bootnode/metrics.go
@@ -1,0 +1,55 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package bootnode
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+
+	"github.com/obolnetwork/charon/app/promauto"
+)
+
+var (
+	newConnsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace:   "bootnode",
+		Subsystem:   "p2p",
+		Name:        "connection_total",
+		Help:        "Total number of connections per peers by cluster",
+		ConstLabels: nil,
+	}, []string{"cluster_hash", "peer"})
+
+	bandwidthInGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   "bootnode",
+		Subsystem:   "p2p",
+		Name:        "bandwidth_in",
+		Help:        "Bandwidth rate in by peer and cluster",
+		ConstLabels: nil,
+	}, []string{"cluster_hash", "peer"})
+
+	bandwidthOutGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace:   "bootnode",
+		Subsystem:   "p2p",
+		Name:        "bandwidth_out",
+		Help:        "Bandwidth rate out by peer and cluster",
+		ConstLabels: nil,
+	}, []string{"cluster_hash", "peer"})
+
+	peerPingLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "bootnode",
+		Subsystem: "p2p",
+		Name:      "ping_latency",
+		Help:      "Ping latency by peer",
+	}, []string{"cluster_hash", "peer"})
+)

--- a/cmd/bootnode/p2p.go
+++ b/cmd/bootnode/p2p.go
@@ -129,9 +129,9 @@ func monitorConnections(ctx context.Context, tcpNode host.Host, reporter metrics
 			name := p2p.PeerName(info.ID)
 			stats := reporter.GetBandwidthForPeer(info.ID)
 
-			bandwidthInGauge.WithLabelValues(info.ClusterHash, name).Set(stats.RateIn)
-			bandwidthOutGauge.WithLabelValues(info.ClusterHash, name).Set(stats.RateOut)
-			newConnsCounter.WithLabelValues(info.ClusterHash, name).Add(float64(conns.New))
+			bandwidthInGauge.WithLabelValues(name, info.ClusterHash).Set(stats.RateIn)
+			bandwidthOutGauge.WithLabelValues(name, info.ClusterHash).Set(stats.RateOut)
+			newConnsCounter.WithLabelValues(name, info.ClusterHash).Add(float64(conns.New))
 
 			// Reset new connection state
 			conns.New = 0
@@ -170,7 +170,7 @@ func monitorConnections(ctx context.Context, tcpNode host.Host, reporter metrics
 						hash = unknownCluster
 					} else {
 						hash = clusterHash(info.LockHash)
-						peerPingLatency.WithLabelValues(hash, name).Observe(rtt.Seconds() / 2)
+						peerPingLatency.WithLabelValues(name, hash).Observe(rtt.Seconds() / 2)
 					}
 
 					//  Enqueue peer for instrumentation (async since blocking)

--- a/cmd/bootnode/p2p.go
+++ b/cmd/bootnode/p2p.go
@@ -121,7 +121,7 @@ func monitorConnections(ctx context.Context, tcpNode host.Host, reporter metrics
 		case <-ctx.Done():
 			return
 		case info := <-infos:
-			// Instrument peer every time we get peerinfo response
+			// Instrument peer every time we get peerinfo respsonse
 			conns, ok := peers[info.ID]
 			if !ok {
 				continue // Peer not connected anymore
@@ -133,13 +133,10 @@ func monitorConnections(ctx context.Context, tcpNode host.Host, reporter metrics
 			bandwidthOutGauge.WithLabelValues(info.ClusterHash, name).Set(stats.RateOut)
 			newConnsCounter.WithLabelValues(info.ClusterHash, name).Add(float64(conns.New))
 
-			// Update/reset state
+			// Reset new connection state
 			conns.New = 0
-			if conns.Active == 0 {
-				delete(peers, info.ID)
-			} else {
-				peers[info.ID] = conns
-			}
+			peers[info.ID] = conns
+
 		case e := <-events:
 			// Update peer connection data on libp2p events.
 			conns := peers[e.Peer]

--- a/cmd/bootnode/p2p.go
+++ b/cmd/bootnode/p2p.go
@@ -18,19 +18,28 @@ package bootnode
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
+	"time"
 
 	relaylog "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
+	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/p2p"
 )
 
 // startP2P returns a started libp2p host or an error.
-func startP2P(ctx context.Context, config Config, key *ecdsa.PrivateKey) (host.Host, error) {
+func startP2P(ctx context.Context, config Config, key *ecdsa.PrivateKey, reporter metrics.Reporter) (host.Host, error) {
 	if config.RelayLogLevel != "" {
 		if err := relaylog.SetLogLevel("relay", config.RelayLogLevel); err != nil {
 			return nil, errors.Wrap(err, "set relay log level")
@@ -48,7 +57,8 @@ func startP2P(ctx context.Context, config Config, key *ecdsa.PrivateKey) (host.H
 		return nil, errors.Wrap(err, "new resource manager")
 	}
 
-	tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(), libp2p.ResourceManager(mgr))
+	tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(),
+		libp2p.ResourceManager(mgr), libp2p.BandwidthReporter(reporter))
 	if err != nil {
 		return nil, errors.Wrap(err, "new tcp node")
 	}
@@ -76,3 +86,137 @@ func startP2P(ctx context.Context, config Config, key *ecdsa.PrivateKey) (host.H
 
 	return tcpNode, nil
 }
+
+const unknownCluster = "unknown"
+
+// monitorConnections blocks instrumenting peer connection metrics until the context is closed.
+func monitorConnections(ctx context.Context, tcpNode host.Host, reporter metrics.Reporter) {
+	// peerConns tracks connection data per peer.
+	type peerConns struct {
+		Active int
+		New    int
+	}
+	// peerInfo combines peer ID with cluster hash.
+	type peerInfo struct {
+		ID          peer.ID
+		ClusterHash string
+	}
+
+	// State
+	var (
+		infos  = make(chan peerInfo)
+		peers  = make(map[peer.ID]peerConns)
+		events = make(chan connEvent)
+	)
+
+	// Listen for connection events.
+	tcpNode.Network().Notify(&connLogger{events: events})
+
+	// Schedule regular peerinfo requests to all peers.
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case info := <-infos:
+			// Instrument peer every time we get peerinfo response
+			conns, ok := peers[info.ID]
+			if !ok {
+				continue // Peer not connected anymore
+			}
+			name := p2p.PeerName(info.ID)
+			stats := reporter.GetBandwidthForPeer(info.ID)
+
+			bandwidthInGauge.WithLabelValues(info.ClusterHash, name).Set(stats.RateIn)
+			bandwidthOutGauge.WithLabelValues(info.ClusterHash, name).Set(stats.RateOut)
+			newConnsCounter.WithLabelValues(info.ClusterHash, name).Add(float64(conns.New))
+
+			// Update/reset state
+			conns.New = 0
+			if conns.Active == 0 {
+				delete(peers, info.ID)
+			} else {
+				peers[info.ID] = conns
+			}
+		case e := <-events:
+			// Update peer connection data on libp2p events.
+			conns := peers[e.Peer]
+			if e.Connected {
+				conns.Active++
+				conns.New++
+			} else {
+				conns.Active--
+			}
+			if conns.Active == 0 {
+				delete(peers, e.Peer)
+			} else {
+				peers[e.Peer] = conns
+			}
+		case <-ticker.C:
+			// Periodically request peerinfo for all peers we have connection data for.
+			for p := range peers {
+				go func(p peer.ID) {
+					name := p2p.PeerName(p)
+					var hash string
+					info, rtt, ok, err := peerinfo.DoOnce(ctx, tcpNode, p)
+					if p2p.IsRelayError(err) {
+						// Ignore relay errors, since peer probably not connected anymore.
+						return
+					} else if err != nil {
+						// Log other errors, but peer probably not connected anymore.
+						log.Warn(ctx, "Protocol peerinfo failed", err, z.Str("peer", name))
+						return
+					} else if !ok {
+						// Group peers that don't support the protocol with unknown cluster hash.
+						hash = unknownCluster
+					} else {
+						hash = clusterHash(info.LockHash)
+						peerPingLatency.WithLabelValues(hash, name).Observe(rtt.Seconds() / 2)
+					}
+
+					//  Enqueue peer for instrumentation (async since blocking)
+					go func() {
+						infos <- peerInfo{ClusterHash: hash, ID: p}
+					}()
+				}(p)
+			}
+		}
+	}
+}
+
+// clusterHash returns the cluster hash hex from the lock hash.
+func clusterHash(lockHash []byte) string {
+	return hex.EncodeToString(lockHash)[:7]
+}
+
+// connEvent is a connection event.
+type connEvent struct {
+	Connected bool
+	Peer      peer.ID
+}
+
+// connLogger implements network.Notifee and only sends logEvents on a channel since
+// it is used as a map key internally in libp2p, it cannot contain complex types.
+type connLogger struct {
+	events chan connEvent
+}
+
+func (l connLogger) Connected(_ network.Network, conn network.Conn) {
+	l.events <- connEvent{
+		Connected: true,
+		Peer:      conn.RemotePeer(),
+	}
+}
+
+func (l connLogger) Disconnected(_ network.Network, conn network.Conn) {
+	l.events <- connEvent{
+		Connected: false,
+		Peer:      conn.RemotePeer(),
+	}
+}
+
+func (connLogger) Listen(network.Network, ma.Multiaddr) {}
+
+func (connLogger) ListenClose(network.Network, ma.Multiaddr) {}

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -593,7 +593,7 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
 
 // waitChainStart blocks until the beacon chain has started.
 func waitChainStart(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
-	for {
+	for ctx.Err() == nil {
 		genesis, err := eth2Cl.GenesisTime(ctx)
 		if err != nil {
 			log.Error(ctx, "Failure getting genesis time", err)
@@ -618,7 +618,7 @@ func waitChainStart(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork
 
 // waitBeaconSync blocks until the beacon node is synced.
 func waitBeaconSync(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
-	for {
+	for ctx.Err() == nil {
 		state, err := eth2Cl.NodeSyncing(ctx)
 		if err != nil {
 			log.Error(ctx, "Failure getting sync state", err)

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -98,7 +98,7 @@ func pingPeerOnce(ctx context.Context, svc *ping.PingService, p peer.ID,
 	defer cancel()
 
 	for result := range svc.Ping(ctx, p) {
-		if isRelayError(result.Error) || errors.Is(result.Error, context.Canceled) {
+		if IsRelayError(result.Error) || errors.Is(result.Error, context.Canceled) {
 			// Just exit if relay error or context cancelled.
 			return
 		}
@@ -117,8 +117,8 @@ func pingPeerOnce(ctx context.Context, svc *ping.PingService, p peer.ID,
 	}
 }
 
-// isRelayError returns true if the error is due to temporary relay circuit recycling.
-func isRelayError(err error) bool {
+// IsRelayError returns true if the error is due to temporary relay circuit recycling.
+func IsRelayError(err error) bool {
 	return errors.Is(err, network.ErrReset) ||
 		errors.Is(err, network.ErrResourceScopeClosed)
 }

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -142,7 +142,7 @@ func (s *Sender) SendReceive(ctx context.Context, tcpNode host.Host, peerID peer
 // withRelayRetry wraps a function and retries it once if the error is a relay error.
 func withRelayRetry(fn func() error) error {
 	err := fn()
-	if isRelayError(err) { // Retry once if relay error
+	if IsRelayError(err) { // Retry once if relay error
 		err = fn()
 	}
 
@@ -248,4 +248,21 @@ func Send(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID pe
 	}
 
 	return nil
+}
+
+// ProtocolSupported returns whether the peer supports the protocol or whether this is unknown.
+func ProtocolSupported(tcpNode host.Host, peerID peer.ID, protocolID protocol.ID) (supported bool, known bool) {
+	// Check if peer supports this protocol.
+	protocols, err := tcpNode.Peerstore().GetProtocols(peerID)
+	if err != nil || len(protocols) == 0 {
+		return false, false // Unknown
+	}
+
+	for _, p := range protocols {
+		if p == string(protocolID) {
+			return true, true // Supported
+		}
+	}
+
+	return false, true // Not supported
 }

--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -37,6 +37,7 @@ services:
     depends_on: []
     environment:
       CHARON_BOOTNODE_HTTP_ADDRESS: 0.0.0.0:3640
+      CHARON_BOOTNODE_MONITORING_ADDRESS: 0.0.0.0:3620
       CHARON_DATA_DIR: /compose/bootnode
       CHARON_P2P_BOOTNODES: ""
       CHARON_P2P_EXTERNAL_HOSTNAME: bootnode

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -108,10 +108,9 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 	lockFile := fmt.Sprintf("/compose/node%d/cluster-lock.json", index)
 
 	p2pBootnodes := "http://bootnode:3640/enr"
-	p2pRelay := "false"
+	p2pRelay := "true"
 	if conf.ExternalBootnode != "" {
 		p2pBootnodes = conf.ExternalBootnode
-		p2pRelay = "true"
 	}
 
 	// Common config

--- a/testutil/compose/static/prometheus/prometheus.yml
+++ b/testutil/compose/static/prometheus/prometheus.yml
@@ -3,6 +3,9 @@ global:
   evaluation_interval: 5s # Evaluate rules every 15 seconds. The default is every 1 minute.
 
 scrape_configs:
+  - job_name: 'bootnode'
+    static_configs:
+      - targets: [ 'bootnode:3620' ]
   - job_name: 'node0'
     static_configs:
       - targets: ['node0:3620']

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
@@ -34,7 +34,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",
@@ -89,7 +89,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",
@@ -144,7 +144,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",
@@ -199,7 +199,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -19,7 +19,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node0
@@ -36,7 +36,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node1
@@ -53,7 +53,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node2
@@ -70,7 +70,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node3
@@ -83,6 +83,7 @@ services:
     depends_on: []
     environment:
       CHARON_BOOTNODE_HTTP_ADDRESS: 0.0.0.0:3640
+      CHARON_BOOTNODE_MONITORING_ADDRESS: 0.0.0.0:3620
       CHARON_DATA_DIR: /compose/bootnode
       CHARON_P2P_BOOTNODES: ""
       CHARON_P2P_EXTERNAL_HOSTNAME: bootnode

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -34,7 +34,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",
@@ -142,7 +142,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",
@@ -250,7 +250,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",
@@ -358,7 +358,7 @@
     },
     {
      "Key": "p2p-bootnode-relay",
-     "Value": "\"false\""
+     "Value": "\"true\""
     },
     {
      "Key": "log-level",

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -19,7 +19,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node0
@@ -54,7 +54,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node1
@@ -89,7 +89,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node2
@@ -124,7 +124,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_P2P_BOOTNODES: http://bootnode:3640/enr
-      CHARON_P2P_BOOTNODE_RELAY: "false"
+      CHARON_P2P_BOOTNODE_RELAY: "true"
       CHARON_LOG_LEVEL: debug
       CHARON_FEATURE_SET: alpha
       CHARON_DATA_DIR: /compose/node3
@@ -155,6 +155,7 @@ services:
     depends_on: []
     environment:
       CHARON_BOOTNODE_HTTP_ADDRESS: 0.0.0.0:3640
+      CHARON_BOOTNODE_MONITORING_ADDRESS: 0.0.0.0:3620
       CHARON_DATA_DIR: /compose/bootnode
       CHARON_P2P_BOOTNODES: ""
       CHARON_P2P_EXTERNAL_HOSTNAME: bootnode


### PR DESCRIPTION
Instrument bootnode peer connection count and bandwidth rates via peerinfo protocol to group by cluster hash.

Also added workaround for teku SSZ blocks.

category: feature
ticket: #1521 