### PR TITLE
app/eth2wrap: use validators at head for synthetic blocks

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -784,6 +784,7 @@ func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeReci
 		}
 		onStartup = false
 
+		// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
 		vals, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys)
 		if err != nil {
 			return err

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -261,16 +261,9 @@ func (c *synthProposerCache) Duties(ctx context.Context, eth2Cl synthProposerEth
 		return duties, nil
 	}
 
-	// Get slotsPerEpoch and the starting slot of the epoch.
-	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	epochSlot := eth2p0.Slot(epoch) * eth2p0.Slot(slotsPerEpoch)
-
 	// Get active validators for the epoch
-	vals, err := eth2Cl.ValidatorsByPubKey(ctx, fmt.Sprint(epochSlot), c.pubkeys)
+	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
+	vals, err := eth2Cl.ValidatorsByPubKey(ctx, "head", c.pubkeys)
 	if err != nil {
 		return nil, err
 	}
@@ -288,6 +281,13 @@ func (c *synthProposerCache) Duties(ctx context.Context, eth2Cl synthProposerEth
 	if err != nil {
 		return nil, err
 	}
+
+	// Get slotsPerEpoch and the starting slot of the epoch.
+	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	epochSlot := eth2p0.Slot(epoch) * eth2p0.Slot(slotsPerEpoch)
 
 	// Mark those not requiring synthetic duties.
 	noSynth := make(map[eth2p0.ValidatorIndex]bool)

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -246,7 +246,7 @@ func delaySlotOffset(ctx context.Context, slot core.Slot, duty core.Duty, delayF
 
 // resolveDuties resolves the duties for the slot's epoch, caching the results.
 func (s *Scheduler) resolveDuties(ctx context.Context, slot core.Slot) error {
-	vals, err := resolveActiveValidators(ctx, s.eth2Cl, s.pubkeys, slot.Slot, s.metricSubmitter)
+	vals, err := resolveActiveValidators(ctx, s.eth2Cl, s.pubkeys, s.metricSubmitter)
 	if err != nil {
 		return err
 	}
@@ -546,7 +546,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.
 
 // resolveActiveValidators returns the active validators (including their validator index) for the slot.
 func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
-	pubkeys []core.PubKey, slot int64, submitter metricSubmitter,
+	pubkeys []core.PubKey, submitter metricSubmitter,
 ) (validators, error) {
 	var e2pks []eth2p0.BLSPubKey
 	for _, pubkey := range pubkeys {
@@ -558,12 +558,7 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
 		e2pks = append(e2pks, e2pk)
 	}
 
-	// Use "head" instead of current slot to mitigate clock skew timing issues.
-	// Note this does introduce the risk that the resulting active validators
-	// is not for this specific slot.
-	// TODO(corver): Explicitly sync with beacon node clock.
-	_ = slot
-
+	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
 	vals, err := eth2Cl.ValidatorsByPubKey(ctx, "head", e2pks)
 	if err != nil {
 		return nil, err

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -141,7 +141,7 @@ func wait(ctx context.Context, chs ...chan struct{}) {
 func activeValidators(ctx context.Context, eth2Cl eth2wrap.Client,
 	pubkeys []eth2p0.BLSPubKey,
 ) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
-	// Using head to mitigate future slot issues.
+	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
 	vals, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys)
 	if err != nil {
 		return nil, err

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -49,17 +49,17 @@ type SignFunc func(pubshare eth2p0.BLSPubKey, data []byte) (eth2p0.BLSSignature,
 func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
 	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
+	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
+	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys)
+	if err != nil {
+		return err
+	}
+
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
 	if err != nil {
 		return err
 	}
-
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
-
-	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, fmt.Sprint(slot), pubkeys)
-	if err != nil {
-		return err
-	}
 
 	var indexes []eth2p0.ValidatorIndex
 	for index, val := range valMap {
@@ -158,17 +158,18 @@ func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc
 func ProposeBlindedBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
 	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
 ) error {
+	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
+	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys)
+	if err != nil {
+		return err
+	}
+
 	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
 	if err != nil {
 		return err
 	}
 
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
-
-	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, fmt.Sprint(slot), pubkeys)
-	if err != nil {
-		return err
-	}
 
 	var indexes []eth2p0.ValidatorIndex
 	for index, val := range valMap {


### PR DESCRIPTION
Always use `head` when querying `validators_by_pubkey` since this is an expensive call and head mitigates against needing to parse and fetch previous state. It also mitigates against errors when querying slots that are too old. Also add TODOs to introduce a cache like Vouch does. Also do this vmock.

category: refactor
ticket: #1486 
