### PR TITLE
app/eth2wrap: use correct fee recipient in synthetic blocks

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	eth2http "github.com/attestantio/go-eth2-client/http"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -71,6 +72,7 @@ func WithSyntheticDuties(cl Client, pubkeys []eth2p0.BLSPubKey) Client {
 	return &synthWrapper{
 		Client:             cl,
 		synthProposerCache: newSynthProposerCache(pubkeys),
+		feeRecipients:      make(map[eth2p0.ValidatorIndex]bellatrix.ExecutionAddress),
 	}
 }
 

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -34,9 +34,6 @@ import (
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 )
 
-// syntheticBlockGraffiti defines the graffiti to identify synthetic blocks.
-const syntheticBlockGraffiti = "SYNTHETIC BLOCK: DO NOT SUBMIT"
-
 // BlockAttestationsProvider is the interface for providing attestations included in blocks.
 // It is a standard beacon API endpoint not implemented by eth2client.
 // See https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockAttestations.

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -68,8 +68,8 @@ func (h *synthWrapper) setFeeRecipients(preparations []*eth2v1.ProposalPreparati
 	}
 }
 
-// getFeeRecipients returns the fee recipient for the provided validator index.
-func (h *synthWrapper) getFeeRecipients(vIdx eth2p0.ValidatorIndex) bellatrix.ExecutionAddress {
+// getFeeRecipient returns the fee recipient for the provided validator index.
+func (h *synthWrapper) getFeeRecipient(vIdx eth2p0.ValidatorIndex) bellatrix.ExecutionAddress {
 	h.mu.RLock()
 	defer h.mu.RUnlock()
 
@@ -183,7 +183,7 @@ func (h *synthWrapper) syntheticBlock(ctx context.Context, slot eth2p0.Slot, vId
 	var synthGraffiti [32]byte
 	copy(synthGraffiti[:], syntheticBlockGraffiti)
 
-	feeRecipient := h.getFeeRecipients(vIdx)
+	feeRecipient := h.getFeeRecipient(vIdx)
 
 	block := &spec.VersionedBeaconBlock{Version: signedBlock.Version}
 

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -319,7 +319,9 @@ func (c *Component) handle(s network.Stream) {
 	defer s.Close()
 
 	b, err := io.ReadAll(s)
-	if err != nil {
+	if p2p.IsRelayError(err) {
+		return // Ignore relay errors.
+	} else if err != nil {
 		log.Error(ctx, "Failed reading consensus stream", err)
 		return
 	}

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -143,6 +143,7 @@ func (s *Sender) SendReceive(ctx context.Context, tcpNode host.Host, peerID peer
 func withRelayRetry(fn func() error) error {
 	err := fn()
 	if IsRelayError(err) { // Retry once if relay error
+		time.Sleep(time.Millisecond * 100)
 		err = fn()
 	}
 


### PR DESCRIPTION
Cache and use correct fee recipients in synthetic blocks.

category: bug
ticket: #1486 
