### PR TITLE
app: increase sniffed message buffer

### DIFF
--- a/app/qbftdebug.go
+++ b/app/qbftdebug.go
@@ -29,7 +29,7 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-const maxQBFTDebugger = 20 * (1 << 20) // 20 MB
+const maxQBFTDebugger = 20 * (1 << 20) // 20MB
 
 // newQBFTDebugger returns a new qbftDebugger.
 func newQBFTDebugger() *qbftDebugger {

--- a/app/qbftdebug.go
+++ b/app/qbftdebug.go
@@ -29,7 +29,7 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-const maxQBFTDebugger = 2 * (1 << 20) // 2 MB
+const maxQBFTDebugger = 20 * (1 << 20) // 20 MB
 
 // newQBFTDebugger returns a new qbftDebugger.
 func newQBFTDebugger() *qbftDebugger {


### PR DESCRIPTION
Increases sniffed message buffer from 2MB to 20MB since it is too small for block proposals. Downloaded messages never contain duty proposer at this point.

category: refactor
ticket: none
