### PR TITLE
app: increase sniffed buffer even more

### DIFF
--- a/app/qbftdebug.go
+++ b/app/qbftdebug.go
@@ -29,7 +29,7 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-const maxQBFTDebugger = 200 * (1 << 20) // 200MB
+const maxQBFTDebugger = 2000 * (1 << 20) // 2GB
 
 // newQBFTDebugger returns a new qbftDebugger.
 func newQBFTDebugger() *qbftDebugger {

--- a/app/qbftdebug.go
+++ b/app/qbftdebug.go
@@ -29,7 +29,7 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-const maxQBFTDebugger = 20 * (1 << 20) // 20MB
+const maxQBFTDebugger = 200 * (1 << 20) // 200MB
 
 // newQBFTDebugger returns a new qbftDebugger.
 func newQBFTDebugger() *qbftDebugger {

--- a/app/qbftdebug.go
+++ b/app/qbftdebug.go
@@ -29,7 +29,7 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-const maxQBFTDebugger = 2000 * (1 << 20) // 2GB
+const maxQBFTDebugger = 2000 * (1 << 20) // 2GB // TODO(corver): revert to under 50MB.
 
 // newQBFTDebugger returns a new qbftDebugger.
 func newQBFTDebugger() *qbftDebugger {


### PR DESCRIPTION
Increase to temporary 2GB buffer to ensure we capture the proposer messages. RAM metrics indicate up to 500MB might be possible.

category: test
ticket: none
