### PR TITLE
app/eth2wrap: decrease synth block sizes

### DIFF
--- a/app/qbftdebug.go
+++ b/app/qbftdebug.go
@@ -29,7 +29,7 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-const maxQBFTDebugger = 2000 * (1 << 20) // 2GB // TODO(corver): revert to under 50MB.
+const maxQBFTDebugger = 50 * (1 << 20) // 50 MB.
 
 // newQBFTDebugger returns a new qbftDebugger.
 func newQBFTDebugger() *qbftDebugger {


### PR DESCRIPTION
Decrease synthetic block sizes to manageable levels so we can test the logic. We need to refactor the wire protocol to send and duplicate much less.

category: refactor 
ticket: none