### PR TITLE
testutil/promrated: add health listener and monitoring endpoint

### DIFF
--- a/testutil/promrated/prometheus.go
+++ b/testutil/promrated/prometheus.go
@@ -24,8 +24,8 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 )
 
-// listenAndServe creates a liveness endpoint and serves metrics to prometheus.
-func listenAndServe(addr string) error {
+// serveMonitoring creates a liveness endpoint and serves metrics to prometheus.
+func serveMonitoring(addr string) error {
 	mux := http.NewServeMux()
 
 	mux.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/testutil/promrated/prometheus.go
+++ b/testutil/promrated/prometheus.go
@@ -16,15 +16,16 @@
 package promrated
 
 import (
-	"context"
 	"net/http"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 // listenAndServe creates a liveness endpoint and serves metrics to prometheus.
-func listenAndServe(ctx context.Context, addr string) error {
+func listenAndServe(addr string) error {
 	mux := http.NewServeMux()
 
 	mux.Handle("/livez", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
@@ -35,9 +36,9 @@ func listenAndServe(ctx context.Context, addr string) error {
 		promhttp.Handler(),
 	)
 
-	// Copied from net/http/pprof/pprof.go
 	server := http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: time.Second}
-	return server.ListenAndServe()
+
+	return errors.Wrap(server.ListenAndServe(), "failed to serve prometheus metrics")
 }
 
 func writeResponse(w http.ResponseWriter, status int, msg string) {

--- a/testutil/promrated/promrated.go
+++ b/testutil/promrated/promrated.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
-	"github.com/obolnetwork/charon/testutil/promrated/prom"
 )
 
 type Config struct {
@@ -33,7 +32,7 @@ type Config struct {
 }
 
 func Run(ctx context.Context, config Config) error {
-	go prom.ListenAndServe(ctx, config.MonitoringAddr)
+	go ListenAndServe(ctx, config.MonitoringAddr)
 
 	for {
 		log.Info(ctx, "Promrated looping.", z.Str("endpoint", config.RatedAPIEndpoint))

--- a/testutil/promrated/promrated.go
+++ b/testutil/promrated/promrated.go
@@ -34,7 +34,7 @@ type Config struct {
 func Run(ctx context.Context, config Config) error {
 	serverErr := make(chan error, 1)
 	go func() {
-		serverErr <- listenAndServe(ctx, config.MonitoringAddr)
+		serverErr <- listenAndServe(config.MonitoringAddr)
 	}()
 
 	go func() {


### PR DESCRIPTION
Start serving prom metrics at the specified address along with a health endpoint to use for a liveness check.

category: misc

ticket: https://github.com/ObolNetwork/charon/issues/1540
