### PR TITLE
cmd: require name in create cluster

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -471,6 +471,10 @@ func checksumAddr(a string) (string, error) {
 
 // validateClusterConfig returns an error if the cluster config is invalid.
 func validateClusterConfig(ctx context.Context, conf clusterConfig) error {
+	if conf.Name == "" {
+		return errors.New("name not provided")
+	}
+
 	if conf.NumNodes < minNodes {
 		return errors.New("insufficient number of nodes (min = 4)")
 	}

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -109,6 +109,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig) {
 	dir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 	conf.ClusterDir = dir
+	conf.Name = t.Name()
 
 	var buf bytes.Buffer
 	err = runCreateCluster(context.Background(), &buf, conf)
@@ -163,6 +164,7 @@ func TestValidNetwork(t *testing.T) {
 	ctx := context.Background()
 
 	conf := clusterConfig{
+		Name:           "test",
 		NumNodes:       4,
 		Threshold:      3,
 		WithdrawalAddr: "0x0000000000000000000000000000000000000000",

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -45,6 +45,7 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 
 		// Only single node to call charon create cluster generate keys
 		n := TmplNode{EnvVars: []kv{
+			{"name", fmt.Sprintf("compose-%d-%d", conf.NumNodes, conf.NumValidators)},
 			{"threshold", fmt.Sprint(conf.Threshold)},
 			{"nodes", fmt.Sprint(conf.NumNodes)},
 			{"cluster-dir", "/compose"},

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
@@ -9,6 +9,10 @@
    "Entrypoint": "",
    "EnvVars": [
     {
+     "Key": "name",
+     "Value": "compose-4-1"
+    },
+    {
      "Key": "threshold",
      "Value": "3"
     },

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
@@ -13,6 +13,7 @@ services:
     <<: *node-base
     
     environment:
+      CHARON_NAME: compose-4-1
       CHARON_THRESHOLD: 3
       CHARON_NODES: 4
       CHARON_CLUSTER_DIR: /compose


### PR DESCRIPTION
Makes the `name` field required in the `charon create cluster` command since clusters without names are hard to debug and monitor.

category: refactor
ticket: none
