### PR TITLE
testutils/promrated: add prom query to collect pubkey to cluster information

### DIFF
--- a/testutil/promrated/prometheus.go
+++ b/testutil/promrated/prometheus.go
@@ -16,13 +16,52 @@
 package promrated
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
 )
+
+const (
+	promEndpoint = "https://vm.monitoring.gcp.obol.tech"
+	promQuery    = "group%20by%20%28cluster_name%2C%20ccluster_hash%2C%20cluster_peer%2C%20cluster_network%2C%20pubkey_full%29%20%28core_scheduler_validator_balance_gwei%29"
+)
+
+type ClusterInfo struct {
+	ClusterName    string `json:"cluster_name"`
+	ClusterHash    string `json:"cluster_hash"`
+	ClusterNetwork string `json:"cluster_network"`
+	ClusterPeer    string `json:"cluster_peer"`
+}
+
+type PromMetric struct {
+	*ClusterInfo
+	PubKey string `json:"pubkey_full"`
+}
+
+type PromResult struct {
+	Metric PromMetric `json:"metric"`
+}
+
+type PromData struct {
+	ResultType string       `json:"resultType"`
+	Result     []PromResult `json:"result"`
+}
+
+type PromResponse struct {
+	Status    string `json:"status"`
+	IsPartial bool   `json:"isPartial"`
+
+	Data PromData `json:"data"`
+}
 
 // serveMonitoring creates a liveness endpoint and serves metrics to prometheus.
 func serveMonitoring(addr string) error {
@@ -39,6 +78,68 @@ func serveMonitoring(addr string) error {
 	server := http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: time.Second}
 
 	return errors.Wrap(server.ListenAndServe(), "failed to serve prometheus metrics")
+}
+
+func getPubkeyToClusterInfo(ctx context.Context, promAuth string) (map[string]prometheus.Labels, error) {
+	req, res := getPromClusters(ctx, promAuth)
+
+	if res.StatusCode == 200 {
+		result, err := readPromJson(ctx, res)
+		if err != nil {
+			return nil, err
+		}
+
+		keyToClusterLabels := make(map[string]prometheus.Labels)
+
+		for _, cluster := range result.Data.Result {
+			if cluster.Metric.ClusterInfo != nil && cluster.Metric.ClusterName != "" {
+				keyToClusterLabels[cluster.Metric.PubKey] = map[string]string{
+					"cluster_name":    cluster.Metric.ClusterName,
+					"cluster_hash":    cluster.Metric.ClusterHash,
+					"cluster_network": cluster.Metric.ClusterNetwork,
+					"cluster_peer":    cluster.Metric.ClusterPeer,
+					"pubkey":          cluster.Metric.PubKey,
+				}
+			}
+		}
+
+		return keyToClusterLabels, nil
+	} else {
+		return nil, fmt.Errorf("error reporting metrics for %q", req.URL)
+	}
+}
+
+func getPromClusters(ctx context.Context, promAuth string) (*http.Request, *http.Response) {
+	client := new(http.Client)
+	url := fmt.Sprintf("%s/query?query=%s", promEndpoint, promQuery)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Error(ctx, "HTTP Request malformed for prom query", err)
+	}
+
+	req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", promAuth))
+	res, err := client.Do(req)
+	if err != nil {
+		log.Error(ctx, "HTTP Request failed for prom query", err)
+	}
+
+	return req, res
+}
+
+func readPromJson(ctx context.Context, res *http.Response) (*PromResponse, error) {
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		log.Error(ctx, "Failed to read body", err)
+		return nil, errors.Wrap(err, "failed to read body")
+	}
+
+	var result *PromResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		log.Error(ctx, "Failed to deserialize json", err)
+	}
+
+	return result, nil
 }
 
 func writeResponse(w http.ResponseWriter, status int, msg string) {

--- a/testutil/promrated/prometheus.go
+++ b/testutil/promrated/prometheus.go
@@ -88,7 +88,7 @@ func getPubkeyToClusterInfo(ctx context.Context, promAuth string) (map[string]pr
 	}
 
 	if res.StatusCode == 200 {
-		result, err := readPromJson(ctx, res)
+		result, err := readPromJSON(ctx, res)
 		if err != nil {
 			return nil, err
 		}
@@ -133,7 +133,7 @@ func getPromClusters(ctx context.Context, promAuth string) (*http.Response, erro
 	return res, nil
 }
 
-func readPromJson(ctx context.Context, res *http.Response) (*PromResponse, error) {
+func readPromJSON(ctx context.Context, res *http.Response) (*PromResponse, error) {
 	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		log.Error(ctx, "Failed to read body", err)

--- a/testutil/promrated/prometheus_internal_test.go
+++ b/testutil/promrated/prometheus_internal_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package promrated
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/testutil"
+)
+
+//go:generate go test . -update -clean
+
+func TestGetValidators(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, promQuery, r.URL.Query()["query"][0])
+		require.Equal(t, "Bearer test", r.Header.Get("Authorization"))
+		_, _ = w.Write([]byte(fixture))
+	}))
+	defer ts.Close()
+
+	vals, err := getValidators(context.Background(), ts.URL, "test")
+	assert.NoError(t, err)
+	testutil.RequireGoldenJSON(t, vals)
+}
+
+const fixture = `
+{
+  "status": "success",
+  "isPartial": false,
+  "data": {
+    "resultType": "vector",
+    "result": [
+      {
+        "metric": {
+          "cluster_hash": "hash1",
+          "cluster_name": "cluster1",
+          "cluster_network": "network1",
+          "pubkey_full": "0x96c85da36a35123aa17ace6588e56e948b1f7fe320f53163015f144541b65645a7aa4df44e5638a00467aff16666629c"
+        },
+        "value": [
+          1671108542,
+          "1"
+        ]
+      },
+      {
+        "metric": {
+          "cluster_hash": "hash2",
+          "cluster_name": "cluster2",
+          "cluster_network": "network2",
+          "pubkey_full": "0x800a9a1c9f6cd9fbe30a3759070646bc8bf17a1da26bbcd5b72c696396ec2dd40265fd7174231dffe9f19cfc6e64df54"
+        },
+        "value": [
+          1671108542,
+          "1"
+        ]
+      }
+	]
+  }
+}`

--- a/testutil/promrated/promrated.go
+++ b/testutil/promrated/promrated.go
@@ -26,17 +26,17 @@ import (
 )
 
 type Config struct {
-	RatedAPIEndpoint string
-	PromEndpoint     string
-	PromAuth         string
-	MonitoringAddr   string
+	RatedEndpoint  string
+	PromEndpoint   string
+	PromAuth       string
+	MonitoringAddr string
 }
 
 // Run blocks running the promrated program until the context is canceled or a fatal error occurs.
 func Run(ctx context.Context, config Config) error {
 	log.Info(ctx, "Promrated started",
-		z.Str("rated_api_endpoint", config.RatedAPIEndpoint), // TODO(corver): This may contain a password
-		z.Str("prom_auth", config.PromAuth),                  // TODO(corver): This may contain a password
+		z.Str("rated_endpoint", config.RatedEndpoint), // TODO(corver): This may contain a password
+		z.Str("prom_auth", config.PromAuth),           // TODO(corver): This may contain a password
 		z.Str("monitoring_addr", config.MonitoringAddr),
 	)
 

--- a/testutil/promrated/promrated.go
+++ b/testutil/promrated/promrated.go
@@ -47,8 +47,6 @@ func Run(ctx context.Context, config Config) error {
 	ticker := time.NewTicker(10 * time.Minute)
 	defer ticker.Stop()
 
-	reportMetrics(ctx, config)
-
 	for {
 		select {
 		case err := <-serverErr:

--- a/testutil/promrated/promrated/main.go
+++ b/testutil/promrated/promrated/main.go
@@ -53,6 +53,6 @@ func newRootCmd(runFunc func(context.Context, promrated.Config) error) *cobra.Co
 
 func bindPromratedFlag(flags *pflag.FlagSet, config *promrated.Config) {
 	flags.StringVar(&config.RatedAPIEndpoint, "rated-api-endpoint", "https://api.rated.network", "Rated API endpoint to poll for validator metrics.")
-	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9100", "Listening address (ip and port) for the prometheus monitoring http server.")
+	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9354", "Listening address (ip and port) for the prometheus monitoring http server.")
 	flags.StringVar(&config.PromAuth, "prom-auth-token", "token", "[REQUIRED] Token for VMetrics Promtetheus API.")
 }

--- a/testutil/promrated/promrated/main.go
+++ b/testutil/promrated/promrated/main.go
@@ -53,6 +53,6 @@ func newRootCmd(runFunc func(context.Context, promrated.Config) error) *cobra.Co
 
 func bindPromratedFlag(flags *pflag.FlagSet, config *promrated.Config) {
 	flags.StringVar(&config.RatedAPIEndpoint, "rated-api-endpoint", "https://api.rated.network", "Rated API endpoint to poll for validator metrics.")
-	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9354", "Listening address (ip and port) for the prometheus monitoring http server.")
+	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9100", "Listening address (ip and port) for the prometheus monitoring http server.")
 	flags.StringVar(&config.PromAuth, "prom-auth-token", "token", "[REQUIRED] Token for VMetrics Promtetheus API.")
 }

--- a/testutil/promrated/promrated/main.go
+++ b/testutil/promrated/promrated/main.go
@@ -53,6 +53,7 @@ func newRootCmd(runFunc func(context.Context, promrated.Config) error) *cobra.Co
 
 func bindPromratedFlag(flags *pflag.FlagSet, config *promrated.Config) {
 	flags.StringVar(&config.RatedAPIEndpoint, "rated-api-endpoint", "https://api.rated.network", "Rated API endpoint to poll for validator metrics.")
-	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9100", "Listening address (ip and port) for the prometheus monitoring http server.")
+	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9102", "Listening address (ip and port) for the prometheus monitoring http server.")
+	flags.StringVar(&config.PromEndpoint, "prom-endpoint", "https://vm.monitoring.gcp.obol.tech/query", "Endpoint for VMetrics Promtetheus API.")
 	flags.StringVar(&config.PromAuth, "prom-auth-token", "token", "[REQUIRED] Token for VMetrics Promtetheus API.")
 }

--- a/testutil/promrated/promrated/main.go
+++ b/testutil/promrated/promrated/main.go
@@ -52,8 +52,8 @@ func newRootCmd(runFunc func(context.Context, promrated.Config) error) *cobra.Co
 }
 
 func bindPromratedFlag(flags *pflag.FlagSet, config *promrated.Config) {
-	flags.StringVar(&config.RatedAPIEndpoint, "rated-api-endpoint", "https://api.rated.network", "Rated API endpoint to poll for validator metrics.")
-	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9102", "Listening address (ip and port) for the prometheus monitoring http server.")
-	flags.StringVar(&config.PromEndpoint, "prom-endpoint", "https://vm.monitoring.gcp.obol.tech/query", "Endpoint for VMetrics Promtetheus API.")
+	flags.StringVar(&config.RatedEndpoint, "rated-endpoint", "https://api.rated.network", "Rated API endpoint to poll for validator metrics.")
+	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:9100", "Listening address (ip and port) for the prometheus monitoring http server.")
+	flags.StringVar(&config.PromEndpoint, "prom-endpoint", "https://vm.monitoring.gcp.obol.tech/query", "Endpoint for VMetrics Prometheus API.")
 	flags.StringVar(&config.PromAuth, "prom-auth-token", "token", "[REQUIRED] Token for VMetrics Promtetheus API.")
 }

--- a/testutil/promrated/testdata/TestGetValidators.golden
+++ b/testutil/promrated/testdata/TestGetValidators.golden
@@ -1,0 +1,14 @@
+[
+ {
+  "pubkey_full": "0x96c85da36a35123aa17ace6588e56e948b1f7fe320f53163015f144541b65645a7aa4df44e5638a00467aff16666629c",
+  "cluster_name": "cluster1",
+  "cluster_hash": "hash1",
+  "cluster_network": "network1"
+ },
+ {
+  "pubkey_full": "0x800a9a1c9f6cd9fbe30a3759070646bc8bf17a1da26bbcd5b72c696396ec2dd40265fd7174231dffe9f19cfc6e64df54",
+  "cluster_name": "cluster2",
+  "cluster_hash": "hash2",
+  "cluster_network": "network2"
+ }
+]


### PR DESCRIPTION
Adding in prometheus query to get all the necessary cluster information and associated private keys.

category: misc
ticket: https://github.com/ObolNetwork/charon/issues/1540
