### PR TITLE
app/log: increase loki batch send timeout to 10s

### DIFF
--- a/app/log/loki/client.go
+++ b/app/log/loki/client.go
@@ -40,7 +40,7 @@ import (
 const (
 	contentType  = "application/x-protobuf"
 	maxErrMsgLen = 1024
-	httpTimeout  = 2 * time.Second
+	httpTimeout  = 10 * time.Second
 	batchWait    = 1 * time.Second
 	batchMax     = 5 * 1 << 20 // 5MB
 )
@@ -141,7 +141,7 @@ func (c *Client) Run() {
 			err := send(ctx, client, c.endpoint, batch, c.labels())
 			if err != nil {
 				// Log async to avoid deadlock by recursive calls to Add.
-				go c.logFunc("Loki batch send failed", err)
+				go c.logFunc("Loki batch send failed (will retry)", err)
 
 				retries++
 				triedAt = time.Now()


### PR DESCRIPTION
Increases batch sending timeout to 10s to solve `context deadline exceeded` issue. 
This aligns with official loki client: https://github.com/grafana/loki/blob/main/clients/pkg/promtail/client/config.go#L21

category: misc
ticket: none
