### PR TITLE
cmd/bootnode: refactor metrics

### DIFF
--- a/cmd/bootnode/bootnode.go
+++ b/cmd/bootnode/bootnode.go
@@ -85,18 +85,16 @@ func Run(ctx context.Context, config Config) error {
 	defer udpNode.Close()
 
 	bwTuples := make(chan bwTuple)
-	reporter := newBandwidthCounter(ctx, bwTuples)
+	counter := newBandwidthCounter(ctx, bwTuples)
 
-	tcpNode, err := startP2P(ctx, config, key, reporter)
+	tcpNode, err := startP2P(ctx, config, key, counter)
 	if err != nil {
 		return err
 	}
 
 	go monitorConnections(ctx, tcpNode, bwTuples)
 
-	labels := map[string]string{
-		"bootnode_peer": p2p.PeerName(tcpNode.ID()),
-	}
+	labels := map[string]string{"bootnode_peer": p2p.PeerName(tcpNode.ID())}
 	log.SetLokiLabels(labels)
 	promRegistry, err := promauto.NewRegistry(labels)
 	if err != nil {

--- a/cmd/bootnode/metrics.go
+++ b/cmd/bootnode/metrics.go
@@ -16,6 +16,11 @@
 package bootnode
 
 import (
+	"context"
+
+	"github.com/libp2p/go-libp2p/core/metrics"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/obolnetwork/charon/app/promauto"
@@ -26,21 +31,28 @@ var (
 		Namespace: "bootnode",
 		Subsystem: "p2p",
 		Name:      "connection_total",
-		Help:      "Total number of connections by peer and cluster",
+		Help:      "Total number of new connections by peer and cluster",
 	}, []string{"peer", "peer_cluster"})
 
-	bandwidthInGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	activeConnsCounter = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "bootnode",
 		Subsystem: "p2p",
-		Name:      "bandwidth_in",
-		Help:      "Bandwidth rate in by peer and cluster",
+		Name:      "active_connections",
+		Help:      "Current number of active connections by peer and cluster",
 	}, []string{"peer", "peer_cluster"})
 
-	bandwidthOutGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	networkTXCounter = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "bootnode",
 		Subsystem: "p2p",
-		Name:      "bandwidth_out",
-		Help:      "Bandwidth rate out by peer and cluster",
+		Name:      "network_sent_bytes_total",
+		Help:      "Total number of network bytes sent to the peer and cluster",
+	}, []string{"peer", "peer_cluster"})
+
+	networkRXCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "bootnode",
+		Subsystem: "p2p",
+		Name:      "network_receive_bytes_total",
+		Help:      "Total number of network bytes received from the peer and cluster",
 	}, []string{"peer", "peer_cluster"})
 
 	peerPingLatency = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -50,3 +62,43 @@ var (
 		Help:      "Ping latency by peer and cluster",
 	}, []string{"peer", "peer_cluster"})
 )
+
+// newBandwidthCounter returns a new bandwidth counter that stops counting when the context is cancelled.
+func newBandwidthCounter(ctx context.Context, ch chan<- bwTuple) metrics.Reporter {
+	return bwCounter{
+		ch:   ch,
+		done: ctx.Done(),
+	}
+}
+
+// bwTuple is a bandwidth counter tuple.
+type bwTuple struct {
+	ID   peer.ID
+	Size int64
+	Sent bool
+}
+
+// bwCounter is a bandwidth counter implementing libp2p metrics.Reporter.
+type bwCounter struct {
+	metrics.Reporter
+	done <-chan struct{}
+	ch   chan<- bwTuple
+}
+
+func (bwCounter) LogSentMessage(int64) {}
+
+func (bwCounter) LogRecvMessage(int64) {}
+
+func (b bwCounter) LogSentMessageStream(size int64, _ protocol.ID, pID peer.ID) {
+	select {
+	case b.ch <- bwTuple{ID: pID, Size: size, Sent: true}:
+	case <-b.done:
+	}
+}
+
+func (b bwCounter) LogRecvMessageStream(size int64, _ protocol.ID, pID peer.ID) {
+	select {
+	case b.ch <- bwTuple{ID: pID, Size: size, Sent: false}:
+	case <-b.done:
+	}
+}


### PR DESCRIPTION
Refactors network bytes metrics into counters (since gauges are sticky and do not reset when peers go away). Adds "active connections" metric.

category: refactor 
ticket: none
