### PR TITLE
cluster: add `Partial()` method to definition

### DIFF
--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -423,7 +423,7 @@ func (d Definition) Partial() error {
 		return errors.New("partial definition config signature empty")
 	}
 	if len(d.DefinitionHash) != 0 {
-		return errors.New("partial definition definition hash not empty")
+		return errors.New("partial definition hash not empty")
 	}
 
 	return nil


### PR DESCRIPTION
Adds `Partial()` method to `Definition` to determine if a definition is "partial". Also, don't set definition-hash when marshalling partial definition.

category: feature
ticket: none 