### PR TITLE
app/bootnode: fix missing cluster hash in metrics

### DIFF
--- a/cmd/bootnode/p2p.go
+++ b/cmd/bootnode/p2p.go
@@ -140,7 +140,7 @@ func monitorConnections(ctx context.Context, tcpNode host.Host, bwTuples <-chan 
 			state, ok := peers[info.ID]
 			if !ok {
 				continue // Peer not connected anymore
-			} else if state.ClusterHash != "" {
+			} else if state.ClusterHash == "" {
 				state.ClusterHash = info.ClusterHash
 			}
 

--- a/cmd/bootnode/p2p.go
+++ b/cmd/bootnode/p2p.go
@@ -140,9 +140,8 @@ func monitorConnections(ctx context.Context, tcpNode host.Host, bwTuples <-chan 
 			state, ok := peers[info.ID]
 			if !ok {
 				continue // Peer not connected anymore
-			} else if state.ClusterHash == "" {
-				state.ClusterHash = info.ClusterHash
 			}
+			state.ClusterHash = info.ClusterHash
 
 			newConnsCounter.WithLabelValues(state.Name, state.ClusterHash).Add(float64(state.New))
 			activeConnsCounter.WithLabelValues(state.Name, state.ClusterHash).Set(float64(state.Active))


### PR DESCRIPTION
Fixes missing cluster_hash in bootnode metrics.

category: bug 
ticket: none