### PR TITLE
core/validatorapi: fix readyz issues in canary clusters

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -100,6 +100,10 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 	getPubShareFunc := func(pubkey eth2p0.BLSPubKey) (eth2p0.BLSPubKey, bool) {
 		share, ok := sharesByKey[pubkey]
 
+		if seenPubkeys != nil {
+			seenPubkeys(core.PubKeyFrom48Bytes(pubkey))
+		}
+
 		return share, ok
 	}
 
@@ -117,10 +121,6 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 			}
 
 			return eth2p0.BLSPubKey{}, errors.New("unknown public key")
-		}
-
-		if seenPubkeys != nil {
-			seenPubkeys(core.PubKeyFrom48Bytes(key))
 		}
 
 		return key, nil


### PR DESCRIPTION
Fixes readyz issues in canary clusters. This is done by moving seenPubkeys logic to getPubShareFunc. In canary clusters such as `canary-goerli-1` it turns out that the nodes reporting value 5 are the ones with lighthouse VC which calls get_validator with validator_index and not pubkey.

category: bug
ticket: #1501 
