### PR TITLE
core/fetcher: add capella support to verify fee recipient for blinded blocks

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -384,7 +384,7 @@ func (c Component) SubmitBeaconBlock(ctx context.Context, block *spec.VersionedS
 		return err
 	}
 
-	log.Debug(ctx, "Beacon block submitted by validator client")
+	log.Debug(ctx, "Beacon block submitted by validator client", z.Str("block_version", block.Version.String()))
 
 	set := core.ParSignedDataSet{pubkey: signedData}
 	for _, sub := range c.subs {


### PR DESCRIPTION
Adds a function to log unexpected fee-recipient for blinded blocks. Also, adds a log to debug capella backwards compatibility tests.

category: refactor
ticket: #1587 
