### PR TITLE
cmd: deprecate discv5 and release relay discovery

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -288,7 +288,8 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	if conf.P2P.RelayDiscovery() {
 		log.Info(ctx, "Relay discovery enabled") // TODO(corver): Remove once stable.
-	} else {
+	}
+	if conf.P2P.Discv5Discovery() {
 		log.Info(ctx, "Discv5 discovery enabled")
 	}
 

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -208,8 +208,8 @@ func pingCluster(t *testing.T, test pingTest) {
 		timeout = time.Minute
 	}
 
-	if test.RelayDiscovery {
-		featureset.EnableForT(t, featureset.RelayDiscovery)
+	if !test.RelayDiscovery {
+		featureset.DisableForT(t, featureset.RelayDiscovery)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -59,7 +59,7 @@ var (
 		QBFTConsensus:  statusStable,
 		Priority:       statusStable,
 		MockAlpha:      statusAlpha,
-		RelayDiscovery: statusAlpha,
+		RelayDiscovery: statusStable,
 		// Add all features and there status here.
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -123,7 +123,7 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 
 func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of discv5 bootnode URLs or ENRs.")
-	cmd.Flags().BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", true, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. Deprecated, should always enabled.")
+	cmd.Flags().BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", true, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. Deprecated, should always be enabled.")
 	cmd.Flags().BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs. Discv5 is deprecated, use relay discovery.")
 	cmd.Flags().StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery. Discv5 is deprecated, use relay discovery.")
 	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
@@ -141,7 +141,7 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 		}
 
 		if !config.BootnodeRelay {
-			log.Warn(ctx, "Deprecated flag 'p2p-bootnode-relay' disabled, it will always be enabled from the next released", nil)
+			log.Warn(ctx, "Deprecated flag 'p2p-bootnode-relay' disabled, it will always be enabled from the next release", nil)
 		}
 
 		if config.UDPBootLock {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,15 +137,15 @@ Flags:
       --monitoring-address string          Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
       --no-verify                          Disables cluster definition and lock file verification.
       --p2p-allowlist string               Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-bootnode-relay                 Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. (default true)
+      --p2p-bootnode-relay                 Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. Deprecated, should always enabled. (default true)
       --p2p-bootnodes strings              Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.lb.gcp.obol.tech:3640/enr])
-      --p2p-bootnodes-from-lockfile        Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs.
+      --p2p-bootnodes-from-lockfile        Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs. Discv5 is deprecated, use relay discovery.
       --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-disable-reuseport              Disables TCP port reuse for outgoing libp2p connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
-      --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery.
+      --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery. Discv5 is deprecated, use relay discovery.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ Flags:
       --monitoring-address string          Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
       --no-verify                          Disables cluster definition and lock file verification.
       --p2p-allowlist string               Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-bootnode-relay                 Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. Deprecated, should always enabled. (default true)
+      --p2p-bootnode-relay                 Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. Deprecated, should always be enabled. (default true)
       --p2p-bootnodes strings              Comma-separated list of discv5 bootnode URLs or ENRs. (default [http://bootnode.lb.gcp.obol.tech:3640/enr])
       --p2p-bootnodes-from-lockfile        Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs. Discv5 is deprecated, use relay discovery.
       --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -49,14 +49,14 @@ type Config struct {
 	DisableReuseport bool
 }
 
-// RelayDiscovery returns true if relay discovery is enabled and discv5 discovery is disabled.
+// RelayDiscovery returns true if relay discovery is enabled.
 func (c Config) RelayDiscovery() bool {
 	return len(c.UDPBootnodes) > 0 && c.BootnodeRelay && featureset.Enabled(featureset.RelayDiscovery)
 }
 
-// Discv5Discovery returns true if discv5 discovery is enabled and relay discovery is disabled.
+// Discv5Discovery returns true if discv5 discovery is enabled.
 func (c Config) Discv5Discovery() bool {
-	return !c.RelayDiscovery()
+	return c.UDPAddr != ""
 }
 
 // ParseTCPAddrs returns the configured tcp addresses as typed net tcp addresses.

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -87,8 +87,8 @@ func NewTCPNode(ctx context.Context, cfg Config, key *ecdsa.PrivateKey, connGate
 		// Enable Autonat (required for hole punching)
 		libp2p.EnableNATService(),
 		libp2p.AddrsFactory(func(addrs []ma.Multiaddr) []ma.Multiaddr {
-			if cfg.Discv5Discovery() {
-				// Do not advertise addresses via libp2p when using discv5 for peer discovery.
+			if !cfg.RelayDiscovery() {
+				// Do not advertise addresses via libp2p when not using relay discovery.
 				return nil
 			}
 


### PR DESCRIPTION
Deprecate discv5 and enable relay discovery by default as part of future v0.13 release.

category: refactor 
ticket: #1606
feature_flag: relay_discovery
