### PR TITLE
core/validatorapi: fix readyz issue

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -123,6 +123,10 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 			return eth2p0.BLSPubKey{}, errors.New("unknown public key")
 		}
 
+		if seenPubkeys != nil {
+			seenPubkeys(core.PubKeyFrom48Bytes(key))
+		}
+
 		return key, nil
 	}
 


### PR DESCRIPTION
Fixes readyz issue of `vc missing some validators` by adding seenPubkeys logic to `getPubKeyFunc`.

category: bug
ticket: #1501 
