### PR TITLE
core/scheduler: trim duties after 3 epochs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -406,7 +406,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return core.NewDeadliner(ctx, label, deadlineFunc)
 	}
 
-	sched, err := scheduler.New(corePubkeys, eth2Cl, deadlinerFunc("scheduler"), conf.BuilderAPI)
+	sched, err := scheduler.New(corePubkeys, eth2Cl, conf.BuilderAPI)
 	if err != nil {
 		return err
 	}

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -144,12 +144,12 @@ func TestStartChecker(t *testing.T) {
 			if tt.err != nil {
 				require.Eventually(t, func() bool {
 					err = readyErrFunc()
-					if !errors.Is(err, errReadyUninitialised) {
-						require.EqualError(t, err, tt.err.Error())
-						return true
+					if !errors.Is(err, tt.err) {
+						t.Logf("Ignoring unexpected error, got=%v, want=%v", err, tt.err)
+						return false
 					}
 
-					return false
+					return true
 				}, time.Second, 100*time.Millisecond)
 			} else {
 				require.Eventually(t, func() bool {


### PR DESCRIPTION
Fixes issue introduced by #1596 that trimmed data after 5 slots which caused inclusion delay calculation to stop working (it requires duties of 32 ago). Instead just delete duties after 3 epochs (avoid races and off-by-one issues of 2 epochs).

category: bug
ticket: none
