### PR TITLE
dkg: fix error handling in TestSyncFlow

### DIFF
--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -291,9 +291,8 @@ func TestSyncFlow(t *testing.T) {
 			stopDkgs := make([]context.CancelFunc, test.nodes)
 
 			var (
-				done           = make(chan struct{})
-				dkgErrChan     = make(chan error)
-				connectedCount int
+				done       = make(chan struct{})
+				dkgErrChan = make(chan error)
 			)
 
 			newCallback := func(required int) func(int, peer.ID) {
@@ -315,6 +314,7 @@ func TestSyncFlow(t *testing.T) {
 			}
 
 			// Wait for initial peers to connect with each other.
+			var connectedCount int
 			for connectedCount != len(test.connect) {
 				select {
 				case <-done:


### PR DESCRIPTION
Fixes error handling in TestSyncFlow. Refer: https://github.com/ObolNetwork/charon/actions/runs/3882432301/jobs/6622576116

category: test
ticket: none
