### PR TITLE
dkg: fix golangci-lint

### DIFF
--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -245,6 +245,7 @@ func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 	}
 }
 
+//nolint:gocognit
 func TestSyncFlow(t *testing.T) {
 	tests := []struct {
 		name       string


### PR DESCRIPTION
Fixes golangci-lint on main.

category: fixbuild
ticket: none
