### PR TITLE
core/tracker: wrap components' input to send events to tracker

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -173,6 +173,11 @@ type Broadcaster interface {
 	Broadcast(context.Context, Duty, PubKey, SignedData) error
 }
 
+// Tracker sends core component events for further analysis and instrumentation.
+type Tracker interface {
+	SendEvent(context.Context, Duty, string, PubKey, error, ParSignedData) error
+}
+
 // wireFuncs defines the core workflow components as a list of input and output functions
 // instead as interfaces, since functions are easier to wrap than interfaces.
 type wireFuncs struct {

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -175,7 +175,8 @@ type Broadcaster interface {
 
 // Tracker sends core component events for further analysis and instrumentation.
 type Tracker interface {
-	SendEvent(context.Context, Duty, string, PubKey, error, ParSignedData) error
+	// Fetcher sends fetcher component's events to tracker.
+	Fetcher(context.Context, Duty, PubKey, error)
 }
 
 // wireFuncs defines the core workflow components as a list of input and output functions

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -175,8 +175,20 @@ type Broadcaster interface {
 
 // Tracker sends core component events for further analysis and instrumentation.
 type Tracker interface {
-	// Fetcher sends fetcher component's events to tracker.
-	Fetcher(context.Context, Duty, PubKey, error)
+	// Fetcher sends Fetcher component's events to tracker.
+	Fetcher(context.Context, Duty, DutyDefinitionSet, error)
+
+	// DutyDBStore sends DutyDB component's store events to tracker.
+	DutyDBStore(context.Context, Duty, UnsignedDataSet, error)
+
+	// ParSigDBStoreInternal sends ParSigDB component's store internal events to tracker.
+	ParSigDBStoreInternal(context.Context, Duty, ParSignedDataSet, error)
+
+	// ParSigDBStoreExternal sends ParSigDB component's store external events to tracker.
+	ParSigDBStoreExternal(context.Context, Duty, ParSignedDataSet, error)
+
+	// BroadcasterBroadcast sends Broadcaster component's broadcast events to tracker.
+	BroadcasterBroadcast(context.Context, Duty, PubKey, SignedData, error)
 }
 
 // wireFuncs defines the core workflow components as a list of input and output functions

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -53,18 +53,6 @@ var stepLabels = map[step]string{
 	sigAgg:            "sig_aggregation",
 }
 
-var labelsToStep = map[string]step{
-	"unknown":             zero,
-	"scheduler":           scheduler,
-	"fetcher":             fetcher,
-	"consensus":           consensus,
-	"validator_api":       validatorAPI,
-	"parsig_db_local":     parSigDBInternal,
-	"parsig_exchange":     parSigEx,
-	"parsig_db_threshold": parSigDBThreshold,
-	"sig_aggregation":     sigAgg,
-}
-
 // step in the core workflow.
 type step int
 
@@ -795,23 +783,20 @@ func (t *Tracker) SigAggEvent(ctx context.Context, duty core.Duty, pubkey core.P
 	return nil
 }
 
-// SendEvent implements core.Tracker interface.
-func (t *Tracker) SendEvent(ctx context.Context, duty core.Duty, label string, pubkey core.PubKey, componentErr error, parSig core.ParSignedData) error {
+// Fetcher implements core.Tracker interface.
+func (t *Tracker) Fetcher(ctx context.Context, duty core.Duty, pubkey core.PubKey, componentErr error) {
 	select {
 	case <-ctx.Done():
-		return ctx.Err()
+		return
 	case <-t.quit:
-		return nil
+		return
 	case t.input <- event{
 		duty:         duty,
-		step:         labelsToStep[label],
+		step:         fetcher,
 		pubkey:       pubkey,
 		componentErr: componentErr,
-		parSig:       &parSig,
 	}:
 	}
-
-	return nil
 }
 
 func reportParSigs(ctx context.Context, duty core.Duty, parsigMsgs parsigsByMsg) {

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -1,0 +1,44 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+import (
+	"context"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+// WithTracking wraps component input functions to support tracking of core components.
+func WithTracking(tracker Tracker) WireOption {
+	return func(w *wireFuncs) {
+		clone := *w
+
+		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
+			fetchErr := clone.FetcherFetch(ctx, duty, set)
+			defer func() {
+				for pubkey := range set {
+					err := tracker.SendEvent(ctx, duty, "fetcher", pubkey, fetchErr, ParSignedData{})
+					if err != nil {
+						log.Error(ctx, "Send event to tracker", err, z.Str("duty", duty.String()))
+					}
+				}
+			}()
+
+			return fetchErr
+		}
+	}
+}

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -17,9 +17,6 @@ package core
 
 import (
 	"context"
-
-	"github.com/obolnetwork/charon/app/log"
-	"github.com/obolnetwork/charon/app/z"
 )
 
 // WithTracking wraps component input functions to support tracking of core components.
@@ -29,14 +26,9 @@ func WithTracking(tracker Tracker) WireOption {
 
 		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
 			fetchErr := clone.FetcherFetch(ctx, duty, set)
-			defer func() {
-				for pubkey := range set {
-					err := tracker.SendEvent(ctx, duty, "fetcher", pubkey, fetchErr, ParSignedData{})
-					if err != nil {
-						log.Error(ctx, "Send event to tracker", err, z.Str("duty", duty.String()))
-					}
-				}
-			}()
+			for pubkey := range set {
+				tracker.Fetcher(ctx, duty, pubkey, fetchErr)
+			}
 
 			return fetchErr
 		}

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -25,12 +25,34 @@ func WithTracking(tracker Tracker) WireOption {
 		clone := *w
 
 		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
-			fetchErr := clone.FetcherFetch(ctx, duty, set)
-			for pubkey := range set {
-				tracker.Fetcher(ctx, duty, pubkey, fetchErr)
-			}
+			err := clone.FetcherFetch(ctx, duty, set)
+			tracker.Fetcher(ctx, duty, set, err)
 
-			return fetchErr
+			return err
+		}
+		w.DutyDBStore = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
+			err := clone.DutyDBStore(ctx, duty, set)
+			tracker.DutyDBStore(ctx, duty, set, err)
+
+			return err
+		}
+		w.ParSigDBStoreInternal = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
+			err := clone.ParSigDBStoreInternal(ctx, duty, set)
+			tracker.ParSigDBStoreInternal(ctx, duty, set, err)
+
+			return err
+		}
+		w.ParSigDBStoreExternal = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
+			err := clone.ParSigDBStoreExternal(ctx, duty, set)
+			tracker.ParSigDBStoreExternal(ctx, duty, set, err)
+
+			return err
+		}
+		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, pubkey PubKey, data SignedData) error {
+			err := clone.BroadcasterBroadcast(ctx, duty, pubkey, data)
+			tracker.BroadcasterBroadcast(ctx, duty, pubkey, data, err)
+
+			return err
 		}
 	}
 }


### PR DESCRIPTION
It is an early PR to propose solution to wrap core component inputs to improve detection of failed duties.

category: feature
ticket: #1478 
