### PR TITLE
cmd: remove deprecated flags from relay command

### DIFF
--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -108,6 +108,7 @@ func bindBootnodeFlag(flags *pflag.FlagSet, config *relay.Config) {
 
 // bindP2PFlagsRelay binds p2p flags for the relay command.
 func bindP2PFlagsRelay(cmd *cobra.Command, config *p2p.Config) {
+	cmd.Flags().StringVar(&config.UDPAddr, "p2p-udp-address", "", "Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery. Discv5 is deprecated, use relay discovery.")
 	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	cmd.Flags().StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
 	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -108,12 +108,7 @@ func bindBootnodeFlag(flags *pflag.FlagSet, config *relay.Config) {
 
 // bindP2PFlagsRelay binds p2p flags for the relay command.
 func bindP2PFlagsRelay(cmd *cobra.Command, config *p2p.Config) {
-	var relays []string
-	cmd.Flags().StringSliceVar(&relays, "p2p-relays", []string{"http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of libp2p relay URLs or ENRs.")
 	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	cmd.Flags().StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
 	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")
-	cmd.Flags().StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
-	cmd.Flags().StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
-	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 }

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -32,7 +32,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 	cmd := &cobra.Command{
 		Use:   "relay",
 		Short: "Start a libp2p relay server",
-		Long:  "Starts a libp2p relay that charon nodes can use to bootstrap their p2p cluster",
+		Long:  "Starts a libp2p relay that charon nodes can use to bootstrap their p2p cluster.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := log.InitLogger(config.LogConfig); err != nil {


### PR DESCRIPTION
Removes deprecated flags from `charon relay` command.

category: refactor
ticket: none 
