### PR TITLE
cmd: re-add previous relay address for backwards compatibility

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -75,7 +75,7 @@ func TestCmdFlags(t *testing.T) {
 					LokiService: "charon",
 				},
 				P2P: p2p.Config{
-					UDPBootnodes:  []string{"https://0.relay.obol.tech/enr"},
+					UDPBootnodes:  []string{"https://0.relay.obol.tech/enr", "http://bootnode.lb.gcp.obol.tech:3640/enr"},
 					UDPAddr:       "",
 					TCPAddrs:      nil,
 					Allowlist:     "",
@@ -102,7 +102,7 @@ func TestCmdFlags(t *testing.T) {
 			Args:    slice("create", "enr"),
 			Datadir: ".charon",
 			P2PConfig: &p2p.Config{
-				UDPBootnodes:  []string{"https://0.relay.obol.tech/enr"},
+				UDPBootnodes:  []string{"https://0.relay.obol.tech/enr", "http://bootnode.lb.gcp.obol.tech:3640/enr"},
 				UDPAddr:       "",
 				TCPAddrs:      nil,
 				Allowlist:     "",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -123,7 +123,7 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 
 func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	var relays []string
-	cmd.Flags().StringSliceVar(&relays, "p2p-relays", []string{"https://0.relay.obol.tech/enr"}, "Comma-separated list of libp2p relay URLs or ENRs.")
+	cmd.Flags().StringSliceVar(&relays, "p2p-relays", []string{"https://0.relay.obol.tech/enr", "http://bootnode.lb.gcp.obol.tech:3640/enr"}, "Comma-separated list of libp2p relay URLs or ENRs.")
 	cmd.Flags().StringSliceVar(&config.UDPBootnodes, "p2p-bootnodes", nil, "Comma-separated list of discv5 bootnode URLs or ENRs. Deprecated, use p2p-relays flag.")
 	cmd.Flags().BoolVar(&config.BootnodeRelay, "p2p-bootnode-relay", true, "Enables using bootnodes as libp2p circuit relays. Useful if some charon nodes are not publicly accessible. Deprecated, should always be enabled.")
 	cmd.Flags().BoolVar(&config.UDPBootLock, "p2p-bootnodes-from-lockfile", false, "Enables using cluster lock ENRs as discv5 bootnodes. Allows skipping explicit bootnodes if key generation ceremony included correct IPs. Discv5 is deprecated, use relay discovery.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ Flags:
       --p2p-disable-reuseport              Disables TCP port reuse for outgoing libp2p connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.
-      --p2p-relays strings                 Comma-separated list of libp2p relay URLs or ENRs. (default [https://0.relay.obol.tech/enr])
+      --p2p-relays strings                 Comma-separated list of libp2p relay URLs or ENRs. (default [https://0.relay.obol.tech/enr,http://bootnode.lb.gcp.obol.tech:3640/enr])
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
       --p2p-udp-address string             Listening UDP address (ip and port) for discv5 discovery. Empty default disables discv5 discovery. Discv5 is deprecated, use relay discovery.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")


### PR DESCRIPTION
Re-adds the previous relay address for backwards compatibility:
 - Keep both default relay addresses
 - https://0.relay.obol.tech/enr points to new relay-cluster
 - http://bootnode.gcp.obol.tech:3640/enr points to the old relay-cluster. 
 - Then existing clusters can smoothly upgrade., nodes either use the old relay or both relays
 - Note discv5 is still required in relay and v0.13 charon nodes to support direct connections with older versions.
 - We can update the old DNS record of http://bootnode.gcp.obol.tech:3640/enr to point to the new relay-cluster at some point if we want. (auto-heal supports this) 
 - We can remove the old URL in v0.15 (or when we want to drop support for v0.12 and older)

category: refactor
ticket: none
