### PR TITLE
testutil/compose: fix dkg shutdown race

### DIFF
--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -16,6 +16,8 @@ services:
     {{end -}}
     {{if .Entrypoint}}entrypoint: {{.Entrypoint}}
     {{end -}}
+    {{if .Command}}command: {{.Command}}
+    {{end -}}
     {{- if .EnvVars}}
     environment:
       {{- range $node.EnvVars}}

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -66,7 +66,11 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 
 		var nodes []TmplNode
 		for i := 0; i < conf.NumNodes; i++ {
-			n := TmplNode{EnvVars: newNodeEnvs(i, conf, "")}
+			n := TmplNode{
+				EnvVars:    newNodeEnvs(i, conf, ""),
+				Entrypoint: "sh",
+				Command:    fmt.Sprintf("[-c,'%s %s && sleep 2']", conf.entrypoint(), cmdDKG), // Sleep after completion to allow other nodes to finish
+			}
 			nodes = append(nodes, n)
 		}
 
@@ -74,12 +78,12 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 			ComposeDir:       dir,
 			CharonImageTag:   conf.ImageTag,
 			CharonEntrypoint: conf.entrypoint(),
-			CharonCommand:    cmdDKG,
+			CharonCommand:    "not used",
 			Bootnode:         true,
 			Nodes:            nodes,
 		}
 	default:
-		return TmplData{}, errors.New("supported keygen")
+		return TmplData{}, errors.New("unsupported keygen", z.Any("keygen", conf.KeyGen))
 	}
 
 	log.Info(ctx, "Creating docker-compose.yml")

--- a/testutil/compose/template.go
+++ b/testutil/compose/template.go
@@ -61,6 +61,7 @@ type TmplVC struct {
 type TmplNode struct {
 	ImageTag   string // ImageTag is empty by default, resulting in CharonImageTag being used.
 	Entrypoint string // Entrypoint is empty by default, resulting in CharonEntrypoint being used.
+	Command    string // Command is empty by default, resulting in CharonCommand being used.
 	EnvVars    []kv
 	Ports      []port
 }

--- a/testutil/compose/testdata/TestDockerCompose_define_create_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_create_template.golden
@@ -7,6 +7,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": null,
    "Ports": null
   }

--- a/testutil/compose/testdata/TestDockerCompose_define_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_dkg_template.golden
@@ -7,6 +7,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": [
     {
      "Key": "name",

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
@@ -7,6 +7,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": [
     {
      "Key": "name",

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
@@ -2,11 +2,12 @@
  "ComposeDir": "testdir",
  "CharonImageTag": "latest",
  "CharonEntrypoint": "/usr/local/bin/charon",
- "CharonCommand": "dkg",
+ "CharonCommand": "not used",
  "Nodes": [
   {
    "ImageTag": "",
-   "Entrypoint": "",
+   "Entrypoint": "sh",
+   "Command": "[-c,'/usr/local/bin/charon dkg \u0026\u0026 sleep 2']",
    "EnvVars": [
     {
      "Key": "private-key-file",
@@ -61,7 +62,8 @@
   },
   {
    "ImageTag": "",
-   "Entrypoint": "",
+   "Entrypoint": "sh",
+   "Command": "[-c,'/usr/local/bin/charon dkg \u0026\u0026 sleep 2']",
    "EnvVars": [
     {
      "Key": "private-key-file",
@@ -116,7 +118,8 @@
   },
   {
    "ImageTag": "",
-   "Entrypoint": "",
+   "Entrypoint": "sh",
+   "Command": "[-c,'/usr/local/bin/charon dkg \u0026\u0026 sleep 2']",
    "EnvVars": [
     {
      "Key": "private-key-file",
@@ -171,7 +174,8 @@
   },
   {
    "ImageTag": "",
-   "Entrypoint": "",
+   "Entrypoint": "sh",
+   "Command": "[-c,'/usr/local/bin/charon dkg \u0026\u0026 sleep 2']",
    "EnvVars": [
     {
      "Key": "private-key-file",

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -3,7 +3,7 @@ version: "3.8"
 x-node-base: &node-base
   image: obolnetwork/charon:latest
   entrypoint: /usr/local/bin/charon
-  command: dkg
+  command: not used
   networks: [compose]
   volumes: [testdir:/compose]
   depends_on: [bootnode] 
@@ -11,6 +11,8 @@ x-node-base: &node-base
 services:
   node0:
     <<: *node-base
+    entrypoint: sh
+    command: [-c,'/usr/local/bin/charon dkg && sleep 2']
     
     environment:
       CHARON_PRIVATE_KEY_FILE: /compose/node0/charon-enr-private-key
@@ -28,6 +30,8 @@ services:
     
   node1:
     <<: *node-base
+    entrypoint: sh
+    command: [-c,'/usr/local/bin/charon dkg && sleep 2']
     
     environment:
       CHARON_PRIVATE_KEY_FILE: /compose/node1/charon-enr-private-key
@@ -45,6 +49,8 @@ services:
     
   node2:
     <<: *node-base
+    entrypoint: sh
+    command: [-c,'/usr/local/bin/charon dkg && sleep 2']
     
     environment:
       CHARON_PRIVATE_KEY_FILE: /compose/node2/charon-enr-private-key
@@ -62,6 +68,8 @@ services:
     
   node3:
     <<: *node-base
+    entrypoint: sh
+    command: [-c,'/usr/local/bin/charon dkg && sleep 2']
     
     environment:
       CHARON_PRIVATE_KEY_FILE: /compose/node3/charon-enr-private-key

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -7,6 +7,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": [
     {
      "Key": "private-key-file",
@@ -115,6 +116,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": [
     {
      "Key": "private-key-file",
@@ -223,6 +225,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": [
     {
      "Key": "private-key-file",
@@ -331,6 +334,7 @@
   {
    "ImageTag": "",
    "Entrypoint": "",
+   "Command": "",
    "EnvVars": [
     {
      "Key": "private-key-file",


### PR DESCRIPTION
Sleep for 2 seconds after successful DKG completion to allow other DKGs to complete as well before exitting causing docker-compose to stop all other containers. This fixes shutdown race in compose DKG tests.

category: test
ticket: #1625
