### PR TITLE
keymanager: api design

### DIFF
--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -13,6 +13,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// Package keymanager provides ETH2 keymanager API (https://ethereum.github.io/keymanager-APIs/) functionalities.
 package keymanager
 
 import (
@@ -42,7 +43,7 @@ type Keymanager struct {
 	baseURL string // Base keymanager URL
 }
 
-// ImportKeystores pushes the keystores to the keymanager API.
+// ImportKeystores pushes the keystores to keymanager.
 // See https://ethereum.github.io/keymanager-APIs/#/Local%20Key%20Manager/importKeystores.
 func (km Keymanager) ImportKeystores(ctx context.Context, keystores []keystore.Keystore, passwords []string) error {
 	addr, err := url.JoinPath(km.baseURL, "/eth/v1/keystores")

--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -1,0 +1,124 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package keymanager
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/eth2util/keystore"
+)
+
+// New returns a new Keymanager.
+func New(url string) Keymanager {
+	return Keymanager{
+		baseURL: url,
+	}
+}
+
+// Keymanager is the REST client for keymanager API requests.
+type Keymanager struct {
+	baseURL string // Base keymanager URL
+}
+
+// ImportKeystores pushes the keystores to the keymanager API.
+// See https://ethereum.github.io/keymanager-APIs/#/Local%20Key%20Manager/importKeystores.
+func (km Keymanager) ImportKeystores(ctx context.Context, keystores []keystore.Keystore, passwords []string) error {
+	addr, err := url.JoinPath(km.baseURL, "/eth/v1/keystores")
+	if err != nil {
+		return errors.Wrap(err, "invalid base url", z.Str("base_url", km.baseURL))
+	}
+
+	req := keymanagerReq{
+		Keystores: keystores,
+		Passwords: passwords,
+	}
+
+	err = postKeys(ctx, addr, req)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// VerifyConnection returns an error if the provided keymanager address is not reachable.
+func (km Keymanager) VerifyConnection(ctx context.Context) error {
+	u, err := url.Parse(km.baseURL)
+	if err != nil {
+		return errors.Wrap(err, "parse address")
+	}
+
+	var d net.Dialer
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
+	conn, err := d.DialContext(ctx, "tcp", u.Host)
+	if err != nil {
+		return errors.Wrap(err, "cannot ping address", z.Str("addr", km.baseURL))
+	}
+	conn.Close()
+
+	return nil
+}
+
+// keymanagerReq represents the keymanager API request body for POST request. Refer: https://ethereum.github.io/keymanager-APIs/#/Local%20Key%20Manager/importKeystores
+type keymanagerReq struct {
+	Keystores []keystore.Keystore `json:"keystores"`
+	Passwords []string            `json:"passwords"`
+}
+
+// postKeys pushes the secrets to the provided keymanager address. The HTTP request times out after 10s.
+func postKeys(ctx context.Context, addr string, reqBody keymanagerReq) error {
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	reqBytes, err := json.Marshal(reqBody)
+	if err != nil {
+		return errors.New("marshal keymanager request body")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, addr, bytes.NewReader(reqBytes))
+	if err != nil {
+		return errors.Wrap(err, "new post request", z.Str("url", addr))
+	}
+	req.Header.Add("Content-Type", `application/json`)
+
+	resp, err := new(http.Client).Do(req)
+	if err != nil {
+		return errors.Wrap(err, "post validator keys to keymanager")
+	}
+
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "read response")
+	}
+	resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return errors.New("failed posting keys", z.Int("status", resp.StatusCode), z.Str("body", string(data)))
+	}
+
+	return nil
+}

--- a/eth2util/keymanager/keymanager_test.go
+++ b/eth2util/keymanager/keymanager_test.go
@@ -1,0 +1,102 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package keymanager_test
+
+import (
+	"context"
+	"crypto/rand"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/eth2util/keymanager"
+	"github.com/obolnetwork/charon/eth2util/keystore"
+	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestImportKeystores(t *testing.T) {
+	var (
+		ctx        = context.Background()
+		numSecrets = 4
+		secrets    []*bls_sig.SecretKey
+	)
+
+	for i := 0; i < numSecrets; i++ {
+		_, secret, err := tbls.Keygen()
+		require.NoError(t, err)
+		secrets = append(secrets, secret)
+	}
+
+	var (
+		keystores []keystore.Keystore
+		passwords []string
+	)
+	for _, secret := range secrets {
+		password, err := testutil.RandomHex32()
+		require.NoError(t, err)
+
+		store, err := keystore.Encrypt(secret, password, rand.Reader)
+		require.NoError(t, err)
+
+		keystores = append(keystores, store)
+		passwords = append(passwords, password)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	t.Run("successful import keystores", func(t *testing.T) {
+		cl := keymanager.New(srv.URL)
+		err := cl.ImportKeystores(ctx, keystores, passwords)
+		require.NoError(t, err)
+	})
+
+	t.Run("mismatching lengths", func(t *testing.T) {
+		cl := keymanager.New("")
+		err := cl.ImportKeystores(ctx, keystores, []string{})
+		require.ErrorContains(t, err, "lengths of keystores and passwords don't match")
+	})
+}
+
+func TestVerifyConnection(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("successful ping", func(t *testing.T) {
+		srv := httptest.NewServer(nil)
+		defer srv.Close()
+
+		cl := keymanager.New(srv.URL)
+		require.NoError(t, cl.VerifyConnection(ctx))
+	})
+
+	t.Run("cannot ping address", func(t *testing.T) {
+		cl := keymanager.New("1.1.1.1")
+		require.Error(t, cl.VerifyConnection(ctx))
+		require.ErrorContains(t, cl.VerifyConnection(ctx), "cannot ping address")
+	})
+
+	t.Run("invalid address", func(t *testing.T) {
+		cl := keymanager.New("1.1.0:34")
+		require.Error(t, cl.VerifyConnection(ctx))
+		require.ErrorContains(t, cl.VerifyConnection(ctx), "parse address")
+	})
+}

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -13,7 +13,7 @@
 // You should have received a copy of the GNU General Public License along with
 // this program.  If not, see <http://www.gnu.org/licenses/>.
 
-// Package Keystore provides functions to store and load private keys
+// Package keystore provides functions to store and load private keys
 // to/from EIP 2335 (https://eips.ethereum.org/EIPS/eip-2335) compatible Keystore files. Passwords are
 // expected/created in files with same identical names as the keystores, except with txt extension.
 package keystore
@@ -47,7 +47,7 @@ type confirmInsecure struct{}
 var ConfirmInsecureKeys confirmInsecure
 
 // StoreKeysInsecure stores the secrets in dir/keystore-insecure-%d.json EIP 2335 Keystore files
-// with new random passwords stored in dir/Keystore-insecure-%d.txt.
+// with new random passwords stored in dir/keystore-insecure-%d.txt.
 //
 // 🚨 The keystores are insecure and should only be used for testing large validator sets
 // as it speeds up encryption and decryption at the cost of security.
@@ -103,12 +103,12 @@ func storeKeysInternal(secrets []*bls_sig.SecretKey, dir string, filenameFmt str
 
 		b, err := json.MarshalIndent(store, "", " ")
 		if err != nil {
-			return errors.Wrap(err, "marshal Keystore")
+			return errors.Wrap(err, "marshal keystore")
 		}
 
 		filename := path.Join(dir, fmt.Sprintf(filenameFmt, i))
 		if err := os.WriteFile(filename, b, 0o444); err != nil {
-			return errors.Wrap(err, "write Keystore")
+			return errors.Wrap(err, "write keystore")
 		}
 
 		if err := storePassword(filename, password); err != nil {
@@ -120,7 +120,7 @@ func storeKeysInternal(secrets []*bls_sig.SecretKey, dir string, filenameFmt str
 }
 
 // LoadKeys returns all secrets stored in dir/keystore-*.json 2335 Keystore files
-// using password stored in dir/Keystore-*.txt.
+// using password stored in dir/keystore-*.txt.
 func LoadKeys(dir string) ([]*bls_sig.SecretKey, error) {
 	files, err := filepath.Glob(path.Join(dir, "keystore-*.json"))
 	if err != nil {
@@ -140,7 +140,7 @@ func LoadKeys(dir string) ([]*bls_sig.SecretKey, error) {
 
 		var store Keystore
 		if err := json.Unmarshal(b, &store); err != nil {
-			return nil, errors.Wrap(err, "unmarshal Keystore")
+			return nil, errors.Wrap(err, "unmarshal keystore")
 		}
 
 		password, err := loadPassword(f)
@@ -190,12 +190,12 @@ func Encrypt(secret *bls_sig.SecretKey, password string, random io.Reader,
 	encryptor := keystorev4.New(opts...)
 	fields, err := encryptor.Encrypt(secretBytes, password)
 	if err != nil {
-		return Keystore{}, errors.Wrap(err, "encrypt Keystore")
+		return Keystore{}, errors.Wrap(err, "encrypt keystore")
 	}
 
 	return Keystore{
 		Crypto:      fields,
-		Description: "", // optional field to help explain the purpose and identify a particular Keystore in a user-friendly manner.
+		Description: "", // optional field to help explain the purpose and identify a particular keystore in a user-friendly manner.
 		Pubkey:      hex.EncodeToString(pubKeyBytes),
 		Path:        "m/12381/3600/0/0/0", // https://eips.ethereum.org/EIPS/eip-2334
 		ID:          uuid(random),
@@ -208,7 +208,7 @@ func decrypt(store Keystore, password string) (*bls_sig.SecretKey, error) {
 	decryptor := keystorev4.New()
 	secretBytes, err := decryptor.Decrypt(store.Crypto, password)
 	if err != nil {
-		return nil, errors.Wrap(err, "decrypt Keystore")
+		return nil, errors.Wrap(err, "decrypt keystore")
 	}
 
 	return tblsconv.SecretFromBytes(secretBytes)
@@ -222,7 +222,7 @@ func uuid(random io.Reader) string {
 	return fmt.Sprintf("%X-%X-%X-%X-%X", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
 }
 
-// loadPassword loads a Keystore password from the Keystore's associated password file.
+// loadPassword loads a keystore password from the Keystore's associated password file.
 func loadPassword(keyFile string) (string, error) {
 	if _, err := os.Stat(keyFile); errors.Is(err, os.ErrNotExist) {
 		return "", errors.New("keystore password file not found " + keyFile)

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 // insecureCost decreases the cipher key cost from the default 18 to 4 which speeds up
@@ -72,7 +73,7 @@ type KeymanagerReq struct {
 func KeymanagerReqBody(secrets []*bls_sig.SecretKey) (KeymanagerReq, error) {
 	var resp KeymanagerReq
 	for _, secret := range secrets {
-		password, err := randomHex32()
+		password, err := testutil.RandomHex32()
 		if err != nil {
 			return KeymanagerReq{}, err
 		}
@@ -91,7 +92,7 @@ func KeymanagerReqBody(secrets []*bls_sig.SecretKey) (KeymanagerReq, error) {
 
 func storeKeysInternal(secrets []*bls_sig.SecretKey, dir string, filenameFmt string, opts ...keystorev4.Option) error {
 	for i, secret := range secrets {
-		password, err := randomHex32()
+		password, err := testutil.RandomHex32()
 		if err != nil {
 			return err
 		}
@@ -247,15 +248,4 @@ func storePassword(keyFile string, password string) error {
 	}
 
 	return nil
-}
-
-// randomHex32 returns a random 32 character hex string.
-func randomHex32() (string, error) {
-	b := make([]byte, 16)
-	_, err := rand.Read(b)
-	if err != nil {
-		return "", errors.Wrap(err, "read random")
-	}
-
-	return hex.EncodeToString(b), nil
 }

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -19,6 +19,7 @@ package testutil
 import (
 	"crypto/ecdsa"
 	crand "crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"math/rand"
@@ -862,4 +863,15 @@ func RandomCoreSignedRandao() core.SignedRandao {
 		Epoch:     RandomEpoch(),
 		Signature: RandomEth2Signature(),
 	}}
+}
+
+// RandomHex32 returns a random 32 character hex string.
+func RandomHex32() (string, error) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", errors.Wrap(err, "read random")
+	}
+
+	return hex.EncodeToString(b), nil
 }


### PR DESCRIPTION
Introduces a new package `eth2util/keymanager` for keymanager api functionalities.

category: feature
ticket: https://github.com/ObolNetwork/charon/issues/1502 
