### PR TITLE
dkg: add keymanager support

### DIFF
--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -57,7 +57,7 @@ this command at the same time.`,
 }
 
 func bindKeymanagerAddrFlag(flags *pflag.FlagSet, addr *string) {
-	flags.StringVar(addr, "keymanager-address", "", "The keymanager URL to push validator keyshares to.")
+	flags.StringVar(addr, "keymanager-address", "", "The keymanager URL to import validator keyshares.")
 }
 
 func bindDefDirFlag(flags *pflag.FlagSet, dataDir *string) {

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -47,12 +47,17 @@ this command at the same time.`,
 	}
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
+	bindKeymanagerAddrFlag(cmd.Flags(), &config.KeymanagerAddr)
 	bindDefDirFlag(cmd.Flags(), &config.DefFile)
 	bindNoVerifyFlag(cmd.Flags(), &config.NoVerify)
 	bindP2PFlags(cmd, &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
 
 	return cmd
+}
+
+func bindKeymanagerAddrFlag(flags *pflag.FlagSet, addr *string) {
+	flags.StringVar(addr, "keymanager-address", "", "The keymanager URL to push validator keyshares to.")
 }
 
 func bindDefDirFlag(flags *pflag.FlagSet, dataDir *string) {

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -17,6 +17,7 @@ package dkg
 
 import (
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -33,8 +34,10 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util/deposit"
+	"github.com/obolnetwork/charon/eth2util/keymanager"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 // loadDefinition returns the cluster definition from disk or an HTTP URL. It returns the test definition if configured.
@@ -95,8 +98,43 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 	return def, nil
 }
 
-// writeKeystores writes the private share keystores to disk.
-func writeKeystores(datadir string, shares []share) error {
+// writeKeysToKeymanager writes validator private keyshares for the node to the provided keymanager address.
+func writeKeysToKeymanager(ctx context.Context, keymanagerURL string, shares []share) error {
+	var (
+		keystores []keystore.Keystore
+		passwords []string
+	)
+
+	for _, s := range shares {
+		password, err := testutil.RandomHex32()
+		if err != nil {
+			return err
+		}
+		passwords = append(passwords, password)
+
+		secret, err := tblsconv.ShareToSecret(s.SecretShare)
+		if err != nil {
+			return err
+		}
+
+		store, err := keystore.Encrypt(secret, password, rand.Reader)
+		if err != nil {
+			return err
+		}
+		keystores = append(keystores, store)
+	}
+
+	cl := keymanager.New(keymanagerURL)
+	err := cl.ImportKeystores(ctx, keystores, passwords)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// writeKeysToDisk writes validator private keyshares for the node to disk.
+func writeKeysToDisk(datadir string, shares []share) error {
 	var secrets []*bls_sig.SecretKey
 	for _, s := range shares {
 		secret, err := tblsconv.ShareToSecret(s.SecretShare)

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -18,6 +18,7 @@ package dkg
 import (
 	"context"
 	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/url"
@@ -37,7 +38,6 @@ import (
 	"github.com/obolnetwork/charon/eth2util/keymanager"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
-	"github.com/obolnetwork/charon/testutil"
 )
 
 // loadDefinition returns the cluster definition from disk or an HTTP URL. It returns the test definition if configured.
@@ -106,7 +106,7 @@ func writeKeysToKeymanager(ctx context.Context, keymanagerURL string, shares []s
 	)
 
 	for _, s := range shares {
-		password, err := testutil.RandomHex32()
+		password, err := randomHex32()
 		if err != nil {
 			return err
 		}
@@ -236,4 +236,15 @@ func validURI(str string) bool {
 	u, err := url.Parse(str)
 
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+}
+
+// randomHex32 returns a random 32 character hex string. It uses crypto/rand.
+func randomHex32() (string, error) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", errors.Wrap(err, "read random")
+	}
+
+	return hex.EncodeToString(b), nil
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -205,7 +205,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		if err = writeKeysToKeymanager(ctx, conf.KeymanagerAddr, shares); err != nil {
 			return err
 		}
-		log.Debug(ctx, "Saved keyshares to keymanager API")
+		log.Debug(ctx, "Saved keyshares to keymanager")
 	} else { // Else save to disk
 		if err = writeKeysToDisk(conf.DataDir, shares); err != nil {
 			return err

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -205,7 +205,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		if err = writeKeysToKeymanager(ctx, conf.KeymanagerAddr, shares); err != nil {
 			return err
 		}
-		log.Debug(ctx, "Saved keyshares to keymanager")
+		log.Debug(ctx, "Imported keyshares to keymanager", z.Str("keymanager_address", conf.KeymanagerAddr))
 	} else { // Else save to disk
 		if err = writeKeysToDisk(conf.DataDir, shares); err != nil {
 			return err

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	if conf.KeymanagerAddr != "" {
 		cl := keymanager.New(conf.KeymanagerAddr)
 		if err = cl.VerifyConnection(ctx); err != nil {
-			return err
+			return errors.Wrap(err, "verify keymanager address")
 		}
 	}
 

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -111,7 +111,7 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*ecdsa.
 		TestDef: &def,
 	}
 
-	allReceived := make(chan struct{}) // Receives struct{} if all `numNodes` keystores are intercepted by the keymanager server
+	allReceived := make(chan struct{}) // Receives struct{} for each `numNodes` keystore intercepted by the keymanager server
 	if keymanager {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			go func() {

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
-	"github.com/obolnetwork/charon/testutil"
 )
 
 // insecureCost decreases the cipher key cost from the default 18 to 4 which speeds up
@@ -65,7 +64,7 @@ func StoreKeys(secrets []*bls_sig.SecretKey, dir string) error {
 
 func storeKeysInternal(secrets []*bls_sig.SecretKey, dir string, filenameFmt string, opts ...keystorev4.Option) error {
 	for i, secret := range secrets {
-		password, err := testutil.RandomHex32()
+		password, err := randomHex32()
 		if err != nil {
 			return err
 		}
@@ -221,4 +220,15 @@ func storePassword(keyFile string, password string) error {
 	}
 
 	return nil
+}
+
+// randomHex32 returns a random 32 character hex string. It uses crypto/rand.
+func randomHex32() (string, error) {
+	b := make([]byte, 16)
+	_, err := rand.Read(b)
+	if err != nil {
+		return "", errors.Wrap(err, "read random")
+	}
+
+	return hex.EncodeToString(b), nil
 }


### PR DESCRIPTION
Adds support for keymanager API to `charon dkg` command.

category: feature
ticket: #1504 
