### PR TITLE
cmd/relay: serve enr

### DIFF
--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -136,13 +136,11 @@ func TestStartChecker(t *testing.T) {
 			advanceClock(clock, 10*time.Second, 2)
 
 			// Advance clock for first epoch tick.
-			advanceClock(clock, 384*time.Second, 2)
-
-			// Advance clock for last tick.
-			advanceClock(clock, 10*time.Second, 2)
+			advanceClock(clock, 32*12*time.Second, 2)
 
 			if tt.err != nil {
 				require.Eventually(t, func() bool {
+					advanceClock(clock, 10*time.Second, 2)
 					err = readyErrFunc()
 					if !errors.Is(err, tt.err) {
 						t.Logf("Ignoring unexpected error, got=%v, want=%v", err, tt.err)
@@ -153,6 +151,7 @@ func TestStartChecker(t *testing.T) {
 				}, time.Second, 100*time.Millisecond)
 			} else {
 				require.Eventually(t, func() bool {
+					advanceClock(clock, 12*time.Second, 2)
 					return readyErrFunc() == nil
 				}, time.Second, 100*time.Millisecond)
 			}

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -156,9 +156,9 @@ func Run(ctx context.Context, config Config) error {
 	}
 }
 
-// newENRHandler returns a handler that returns the nodes ID and public address encoded as a ENR.
+// newENRHandler returns a handler that returns the node's ID and public address encoded as a ENR.
 func newENRHandler(ctx context.Context, tcpNode host.Host, p2pKey *ecdsa.PrivateKey, config p2p.Config) func(ctx context.Context) ([]byte, error) {
-	// Resolve external hostname peridodically.
+	// Resolve external hostname periodically.
 	var (
 		extHostMu sync.Mutex
 		extHostIP net.IP
@@ -226,7 +226,7 @@ func newENRHandler(ctx context.Context, tcpNode host.Host, p2pKey *ecdsa.Private
 		}
 		tcpAddr, ok := addr.(*net.TCPAddr)
 		if !ok {
-			return nil, errors.New("not a TCP address")
+			return nil, errors.New("invalid TCP address")
 		}
 
 		// Override IP with external IP or external hostname if set.

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -17,14 +17,20 @@ package relay
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/pprof"
 	"os"
+	"sort"
+	"sync"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/host"
 	ma "github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -32,6 +38,7 @@ import (
 	"github.com/obolnetwork/charon/app/promauto"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/eth2util/enr"
 	"github.com/obolnetwork/charon/p2p"
 )
 
@@ -98,29 +105,8 @@ func Run(ctx context.Context, config Config) error {
 		}
 
 		mux := http.NewServeMux()
-		mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			p2pAddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", tcpNode.ID()))
-			if err != nil {
-				log.Error(r.Context(), "Peer address", err)
-				w.WriteHeader(http.StatusInternalServerError)
-
-				return
-			}
-
-			var addrs []ma.Multiaddr
-			for _, addr := range tcpNode.Addrs() {
-				addrs = append(addrs, addr.Encapsulate(p2pAddr))
-			}
-
-			b, err := json.Marshal(addrs)
-			if err != nil {
-				log.Error(r.Context(), "Marshal multiaddrs", err)
-				w.WriteHeader(http.StatusInternalServerError)
-
-				return
-			}
-			_, _ = w.Write(b)
-		})
+		mux.HandleFunc("/", wrapHandler(newMultiaddrHandler(tcpNode)))
+		mux.HandleFunc("/enr", wrapHandler(newENRHandler(ctx, tcpNode, key, config.P2PConfig)))
 		server := http.Server{Addr: config.HTTPAddr, Handler: mux, ReadHeaderTimeout: time.Second}
 		serverErr <- server.ListenAndServe()
 	}()
@@ -156,7 +142,7 @@ func Run(ctx context.Context, config Config) error {
 			z.Str("url", fmt.Sprintf("http://%s", config.HTTPAddr)),
 		)
 	} else {
-		log.Info(ctx, "Runtime ENR not available via http, since http-address flag is not set")
+		log.Info(ctx, "Runtime multiaddrs not available via http, since http-address flag is not set")
 	}
 
 	for {
@@ -167,5 +153,133 @@ func Run(ctx context.Context, config Config) error {
 			log.Info(ctx, "Shutting down")
 			return nil
 		}
+	}
+}
+
+// newENRHandler returns a handler that returns the nodes ID and public address encoded as a ENR.
+func newENRHandler(ctx context.Context, tcpNode host.Host, p2pKey *ecdsa.PrivateKey, config p2p.Config) func(ctx context.Context) ([]byte, error) {
+	// Resolve external hostname peridodically.
+	var (
+		extHostMu sync.Mutex
+		extHostIP net.IP
+	)
+	go func() {
+		if config.ExternalHost == "" {
+			return
+		}
+
+		resolveExtHost := func() {
+			ip, err := net.LookupIP(config.ExternalHost)
+			if err != nil {
+				log.Warn(ctx, "Failed to resolve external host", err, z.Str("host", config.ExternalHost))
+				return
+			}
+			extHostMu.Lock()
+			extHostIP = ip[0]
+			extHostMu.Unlock()
+		}
+
+		onStartup := make(chan struct{}, 1)
+		onStartup <- struct{}{}
+
+		for {
+			select {
+			case <-onStartup:
+				resolveExtHost()
+			case <-time.After(5 * time.Minute):
+				resolveExtHost()
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// getExtHostIP returns the external host IP and true if it is set.
+	getExtHostIP := func() (net.IP, bool) {
+		extHostMu.Lock()
+		defer extHostMu.Unlock()
+
+		return extHostIP, len(extHostIP) != 0
+	}
+
+	return func(ctx context.Context) ([]byte, error) {
+		// Use libp2p configured and detected addresses.
+		addrs := tcpNode.Addrs()
+		if len(addrs) == 0 {
+			return nil, errors.New("no addresses")
+		}
+
+		// Order public addresses first.
+		sort.SliceStable(addrs, func(i, j int) bool {
+			iPublic, jPublic := manet.IsPublicAddr(addrs[i]), manet.IsPublicAddr(addrs[j])
+			if jPublic && !iPublic {
+				return true // Only swap if j is public and i is not.
+			}
+
+			return false
+		})
+
+		// Use first address (ip and port).
+		addr, err := manet.ToNetAddr(addrs[0])
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to convert multiaddr to net addr")
+		}
+		tcpAddr, ok := addr.(*net.TCPAddr)
+		if !ok {
+			return nil, errors.New("not a TCP address")
+		}
+
+		// Override IP with external IP or external hostname if set.
+		if config.ExternalIP != "" {
+			tcpAddr.IP = net.ParseIP(config.ExternalIP)
+		} else if extHostIP, ok := getExtHostIP(); ok {
+			tcpAddr.IP = extHostIP
+		}
+
+		// Build the ENR
+		r, err := enr.New(p2pKey, enr.WithIP(tcpAddr.IP), enr.WithTCP(tcpAddr.Port))
+		if err != nil {
+			return nil, err
+		}
+
+		return []byte(r.String()), nil
+	}
+}
+
+// newMultiaddrHandler returns a handler that returns the nodes multiaddrs (as json array).
+func newMultiaddrHandler(tcpNode host.Host) func(ctx context.Context) ([]byte, error) {
+	return func(ctx context.Context) ([]byte, error) {
+		p2pAddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", tcpNode.ID()))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create p2p multiaddr")
+		}
+
+		var addrs []ma.Multiaddr
+		for _, addr := range tcpNode.Addrs() {
+			addrs = append(addrs, addr.Encapsulate(p2pAddr))
+		}
+
+		b, err := json.Marshal(addrs)
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal json")
+		}
+
+		return b, nil
+	}
+}
+
+func wrapHandler(handler func(ctx context.Context) (response []byte, err error)) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		response, err := handler(ctx)
+		if err != nil {
+			log.Error(ctx, "Handler error", err, z.Str("path", r.URL.Path))
+			w.WriteHeader(http.StatusInternalServerError)
+
+			return
+		}
+
+		_, _ = w.Write(response)
 	}
 }

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -268,6 +268,7 @@ func newMultiaddrHandler(tcpNode host.Host) func(ctx context.Context) ([]byte, e
 	}
 }
 
+// wrapHandler returns a http handler by wrapping the provided function with error handling.
 func wrapHandler(handler func(ctx context.Context) (response []byte, err error)) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/cmd/relay/relay_internal_test.go
+++ b/cmd/relay/relay_internal_test.go
@@ -19,16 +19,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"testing"
 	"time"
 
 	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/eth2util/enr"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
 )
@@ -79,7 +83,113 @@ func TestRunBootnodeAutoP2P(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestServeMultiAddrs(t *testing.T) {
+func TestServeAddrs(t *testing.T) {
+	t.Run("multiaddrs", func(t *testing.T) {
+		testServeAddrs(t,
+			p2p.Config{TCPAddrs: []string{testutil.AvailableAddr(t).String()}},
+			"",
+			func(t *testing.T, data []byte) bool {
+				t.Helper()
+				var addrs []string
+				err := json.Unmarshal(data, &addrs)
+				if err != nil {
+					t.Logf("failed to unmarshal multiaddrs: %v [%s]", err, data)
+					return false
+				}
+
+				if len(addrs) == 0 {
+					t.Logf("no addrs")
+					return false
+				}
+
+				for _, addr := range addrs {
+					_, err := ma.NewMultiaddr(addr)
+					if err != nil {
+						t.Logf("failed to parse multiaddr: %v [%v]", err, addr)
+						return false
+					}
+				}
+
+				return true
+			},
+		)
+	})
+
+	t.Run("enr", func(t *testing.T) {
+		testServeAddrs(t,
+			p2p.Config{TCPAddrs: []string{testutil.AvailableAddr(t).String()}},
+			"enr",
+			func(t *testing.T, data []byte) bool {
+				t.Helper()
+				r, err := enr.Parse(string(data))
+				if err != nil {
+					t.Logf("failed to parse enr: %v [%s]", err, data)
+					return false
+				}
+
+				ip, ok := r.IP()
+				require.True(t, ok)
+				require.Equal(t, "127.0.0.1", ip.String())
+
+				return true
+			},
+		)
+	})
+
+	t.Run("enr_ext_ip", func(t *testing.T) {
+		testServeAddrs(t,
+			p2p.Config{
+				TCPAddrs:   []string{testutil.AvailableAddr(t).String()},
+				ExternalIP: "222.222.222.222",
+			},
+			"enr",
+			func(t *testing.T, data []byte) bool {
+				t.Helper()
+				r, err := enr.Parse(string(data))
+				if err != nil {
+					t.Logf("failed to parse enr: %v [%s]", err, data)
+					return false
+				}
+
+				ip, ok := r.IP()
+				require.True(t, ok)
+				require.Equal(t, "222.222.222.222", ip.String())
+
+				return true
+			},
+		)
+	})
+
+	t.Run("enr_ext_host", func(t *testing.T) {
+		testServeAddrs(t,
+			p2p.Config{
+				TCPAddrs:     []string{testutil.AvailableAddr(t).String()},
+				ExternalHost: "www.google.com",
+			},
+			"enr",
+			func(t *testing.T, data []byte) bool {
+				t.Helper()
+				r, err := enr.Parse(string(data))
+				if err != nil {
+					t.Logf("failed to parse enr: %v [%s]", err, data)
+					return false
+				}
+
+				ip, ok := r.IP()
+				require.True(t, ok)
+				if ip.IsLoopback() {
+					t.Logf("ip is loopback")
+					return false
+				}
+
+				return true
+			},
+		)
+	})
+}
+
+func testServeAddrs(t *testing.T, p2pConfig p2p.Config, path string, asserter func(*testing.T, []byte) bool) {
+	t.Helper()
 	temp, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
@@ -87,7 +197,7 @@ func TestServeMultiAddrs(t *testing.T) {
 		AutoP2PKey: true,
 		DataDir:    temp,
 		LogConfig:  log.DefaultConfig(),
-		P2PConfig:  p2p.Config{TCPAddrs: []string{testutil.AvailableAddr(t).String()}},
+		P2PConfig:  p2pConfig,
 		HTTPAddr:   testutil.AvailableAddr(t).String(),
 	}
 
@@ -98,37 +208,28 @@ func TestServeMultiAddrs(t *testing.T) {
 		return Run(ctx, config)
 	})
 	eg.Go(func() error {
-		require.Eventually(t, func() bool {
-			b, err := http.Get(fmt.Sprintf("http://%s", config.HTTPAddr))
+		ok := assert.Eventually(t, func() bool {
+			resp, err := http.Get(fmt.Sprintf("http://%s/%s", config.HTTPAddr, path))
 			if err != nil {
 				t.Logf("failed to get: %v", err)
 				return false
 			}
-			var addrs []string
-			err = json.NewDecoder(b.Body).Decode(&addrs)
+			defer resp.Body.Close()
+			b, err := io.ReadAll(resp.Body)
 			if err != nil {
 				t.Logf("failed to decode: %v", err)
 				return false
 			}
 
-			if len(addrs) == 0 {
-				t.Logf("no addrs")
-				return false
-			}
-
-			for _, addr := range addrs {
-				_, err := ma.NewMultiaddr(addr)
-				if err != nil {
-					t.Logf("failed to parse multiaddr: %v [%v]", err, addr)
-					return false
-				}
-			}
-
-			return true
+			return asserter(t, b)
 		}, 2*time.Second, 100*time.Millisecond)
 		cancel()
 
-		return Run(ctx, config)
+		if !ok {
+			return errors.New("assert failed")
+		}
+
+		return nil
 	})
 
 	err = eg.Wait()

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -90,7 +90,7 @@ func NewRelays(ctx context.Context, relayAddrs []string, lockHashHex string,
 func resolveRelay(ctx context.Context, rawURL, lockHashHex string, callback func(Peer)) {
 	var (
 		prevAddrs      string
-		backoff, reset = expbackoff.NewWithReset(ctx)
+		backoff, reset = expbackoff.NewWithReset(ctx, expbackoff.WithFastConfig()) // Fast retries mostly for unit tests.
 	)
 	for ctx.Err() == nil {
 		addrs, err := queryRelayAddrs(ctx, rawURL, backoff, lockHashHex)


### PR DESCRIPTION
Reintroduces the ability for the relay to serve its ID and address via an ENR for backwards compatibility to v0.13 charon nodes.

category: bug
ticket: none
