### PR TITLE
core: use multiple fee-recipient addresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -400,7 +400,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	sched.SubscribeSlots(setFeeRecipient(eth2Cl, eth2Pubkeys, feeRecipientFunc))
 	sched.SubscribeSlots(tracker.NewInclDelayFunc(eth2Cl, sched.GetDutyDefinition))
 
-	fetch, err := fetcher.New(eth2Cl, feeRecipientAddrByCorePubkey)
+	fetch, err := fetcher.New(eth2Cl, feeRecipientFunc)
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -317,14 +317,21 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	eth2Cl eth2wrap.Client, peerIDs []peer.ID, sender *p2p.Sender,
 	qbftSniffer func(*pbv1.SniffedConsensusInstance), seenPubkeys func(core.PubKey),
 ) error {
+	feeRecipientAddrs, err := lock.FeeRecipientAddresses()
+	if err != nil {
+		return err
+	}
+
 	// Convert and prep public keys and public shares
 	var (
-		corePubkeys       []core.PubKey
-		eth2Pubkeys       []eth2p0.BLSPubKey
-		pubshares         []eth2p0.BLSPubKey
-		allPubSharesByKey = make(map[core.PubKey]map[int]*bls_sig.PublicKey) // map[pubkey]map[shareIdx]pubshare
+		corePubkeys                  []core.PubKey
+		eth2Pubkeys                  []eth2p0.BLSPubKey
+		pubshares                    []eth2p0.BLSPubKey
+		allPubSharesByKey            = make(map[core.PubKey]map[int]*bls_sig.PublicKey) // map[pubkey]map[shareIdx]pubshare
+		feeRecipientAddsByEth2Pubkey = make(map[eth2p0.BLSPubKey]string)
+		feeRecipientAddsByCorePubkey = make(map[core.PubKey]string)
 	)
-	for _, dv := range lock.Validators {
+	for i, dv := range lock.Validators {
 		pubkey, err := dv.PublicKey()
 		if err != nil {
 			return err
@@ -365,6 +372,8 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		corePubkeys = append(corePubkeys, corePubkey)
 		pubshares = append(pubshares, eth2Share)
 		allPubSharesByKey[corePubkey] = allPubShares
+		feeRecipientAddsByEth2Pubkey[eth2Pubkey] = feeRecipientAddrs[i]
+		feeRecipientAddsByCorePubkey[corePubkey] = feeRecipientAddrs[i]
 	}
 
 	peers, err := lock.Peers()
@@ -386,23 +395,17 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	// TODO(corver): refactor to support multiple fee recipient addresses.
-	vaddrs, err := lock.LegacyValidatorAddresses()
-	if err != nil {
-		return err
-	}
-
-	sched.SubscribeSlots(setFeeRecipient(eth2Cl, eth2Pubkeys, vaddrs.FeeRecipientAddress))
+	sched.SubscribeSlots(setFeeRecipient(eth2Cl, eth2Pubkeys, feeRecipientAddsByEth2Pubkey))
 	sched.SubscribeSlots(tracker.NewInclDelayFunc(eth2Cl, sched.GetDutyDefinition))
 
-	fetch, err := fetcher.New(eth2Cl, vaddrs.FeeRecipientAddress)
+	fetch, err := fetcher.New(eth2Cl, feeRecipientAddsByCorePubkey)
 	if err != nil {
 		return err
 	}
 
 	dutyDB := dutydb.NewMemDB(deadlinerFunc("dutydb"))
 
-	vapi, err := validatorapi.NewComponent(eth2Cl, allPubSharesByKey, nodeIdx.ShareIdx, vaddrs.FeeRecipientAddress,
+	vapi, err := validatorapi.NewComponent(eth2Cl, allPubSharesByKey, nodeIdx.ShareIdx, feeRecipientAddsByCorePubkey,
 		conf.BuilderAPI, seenPubkeys)
 	if err != nil {
 		return err
@@ -772,7 +775,7 @@ func wireTracing(life *lifecycle.Manager, conf Config) error {
 
 // setFeeRecipient returns a slot subscriber for scheduler which calls prepare_beacon_proposer endpoint at start of each epoch.
 // TODO(dhruv): move this somewhere else once more use-cases like this becomes clear.
-func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeRecipient string) func(ctx context.Context, slot core.Slot) error {
+func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeRecipientByPubkey map[eth2p0.BLSPubKey]string) func(ctx context.Context, slot core.Slot) error {
 	onStartup := true
 
 	return func(ctx context.Context, slot core.Slot) error {
@@ -788,29 +791,31 @@ func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeReci
 			return err
 		}
 
-		var activeIdxs []eth2p0.ValidatorIndex
+		var activeVals []*eth2v1.Validator
 		for _, validator := range vals {
 			if validator.Status != eth2v1.ValidatorStateActiveOngoing {
 				continue
 			}
-			activeIdxs = append(activeIdxs, validator.Index)
+			activeVals = append(activeVals, validator)
 		}
 
-		if len(activeIdxs) == 0 {
+		if len(activeVals) == 0 {
 			return nil // No active validators.
 		}
 
-		var addr bellatrix.ExecutionAddress
-		b, err := hex.DecodeString(strings.TrimPrefix(feeRecipient, "0x"))
-		if err != nil {
-			return errors.Wrap(err, "hex decode fee recipient address")
-		}
-		copy(addr[:], b)
-
 		var preps []*eth2v1.ProposalPreparation
-		for _, vIdx := range activeIdxs {
+		for _, val := range activeVals {
+			feeRecipient := feeRecipientByPubkey[val.Validator.PublicKey]
+
+			var addr bellatrix.ExecutionAddress
+			b, err := hex.DecodeString(strings.TrimPrefix(feeRecipient, "0x"))
+			if err != nil {
+				return errors.Wrap(err, "hex decode fee recipient address")
+			}
+			copy(addr[:], b)
+
 			preps = append(preps, &eth2v1.ProposalPreparation{
-				ValidatorIndex: vIdx,
+				ValidatorIndex: val.Index,
 				FeeRecipient:   addr,
 			})
 		}

--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -125,7 +126,12 @@ func TestSetFeeRecipient(t *testing.T) {
 			return nil
 		}
 
-		fn := setFeeRecipient(bmock, clone.PublicKeys(), "0xdead")
+		feeRecipientByPubkey := make(map[eth2p0.BLSPubKey]string)
+		for _, pubkey := range clone.PublicKeys() {
+			feeRecipientByPubkey[pubkey] = "0xdead"
+		}
+
+		fn := setFeeRecipient(bmock, clone.PublicKeys(), feeRecipientByPubkey)
 		err = fn(context.Background(), core.Slot{SlotsPerEpoch: 1})
 		require.NoError(t, err)
 

--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
-	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -126,12 +125,9 @@ func TestSetFeeRecipient(t *testing.T) {
 			return nil
 		}
 
-		feeRecipientByPubkey := make(map[eth2p0.BLSPubKey]string)
-		for _, pubkey := range clone.PublicKeys() {
-			feeRecipientByPubkey[pubkey] = "0xdead"
-		}
-
-		fn := setFeeRecipient(bmock, clone.PublicKeys(), feeRecipientByPubkey)
+		fn := setFeeRecipient(bmock, clone.PublicKeys(), func(core.PubKey) string {
+			return "0xdead"
+		})
 		err = fn(context.Background(), core.Slot{SlotsPerEpoch: 1})
 		require.NoError(t, err)
 

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -312,6 +312,16 @@ func (d Definition) WithdrawalAddresses() ([]string, error) {
 	return resp, nil
 }
 
+// FeeRecipientAddresses is a convenience function to return all fee-recipient address from the validator addresses slice.
+func (d Definition) FeeRecipientAddresses() ([]string, error) {
+	var resp []string
+	for _, vaddrs := range d.ValidatorAddresses {
+		resp = append(resp, vaddrs.FeeRecipientAddress)
+	}
+
+	return resp, nil
+}
+
 // SetDefinitionHashes returns a copy of the definition with the config hash and definition hash populated.
 func (d Definition) SetDefinitionHashes() (Definition, error) {
 	// Marshal config hash

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -34,20 +34,20 @@ import (
 )
 
 // New returns a new fetcher instance.
-func New(eth2Cl eth2wrap.Client, feeRecipientAddress string) (*Fetcher, error) {
+func New(eth2Cl eth2wrap.Client, feeRecipientAddressByPubkey map[core.PubKey]string) (*Fetcher, error) {
 	return &Fetcher{
-		eth2Cl:              eth2Cl,
-		feeRecipientAddress: feeRecipientAddress,
+		eth2Cl:                      eth2Cl,
+		feeRecipientAddressByPubkey: feeRecipientAddressByPubkey,
 	}, nil
 }
 
 // Fetcher fetches proposed duty data.
 type Fetcher struct {
-	eth2Cl              eth2wrap.Client
-	feeRecipientAddress string
-	subs                []func(context.Context, core.Duty, core.UnsignedDataSet) error
-	aggSigDBFunc        func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
-	awaitAttDataFunc    func(ctx context.Context, slot int64, commIdx int64) (*eth2p0.AttestationData, error)
+	eth2Cl                      eth2wrap.Client
+	feeRecipientAddressByPubkey map[core.PubKey]string
+	subs                        []func(context.Context, core.Duty, core.UnsignedDataSet) error
+	aggSigDBFunc                func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
+	awaitAttDataFunc            func(ctx context.Context, slot int64, commIdx int64) (*eth2p0.AttestationData, error)
 }
 
 // Subscribe registers a callback for fetched duties.
@@ -260,7 +260,7 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot int64, defSet core
 		}
 
 		// Ensure fee recipient is correctly populated in block.
-		verifyFeeRecipient(ctx, block, f.feeRecipientAddress)
+		verifyFeeRecipient(ctx, block, f.feeRecipientAddressByPubkey[pubkey])
 
 		coreBlock, err := core.NewVersionedBeaconBlock(block)
 		if err != nil {
@@ -297,7 +297,7 @@ func (f *Fetcher) fetchBuilderProposerData(ctx context.Context, slot int64, defS
 			return nil, err
 		}
 
-		verifyFeeRecipientBlindedBlock(ctx, block, f.feeRecipientAddress)
+		verifyFeeRecipientBlindedBlock(ctx, block, f.feeRecipientAddressByPubkey[pubkey])
 
 		coreBlock, err := core.NewVersionedBlindedBeaconBlock(block)
 		if err != nil {

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -220,11 +220,6 @@ func TestFetchProposer(t *testing.T) {
 		vIdxB: testutil.RandomCorePubKey(t),
 	}
 
-	feeRecipientByPubkey := map[core.PubKey]string{
-		pubkeysByIdx[vIdxA]: feeRecipientAddr,
-		pubkeysByIdx[vIdxB]: feeRecipientAddr,
-	}
-
 	dutyA := eth2v1.ProposerDuty{
 		Slot:           slot,
 		ValidatorIndex: vIdxA,
@@ -248,7 +243,9 @@ func TestFetchProposer(t *testing.T) {
 
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
-	fetch, err := fetcher.New(bmock, feeRecipientByPubkey)
+	fetch, err := fetcher.New(bmock, func(core.PubKey) string {
+		return feeRecipientAddr
+	})
 	require.NoError(t, err)
 
 	fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -270,6 +267,7 @@ func TestFetchProposer(t *testing.T) {
 		slotB, err := dutyDataB.Slot()
 		require.NoError(t, err)
 		require.EqualValues(t, slot, slotB)
+		require.Equal(t, feeRecipientAddr, fmt.Sprintf("%#x", dutyDataB.Capella.Body.ExecutionPayload.FeeRecipient))
 		assertRandao(t, randaoByPubKey[pubkeysByIdx[vIdxB]].Signature().ToETH2(), dutyDataB)
 
 		return nil
@@ -292,11 +290,6 @@ func TestFetchBuilderProposer(t *testing.T) {
 	pubkeysByIdx := map[eth2p0.ValidatorIndex]core.PubKey{
 		vIdxA: testutil.RandomCorePubKey(t),
 		vIdxB: testutil.RandomCorePubKey(t),
-	}
-
-	feeRecipientByPubkey := map[core.PubKey]string{
-		pubkeysByIdx[vIdxA]: feeRecipientAddr,
-		pubkeysByIdx[vIdxB]: feeRecipientAddr,
 	}
 
 	dutyA := eth2v1.ProposerDuty{
@@ -322,7 +315,9 @@ func TestFetchBuilderProposer(t *testing.T) {
 
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
-	fetch, err := fetcher.New(bmock, feeRecipientByPubkey)
+	fetch, err := fetcher.New(bmock, func(core.PubKey) string {
+		return feeRecipientAddr
+	})
 	require.NoError(t, err)
 
 	fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -344,6 +339,7 @@ func TestFetchBuilderProposer(t *testing.T) {
 		slotB, err := dutyDataB.Slot()
 		require.NoError(t, err)
 		require.EqualValues(t, slot, slotB)
+		require.Equal(t, feeRecipientAddr, fmt.Sprintf("%#x", dutyDataB.Capella.Body.ExecutionPayloadHeader.FeeRecipient))
 		assertRandaoBlindedBlock(t, randaoByPubKey[pubkeysByIdx[vIdxB]].Signature().ToETH2(), dutyDataB)
 
 		return nil

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -75,7 +75,7 @@ func TestFetchAttester(t *testing.T) {
 	duty := core.NewAttesterDuty(slot)
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
-	fetch, err := fetcher.New(bmock, "")
+	fetch, err := fetcher.New(bmock, nil)
 	require.NoError(t, err)
 
 	fetch.Subscribe(func(ctx context.Context, resDuty core.Duty, resDataSet core.UnsignedDataSet) error {
@@ -163,7 +163,7 @@ func TestFetchAggregator(t *testing.T) {
 		return nil, errors.New("expected unknown root")
 	}
 
-	fetch, err := fetcher.New(bmock, "")
+	fetch, err := fetcher.New(bmock, nil)
 	require.NoError(t, err)
 
 	fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -220,6 +220,11 @@ func TestFetchProposer(t *testing.T) {
 		vIdxB: testutil.RandomCorePubKey(t),
 	}
 
+	feeRecipientByPubkey := map[core.PubKey]string{
+		pubkeysByIdx[vIdxA]: feeRecipientAddr,
+		pubkeysByIdx[vIdxB]: feeRecipientAddr,
+	}
+
 	dutyA := eth2v1.ProposerDuty{
 		Slot:           slot,
 		ValidatorIndex: vIdxA,
@@ -243,7 +248,7 @@ func TestFetchProposer(t *testing.T) {
 
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
-	fetch, err := fetcher.New(bmock, feeRecipientAddr)
+	fetch, err := fetcher.New(bmock, feeRecipientByPubkey)
 	require.NoError(t, err)
 
 	fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -289,6 +294,11 @@ func TestFetchBuilderProposer(t *testing.T) {
 		vIdxB: testutil.RandomCorePubKey(t),
 	}
 
+	feeRecipientByPubkey := map[core.PubKey]string{
+		pubkeysByIdx[vIdxA]: feeRecipientAddr,
+		pubkeysByIdx[vIdxB]: feeRecipientAddr,
+	}
+
 	dutyA := eth2v1.ProposerDuty{
 		Slot:           slot,
 		ValidatorIndex: vIdxA,
@@ -312,7 +322,7 @@ func TestFetchBuilderProposer(t *testing.T) {
 
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
-	fetch, err := fetcher.New(bmock, feeRecipientAddr)
+	fetch, err := fetcher.New(bmock, feeRecipientByPubkey)
 	require.NoError(t, err)
 
 	fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -446,7 +456,7 @@ func TestFetchSyncContribution(t *testing.T) {
 		}
 
 		// Construct fetcher component.
-		fetch, err := fetcher.New(bmock, "")
+		fetch, err := fetcher.New(bmock, nil)
 		require.NoError(t, err)
 
 		fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -507,7 +517,7 @@ func TestFetchSyncContribution(t *testing.T) {
 		require.NoError(t, err)
 
 		// Construct fetcher component.
-		fetch, err := fetcher.New(bmock, "")
+		fetch, err := fetcher.New(bmock, nil)
 		require.NoError(t, err)
 
 		fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {
@@ -537,7 +547,7 @@ func TestFetchSyncContribution(t *testing.T) {
 		require.NoError(t, err)
 
 		// Construct fetcher component.
-		fetch, err := fetcher.New(bmock, "")
+		fetch, err := fetcher.New(bmock, nil)
 		require.NoError(t, err)
 
 		fetch.RegisterAggSigDB(func(ctx context.Context, duty core.Duty, key core.PubKey) (core.SignedData, error) {

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -43,9 +43,15 @@ type TekuProposerConfigProvider interface {
 }
 
 func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigResponse, error) {
+	var defaultFeeRecipientAddr string
+	for _, addr := range c.feeRecipientAddressByPubkey {
+		defaultFeeRecipientAddr = addr
+		break
+	}
 	resp := TekuProposerConfigResponse{
 		Proposers: make(map[string]TekuProposerConfig),
 		Default: TekuProposerConfig{ // Default doesn't make sense, disable for now.
+			FeeRecipient: defaultFeeRecipientAddr,
 			Builder: TekuBuilder{
 				Enabled:  false,
 				GasLimit: gasLimit,

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -46,7 +46,6 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 	resp := TekuProposerConfigResponse{
 		Proposers: make(map[string]TekuProposerConfig),
 		Default: TekuProposerConfig{ // Default doesn't make sense, disable for now.
-			FeeRecipient: c.feeRecipientAddress,
 			Builder: TekuBuilder{
 				Enabled:  false,
 				GasLimit: gasLimit,
@@ -61,7 +60,7 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 
 	for pubkey, pubshare := range c.sharesByKey {
 		resp.Proposers[string(pubshare)] = TekuProposerConfig{
-			FeeRecipient: c.feeRecipientAddress,
+			FeeRecipient: c.feeRecipientAddressByPubkey[pubkey],
 			Builder: TekuBuilder{
 				Enabled:  c.builderAPI,
 				GasLimit: gasLimit,

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -58,7 +58,7 @@ func NewComponentInsecure(_ *testing.T, eth2Cl eth2wrap.Client, shareIdx int) (*
 //
 //nolint:gocognit
 func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey,
-	shareIdx int, feeRecipientAddressByPubkey map[core.PubKey]string, builderAPI bool, seenPubkeys func(core.PubKey),
+	shareIdx int, feeRecipientFunc func(core.PubKey) string, builderAPI bool, seenPubkeys func(core.PubKey),
 ) (*Component, error) {
 	var (
 		sharesByKey     = make(map[eth2p0.BLSPubKey]eth2p0.BLSPubKey)
@@ -133,23 +133,23 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 	}
 
 	return &Component{
-		getVerifyShareFunc:          getVerifyShareFunc,
-		getPubShareFunc:             getPubShareFunc,
-		getPubKeyFunc:               getPubKeyFunc,
-		sharesByKey:                 coreSharesByKey,
-		eth2Cl:                      eth2Cl,
-		shareIdx:                    shareIdx,
-		feeRecipientAddressByPubkey: feeRecipientAddressByPubkey,
-		builderAPI:                  builderAPI,
+		getVerifyShareFunc: getVerifyShareFunc,
+		getPubShareFunc:    getPubShareFunc,
+		getPubKeyFunc:      getPubKeyFunc,
+		sharesByKey:        coreSharesByKey,
+		eth2Cl:             eth2Cl,
+		shareIdx:           shareIdx,
+		feeRecipientFunc:   feeRecipientFunc,
+		builderAPI:         builderAPI,
 	}, nil
 }
 
 type Component struct {
-	eth2Cl                      eth2wrap.Client
-	shareIdx                    int
-	insecureTest                bool
-	feeRecipientAddressByPubkey map[core.PubKey]string
-	builderAPI                  bool
+	eth2Cl           eth2wrap.Client
+	shareIdx         int
+	insecureTest     bool
+	feeRecipientFunc func(core.PubKey) string
+	builderAPI       bool
 
 	// getVerifyShareFunc maps public shares (what the VC thinks as its public key)
 	// to public keys (the DV root public key)

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -58,7 +58,7 @@ func NewComponentInsecure(_ *testing.T, eth2Cl eth2wrap.Client, shareIdx int) (*
 //
 //nolint:gocognit
 func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey,
-	shareIdx int, feeRecipientAddress string, builderAPI bool, seenPubkeys func(core.PubKey),
+	shareIdx int, feeRecipientAddressByPubkey map[core.PubKey]string, builderAPI bool, seenPubkeys func(core.PubKey),
 ) (*Component, error) {
 	var (
 		sharesByKey     = make(map[eth2p0.BLSPubKey]eth2p0.BLSPubKey)
@@ -133,23 +133,23 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 	}
 
 	return &Component{
-		getVerifyShareFunc:  getVerifyShareFunc,
-		getPubShareFunc:     getPubShareFunc,
-		getPubKeyFunc:       getPubKeyFunc,
-		sharesByKey:         coreSharesByKey,
-		eth2Cl:              eth2Cl,
-		shareIdx:            shareIdx,
-		feeRecipientAddress: feeRecipientAddress,
-		builderAPI:          builderAPI,
+		getVerifyShareFunc:          getVerifyShareFunc,
+		getPubShareFunc:             getPubShareFunc,
+		getPubKeyFunc:               getPubKeyFunc,
+		sharesByKey:                 coreSharesByKey,
+		eth2Cl:                      eth2Cl,
+		shareIdx:                    shareIdx,
+		feeRecipientAddressByPubkey: feeRecipientAddressByPubkey,
+		builderAPI:                  builderAPI,
 	}, nil
 }
 
 type Component struct {
-	eth2Cl              eth2wrap.Client
-	shareIdx            int
-	insecureTest        bool
-	feeRecipientAddress string
-	builderAPI          bool
+	eth2Cl                      eth2wrap.Client
+	shareIdx                    int
+	insecureTest                bool
+	feeRecipientAddressByPubkey map[core.PubKey]string
+	builderAPI                  bool
 
 	// getVerifyShareFunc maps public shares (what the VC thinks as its public key)
 	// to public keys (the DV root public key)

--- a/core/validatorapi/validatorapi_internal_test.go
+++ b/core/validatorapi/validatorapi_internal_test.go
@@ -42,7 +42,7 @@ func TestMismatchKeysFunc(t *testing.T) {
 	t.Run("no mismatch", func(t *testing.T) {
 		allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey}} // Maps self to self since not tbls
 
-		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, "", false, nil)
+		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, false, nil)
 		require.NoError(t, err)
 		pk, err := vapi.getPubKeyFunc(eth2Pubkey)
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestMismatchKeysFunc(t *testing.T) {
 		require.NoError(t, err)
 		allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey, shareIdx + 1: pk}}
 
-		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, "", false, nil)
+		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, false, nil)
 		require.NoError(t, err)
 
 		resp, err := vapi.getPubKeyFunc(pubshare) // Ask for a mismatching key
@@ -74,7 +74,7 @@ func TestMismatchKeysFunc(t *testing.T) {
 		require.NoError(t, err)
 		allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey}}
 
-		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, "", false, nil)
+		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, false, nil)
 		require.NoError(t, err)
 
 		_, err = vapi.getPubKeyFunc(pubshare) // Ask for a mismatching key

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1246,7 +1246,11 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 
 func TestComponent_TekuProposerConfig(t *testing.T) {
 	ctx := context.Background()
-	shareIdx := 1
+	const (
+		zeroAddr     = "0x0000000000000000000000000000000000000000"
+		feeRecipient = "0x123456"
+		shareIdx     = 1
+	)
 	// Create keys (just use normal keys, not split tbls)
 	pubkey, _, err := tbls.Keygen()
 	require.NoError(t, err)
@@ -1260,11 +1264,10 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	const feeRecipient = "0x123456"
-	feeRecipientByPubkey := map[core.PubKey]string{corePubKey: feeRecipient}
-
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, feeRecipientByPubkey, true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, func(core.PubKey) string {
+		return feeRecipient
+	}, true, nil)
 	require.NoError(t, err)
 
 	resp, err := vapi.TekuProposerConfig(ctx)
@@ -1291,7 +1294,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 			},
 		},
 		Default: validatorapi.TekuProposerConfig{
-			FeeRecipient: feeRecipient,
+			FeeRecipient: zeroAddr,
 			Builder: validatorapi.TekuBuilder{
 				Enabled:  false,
 				GasLimit: 30000000,

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -196,7 +196,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error) {
@@ -300,7 +300,7 @@ func TestSignAndVerify(t *testing.T) {
 	allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey}} // Maps self to self since not tbls
 
 	// Setup validatorapi component.
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 	vapi.RegisterPubKeyByAttestation(func(context.Context, int64, int64, int64) (core.PubKey, error) {
 		return tblsconv.KeyToCore(pubkey)
@@ -423,7 +423,7 @@ func TestComponent_SubmitBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -502,7 +502,7 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -560,7 +560,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -724,7 +724,7 @@ func TestComponent_SubmitBlindedBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, true, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -799,7 +799,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, true, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -859,7 +859,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, true, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -943,7 +943,7 @@ func TestComponent_SubmitVoluntaryExit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned voluntary exit
@@ -1009,7 +1009,7 @@ func TestComponent_SubmitVoluntaryExitInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	// Register subscriber
@@ -1067,7 +1067,7 @@ func TestComponent_Duties(t *testing.T) {
 		}
 
 		// Construct the validator api component
-		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 		require.NoError(t, err)
 		duties, err := vapi.ProposerDuties(ctx, eth2p0.Epoch(epch), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
 		require.NoError(t, err)
@@ -1087,7 +1087,7 @@ func TestComponent_Duties(t *testing.T) {
 		}
 
 		// Construct the validator api component
-		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 		require.NoError(t, err)
 		duties, err := vapi.AttesterDuties(ctx, eth2p0.Epoch(epch), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
 		require.NoError(t, err)
@@ -1107,7 +1107,7 @@ func TestComponent_Duties(t *testing.T) {
 		}
 
 		// Construct the validator api component
-		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 		require.NoError(t, err)
 		duties, err := vapi.SyncCommitteeDuties(ctx, eth2p0.Epoch(epch), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
 		require.NoError(t, err)
@@ -1138,7 +1138,7 @@ func TestComponent_SubmitValidatorRegistration(t *testing.T) {
 	builderAPI := true
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", builderAPI, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, builderAPI, nil)
 	require.NoError(t, err)
 
 	unsigned := testutil.RandomValidatorRegistration(t)
@@ -1214,7 +1214,7 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 	builderAPI := true
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", builderAPI, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, builderAPI, nil)
 	require.NoError(t, err)
 
 	unsigned := testutil.RandomValidatorRegistration(t)
@@ -1260,13 +1260,11 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	feeRecipient := "0x123456"
-
-	// Enable builder API
-	builderAPI := true
+	const feeRecipient = "0x123456"
+	feeRecipientByPubkey := map[core.PubKey]string{corePubKey: feeRecipient}
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, feeRecipient, builderAPI, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, feeRecipientByPubkey, true, nil)
 	require.NoError(t, err)
 
 	resp, err := vapi.TekuProposerConfig(ctx)
@@ -1293,7 +1291,6 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 			},
 		},
 		Default: validatorapi.TekuProposerConfig{
-			FeeRecipient: feeRecipient,
 			Builder: validatorapi.TekuBuilder{
 				Enabled:  false,
 				GasLimit: 30000000,
@@ -1427,7 +1424,7 @@ func TestComponent_SubmitAggregateAttestationVerify(t *testing.T) {
 	}
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -1556,7 +1553,7 @@ func TestComponent_SubmitSyncCommitteeContributionsVerify(t *testing.T) {
 	}
 
 	// Construct validatorapi component.
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -1634,7 +1631,7 @@ func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {
 	}
 
 	// Construct the validator api component.
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, "", false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterAwaitAggSigDB(func(ctx context.Context, duty core.Duty, pubkey core.PubKey) (core.SignedData, error) {

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1291,6 +1291,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 			},
 		},
 		Default: validatorapi.TekuProposerConfig{
+			FeeRecipient: feeRecipient,
 			Builder: validatorapi.TekuBuilder{
 				Enabled:  false,
 				GasLimit: 30000000,


### PR DESCRIPTION
Uses multiple fee-recipient addresses from lock introduced in v1.5.

category: feature
ticket: #1651 
