### PR TITLE
app/k1util: ports geth crypto package helper functions

### DIFF
--- a/app/k1util/k1util.go
+++ b/app/k1util/k1util.go
@@ -1,0 +1,173 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Package k1util provides helper function for working with secp256k1 keys.
+package k1util
+
+import (
+	"encoding/hex"
+	"os"
+
+	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
+	"github.com/libp2p/go-libp2p/core/crypto"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+const (
+	scalarLen = 32
+	// k1HashLen is the length of secp256k1 signature hash/digest.
+	k1HashLen = 32
+	// k1SigLen is the Ethereum format length of secp256k1 signatures.
+	k1SigLen = 65
+	// k1RecIdx is the Ethereum format secp256k1 signature recovery id index.
+	k1RecIdx = 64
+
+	// compactSigMagicOffset is a value used when creating the compact signature
+	// recovery code inherited from Bitcoin.
+	compactSigMagicOffset = 27
+)
+
+// PublicKeyFromLibP2P returns the libp2p public key as a secp256k1 public key.
+func PublicKeyFromLibP2P(key crypto.PubKey) (*k1.PublicKey, error) {
+	k1Key, ok := key.(*crypto.Secp256k1PublicKey)
+	if !ok {
+		return nil, errors.New("invalid public key type")
+	}
+
+	return (*k1.PublicKey)(k1Key), nil
+}
+
+// Sign returns a signature from input data.
+//
+// The produced signature is 65 bytes in the [R || S || V] format where V is 0 or 1.
+func Sign(key *k1.PrivateKey, hash []byte) ([]byte, error) {
+	if len(hash) != k1HashLen {
+		return nil, errors.New("signing hash/digest not 32 bytes", z.Int("len", len(hash)))
+	}
+
+	sig := ecdsa.SignCompact(key, hash, false)
+
+	// Convert signature from "compact" into "Ethereum R S V" format.
+
+	recovery := sig[0] // Compact sig recovery code is the value 27 + public key recovery code
+	sig = append(sig[1:], recovery-compactSigMagicOffset)
+
+	return sig, nil
+}
+
+// Verify returns whether the signature is valid for the provided hash
+// and secp256k1 public key.
+//
+// Note the signature MUST be 64 bytes in the [R || S] format without recovery ID.
+func Verify(pubkey *k1.PublicKey, hash []byte, sig []byte) (bool, error) {
+	if len(sig) != 2*scalarLen {
+		return false, errors.New("signature not 64 bytes")
+	}
+
+	r, err := to32Scalar(sig[:scalarLen])
+	if err != nil {
+		return false, errors.Wrap(err, "invalid signature R")
+	}
+
+	s, err := to32Scalar(sig[scalarLen : 2*scalarLen])
+	if err != nil {
+		return false, errors.Wrap(err, "invalid signature S")
+	}
+
+	return ecdsa.NewSignature(r, s).Verify(hash, pubkey), nil
+}
+
+// Recover returns the recovered public key from signature hash.
+//
+// Note the signature MUST be 65 bytes in the [R || S || V] format where V is 0/27 or 1/28.
+func Recover(hash []byte, sig []byte) (*k1.PublicKey, error) {
+	if len(hash) != k1HashLen {
+		return nil, errors.New("signing hash/digest not 32 bytes", z.Int("len", len(hash)))
+	}
+
+	if len(sig) != k1SigLen {
+		return nil, errors.New("signature not 65 bytes")
+	}
+
+	// Convert from ethereum RSV format
+	if sig[k1RecIdx] != 0 && sig[k1RecIdx] != 1 && sig[k1RecIdx] != compactSigMagicOffset && sig[k1RecIdx] != compactSigMagicOffset+1 {
+		return nil, errors.New("invalid recovery id", z.Any("id", sig[k1RecIdx]))
+	}
+
+	if sig[k1RecIdx] == 0 || sig[k1RecIdx] == 1 {
+		sig[k1RecIdx] += compactSigMagicOffset // Make the last byte 27 or 28 since that is required below.
+	}
+
+	// Put recovery ID first.
+	sig = append([]byte{sig[k1RecIdx]}, sig[:k1RecIdx]...)
+
+	pubkey, _, err := ecdsa.RecoverCompact(sig, hash)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse signature")
+	}
+
+	return pubkey, nil
+}
+
+// Load returns a private key by reading it from a hex encoded file on disk.
+func Load(file string) (*k1.PrivateKey, error) {
+	hexStr, err := os.ReadFile(file)
+	if err != nil {
+		return nil, errors.Wrap(err, "read private key from disk", z.Str("file", file))
+	}
+
+	b, err := hex.DecodeString(string(hexStr))
+	if err != nil {
+		return nil, errors.Wrap(err, "decode private key hex")
+	}
+
+	return k1.PrivKeyFromBytes(b), nil
+}
+
+// Save writes the hex encoded private key to disk.
+func Save(key *k1.PrivateKey, file string) error {
+	hexStr := hex.EncodeToString(key.Serialize())
+
+	if err := os.WriteFile(file, []byte(hexStr), 0o600); err != nil {
+		return errors.Wrap(err, "write private key to disk", z.Str("file", file))
+	}
+
+	return nil
+}
+
+// to32Scalar returns the 256-bit big-endian unsigned
+// integer as a scalar.
+func to32Scalar(b []byte) (*k1.ModNScalar, error) {
+	if len(b) != scalarLen {
+		return nil, errors.New("invalid scalar length")
+	}
+
+	// Strip leading zeroes from S.
+	for len(b) > 0 && b[0] == 0x00 {
+		b = b[1:]
+	}
+
+	var s k1.ModNScalar
+	if overflow := s.SetByteSlice(b); overflow {
+		return nil, errors.New("scalar overflow")
+	} else if s.IsZero() {
+		return nil, errors.New("zero overflow")
+	}
+
+	return &s, nil
+}

--- a/app/k1util/k1util_test.go
+++ b/app/k1util/k1util_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package k1util_test
+
+import (
+	"crypto/ecdsa"
+	"encoding/hex"
+	"math/rand"
+	"testing"
+
+	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/k1util"
+)
+
+const (
+	privKey1 = "41d3ff12045b73c870529fe44f70dca2745bafbe1698ffc3c8759eef3cfbaee1"
+	pubKey1  = "02bc8e7cdb50e0ffd52a54faf984d6ac8fe5ee6856d38a5f8acd9bd33fc9c7d50d"
+	digest1  = "52fdfc072182654f163f5f0f9a621d729566c74d10037c4d7bbb0407d1e2c649" // 32 byte digest.
+	sig1     = "e08097bed6dc40d70aa0076f9d8250057566cdf40c652b3785ad9c06b1e38d584f8f331bf46f68e3737823a3bda905e90ca96735d510a6934b215753c09acec201"
+)
+
+func TestLegacyGethCrypto(t *testing.T) {
+	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(0)))
+	require.NoError(t, err)
+
+	require.Equal(t, fromHex(t, privKey1), crypto.FromECDSA(key))
+	require.Equal(t, fromHex(t, pubKey1), crypto.CompressPubkey(&key.PublicKey))
+
+	digest := fromHex(t, digest1)
+
+	sig, err := crypto.Sign(digest, key)
+	require.NoError(t, err)
+	require.Equal(t, fromHex(t, sig1), sig)
+
+	ok := crypto.VerifySignature(
+		crypto.CompressPubkey(&key.PublicKey),
+		digest,
+		sig[:len(sig)-1])
+	require.True(t, ok)
+}
+
+func TestK1Util(t *testing.T) {
+	key := k1.PrivKeyFromBytes(fromHex(t, privKey1))
+
+	require.Equal(t, fromHex(t, privKey1), key.Serialize())
+	require.Equal(t, fromHex(t, pubKey1), key.PubKey().SerializeCompressed())
+
+	digest := fromHex(t, digest1)
+
+	sig, err := k1util.Sign(key, digest)
+	require.NoError(t, err)
+	require.Equal(t, fromHex(t, sig1), sig)
+
+	ok, err := k1util.Verify(
+		key.PubKey(),
+		digest,
+		sig[:len(sig)-1])
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	recovered, err := k1util.Recover(
+		digest,
+		sig)
+	require.NoError(t, err)
+	require.True(t, key.PubKey().IsEqual(recovered))
+}
+
+func TestRandom(t *testing.T) {
+	key, err := k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	digest := make([]byte, 32)
+	_, _ = rand.Read(digest)
+
+	sig, err := k1util.Sign(key, digest)
+	require.NoError(t, err)
+
+	ok, err := k1util.Verify(
+		key.PubKey(),
+		digest,
+		sig[:len(sig)-1])
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	recovered, err := k1util.Recover(
+		digest,
+		sig)
+	require.NoError(t, err)
+	require.True(t, key.PubKey().IsEqual(recovered))
+}
+
+func fromHex(t *testing.T, hexStr string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(hexStr)
+	require.NoError(t, err)
+
+	return b
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/attestantio/go-eth2-client v0.15.2
 	github.com/bufbuild/buf v1.12.0
 	github.com/coinbase/kryptology v1.5.6-0.20220316191335-269410e1b06b
+	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/ferranbt/fastssz v0.1.2
 	github.com/golang/snappy v0.0.4
@@ -63,7 +64,6 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
-	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect
 	github.com/docker/cli v20.10.21+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v20.10.21+incompatible // indirect


### PR DESCRIPTION
Adds a `app/k1util` package that will replace the `geth/crypto` package. The aim is to work with underlying `github.com/decred/dcrd/dcrec/secp256k1/v4` types which is aligned with libp2p's way of doing this:
 - `k1.PrivateKey` to replace `ecdsa.PrivateKey`
 - `k1.PublicKey` to replace `ecdsa.PublicKey`

category: refactor
ticket: #1626 
