### PR TITLE
golangci: disable gocognit lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -130,6 +130,7 @@ linters:
     - forcetypeassert
     - gci
     - gochecknoglobals
+    - gocognit
     - gocyclo
     - godox
     - goerr113

--- a/app/app.go
+++ b/app/app.go
@@ -310,8 +310,6 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 }
 
 // wireCoreWorkflow wires the core workflow components.
-//
-//nolint:gocognit
 func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	lock cluster.Lock, nodeIdx cluster.NodeIdx, tcpNode host.Host, p2pKey *k1.PrivateKey,
 	eth2Cl eth2wrap.Client, peerIDs []peer.ID, sender *p2p.Sender,

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -307,7 +307,6 @@ func writeTemplate(methods []Method, providers []string, imprts []string) error 
 	return nil
 }
 
-//nolint:gocognit
 func parseEth2Methods(pkg *packages.Package) ([]Method, []string, error) {
 	var (
 		methods   []Method

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -42,8 +42,6 @@ const (
 )
 
 // TestEncode tests whether charon can correctly encode lock and definition files.
-//
-//nolint:gocognit
 func TestEncode(t *testing.T) {
 	for _, version := range cluster.SupportedVersionsForT(t) {
 		t.Run(version, func(t *testing.T) {

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -165,7 +165,7 @@ func (d Definition) NodeIdx(pID peer.ID) (NodeIdx, error) {
 
 // VerifySignatures returns true if all config signatures are fully populated and valid. A verified definition is ready for use in DKG.
 //
-//nolint:nestif,gocognit // We should try and break this into functions.
+//nolint:nestif
 func (d Definition) VerifySignatures() error {
 	// Skip signature verification for definition versions earlier than v1.3 since there are no EIP712 signatures before v1.3.0.
 	if !supportEIP712Sigs(d.Version) && !eip712SigsPresent(d.Operators) {

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -94,8 +94,6 @@ func startP2P(ctx context.Context, config Config, key *k1.PrivateKey, reporter m
 const unknownCluster = "unknown"
 
 // monitorConnections blocks instrumenting peer connection metrics until the context is closed.
-//
-//nolint:gocognit // Long but not complex.
 func monitorConnections(ctx context.Context, tcpNode host.Host, bwTuples <-chan bwTuple) {
 	// peerState tracks connection data per peer.
 	type peerState struct {

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -52,7 +52,7 @@ type Broadcaster struct {
 }
 
 // Broadcast broadcasts the aggregated signed duty data object to the beacon-node.
-func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, pubkey core.PubKey, aggData core.SignedData) (err error) { //nolint:gocognit
+func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, pubkey core.PubKey, aggData core.SignedData) (err error) {
 	ctx = log.WithTopic(ctx, "bcast")
 	ctx = log.WithCtx(ctx, z.Any("pubkey", pubkey))
 	defer func() {

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -86,8 +86,6 @@ func (db *MemDB) Shutdown() {
 }
 
 // Store implements core.DutyDB, see its godoc.
-//
-//nolint:gocognit
 func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.UnsignedDataSet) error {
 	db.mu.Lock()
 	defer db.mu.Unlock()

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -316,7 +316,6 @@ func TestFetchBlocks(t *testing.T) {
 	})
 }
 
-//nolint:gocognit
 func TestFetchSyncContribution(t *testing.T) {
 	ctx := context.Background()
 

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -168,8 +168,6 @@ type dedupKey struct {
 // Run executes the consensus algorithm until the context closed.
 // The generic type I is the instance of consensus and can be anything.
 // The generic type V is the arbitrary data value being proposed; it only requires an Equal method.
-//
-//nolint:gocognit // It is indeed a complex algorithm.
 func Run[I any, V comparable](ctx context.Context, d Definition[I, V], t Transport[I, V], instance I, process int64, inputValue V) (err error) {
 	if isZeroVal(inputValue) {
 		return errors.New("zero input value not supported")

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -205,7 +205,6 @@ type test struct {
 	Fuzz          bool                    // Enables fuzzing by Node 1.
 }
 
-//nolint:gocognit
 func testQBFT(t *testing.T, test test) {
 	t.Helper()
 

--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -41,8 +41,6 @@ func NewInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc) func(contex
 }
 
 // newInclDelayFunc extends NewInclDelayFunc with abstracted callback.
-//
-//nolint:gocognit
 func newInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc, callback func([]int64)) func(context.Context, core.Slot) error {
 	// dutyStartSlot is the first slot we can instrument (since dutiesFunc will not have duties from older slots).
 	var dutyStartSlot int64

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -55,8 +55,6 @@ func NewComponentInsecure(_ *testing.T, eth2Cl eth2wrap.Client, shareIdx int) (*
 }
 
 // NewComponent returns a new instance of the validator API core workflow component.
-//
-//nolint:gocognit
 func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey,
 	shareIdx int, feeRecipientFunc func(core.PubKey) string, builderAPI bool, seenPubkeys func(core.PubKey),
 ) (*Component, error) {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -56,8 +56,6 @@ type Config struct {
 }
 
 // Run executes a dkg ceremony and writes secret share keystore and cluster lock files as output to disk.
-//
-//nolint:gocognit
 func Run(ctx context.Context, conf Config) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -286,7 +286,6 @@ func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 	}
 }
 
-//nolint:gocognit
 func TestSyncFlow(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/testutil/combine/main.go
+++ b/testutil/combine/main.go
@@ -88,7 +88,6 @@ func run(ctx context.Context, lockfile, inputDir, outputDir string) error {
 	return keystore.StoreKeys([]*bls_sig.SecretKey{secret}, outputDir)
 }
 
-//nolint:gocognit // It is just nested loops searching through all DVs to find the index of each share.
 func secretsToShares(lock cluster.Lock, secrets []*bls_sig.SecretKey) ([]*bls_sig.SecretKeyShare, error) {
 	n := len(lock.Operators)
 

--- a/testutil/compose/alert.go
+++ b/testutil/compose/alert.go
@@ -105,7 +105,6 @@ func getActiveAlerts(alerts promAlerts) []string {
 }
 
 // promAlerts is the json response returned by querying prometheus alerts.
-// nolint: revive // Nested structs are ok in this case.
 type promAlerts struct {
 	Status string `json:"status"`
 	Data   struct {

--- a/testutil/compose/auto.go
+++ b/testutil/compose/auto.go
@@ -46,8 +46,6 @@ type AutoConfig struct {
 }
 
 // Auto runs all three steps (define,lock,run) sequentially with support for detecting alerts.
-//
-//nolint:gocognit
 func Auto(ctx context.Context, conf AutoConfig) error {
 	ctx = log.WithTopic(ctx, "auto")
 

--- a/testutil/trackpr/track.go
+++ b/testutil/trackpr/track.go
@@ -122,7 +122,7 @@ func track(ctx context.Context, ghToken string, pr PR, organization string, proj
 }
 
 // getProjectData returns project data for the GitHub project.
-func getProjectData(ctx context.Context, client *gh.Client, organization string, projectNumber int) (projectData, error) { //nolint:gocognit
+func getProjectData(ctx context.Context, client *gh.Client, organization string, projectNumber int) (projectData, error) {
 	query := new(projectQuery)
 	variables := map[string]interface{}{
 		"org":    gh.String(organization),

--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -15,7 +15,7 @@
 
 // Command verifypr provides a tool to verify charon PRs against the template defined in docs/contibuting.md.
 //
-//nolint:revive,gocognit,cyclop,nestif
+//nolint:revive,cyclop,nestif
 package main
 
 import (


### PR DESCRIPTION
We keep on ignoring `gocognit`, rather just disable it.

category: fixbuild
ticket: none
