### PR TITLE
golangci: lint everything all the time

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.50.1
-          only-new-issues: true
 
       - name: notify failure
         if: failure() && github.ref == 'refs/heads/main'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,10 @@ repos:
 
   # Then run code validators (on the formatted code)
 
-  - repo: https://github.com/golangci/golangci-lint
+  - repo: https://github.com/golangci/golangci-lint # See .golangci.yml for config
     rev: v1.50.1
     hooks:
       - id: golangci-lint
-        args: [ -n ] # See .golangci.yml for config
 
   - repo: local
     hooks:


### PR DESCRIPTION
Remove "only linting new issues" since it only results in some lints being skipped and then the main build failing, rather fail fast and early.

category: misc
ticket: none
