### PR TITLE
app/log: fix loki caller

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,7 @@ linters-settings:
          - "errors" # Prefer ./app/errors
          - "github.com/pkg/errors" # Prefer ./app/errors
          - "github.com/golang/protobuf" # Prefer google.golang.org/protobuf
+         - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
     go: "1.19.3"

--- a/app/log/loki/client.go
+++ b/app/log/loki/client.go
@@ -125,8 +125,8 @@ func (c *Client) Run() {
 			_ = send(ctx, client, c.endpoint, batch, c.labels()) // On shutdown just try to send once as best effort.
 			return
 		case <-ticker.C:
-			// Do not send if the batch is too young or labels not ready yet.
-			if batch.Age() < c.batchWait || !c.labelsReady() {
+			// Do not send if the batch is empty or too young or labels not ready yet.
+			if batch.Size() == 0 || batch.Age() < c.batchWait || !c.labelsReady() {
 				continue
 			}
 


### PR DESCRIPTION
Fixes the resulting log `caller` field when using the multilogger (when pushing logs to loki).

Previously all loki logs had the caller: `log/log.go:82`.

category: bug
ticket: none

