### PR TITLE
core/scheduler: mark epoch as resolve if no validators

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -262,6 +262,8 @@ func (s *Scheduler) resolveDuties(ctx context.Context, slot core.Slot) error {
 
 	if len(vals) == 0 {
 		log.Info(ctx, "No active validators for slot", z.I64("slot", slot.Slot))
+		s.setResolvedEpoch(slot.Epoch())
+
 		return nil
 	}
 


### PR DESCRIPTION
Marks scheduler epoch as resolved when no validators are active. This mitigates errors on new clusters:
```
Emit scheduled slot event: epoch not resolved yet
```

category: bug
ticket: none

