### PR TITLE
gomod: remove geth dependency

### DIFF
--- a/app/k1util/k1util_test.go
+++ b/app/k1util/k1util_test.go
@@ -16,13 +16,11 @@
 package k1util_test
 
 import (
-	"crypto/ecdsa"
 	"encoding/hex"
 	"math/rand"
 	"testing"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
-	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/k1util"
@@ -35,25 +33,27 @@ const (
 	sig1     = "e08097bed6dc40d70aa0076f9d8250057566cdf40c652b3785ad9c06b1e38d584f8f331bf46f68e3737823a3bda905e90ca96735d510a6934b215753c09acec201"
 )
 
-func TestLegacyGethCrypto(t *testing.T) {
-	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(0)))
-	require.NoError(t, err)
-
-	require.Equal(t, fromHex(t, privKey1), crypto.FromECDSA(key))
-	require.Equal(t, fromHex(t, pubKey1), crypto.CompressPubkey(&key.PublicKey))
-
-	digest := fromHex(t, digest1)
-
-	sig, err := crypto.Sign(digest, key)
-	require.NoError(t, err)
-	require.Equal(t, fromHex(t, sig1), sig)
-
-	ok := crypto.VerifySignature(
-		crypto.CompressPubkey(&key.PublicKey),
-		digest,
-		sig[:len(sig)-1])
-	require.True(t, ok)
-}
+// TestLegacyGethCrypto ensures compatibility with github.com/ethereum/go-ethereum/crypto.
+// But since we do not want the dependency, it has been commented out.
+// func TestLegacyGethCrypto(t *testing.T) {
+//	key, err := ecdsa.GenerateKey(crypto.S256(), rand.New(rand.NewSource(0)))
+//	require.NoError(t, err)
+//
+//	require.Equal(t, fromHex(t, privKey1), crypto.FromECDSA(key))
+//	require.Equal(t, fromHex(t, pubKey1), crypto.CompressPubkey(&key.PublicKey))
+//
+//	digest := fromHex(t, digest1)
+//
+//	sig, err := crypto.Sign(digest, key)
+//	require.NoError(t, err)
+//	require.Equal(t, fromHex(t, sig1), sig)
+//
+//	ok := crypto.VerifySignature(
+//		crypto.CompressPubkey(&key.PublicKey),
+//		digest,
+//		sig[:len(sig)-1])
+//	require.True(t, ok)
+//}
 
 func TestK1Util(t *testing.T) {
 	key := k1.PrivKeyFromBytes(fromHex(t, privKey1))

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/bufbuild/buf v1.13.0
 	github.com/coinbase/kryptology v1.5.6-0.20220316191335-269410e1b06b
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
-	github.com/ethereum/go-ethereum v1.10.26
 	github.com/ferranbt/fastssz v0.1.2
 	github.com/golang/snappy v0.0.4
 	github.com/gorilla/mux v1.8.0
@@ -52,7 +51,6 @@ require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd v0.22.1 // indirect
-	github.com/btcsuite/btcd/btcec/v2 v2.2.0 // indirect
 	github.com/bufbuild/connect-go v1.4.1 // indirect
 	github.com/bufbuild/protocompile v0.1.0 // indirect
 	github.com/bwesterb/go-ristretto v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -69,8 +69,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBTaaSFSlLx/70C2HPIMNZpVV8+vt/A+FMnYP11g=
 github.com/btcsuite/btcd v0.22.1 h1:CnwP9LM/M9xuRrGSCGeMVs9iv09uMqwsVX7EeIpgV2c=
 github.com/btcsuite/btcd v0.22.1/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0 h1:fzn1qaOt32TuLjFlkzYSsBC35Q3KUjT1SwPxiMSCF5k=
-github.com/btcsuite/btcd/btcec/v2 v2.2.0/go.mod h1:U7MHm051Al6XmscBQ0BoNydpOTsFAn707034b5nY8zU=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
 github.com/bufbuild/buf v1.13.0 h1:6tpG6HpfQgMVYS8X94FpsYyf0C+eCrFzA/eDCRpv8dQ=
 github.com/bufbuild/buf v1.13.0/go.mod h1:dlUu+5hsNzyaN3ymq6Gnziu7mM8h4Jvm4JBF5cLqEqs=
@@ -144,8 +142,6 @@ github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1m
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
-github.com/ethereum/go-ethereum v1.10.26 h1:i/7d9RBBwiXCEuyduBQzJw/mKmnvzsN14jqBmytw72s=
-github.com/ethereum/go-ethereum v1.10.26/go.mod h1:EYFyF19u3ezGLD4RqOkLq+ZCXzYbLoNDdZlMt7kyKFg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=


### PR DESCRIPTION
Finally removes all traces of go-ethereum and the dependency.

category: refactor
ticket: #1698 