### PR TITLE
*: update to go v1.19.5

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -v -test ./...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.19.3'
+        go-version: '1.19.5'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
       - uses: actions/cache@v3
         with:
           path: |
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
       - uses: actions/cache@v3
         with:
           path: |
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/track-pr.yml
+++ b/.github/workflows/track-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
 
       - name: "Track PR"
         run: go run github.com/obolnetwork/charon/testutil/trackpr

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.19.3'
+          go-version: '1.19.5'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.19.3"
+  go: "1.19.5"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -85,7 +85,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.19.3"
+    go: "1.19.5"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v0.0.3
     hooks:
       - id: check-go-version
-        args: [ -v=go1.19.3 ]
+        args: [ -v=go1.19.5 ]
         pass_filenames: false
         additional_dependencies: [ packaging ]
       - id: check-licence-header

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.19.3-alpine AS builder
+FROM golang:1.19.5-alpine AS builder
 # Install dependencies
 RUN apk add --no-cache build-base git
 # Prep and copy source

--- a/testutil/promrated/Dockerfile
+++ b/testutil/promrated/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.3-alpine AS builder
+FROM golang:1.19.5-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache build-base git


### PR DESCRIPTION
Mitigates again https://pkg.go.dev/vuln/GO-2022-1143 although we do not use that code.

category: misc
ticket: none
