### PR TITLE
app/log: fix missing stacktraces

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.19.5-alpine AS builder
 # Install dependencies
 RUN apk add --no-cache build-base git
 # Prep and copy source
-WORKDIR /app
+WORKDIR /app/charon
 COPY . .
 # Build with Go module and Go build caches.
 RUN \
@@ -15,7 +15,7 @@ RUN \
 FROM alpine:3
 ARG GITHUB_SHA=local
 ENV GITHUB_SHA=${GITHUB_SHA}
-COPY --from=builder /app/charon /usr/local/bin/
+COPY --from=builder /app/charon/charon /usr/local/bin/
 # Don't run container as root
 ENV USER=charon
 ENV UID=1000

--- a/app/log/config.go
+++ b/app/log/config.go
@@ -359,7 +359,7 @@ func formatZapStack(zapStack string) string {
 
 	for _, line := range strings.Split(zapStack, "\n") {
 		if strings.HasPrefix(line, "\t") {
-			const sep = "charon/"
+			const sep = "charon/" // TODO(corver): This only works if source built in a folder named 'charon'.
 			i := strings.LastIndex(line, sep)
 			if i < 0 {
 				// Skip non-charon lines


### PR DESCRIPTION
Fixes missing error/warn stack traces when logged from docker built binaries. This is due to `formatZapStack` that assumes the source code was located in a `.../charon/` folder when built. Not sure how to fix that properly, so the workaround is to rename the folder used when building the source.  

category: bug
ticket: none
