### PR TITLE
github: build compose local binary with cgo

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
+      - run: GOOS=linux GOARCH=amd64 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,6 +62,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
+      - run: ls -la testutil/compose/smoke
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: GOOS=linux GOARCH=amd64 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
-      - run: ls -la testutil/compose/smoke
+      - run: docker pull obolnetwork/charon:latest # Remove once cgo is working.
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3
         if: always()


### PR DESCRIPTION
Enables cgo when building compose smoke test local binary.

category: misc
ticket: none
