### PR TITLE
core/infosync: prioritise proposal types

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -515,7 +515,11 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, t
 		return err
 	}
 
-	sync := infosync.New(prio, version.Supported(), Protocols())
+	sync := infosync.New(prio,
+		version.Supported(),
+		Protocols(),
+		ProposalTypes(conf.BuilderAPI, conf.SyntheticBlockProposals),
+	)
 
 	// Trigger info syncs in last slot of the epoch (for the next epoch).
 	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
@@ -881,6 +885,20 @@ func Protocols() []protocol.ID {
 	resp = append(resp, parsigex.Protocols()...)
 	resp = append(resp, peerinfo.Protocols()...)
 	resp = append(resp, priority.Protocols()...)
+
+	return resp
+}
+
+// ProposalTypes returns the local proposal types in order of precedence.
+func ProposalTypes(builder bool, synthetic bool) []core.ProposalType {
+	var resp []core.ProposalType
+	if builder {
+		resp = append(resp, core.ProposalTypeBuilder)
+	}
+	if synthetic {
+		resp = append(resp, core.ProposalTypeSynthetic)
+	}
+	resp = append(resp, core.ProposalTypeFull) // Always support full as fallback.
 
 	return resp
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -413,6 +413,7 @@ func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Contex
 		expect := map[string]string{
 			"version":  fmt.Sprint(version.Supported()),
 			"protocol": fmt.Sprint(app.Protocols()),
+			"proposal": fmt.Sprint(app.ProposalTypes(false, false)),
 		}
 
 		if !assert.Len(t, results, len(expect)) {

--- a/core/infosync/infosync.go
+++ b/core/infosync/infosync.go
@@ -178,7 +178,7 @@ func protocolsToStrings(features []protocol.ID) []string {
 	return resp
 }
 
-// protocolsToStrings returns the protocols as strings.
+// proposalsToStrings returns the protocols as strings.
 func proposalsToStrings(proposals []core.ProposalType) []string {
 	var resp []string
 	for _, proposal := range proposals {

--- a/core/types.go
+++ b/core/types.go
@@ -102,6 +102,20 @@ func (d Duty) String() string {
 	return fmt.Sprintf("%d/%s", d.Slot, d.Type)
 }
 
+// ProposalType defines a tyoe of block proposal process.
+type ProposalType string
+
+const (
+	// Note these ProposalType strings MUST NOT be changed as it will break wire compatibility.
+
+	// ProposalTypeFull defines normal full beacon block proposals.
+	ProposalTypeFull ProposalType = "full"
+	// ProposalTypeBuilder defines builder API blinded beacon block proposals.
+	ProposalTypeBuilder ProposalType = "blinded"
+	// ProposalTypeSynthetic defines synthetic block proposals, can be either full or builder.
+	ProposalTypeSynthetic ProposalType = "synthetic"
+)
+
 // NewAttesterDuty returns a new attester duty. It is a convenience function that is
 // slightly more readable and concise than the struct literal equivalent:
 //

--- a/core/types.go
+++ b/core/types.go
@@ -111,7 +111,7 @@ const (
 	// ProposalTypeFull defines normal full beacon block proposals.
 	ProposalTypeFull ProposalType = "full"
 	// ProposalTypeBuilder defines builder API blinded beacon block proposals.
-	ProposalTypeBuilder ProposalType = "blinded"
+	ProposalTypeBuilder ProposalType = "builder"
 	// ProposalTypeSynthetic defines synthetic block proposals, can be either full or builder.
 	ProposalTypeSynthetic ProposalType = "synthetic"
 )


### PR DESCRIPTION
Includes local proposal type in infosync protocol. Note the output isn't used yet.

category: feature
ticket: #1652 
