### PR TITLE
testutil/compose: run jaeger in in-memory mode, limited stored traces

### DIFF
--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -101,6 +101,9 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     networks: [compose]
+    environment:
+      SPAN_STORAGE_TYPE: memory
+      MEMORY_MAX_TRACES: 10000
     {{if .MonitoringPorts}}ports:
       - "16686:16686"
     {{end}}

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -224,6 +224,9 @@ services:
   jaeger:
     image: jaegertracing/all-in-one:latest
     networks: [compose]
+    environment:
+      SPAN_STORAGE_TYPE: memory
+      MEMORY_MAX_TRACES: 10000
     ports:
       - "16686:16686"
     


### PR DESCRIPTION
This commit makes jaeger run with an in-memory database rather than Badger.

It also limits the amount of stored traces to 10K.

category: bug
ticket: none
