### PR TITLE
featureset: `herumi_bls` feature flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: GOOS=linux GOARCH=amd64 go build -o -ldflags="-linkmode 'external' -extldflags '-static'" -tags netgo testutil/compose/smoke # Pre-build current SHA charon binary
+      - run: GOOS=linux GOARCH=amd64 go build -ldflags="-linkmode 'external' -extldflags '-static'" -tags -o netgo testutil/compose/smoke # Pre-build current SHA charon binary
       - run: docker pull obolnetwork/charon:latest # Remove once cgo is working.
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: GOOS=linux GOARCH=amd64 go build -ldflags="-linkmode 'external' -extldflags '-static'" -tags -o netgo testutil/compose/smoke # Pre-build current SHA charon binary
+      - run: GOOS=linux GOARCH=amd64 go build -ldflags="-linkmode 'external' -extldflags '-static'" -tags netgo -o testutil/compose/smoke # Pre-build current SHA charon binary
       - run: docker pull obolnetwork/charon:latest # Remove once cgo is working.
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: GOOS=linux GOARCH=amd64 go build -o testutil/compose/smoke # Pre-build current SHA charon binary
+      - run: GOOS=linux GOARCH=amd64 go build -o -ldflags="-linkmode 'external' -extldflags '-static'" -tags netgo testutil/compose/smoke # Pre-build current SHA charon binary
       - run: docker pull obolnetwork/charon:latest # Remove once cgo is working.
       - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -prebuilt-binary=charon -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3

--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
+	blsv2 "github.com/obolnetwork/charon/tbls/v2"
+	"github.com/obolnetwork/charon/tbls/v2/herumi"
+	"github.com/obolnetwork/charon/tbls/v2/kryptology"
 	"net/http"
 	"strings"
 	"time"
@@ -428,6 +431,13 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		}
 
 		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc)
+	}
+
+	blsv2.SetImplementation(kryptology.Kryptology{})
+
+	if featureset.Enabled(featureset.HerumiBLS) {
+		log.Info(ctx, "enabling Herumi BLS signature backend")
+		blsv2.SetImplementation(herumi.Herumi{})
 	}
 
 	sigAgg := sigagg.New(lock.Threshold)

--- a/app/app.go
+++ b/app/app.go
@@ -21,9 +21,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/hex"
-	blsv2 "github.com/obolnetwork/charon/tbls/v2"
-	"github.com/obolnetwork/charon/tbls/v2/herumi"
-	"github.com/obolnetwork/charon/tbls/v2/kryptology"
 	"net/http"
 	"strings"
 	"time"
@@ -72,6 +69,9 @@ import (
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	blsv2 "github.com/obolnetwork/charon/tbls/v2"
+	"github.com/obolnetwork/charon/tbls/v2/herumi"
+	"github.com/obolnetwork/charon/tbls/v2/kryptology"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 

--- a/app/app.go
+++ b/app/app.go
@@ -436,7 +436,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	blsv2.SetImplementation(kryptology.Kryptology{})
 
 	if featureset.Enabled(featureset.HerumiBLS) {
-		log.Info(ctx, "enabling Herumi BLS signature backend")
+		log.Info(ctx, "Enabling Herumi BLS signature backend")
 		blsv2.SetImplementation(herumi.Herumi{})
 	}
 

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -51,6 +51,9 @@ const (
 	//   - When connected via relay, libp2p's identify protocol detects the remote peer's addresses.
 	//   - Those are added to the peer store so libp2p will try to use them.
 	RelayDiscovery Feature = "relay_discovery"
+
+	// HerumiBLS enables usage of the Herumi BLS12-381 implementation, rather than Kryptology.
+	HerumiBLS Feature = "herumi_bls"
 )
 
 var (
@@ -60,6 +63,7 @@ var (
 		Priority:       statusStable,
 		MockAlpha:      statusAlpha,
 		RelayDiscovery: statusStable,
+		HerumiBLS:      statusBeta,
 		// Add all features and there status here.
 	}
 

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -252,7 +252,7 @@ func buildLocal(ctx context.Context, dir string) error {
 
 	log.Info(ctx, "Building local charon binary", z.Str("repo", repo), z.Str("target", target))
 
-	cmd := exec.CommandContext(ctx, "go", "build", "-o", target)
+	cmd := exec.CommandContext(ctx, "go", "build", "-ldflags='-linkmode 'external' -extldflags '-static'", "-o", target)
 	cmd.Env = append(os.Environ(), "GOOS=linux", "GOARCH=amd64")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This PR adds support for the `herumi_bls` feature flag.

Right now the flag is used in `app/app.go` in preparation for #1744, but apart for that this is 100% dormant code.

I had to update the way we compile binaries for `compose` so that we don't end up with glibc issues between host and Docker.

category: feature
ticket: #1743
