### PR TITLE
core: introduce mutable builder enabled config

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -390,7 +390,9 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return core.NewDeadliner(ctx, label, deadlineFunc)
 	}
 
-	sched, err := scheduler.New(corePubkeys, eth2Cl, conf.BuilderAPI)
+	mutableConf := newMutableConfig(conf)
+
+	sched, err := scheduler.New(corePubkeys, eth2Cl, mutableConf.BuilderAPI)
 	if err != nil {
 		return err
 	}
@@ -410,7 +412,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	dutyDB := dutydb.NewMemDB(deadlinerFunc("dutydb"))
 
 	vapi, err := validatorapi.NewComponent(eth2Cl, allPubSharesByKey, nodeIdx.ShareIdx, feeRecipientFunc,
-		conf.BuilderAPI, seenPubkeys)
+		mutableConf.BuilderAPI, seenPubkeys)
 	if err != nil {
 		return err
 	}
@@ -467,7 +469,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	err = wirePrioritise(ctx, conf, life, tcpNode, peerIDs, lock.Threshold,
-		sender.SendReceive, cons, sched, p2pKey, deadlineFunc)
+		sender.SendReceive, cons, sched, p2pKey, deadlineFunc, mutableConf)
 	if err != nil {
 		return err
 	}
@@ -504,6 +506,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, tcpNode host.Host,
 	peers []peer.ID, threshold int, sendFunc p2p.SendReceiveFunc, coreCons core.Consensus,
 	sched core.Scheduler, p2pKey *k1.PrivateKey, deadlineFunc func(duty core.Duty) (time.Time, bool),
+	mutableConf *mutableConfig,
 ) error {
 	if !featureset.Enabled(featureset.Priority) {
 		return nil
@@ -525,11 +528,13 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, t
 		return err
 	}
 
-	sync := infosync.New(prio,
+	isync := infosync.New(prio,
 		version.Supported(),
 		Protocols(),
 		ProposalTypes(conf.BuilderAPI, conf.SyntheticBlockProposals),
 	)
+
+	mutableConf.SetInfoSync(isync)
 
 	// Trigger info syncs in last slot of the epoch (for the next epoch).
 	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
@@ -537,7 +542,7 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, t
 			return nil
 		}
 
-		return sync.Trigger(ctx, slot.Slot)
+		return isync.Trigger(ctx, slot.Slot)
 	})
 
 	if conf.TestConfig.PrioritiseCallback != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -390,7 +390,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return core.NewDeadliner(ctx, label, deadlineFunc)
 	}
 
-	mutableConf := newMutableConfig(conf)
+	mutableConf := newMutableConfig(ctx, conf)
 
 	sched, err := scheduler.New(corePubkeys, eth2Cl, mutableConf.BuilderAPI)
 	if err != nil {

--- a/app/priorities.go
+++ b/app/priorities.go
@@ -1,0 +1,65 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package app
+
+import (
+	"sync"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/infosync"
+)
+
+// newMutableConfig returns a new mutable config.
+func newMutableConfig(conf Config) *mutableConfig {
+	return &mutableConfig{conf: conf}
+}
+
+// mutableConfig defines mutable cluster wide config.
+type mutableConfig struct {
+	conf Config
+
+	mu       sync.RWMutex
+	infosync *infosync.Component
+}
+
+func (p *mutableConfig) SetInfoSync(infosync *infosync.Component) {
+	p.mu.Lock()
+	p.infosync = infosync
+	p.mu.Unlock()
+}
+
+func (p *mutableConfig) getInfoSync() (*infosync.Component, bool) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	return p.infosync, p.infosync != nil
+}
+
+// BuilderAPI returns true if the cluster supports the builder API for the provided slot.
+func (p *mutableConfig) BuilderAPI(slot int64) bool {
+	isync, ok := p.getInfoSync()
+	if !ok {
+		return p.conf.BuilderAPI
+	}
+
+	for _, proposal := range isync.Proposals(slot) {
+		if proposal == core.ProposalTypeBuilder {
+			return true
+		}
+	}
+
+	return false
+}

--- a/core/config.go
+++ b/core/config.go
@@ -1,0 +1,19 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package core
+
+// BuilderEnabled determines whether the builderAPI is enabled for the provided slot.
+type BuilderEnabled func(slot int64) bool

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -67,7 +67,8 @@ func TestIntegration(t *testing.T) {
 		"0xb790b322e1cce41c48e3c344cf8d752bdc3cfd51e8eeef44a4bdaac081bc92b53b73e823a9878b5d7a532eb9d9dce1e3",
 	}
 
-	s, err := scheduler.New(pubkeys, eth2Cl, false)
+	builderDisabled := func(int64) bool { return false }
+	s, err := scheduler.New(pubkeys, eth2Cl, builderDisabled)
 	require.NoError(t, err)
 
 	count := 10

--- a/core/validatorapi/teku.go
+++ b/core/validatorapi/teku.go
@@ -18,6 +18,7 @@ package validatorapi
 import (
 	"context"
 	"fmt"
+	"time"
 )
 
 type TekuProposerConfigResponse struct {
@@ -62,11 +63,16 @@ func (c Component) TekuProposerConfig(ctx context.Context) (TekuProposerConfigRe
 		return TekuProposerConfigResponse{}, err
 	}
 
+	slot, err := c.slotFromTimestamp(ctx, time.Now())
+	if err != nil {
+		return TekuProposerConfigResponse{}, err
+	}
+
 	for pubkey, pubshare := range c.sharesByKey {
 		resp.Proposers[string(pubshare)] = TekuProposerConfig{
 			FeeRecipient: c.feeRecipientFunc(pubkey),
 			Builder: TekuBuilder{
-				Enabled:  c.builderAPI,
+				Enabled:  c.builderEnabled(int64(slot)),
 				GasLimit: gasLimit,
 				Overrides: map[string]string{
 					"timestamp":  fmt.Sprint(genesis.Unix()),

--- a/core/validatorapi/validatorapi_internal_test.go
+++ b/core/validatorapi/validatorapi_internal_test.go
@@ -42,7 +42,7 @@ func TestMismatchKeysFunc(t *testing.T) {
 	t.Run("no mismatch", func(t *testing.T) {
 		allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey}} // Maps self to self since not tbls
 
-		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, false, nil)
+		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 		require.NoError(t, err)
 		pk, err := vapi.getPubKeyFunc(eth2Pubkey)
 		require.NoError(t, err)
@@ -57,7 +57,7 @@ func TestMismatchKeysFunc(t *testing.T) {
 		require.NoError(t, err)
 		allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey, shareIdx + 1: pk}}
 
-		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, false, nil)
+		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 		require.NoError(t, err)
 
 		resp, err := vapi.getPubKeyFunc(pubshare) // Ask for a mismatching key
@@ -74,7 +74,7 @@ func TestMismatchKeysFunc(t *testing.T) {
 		require.NoError(t, err)
 		allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey}}
 
-		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, false, nil)
+		vapi, err := NewComponent(nil, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 		require.NoError(t, err)
 
 		_, err = vapi.getPubKeyFunc(pubshare) // Ask for a mismatching key

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -196,7 +196,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx int64) (core.PubKey, error) {
@@ -300,7 +300,7 @@ func TestSignAndVerify(t *testing.T) {
 	allPubSharesByKey := map[core.PubKey]map[int]*bls_sig.PublicKey{corePubKey: {shareIdx: pubkey}} // Maps self to self since not tbls
 
 	// Setup validatorapi component.
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 	vapi.RegisterPubKeyByAttestation(func(context.Context, int64, int64, int64) (core.PubKey, error) {
 		return tblsconv.KeyToCore(pubkey)
@@ -423,7 +423,7 @@ func TestComponent_SubmitBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -502,7 +502,7 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -560,7 +560,7 @@ func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -724,7 +724,7 @@ func TestComponent_SubmitBlindedBeaconBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -799,7 +799,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned beacon block
@@ -859,7 +859,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidBlock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, true, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
@@ -943,7 +943,7 @@ func TestComponent_SubmitVoluntaryExit(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	// Prepare unsigned voluntary exit
@@ -1009,7 +1009,7 @@ func TestComponent_SubmitVoluntaryExitInvalidSignature(t *testing.T) {
 	require.NoError(t, err)
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	// Register subscriber
@@ -1067,7 +1067,7 @@ func TestComponent_Duties(t *testing.T) {
 		}
 
 		// Construct the validator api component
-		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 		require.NoError(t, err)
 		duties, err := vapi.ProposerDuties(ctx, eth2p0.Epoch(epch), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
 		require.NoError(t, err)
@@ -1087,7 +1087,7 @@ func TestComponent_Duties(t *testing.T) {
 		}
 
 		// Construct the validator api component
-		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 		require.NoError(t, err)
 		duties, err := vapi.AttesterDuties(ctx, eth2p0.Epoch(epch), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
 		require.NoError(t, err)
@@ -1107,7 +1107,7 @@ func TestComponent_Duties(t *testing.T) {
 		}
 
 		// Construct the validator api component
-		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+		vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 		require.NoError(t, err)
 		duties, err := vapi.SyncCommitteeDuties(ctx, eth2p0.Epoch(epch), []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex(vIdx)})
 		require.NoError(t, err)
@@ -1134,11 +1134,8 @@ func TestComponent_SubmitValidatorRegistration(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	// Enable builder API
-	builderAPI := true
-
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, builderAPI, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
 	unsigned := testutil.RandomValidatorRegistration(t)
@@ -1210,11 +1207,8 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	// Enable builder API
-	builderAPI := true
-
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, builderAPI, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
 	unsigned := testutil.RandomValidatorRegistration(t)
@@ -1267,7 +1261,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 	// Construct the validator api component
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, func(core.PubKey) string {
 		return feeRecipient
-	}, true, nil)
+	}, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
 	resp, err := vapi.TekuProposerConfig(ctx)
@@ -1428,7 +1422,7 @@ func TestComponent_SubmitAggregateAttestationVerify(t *testing.T) {
 	}
 
 	// Construct the validator api component
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -1557,7 +1551,7 @@ func TestComponent_SubmitSyncCommitteeContributionsVerify(t *testing.T) {
 	}
 
 	// Construct validatorapi component.
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -1635,7 +1629,7 @@ func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {
 	}
 
 	// Construct the validator api component.
-	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, nil)
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
 	vapi.RegisterAwaitAggSigDB(func(ctx context.Context, duty core.Duty, pubkey core.PubKey) (core.SignedData, error) {

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -1,0 +1,22 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package testutil
+
+// BuilderFalse is a core.BuilderEnabled function that always returns false.
+var BuilderFalse = func(slot int64) bool { return false }
+
+// BuilderTrue is a core.BuilderEnabled function that always returns true.
+var BuilderTrue = func(slot int64) bool { return true }


### PR DESCRIPTION
Introduces `core.BuilderEnabled` that abstracts `app.mutableConfig` which wraps `infosync.Component` such that whether builderAPI is enabled is dynamically based on prioritise results.

category: feature
ticket: #1652 
