### PR TITLE
core/sigagg: refactor to use tbls/v2

### DIFF
--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -18,6 +18,7 @@ package sigagg_test
 import (
 	"context"
 	"crypto/rand"
+	"os"
 	"testing"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -36,8 +37,15 @@ import (
 	"github.com/obolnetwork/charon/core/sigagg"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	"github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumi.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestSigAgg_DutyAttester(t *testing.T) {
 	ctx := context.Background()

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -17,7 +17,6 @@ package sigagg_test
 
 import (
 	"context"
-	"crypto/rand"
 	"os"
 	"testing"
 
@@ -30,13 +29,10 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/sigagg"
-	"github.com/obolnetwork/charon/tbls"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	"github.com/obolnetwork/charon/tbls/v2/herumi"
 	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
@@ -127,41 +123,48 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	msg := []byte("RANDAO reveal")
 
 	// Generate private shares
-	tss, secrets, err := tbls.GenerateTSS(threshold, peers, rand.Reader)
+	secretKey, err := tblsv2.GenerateSecretKey()
+	require.NoError(t, err)
+
+	pubKey, err := tblsv2.SecretToPublicKey(secretKey)
+	require.NoError(t, err)
+
+	secrets, err := tblsv2.ThresholdSplit(secretKey, peers, threshold)
 	require.NoError(t, err)
 
 	// Create partial signatures (in two formats)
 	var (
 		parsigs []core.ParSignedData
-		psigs   []*bls_sig.PartialSignature
+		psigs   map[int]tblsv2.Signature
 	)
-	for _, secret := range secrets {
-		psig, err := tbls.PartialSign(secret, msg)
+
+	psigs = make(map[int]tblsv2.Signature)
+
+	for idx, secret := range secrets {
+		sig, err := tblsv2.Sign(secret, msg)
 		require.NoError(t, err)
 
-		sig := tblsconv.SigToETH2(tblsconv.SigFromPartial(psig))
-		parsig := core.NewPartialSignedRandao(epoch, sig, int(psig.Identifier))
+		eth2Sig := tblsconv2.SigToETH2(sig)
+		parsig := core.NewPartialSignedRandao(epoch, eth2Sig, idx)
 
-		psigs = append(psigs, psig)
+		psigs[idx] = sig
 		parsigs = append(parsigs, parsig)
 	}
 
 	// Create expected aggregated signature
-	aggSig, err := tbls.Aggregate(psigs)
+	aggSig, err := tblsv2.ThresholdAggregate(psigs)
 	require.NoError(t, err)
-	expect := tblsconv.SigToCore(aggSig)
+	expect := tblsconv2.SigToCore(aggSig)
 
 	agg := sigagg.New(threshold)
 
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 		require.Equal(t, expect, aggData.Signature())
-		sig, err := tblsconv.SigFromCore(aggData.Signature())
-		require.NoError(t, err)
+		sig := tblsconv2.SigFromCore(aggData.Signature())
 
-		ok, err := tbls.Verify(tss.PublicKey(), msg, sig)
+		require.NoError(t, tblsv2.Verify(pubKey, msg, sig))
 		require.NoError(t, err)
-		require.True(t, ok)
 
 		return nil
 	})
@@ -180,7 +183,13 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	)
 
 	// Generate private shares
-	tss, secrets, err := tbls.GenerateTSS(threshold, peers, rand.Reader)
+	secretKey, err := tblsv2.GenerateSecretKey()
+	require.NoError(t, err)
+
+	pubKey, err := tblsv2.SecretToPublicKey(secretKey)
+	require.NoError(t, err)
+
+	secrets, err := tblsv2.ThresholdSplit(secretKey, peers, threshold)
 	require.NoError(t, err)
 
 	exit := testutil.RandomExit()
@@ -190,38 +199,39 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	// Create partial signatures (in two formats)
 	var (
 		parsigs []core.ParSignedData
-		psigs   []*bls_sig.PartialSignature
+		psigs   map[int]tblsv2.Signature
 	)
-	for _, secret := range secrets {
+
+	psigs = make(map[int]tblsv2.Signature)
+
+	for idx, secret := range secrets {
 		// Ignoring domain for this test
-		psig, err := tbls.PartialSign(secret, msg)
+		sig, err := tblsv2.Sign(secret, msg)
 		require.NoError(t, err)
 
-		sig := tblsconv.SigToETH2(tblsconv.SigFromPartial(psig))
+		eth2Sig := tblsconv2.SigToETH2(sig)
 		parsig := core.NewPartialSignedVoluntaryExit(&eth2p0.SignedVoluntaryExit{
 			Message:   exit.Message,
-			Signature: sig,
-		}, int(psig.Identifier))
+			Signature: eth2Sig,
+		}, idx)
 
-		psigs = append(psigs, psig)
+		psigs[idx] = sig
 		parsigs = append(parsigs, parsig)
 	}
 
-	aggSig, err := tbls.Aggregate(psigs)
+	aggSig, err := tblsv2.ThresholdAggregate(psigs)
 	require.NoError(t, err)
-	expect := tblsconv.SigToCore(aggSig)
+	expect := tblsconv2.SigToCore(aggSig)
 
 	agg := sigagg.New(threshold)
 
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 		require.Equal(t, expect, aggData.Signature())
-		sig, err := tblsconv.SigFromCore(aggData.Signature())
-		require.NoError(t, err)
+		sig := tblsconv2.SigFromCore(aggData.Signature())
 
-		ok, err := tbls.Verify(tss.PublicKey(), msg, sig)
+		require.NoError(t, tblsv2.Verify(pubKey, msg, sig))
 		require.NoError(t, err)
-		require.True(t, ok)
 
 		return nil
 	})
@@ -240,7 +250,13 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 	)
 
 	// Generate private shares
-	tss, secrets, err := tbls.GenerateTSS(threshold, peers, rand.Reader)
+	secretKey, err := tblsv2.GenerateSecretKey()
+	require.NoError(t, err)
+
+	pubKey, err := tblsv2.SecretToPublicKey(secretKey)
+	require.NoError(t, err)
+
+	secrets, err := tblsv2.ThresholdSplit(secretKey, peers, threshold)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -298,43 +314,44 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			// Create partial signatures (in two formats)
 			var (
 				parsigs []core.ParSignedData
-				psigs   []*bls_sig.PartialSignature
+				psigs   map[int]tblsv2.Signature
 			)
-			for _, secret := range secrets {
-				psig, err := tbls.PartialSign(secret, msg[:])
+
+			psigs = make(map[int]tblsv2.Signature)
+
+			for idx, secret := range secrets {
+				sig, err := tblsv2.Sign(secret, msg[:])
 				require.NoError(t, err)
 
 				block, err := core.NewVersionedSignedBeaconBlock(test.block)
 				require.NoError(t, err)
 
-				sig := tblsconv.SigToCore(tblsconv.SigFromPartial(psig))
-				signed, err := block.SetSignature(sig)
+				sigCore := tblsconv2.SigToCore(sig)
+				signed, err := block.SetSignature(sigCore)
 				require.NoError(t, err)
-				require.Equal(t, sig, signed.Signature())
+				require.Equal(t, sig, tblsconv2.SigFromCore(signed.Signature()))
 
-				psigs = append(psigs, psig)
+				psigs[idx] = sig
 				parsigs = append(parsigs, core.ParSignedData{
 					SignedData: signed,
-					ShareIdx:   int(psig.Identifier),
+					ShareIdx:   idx,
 				})
 			}
 
 			// Create expected aggregated signature
-			aggSig, err := tbls.Aggregate(psigs)
+			aggSig, err := tblsv2.ThresholdAggregate(psigs)
 			require.NoError(t, err)
-			expect := tblsconv.SigToCore(aggSig)
+			expect := tblsconv2.SigToCore(aggSig)
 
 			agg := sigagg.New(threshold)
 
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 				require.Equal(t, expect, aggData.Signature())
-				sig, err := tblsconv.SigFromCore(aggData.Signature())
-				require.NoError(t, err)
+				sig := tblsconv2.SigFromCore(aggData.Signature())
 
-				ok, err := tbls.Verify(tss.PublicKey(), msg[:], sig)
+				require.NoError(t, tblsv2.Verify(pubKey, msg[:], sig))
 				require.NoError(t, err)
-				require.True(t, ok)
 
 				return nil
 			})
@@ -355,7 +372,13 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 	)
 
 	// Generate private shares
-	tss, secrets, err := tbls.GenerateTSS(threshold, peers, rand.Reader)
+	secretKey, err := tblsv2.GenerateSecretKey()
+	require.NoError(t, err)
+
+	pubKey, err := tblsv2.SecretToPublicKey(secretKey)
+	require.NoError(t, err)
+
+	secrets, err := tblsv2.ThresholdSplit(secretKey, peers, threshold)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -393,43 +416,44 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			// Create partial signatures (in two formats)
 			var (
 				parsigs []core.ParSignedData
-				psigs   []*bls_sig.PartialSignature
+				psigs   map[int]tblsv2.Signature
 			)
-			for _, secret := range secrets {
-				psig, err := tbls.PartialSign(secret, msg[:])
+
+			psigs = make(map[int]tblsv2.Signature)
+
+			for idx, secret := range secrets {
+				sig, err := tblsv2.Sign(secret, msg[:])
 				require.NoError(t, err)
 
 				block, err := core.NewVersionedSignedBlindedBeaconBlock(test.block)
 				require.NoError(t, err)
 
-				sig := tblsconv.SigToCore(tblsconv.SigFromPartial(psig))
-				signed, err := block.SetSignature(sig)
+				sigCore := tblsconv2.SigToCore(sig)
+				signed, err := block.SetSignature(sigCore)
 				require.NoError(t, err)
-				require.Equal(t, sig, signed.Signature())
+				require.Equal(t, sig, tblsconv2.SigFromCore(signed.Signature()))
 
-				psigs = append(psigs, psig)
+				psigs[idx] = sig
 				parsigs = append(parsigs, core.ParSignedData{
 					SignedData: signed,
-					ShareIdx:   int(psig.Identifier),
+					ShareIdx:   idx,
 				})
 			}
 
 			// Create expected aggregated signature
-			aggSig, err := tbls.Aggregate(psigs)
+			aggSig, err := tblsv2.ThresholdAggregate(psigs)
 			require.NoError(t, err)
-			expect := tblsconv.SigToCore(aggSig)
+			expect := tblsconv2.SigToCore(aggSig)
 
 			agg := sigagg.New(threshold)
 
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 				require.Equal(t, expect, aggData.Signature())
-				sig, err := tblsconv.SigFromCore(aggData.Signature())
-				require.NoError(t, err)
+				sig := tblsconv2.SigFromCore(aggData.Signature())
 
-				ok, err := tbls.Verify(tss.PublicKey(), msg[:], sig)
+				require.NoError(t, tblsv2.Verify(pubKey, msg[:], sig))
 				require.NoError(t, err)
-				require.True(t, ok)
 
 				return nil
 			})
@@ -450,7 +474,13 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 	)
 
 	// Generate private shares
-	tss, secrets, err := tbls.GenerateTSS(threshold, peers, rand.Reader)
+	secretKey, err := tblsv2.GenerateSecretKey()
+	require.NoError(t, err)
+
+	pubKey, err := tblsv2.SecretToPublicKey(secretKey)
+	require.NoError(t, err)
+
+	secrets, err := tblsv2.ThresholdSplit(secretKey, peers, threshold)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -478,43 +508,44 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 			// Create partial signatures (in two formats)
 			var (
 				parsigs []core.ParSignedData
-				psigs   []*bls_sig.PartialSignature
+				psigs   map[int]tblsv2.Signature
 			)
-			for _, secret := range secrets {
-				psig, err := tbls.PartialSign(secret, msg[:])
+
+			psigs = make(map[int]tblsv2.Signature)
+
+			for idx, secret := range secrets {
+				sig, err := tblsv2.Sign(secret, msg[:])
 				require.NoError(t, err)
 
 				block, err := core.NewVersionedSignedValidatorRegistration(test.registration)
 				require.NoError(t, err)
 
-				sig := tblsconv.SigToCore(tblsconv.SigFromPartial(psig))
-				signed, err := block.SetSignature(sig)
+				sigCore := tblsconv2.SigToCore(sig)
+				signed, err := block.SetSignature(sigCore)
 				require.NoError(t, err)
-				require.Equal(t, sig, signed.Signature())
+				require.Equal(t, sig, tblsconv2.SigFromCore(signed.Signature()))
 
-				psigs = append(psigs, psig)
+				psigs[idx] = sig
 				parsigs = append(parsigs, core.ParSignedData{
 					SignedData: signed,
-					ShareIdx:   int(psig.Identifier),
+					ShareIdx:   idx,
 				})
 			}
 
 			// Create expected aggregated signature
-			aggSig, err := tbls.Aggregate(psigs)
+			aggSig, err := tblsv2.ThresholdAggregate(psigs)
 			require.NoError(t, err)
-			expect := tblsconv.SigToCore(aggSig)
+			expect := tblsconv2.SigToCore(aggSig)
 
 			agg := sigagg.New(threshold)
 
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 				require.Equal(t, expect, aggData.Signature())
-				sig, err := tblsconv.SigFromCore(aggData.Signature())
-				require.NoError(t, err)
+				sig := tblsconv2.SigFromCore(aggData.Signature())
 
-				ok, err := tbls.Verify(tss.PublicKey(), msg[:], sig)
+				require.NoError(t, tblsv2.Verify(pubKey, msg[:], sig))
 				require.NoError(t, err)
-				require.True(t, ok)
 
 				return nil
 			})

--- a/tbls/v2/tblsconv/tblsconv.go
+++ b/tbls/v2/tblsconv/tblsconv.go
@@ -1,0 +1,39 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tblsconv
+
+import (
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/core"
+	v2 "github.com/obolnetwork/charon/tbls/v2"
+)
+
+// SigFromCore converts a core workflow Signature type into a tbls.Signature.
+func SigFromCore(sig core.Signature) v2.Signature {
+	rawSig := (*[96]byte)(sig.Signature())
+	return *rawSig
+}
+
+// SigToCore converts a tbls.Signature into a core workflow Signature type.
+func SigToCore(sig v2.Signature) core.Signature {
+	return core.SigFromETH2(eth2p0.BLSSignature(sig))
+}
+
+// SigToETH2 converts a tbls.Signature into an eth2 phase0 bls signature.
+func SigToETH2(sig v2.Signature) eth2p0.BLSSignature {
+	return eth2p0.BLSSignature(sig)
+}


### PR DESCRIPTION
This PR moves `core/sigagg` package to use `tbls/v2` package, which allows us to leverage Herumi BLS.

category: refactor
ticket: #1744 
feature_flag: herumi_bls
