### PR TITLE
cmd: validator all withdrawal addresses

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -319,11 +319,6 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	eth2Cl eth2wrap.Client, peerIDs []peer.ID, sender *p2p.Sender,
 	qbftSniffer func(*pbv1.SniffedConsensusInstance), seenPubkeys func(core.PubKey),
 ) error {
-	feeRecipientAddrs, err := lock.FeeRecipientAddresses()
-	if err != nil {
-		return err
-	}
-
 	// Convert and prep public keys and public shares
 	var (
 		corePubkeys                  []core.PubKey
@@ -373,7 +368,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		corePubkeys = append(corePubkeys, corePubkey)
 		pubshares = append(pubshares, eth2Share)
 		allPubSharesByKey[corePubkey] = allPubShares
-		feeRecipientAddrByCorePubkey[corePubkey] = feeRecipientAddrs[i]
+		feeRecipientAddrByCorePubkey[corePubkey] = lock.FeeRecipientAddresses()[i]
 	}
 
 	peers, err := lock.Peers()

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -303,23 +303,23 @@ func (d Definition) LegacyValidatorAddresses() (ValidatorAddresses, error) {
 }
 
 // WithdrawalAddresses is a convenience function to return all withdrawal address from the validator addresses slice.
-func (d Definition) WithdrawalAddresses() ([]string, error) {
+func (d Definition) WithdrawalAddresses() []string {
 	var resp []string
 	for _, vaddrs := range d.ValidatorAddresses {
 		resp = append(resp, vaddrs.WithdrawalAddress)
 	}
 
-	return resp, nil
+	return resp
 }
 
 // FeeRecipientAddresses is a convenience function to return all fee-recipient address from the validator addresses slice.
-func (d Definition) FeeRecipientAddresses() ([]string, error) {
+func (d Definition) FeeRecipientAddresses() []string {
 	var resp []string
 	for _, vaddrs := range d.ValidatorAddresses {
 		resp = append(resp, vaddrs.FeeRecipientAddress)
 	}
 
-	return resp, nil
+	return resp
 }
 
 // SetDefinitionHashes returns a copy of the definition with the config hash and definition hash populated.

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -190,13 +190,8 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		}
 	}
 
-	withdrawalAddresses, err := def.WithdrawalAddresses()
-	if err != nil {
-		return err
-	}
-
 	// Write deposit-data file
-	if err = writeDepositData(withdrawalAddresses, conf.ClusterDir, def.ForkVersion, numNodes, secrets); err != nil {
+	if err = writeDepositData(def.WithdrawalAddresses(), conf.ClusterDir, def.ForkVersion, numNodes, secrets); err != nil {
 		return err
 	}
 
@@ -599,13 +594,13 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 		return errors.New("unsupported network", z.Str("network", network))
 	}
 
-	// TODO(corver): Refactor validateWithdrawalAddr to take a slice of withdrawal addresses.
-	vaddrs, err := def.LegacyValidatorAddresses()
-	if err != nil {
-		return err
+	for _, waddr := range def.WithdrawalAddresses() {
+		if err := validateWithdrawalAddr(waddr, network); err != nil {
+			return err
+		}
 	}
 
-	return validateWithdrawalAddr(vaddrs.WithdrawalAddress, network)
+	return nil
 }
 
 // aggSign returns a bls aggregate signatures of the message signed by all the shares.

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -186,13 +186,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
-	withdrawalAddresses, err := lock.WithdrawalAddresses()
-	if err != nil {
-		return err
-	}
-
 	// Sign, exchange and aggregate Deposit Data signatures
-	pubkeys, depositDataSigs, err := signAndAggDepositData(ctx, ex, shares, withdrawalAddresses, network, nodeIdx)
+	pubkeys, depositDataSigs, err := signAndAggDepositData(ctx, ex, shares, lock.WithdrawalAddresses(), network, nodeIdx)
 	if err != nil {
 		return err
 	}
@@ -222,7 +217,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Saved lock file to disk")
 
-	if err := writeDepositData(pubkeys, depositDataSigs, withdrawalAddresses, network, conf.DataDir); err != nil {
+	if err := writeDepositData(pubkeys, depositDataSigs, lock.WithdrawalAddresses(), network, conf.DataDir); err != nil {
 		return err
 	}
 	log.Debug(ctx, "Saved deposit data file to disk")


### PR DESCRIPTION
Verify all withdrawal addresses in `create cluster` command.

category: refactor
ticket: none
