### PR TITLE
app/eth2wrap: add lazy init

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -771,3 +771,363 @@ func (m multi) GenesisTime(ctx context.Context) (time.Time, error) {
 
 	return res0, err
 }
+
+// NodeVersion returns a free-text string with the node version.
+func (l *lazy) NodeVersion(ctx context.Context) (res0 string, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.NodeVersion(ctx)
+}
+
+// SlotDuration provides the duration of a slot of the chain.
+func (l *lazy) SlotDuration(ctx context.Context) (res0 time.Duration, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.SlotDuration(ctx)
+}
+
+// SlotsPerEpoch provides the slots per epoch of the chain.
+func (l *lazy) SlotsPerEpoch(ctx context.Context) (res0 uint64, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.SlotsPerEpoch(ctx)
+}
+
+// DepositContract provides details of the Ethereum 1 deposit contract for the chain.
+func (l *lazy) DepositContract(ctx context.Context) (res0 *apiv1.DepositContract, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.DepositContract(ctx)
+}
+
+// SignedBeaconBlock fetches a signed beacon block given a block ID.
+func (l *lazy) SignedBeaconBlock(ctx context.Context, blockID string) (res0 *spec.VersionedSignedBeaconBlock, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.SignedBeaconBlock(ctx, blockID)
+}
+
+// AggregateAttestation fetches the aggregate attestation given an attestation.
+func (l *lazy) AggregateAttestation(ctx context.Context, slot phase0.Slot, attestationDataRoot phase0.Root) (res0 *phase0.Attestation, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.AggregateAttestation(ctx, slot, attestationDataRoot)
+}
+
+// SubmitAggregateAttestations submits aggregate attestations.
+func (l *lazy) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitAggregateAttestations(ctx, aggregateAndProofs)
+}
+
+// AttestationData fetches the attestation data for the given slot and committee index.
+func (l *lazy) AttestationData(ctx context.Context, slot phase0.Slot, committeeIndex phase0.CommitteeIndex) (res0 *phase0.AttestationData, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.AttestationData(ctx, slot, committeeIndex)
+}
+
+// SubmitAttestations submits attestations.
+func (l *lazy) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitAttestations(ctx, attestations)
+}
+
+// AttesterDuties obtains attester duties.
+// If validatorIndicess is nil it will return all duties for the given epoch.
+func (l *lazy) AttesterDuties(ctx context.Context, epoch phase0.Epoch, validatorIndices []phase0.ValidatorIndex) (res0 []*apiv1.AttesterDuty, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.AttesterDuties(ctx, epoch, validatorIndices)
+}
+
+// SyncCommitteeDuties obtains sync committee duties.
+// If validatorIndicess is nil it will return all duties for the given epoch.
+func (l *lazy) SyncCommitteeDuties(ctx context.Context, epoch phase0.Epoch, validatorIndices []phase0.ValidatorIndex) (res0 []*apiv1.SyncCommitteeDuty, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.SyncCommitteeDuties(ctx, epoch, validatorIndices)
+}
+
+// SubmitSyncCommitteeMessages submits sync committee messages.
+func (l *lazy) SubmitSyncCommitteeMessages(ctx context.Context, messages []*altair.SyncCommitteeMessage) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitSyncCommitteeMessages(ctx, messages)
+}
+
+// SubmitSyncCommitteeSubscriptions subscribes to sync committees.
+func (l *lazy) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscriptions []*apiv1.SyncCommitteeSubscription) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitSyncCommitteeSubscriptions(ctx, subscriptions)
+}
+
+// SyncCommitteeContribution provides a sync committee contribution.
+func (l *lazy) SyncCommitteeContribution(ctx context.Context, slot phase0.Slot, subcommitteeIndex uint64, beaconBlockRoot phase0.Root) (res0 *altair.SyncCommitteeContribution, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.SyncCommitteeContribution(ctx, slot, subcommitteeIndex, beaconBlockRoot)
+}
+
+// SubmitSyncCommitteeContributions submits sync committee contributions.
+func (l *lazy) SubmitSyncCommitteeContributions(ctx context.Context, contributionAndProofs []*altair.SignedContributionAndProof) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitSyncCommitteeContributions(ctx, contributionAndProofs)
+}
+
+// BeaconBlockProposal fetches a proposed beacon block for signing.
+func (l *lazy) BeaconBlockProposal(ctx context.Context, slot phase0.Slot, randaoReveal phase0.BLSSignature, graffiti []byte) (res0 *spec.VersionedBeaconBlock, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.BeaconBlockProposal(ctx, slot, randaoReveal, graffiti)
+}
+
+// BeaconBlockRoot fetches a block's root given a block ID.
+func (l *lazy) BeaconBlockRoot(ctx context.Context, blockID string) (res0 *phase0.Root, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.BeaconBlockRoot(ctx, blockID)
+}
+
+// SubmitBeaconBlock submits a beacon block.
+func (l *lazy) SubmitBeaconBlock(ctx context.Context, block *spec.VersionedSignedBeaconBlock) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitBeaconBlock(ctx, block)
+}
+
+// SubmitBeaconCommitteeSubscriptions subscribes to beacon committees.
+func (l *lazy) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*apiv1.BeaconCommitteeSubscription) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitBeaconCommitteeSubscriptions(ctx, subscriptions)
+}
+
+// BlindedBeaconBlockProposal fetches a blinded proposed beacon block for signing.
+func (l *lazy) BlindedBeaconBlockProposal(ctx context.Context, slot phase0.Slot, randaoReveal phase0.BLSSignature, graffiti []byte) (res0 *api.VersionedBlindedBeaconBlock, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.BlindedBeaconBlockProposal(ctx, slot, randaoReveal, graffiti)
+}
+
+// SubmitBlindedBeaconBlock submits a beacon block.
+func (l *lazy) SubmitBlindedBeaconBlock(ctx context.Context, block *api.VersionedSignedBlindedBeaconBlock) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitBlindedBeaconBlock(ctx, block)
+}
+
+// SubmitValidatorRegistrations submits a validator registration.
+func (l *lazy) SubmitValidatorRegistrations(ctx context.Context, registrations []*api.VersionedSignedValidatorRegistration) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitValidatorRegistrations(ctx, registrations)
+}
+
+// Events feeds requested events with the given topics to the supplied handler.
+func (l *lazy) Events(ctx context.Context, topics []string, handler eth2client.EventHandlerFunc) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.Events(ctx, topics, handler)
+}
+
+// Fork fetches fork information for the given state.
+func (l *lazy) Fork(ctx context.Context, stateID string) (res0 *phase0.Fork, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.Fork(ctx, stateID)
+}
+
+// ForkSchedule provides details of past and future changes in the chain's fork version.
+func (l *lazy) ForkSchedule(ctx context.Context) (res0 []*phase0.Fork, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.ForkSchedule(ctx)
+}
+
+// Genesis fetches genesis information for the chain.
+func (l *lazy) Genesis(ctx context.Context) (res0 *apiv1.Genesis, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.Genesis(ctx)
+}
+
+// NodeSyncing provides the state of the node's synchronization with the chain.
+func (l *lazy) NodeSyncing(ctx context.Context) (res0 *apiv1.SyncState, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.NodeSyncing(ctx)
+}
+
+// SubmitProposalPreparations provides the beacon node with information required if a proposal for the given validators
+// shows up in the next epoch.
+func (l *lazy) SubmitProposalPreparations(ctx context.Context, preparations []*apiv1.ProposalPreparation) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitProposalPreparations(ctx, preparations)
+}
+
+// ProposerDuties obtains proposer duties for the given epoch.
+// If validatorIndices is empty all duties are returned, otherwise only matching duties are returned.
+func (l *lazy) ProposerDuties(ctx context.Context, epoch phase0.Epoch, validatorIndices []phase0.ValidatorIndex) (res0 []*apiv1.ProposerDuty, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.ProposerDuties(ctx, epoch, validatorIndices)
+}
+
+// Spec provides the spec information of the chain.
+func (l *lazy) Spec(ctx context.Context) (res0 map[string]interface{}, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.Spec(ctx)
+}
+
+// Validators provides the validators, with their balance and status, for a given state.
+// stateID can be a slot number or state root, or one of the special values "genesis", "head", "justified" or "finalized".
+// validatorIndices is a list of validator indices to restrict the returned values.  If no validators IDs are supplied no filter
+// will be applied.
+func (l *lazy) Validators(ctx context.Context, stateID string, validatorIndices []phase0.ValidatorIndex) (res0 map[phase0.ValidatorIndex]*apiv1.Validator, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.Validators(ctx, stateID, validatorIndices)
+}
+
+// ValidatorsByPubKey provides the validators, with their balance and status, for a given state.
+// stateID can be a slot number or state root, or one of the special values "genesis", "head", "justified" or "finalized".
+// validatorPubKeys is a list of validator public keys to restrict the returned values.  If no validators public keys are
+// supplied no filter will be applied.
+func (l *lazy) ValidatorsByPubKey(ctx context.Context, stateID string, validatorPubKeys []phase0.BLSPubKey) (res0 map[phase0.ValidatorIndex]*apiv1.Validator, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.ValidatorsByPubKey(ctx, stateID, validatorPubKeys)
+}
+
+// SubmitVoluntaryExit submits a voluntary exit.
+func (l *lazy) SubmitVoluntaryExit(ctx context.Context, voluntaryExit *phase0.SignedVoluntaryExit) (err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitVoluntaryExit(ctx, voluntaryExit)
+}
+
+// Domain provides a domain for a given domain type at a given epoch.
+func (l *lazy) Domain(ctx context.Context, domainType phase0.DomainType, epoch phase0.Epoch) (res0 phase0.Domain, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.Domain(ctx, domainType, epoch)
+}
+
+// GenesisTime provides the genesis time of the chain.
+func (l *lazy) GenesisTime(ctx context.Context) (res0 time.Time, err error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.GenesisTime(ctx)
+}

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -88,6 +88,18 @@ type Client interface {
 		return {{.ResultNames}}
 	}
 {{end}}
+
+{{range .Methods}}
+	{{.Doc -}}
+	func (l *lazy) {{.Name}}({{.Params}}) ({{.NamedResults}}) {
+		cl, err := l.getClient()
+		if err != nil {
+			return {{.ResultNames}}
+		}
+
+		return cl.{{.Name}}({{.ParamNames}})
+	}
+{{end}}
 `
 
 	// interfaces defines all the interfaces to implement and whether to measure latency for each.
@@ -180,6 +192,15 @@ func (m Method) ParamNames() string {
 	var resp []string
 	for _, param := range m.params {
 		resp = append(resp, param.Name)
+	}
+
+	return strings.Join(resp, ", ")
+}
+
+func (m Method) NamedResults() string {
+	var resp []string
+	for _, result := range m.results {
+		resp = append(resp, fmt.Sprintf("%s %s", result.Name, result.Type))
 	}
 
 	return strings.Join(resp, ", ")

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -72,7 +72,6 @@ func newHTTPAdapter(ethSvc *eth2http.Service, address string, timeout time.Durat
 // httpAdapter implements Client by wrapping and adding the following to eth2http.Service:
 //   - interfaces not present in go-eth2-client
 //   - experimental interfaces
-//   - synthetic duties
 type httpAdapter struct {
 	*eth2http.Service
 	address string
@@ -143,7 +142,7 @@ func (h *httpAdapter) BlockAttestations(ctx context.Context, stateID string) ([]
 // NodePeerCount provides the peer count of the beacon node.
 // See https://ethereum.github.io/beacon-APIs/#/Node/getPeerCount.
 func (h *httpAdapter) NodePeerCount(ctx context.Context) (int, error) {
-	path := "/eth/v1/node/peer_count"
+	const path = "/eth/v1/node/peer_count"
 	respBody, statusCode, err := httpGet(ctx, h.address, path, h.timeout)
 	if err != nil {
 		return 0, errors.Wrap(err, "request beacon node peer count")

--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -1,0 +1,118 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package eth2wrap
+
+import (
+	"context"
+	"sync"
+
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/eth2util/eth2exp"
+)
+
+// newLazy creates a new lazy client.
+func newLazy(provider func() (Client, error)) *lazy {
+	return &lazy{
+		provider: provider,
+	}
+}
+
+// lazy is a client that is created on demand.
+type lazy struct {
+	provider func() (Client, error)
+	client   Client
+	mu       sync.RWMutex
+}
+
+// getClient returns the client, creating it if necessary.
+func (l *lazy) getClient() (Client, error) {
+	// Check if the client is available.
+	l.mu.RLock()
+	if l.client != nil {
+		l.mu.RUnlock()
+		return l.client, nil
+	}
+	l.mu.RUnlock()
+
+	// Else create a new client.
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	// Check again in case another goroutine created the client.
+	if l.client != nil {
+		return l.client, nil
+	}
+
+	var err error
+	l.client, err = l.provider()
+
+	return l.client, err
+}
+
+func (l *lazy) Name() string {
+	cl, err := l.getClient()
+	if err != nil {
+		return ""
+	}
+
+	return cl.Name()
+}
+
+func (l *lazy) Address() string {
+	cl, err := l.getClient()
+	if err != nil {
+		return ""
+	}
+
+	return cl.Address()
+}
+
+func (l *lazy) AggregateBeaconCommitteeSelections(ctx context.Context, partialSelections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.AggregateBeaconCommitteeSelections(ctx, partialSelections)
+}
+
+func (l *lazy) AggregateSyncCommitteeSelections(ctx context.Context, partialSelections []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.AggregateSyncCommitteeSelections(ctx, partialSelections)
+}
+
+func (l *lazy) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.BlockAttestations(ctx, stateID)
+}
+
+func (l *lazy) NodePeerCount(ctx context.Context) (int, error) {
+	cl, err := l.getClient()
+	if err != nil {
+		return 0, err
+	}
+
+	return cl.NodePeerCount(ctx)
+}

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -122,12 +122,7 @@ func (h *synthWrapper) BlindedBeaconBlockProposal(ctx context.Context, slot eth2
 		return nil, err
 	}
 
-	switch block.Version {
-	case spec.DataVersionBellatrix, spec.DataVersionCapella:
-		return blindedBlock(block), nil
-	default:
-		return nil, errors.New("unsupported blinded block version")
-	}
+	return blindedBlock(block)
 }
 
 // syntheticBlock returns a synthetic beacon block to propose.
@@ -414,10 +409,10 @@ func getStandardHashFn() shuffle.HashFn {
 }
 
 // blindedBlock converts a normal block into a blinded block.
-func blindedBlock(block *spec.VersionedBeaconBlock) *api.VersionedBlindedBeaconBlock {
+func blindedBlock(block *spec.VersionedBeaconBlock) (*api.VersionedBlindedBeaconBlock, error) {
 	var resp *api.VersionedBlindedBeaconBlock
 	// Blinded blocks are only available from bellatrix.
-	switch block.Version { //nolint:exhaustive
+	switch block.Version {
 	case spec.DataVersionBellatrix:
 		resp = &api.VersionedBlindedBeaconBlock{
 			Version: block.Version,
@@ -492,7 +487,9 @@ func blindedBlock(block *spec.VersionedBeaconBlock) *api.VersionedBlindedBeaconB
 				},
 			},
 		}
+	default:
+		return nil, errors.New("unsupported blinded block version")
 	}
 
-	return resp
+	return resp, nil
 }


### PR DESCRIPTION
Wraps eth2clients in a "lazy loader", this allows charon to start even if one or more beacon nodes are down (as long as one is up and available).

category: feature
ticket: #1312 
