### PR TITLE
tbls/v2: implement FastAggregateVerify and CombineSignatures methods

### DIFF
--- a/tbls/v2/herumi/herumi.go
+++ b/tbls/v2/herumi/herumi.go
@@ -124,10 +124,11 @@ func (Herumi) ThresholdSplit(secret v2.PrivateKey, total uint, threshold uint) (
 }
 
 func (Herumi) RecoverSecret(shares map[int]v2.PrivateKey, _, _ uint) (v2.PrivateKey, error) {
-	var pk bls.SecretKey
-
-	var rawKeys []bls.SecretKey
-	var rawIDs []bls.ID
+	var (
+		pk      bls.SecretKey
+		rawKeys []bls.SecretKey
+		rawIDs  []bls.ID
+	)
 
 	for idx, key := range shares {
 		// do a local copy, we're dealing with references here
@@ -162,10 +163,11 @@ func (Herumi) RecoverSecret(shares map[int]v2.PrivateKey, _, _ uint) (v2.Private
 	return *(*v2.PrivateKey)(pk.Serialize()), nil
 }
 
-func (Herumi) CombineSignatures(signs []v2.Signature) (v2.Signature, error) {
-	var sig bls.Sign
-
-	var rawSigns []bls.Sign
+func (Herumi) Aggregate(signs []v2.Signature) (v2.Signature, error) {
+	var (
+		sig      bls.Sign
+		rawSigns []bls.Sign
+	)
 
 	for idx, rawSignature := range signs {
 		var signature bls.Sign
@@ -186,8 +188,10 @@ func (Herumi) CombineSignatures(signs []v2.Signature) (v2.Signature, error) {
 }
 
 func (Herumi) ThresholdAggregate(partialSignaturesByIndex map[int]v2.Signature) (v2.Signature, error) {
-	var rawSigns []bls.Sign
-	var rawIDs []bls.ID
+	var (
+		rawSigns []bls.Sign
+		rawIDs   []bls.ID
+	)
 
 	for idx, rawSignature := range partialSignaturesByIndex {
 		// do a local copy, we're dealing with references here
@@ -254,15 +258,17 @@ func (Herumi) Sign(privateKey v2.PrivateKey, data []byte) (v2.Signature, error) 
 	return *(*v2.Signature)(sigBytes), nil
 }
 
-func (Herumi) FastAggregateVerify(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
-	var rawShares []bls.PublicKey
-	var sig bls.Sign
+func (Herumi) VerifyAggregate(publicShares []v2.PublicKey, signature v2.Signature, data []byte) error {
+	var (
+		rawShares []bls.PublicKey
+		sig       bls.Sign
+	)
 
 	if err := sig.Deserialize(signature[:]); err != nil {
 		return errors.Wrap(err, "cannot unmarshal signature into Herumi signature")
 	}
 
-	for _, share := range shares {
+	for _, share := range publicShares {
 		var pubKey bls.PublicKey
 		if err := pubKey.Deserialize(share[:]); err != nil {
 			return errors.Wrap(err, "cannot set compressed public key in Herumi format")

--- a/tbls/v2/kryptology/kryptology.go
+++ b/tbls/v2/kryptology/kryptology.go
@@ -134,7 +134,7 @@ func (Kryptology) RecoverSecret(shares map[int]v2.PrivateKey, total uint, thresh
 	return *(*v2.PrivateKey)(ret), nil
 }
 
-func (Kryptology) CombineSignatures(signs []v2.Signature) (v2.Signature, error) {
+func (Kryptology) Aggregate(signs []v2.Signature) (v2.Signature, error) {
 	sig := bls_sig.NewSigEth2()
 
 	var rawSigns []*bls_sig.Signature
@@ -239,7 +239,7 @@ func (Kryptology) Sign(privateKey v2.PrivateKey, data []byte) (v2.Signature, err
 	return *(*v2.Signature)(ret), nil
 }
 
-func (Kryptology) FastAggregateVerify(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
+func (Kryptology) VerifyAggregate(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
 	sig := bls_sig.NewSigEth2()
 
 	rawSign := new(bls_sig.Signature)
@@ -259,7 +259,7 @@ func (Kryptology) FastAggregateVerify(shares []v2.PublicKey, signature v2.Signat
 
 	verified, err := sig.FastAggregateVerify(rawKeys, data, rawSign)
 	if err != nil {
-		return errors.Wrap(err, "kryptology FastAggregateVerify failed")
+		return errors.Wrap(err, "kryptology VerifyAggregate failed")
 	}
 
 	if !verified {

--- a/tbls/v2/kryptology/kryptology.go
+++ b/tbls/v2/kryptology/kryptology.go
@@ -23,6 +23,7 @@ import (
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 	v2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
@@ -133,6 +134,39 @@ func (Kryptology) RecoverSecret(shares map[int]v2.PrivateKey, total uint, thresh
 	return *(*v2.PrivateKey)(ret), nil
 }
 
+func (Kryptology) CombineSignatures(signs []v2.Signature) (v2.Signature, error) {
+	sig := bls_sig.NewSigEth2()
+
+	var rawSigns []*bls_sig.Signature
+
+	for idx, rawSignature := range signs {
+		rawSignature := rawSignature
+		var signature bls_sig.Signature
+
+		if err := signature.UnmarshalBinary(rawSignature[:]); err != nil {
+			return v2.Signature{}, errors.Wrap(
+				err,
+				"cannot unmarshal signature into Kryptology signature",
+				z.Int("signature_number", idx),
+			)
+		}
+
+		rawSigns = append(rawSigns, &signature)
+	}
+
+	s, err := sig.AggregateSignatures(rawSigns...)
+	if err != nil {
+		return v2.Signature{}, errors.Wrap(err, "cannot aggregate signatures")
+	}
+
+	sbytes, err := s.MarshalBinary()
+	if err != nil {
+		return v2.Signature{}, errors.Wrap(err, "cannot marshal signature")
+	}
+
+	return *(*v2.Signature)(sbytes), nil
+}
+
 func (Kryptology) ThresholdAggregate(partialSignaturesByIndex map[int]v2.Signature) (v2.Signature, error) {
 	var kryptologyPartialSigs []*bls_sig.PartialSignature
 
@@ -203,4 +237,34 @@ func (Kryptology) Sign(privateKey v2.PrivateKey, data []byte) (v2.Signature, err
 	}
 
 	return *(*v2.Signature)(ret), nil
+}
+
+func (Kryptology) FastAggregateVerify(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
+	sig := bls_sig.NewSigEth2()
+
+	rawSign := new(bls_sig.Signature)
+	if err := rawSign.UnmarshalBinary(signature[:]); err != nil {
+		return errors.Wrap(err, "unmarshal raw signature into kryptology object")
+	}
+
+	var rawKeys []*bls_sig.PublicKey
+	for _, keyShare := range shares {
+		rawKey := new(bls_sig.PublicKey)
+		if err := rawKey.UnmarshalBinary(keyShare[:]); err != nil {
+			return errors.Wrap(err, "unmarshal raw public key into kryptology object")
+		}
+
+		rawKeys = append(rawKeys, rawKey)
+	}
+
+	verified, err := sig.FastAggregateVerify(rawKeys, data, rawSign)
+	if err != nil {
+		return errors.Wrap(err, "kryptology FastAggregateVerify failed")
+	}
+
+	if !verified {
+		return errors.New("signature verification failed")
+	}
+
+	return nil
 }

--- a/tbls/v2/tbls.go
+++ b/tbls/v2/tbls.go
@@ -104,10 +104,10 @@ func Sign(privateKey PrivateKey, data []byte) (Signature, error) {
 	return impl.Sign(privateKey, data)
 }
 
-func FastAggregateVerify(shares []PublicKey, signature Signature, data []byte) error {
+func VerifyAggregate(shares []PublicKey, signature Signature, data []byte) error {
 	return impl.VerifyAggregate(shares, signature, data)
 }
 
-func CombineSignatures(signs []Signature) (Signature, error) {
+func Aggregate(signs []Signature) (Signature, error) {
 	return impl.Aggregate(signs)
 }

--- a/tbls/v2/tbls.go
+++ b/tbls/v2/tbls.go
@@ -60,13 +60,13 @@ type Implementation interface {
 	// This function works on both shares of private keys, and complete private keys.
 	Sign(privateKey PrivateKey, data []byte) (Signature, error)
 
-	// FastAggregateVerify is the BLS standard FastAggregateVerify call, as defined by the standard:
+	// VerifyAggregate is the BLS standard FastAggregateVerify call, as defined by the standard:
 	// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-3.3.4.
-	FastAggregateVerify(shares []PublicKey, signature Signature, data []byte) error
+	VerifyAggregate(shares []PublicKey, signature Signature, data []byte) error
 
-	// CombineSignatures combines signs in a single Signature with standard BLS signature aggregation,
+	// Aggregate combines signs in a single Signature with standard BLS signature aggregation,
 	// as defined by the standard: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.8.
-	CombineSignatures(signs []Signature) (Signature, error)
+	Aggregate(signs []Signature) (Signature, error)
 }
 
 // SetImplementation sets newImpl as the package backing implementation.
@@ -105,9 +105,9 @@ func Sign(privateKey PrivateKey, data []byte) (Signature, error) {
 }
 
 func FastAggregateVerify(shares []PublicKey, signature Signature, data []byte) error {
-	return impl.FastAggregateVerify(shares, signature, data)
+	return impl.VerifyAggregate(shares, signature, data)
 }
 
 func CombineSignatures(signs []Signature) (Signature, error) {
-	return impl.CombineSignatures(signs)
+	return impl.Aggregate(signs)
 }

--- a/tbls/v2/tbls.go
+++ b/tbls/v2/tbls.go
@@ -59,6 +59,14 @@ type Implementation interface {
 	// Sign signs data with the provided private key, and returns the resulting signature.
 	// This function works on both shares of private keys, and complete private keys.
 	Sign(privateKey PrivateKey, data []byte) (Signature, error)
+
+	// FastAggregateVerify is the BLS standard FastAggregateVerify call, as defined by the standard:
+	// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-3.3.4.
+	FastAggregateVerify(shares []PublicKey, signature Signature, data []byte) error
+
+	// CombineSignatures combines signs in a single Signature with standard BLS signature aggregation,
+	// as defined by the standard: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.8.
+	CombineSignatures(signs []Signature) (Signature, error)
 }
 
 // SetImplementation sets newImpl as the package backing implementation.
@@ -94,4 +102,12 @@ func Verify(compressedPublicKey PublicKey, data []byte, signature Signature) err
 
 func Sign(privateKey PrivateKey, data []byte) (Signature, error) {
 	return impl.Sign(privateKey, data)
+}
+
+func FastAggregateVerify(shares []PublicKey, signature Signature, data []byte) error {
+	return impl.FastAggregateVerify(shares, signature, data)
+}
+
+func CombineSignatures(signs []Signature) (Signature, error) {
+	return impl.CombineSignatures(signs)
 }

--- a/tbls/v2/tbls_test.go
+++ b/tbls/v2/tbls_test.go
@@ -141,6 +141,46 @@ func (ts *TestSuite) Test_Sign() {
 	require.NotEmpty(ts.T(), signature)
 }
 
+func (ts *TestSuite) Test_FastAggregateVerify() {
+	data := []byte("hello obol!")
+
+	type key struct {
+		pub  v2.PublicKey
+		priv v2.PrivateKey
+	}
+
+	var keys []key
+
+	for i := 0; i < 10; i++ {
+		secret, err := v2.GenerateSecretKey()
+		require.NoError(ts.T(), err)
+		require.NotEmpty(ts.T(), secret)
+
+		pubkey, err := v2.SecretToPublicKey(secret)
+		require.NoError(ts.T(), err)
+
+		keys = append(keys, key{
+			pub:  pubkey,
+			priv: secret,
+		})
+	}
+
+	var signs []v2.Signature
+	var pshares []v2.PublicKey
+
+	for _, key := range keys {
+		s, err := v2.Sign(key.priv, data)
+		require.NoError(ts.T(), err)
+		signs = append(signs, s)
+		pshares = append(pshares, key.pub)
+	}
+
+	sig, err := v2.CombineSignatures(signs)
+	require.NoError(ts.T(), err)
+
+	require.NoError(ts.T(), v2.FastAggregateVerify(pshares, sig, data))
+}
+
 func runSuite(t *testing.T, i v2.Implementation) {
 	t.Helper()
 	ts := NewTestSuite(i)
@@ -177,6 +217,7 @@ func runBenchmark(b *testing.B, impl v2.Implementation) {
 		s.Test_ThresholdAggregate()
 		s.Test_Verify()
 		s.Test_Sign()
+		s.Test_FastAggregateVerify()
 	}
 }
 
@@ -280,6 +321,24 @@ func (r randomizedImpl) Sign(privateKey v2.PrivateKey, data []byte) (v2.Signatur
 	}
 
 	return impl.Sign(privateKey, data)
+}
+
+func (r randomizedImpl) FastAggregateVerify(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
+	impl, err := r.selectImpl()
+	if err != nil {
+		return err
+	}
+
+	return impl.FastAggregateVerify(shares, signature, data)
+}
+
+func (r randomizedImpl) CombineSignatures(signs []v2.Signature) (v2.Signature, error) {
+	impl, err := r.selectImpl()
+	if err != nil {
+		return v2.Signature{}, err
+	}
+
+	return impl.CombineSignatures(signs)
 }
 
 func FuzzRandomImplementations(f *testing.F) {

--- a/tbls/v2/tbls_test.go
+++ b/tbls/v2/tbls_test.go
@@ -323,22 +323,22 @@ func (r randomizedImpl) Sign(privateKey v2.PrivateKey, data []byte) (v2.Signatur
 	return impl.Sign(privateKey, data)
 }
 
-func (r randomizedImpl) FastAggregateVerify(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
+func (r randomizedImpl) VerifyAggregate(shares []v2.PublicKey, signature v2.Signature, data []byte) error {
 	impl, err := r.selectImpl()
 	if err != nil {
 		return err
 	}
 
-	return impl.FastAggregateVerify(shares, signature, data)
+	return impl.VerifyAggregate(shares, signature, data)
 }
 
-func (r randomizedImpl) CombineSignatures(signs []v2.Signature) (v2.Signature, error) {
+func (r randomizedImpl) Aggregate(signs []v2.Signature) (v2.Signature, error) {
 	impl, err := r.selectImpl()
 	if err != nil {
 		return v2.Signature{}, err
 	}
 
-	return impl.CombineSignatures(signs)
+	return impl.Aggregate(signs)
 }
 
 func FuzzRandomImplementations(f *testing.F) {

--- a/tbls/v2/tbls_test.go
+++ b/tbls/v2/tbls_test.go
@@ -141,7 +141,7 @@ func (ts *TestSuite) Test_Sign() {
 	require.NotEmpty(ts.T(), signature)
 }
 
-func (ts *TestSuite) Test_FastAggregateVerify() {
+func (ts *TestSuite) Test_VerifyAggregate() {
 	data := []byte("hello obol!")
 
 	type key struct {
@@ -175,10 +175,10 @@ func (ts *TestSuite) Test_FastAggregateVerify() {
 		pshares = append(pshares, key.pub)
 	}
 
-	sig, err := v2.CombineSignatures(signs)
+	sig, err := v2.Aggregate(signs)
 	require.NoError(ts.T(), err)
 
-	require.NoError(ts.T(), v2.FastAggregateVerify(pshares, sig, data))
+	require.NoError(ts.T(), v2.VerifyAggregate(pshares, sig, data))
 }
 
 func runSuite(t *testing.T, i v2.Implementation) {
@@ -217,7 +217,7 @@ func runBenchmark(b *testing.B, impl v2.Implementation) {
 		s.Test_ThresholdAggregate()
 		s.Test_Verify()
 		s.Test_Sign()
-		s.Test_FastAggregateVerify()
+		s.Test_VerifyAggregate()
 	}
 }
 

--- a/tbls/v2/unimplemented.go
+++ b/tbls/v2/unimplemented.go
@@ -52,10 +52,10 @@ func (Unimplemented) Sign(_ PrivateKey, _ []byte) (Signature, error) {
 	return Signature{}, ErrNotImplemented
 }
 
-func (Unimplemented) FastAggregateVerify(_ []PublicKey, _ Signature, _ []byte) error {
+func (Unimplemented) VerifyAggregate(_ []PublicKey, _ Signature, _ []byte) error {
 	return ErrNotImplemented
 }
 
-func (Unimplemented) CombineSignatures(_ []Signature) (Signature, error) {
+func (Unimplemented) Aggregate(_ []Signature) (Signature, error) {
 	return Signature{}, ErrNotImplemented
 }

--- a/tbls/v2/unimplemented.go
+++ b/tbls/v2/unimplemented.go
@@ -51,3 +51,11 @@ func (Unimplemented) Verify(_ PublicKey, _ []byte, _ Signature) error {
 func (Unimplemented) Sign(_ PrivateKey, _ []byte) (Signature, error) {
 	return Signature{}, ErrNotImplemented
 }
+
+func (Unimplemented) FastAggregateVerify(_ []PublicKey, _ Signature, _ []byte) error {
+	return ErrNotImplemented
+}
+
+func (Unimplemented) CombineSignatures(_ []Signature) (Signature, error) {
+	return Signature{}, ErrNotImplemented
+}


### PR DESCRIPTION
We were missing those two important methods, needed for the Charon migration to `tbls/v2`.

category: feature
ticket: none

