### PR TITLE
ethu2util/signing: refactor to use tbls/v2

### DIFF
--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -21,6 +21,7 @@ import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
@@ -52,7 +53,13 @@ func VerifyEth2SignedData(ctx context.Context, eth2Cl eth2wrap.Client, data Eth2
 		return err
 	}
 
-	return signing.Verify(ctx, eth2Cl, data.DomainName(), epoch, sigRoot, data.Signature().ToETH2(), pubkey)
+	// TODO(gsora): refactor this to tblsv2.PublicKey
+	pkBytes, err := pubkey.MarshalBinary()
+	if err != nil {
+		return errors.Wrap(err, "cannot serialize public key")
+	}
+
+	return signing.Verify(ctx, eth2Cl, data.DomainName(), epoch, sigRoot, data.Signature().ToETH2(), pkBytes)
 }
 
 // Implement Eth2SignedData for VersionedSignedBeaconBlock.

--- a/core/eth2signeddata_test.go
+++ b/core/eth2signeddata_test.go
@@ -17,6 +17,7 @@ package core_test
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -27,9 +28,16 @@ import (
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestVerifyEth2SignedData(t *testing.T) {
 	tests := []struct {

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -17,6 +17,7 @@ package parsigex_test
 
 import (
 	"context"
+	"os"
 	"sync"
 	"testing"
 
@@ -35,9 +36,16 @@ import (
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestParSigEx(t *testing.T) {
 	const (

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -18,6 +18,7 @@ package validatorapi_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"testing"
@@ -43,10 +44,17 @@ import (
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 	"github.com/obolnetwork/charon/testutil/validatormock"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestComponent_ValidSubmitAttestations(t *testing.T) {
 	ctx := context.Background()
@@ -541,7 +549,7 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	})
 
 	err = vapi.SubmitBeaconBlock(ctx, signedBlock)
-	require.ErrorContains(t, err, "invalid signature")
+	require.ErrorContains(t, err, "signature not verified")
 }
 
 func TestComponent_SubmitBeaconBlockInvalidBlock(t *testing.T) {
@@ -840,7 +848,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	})
 
 	err = vapi.SubmitBlindedBeaconBlock(ctx, signedBlindedBlock)
-	require.ErrorContains(t, err, "invalid signature")
+	require.ErrorContains(t, err, "signature not verified")
 }
 
 func TestComponent_SubmitBlindedBeaconBlockInvalidBlock(t *testing.T) {
@@ -1026,7 +1034,7 @@ func TestComponent_SubmitVoluntaryExitInvalidSignature(t *testing.T) {
 	exit.Signature = tblsconv.SigToETH2(sig)
 
 	err = vapi.SubmitVoluntaryExit(ctx, exit)
-	require.ErrorContains(t, err, "invalid signature")
+	require.ErrorContains(t, err, "signature not verified")
 }
 
 func TestComponent_Duties(t *testing.T) {
@@ -1235,7 +1243,7 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 	}
 
 	err = vapi.SubmitValidatorRegistrations(ctx, []*eth2api.VersionedSignedValidatorRegistration{signed})
-	require.ErrorContains(t, err, "invalid signature")
+	require.ErrorContains(t, err, "signature not verified")
 }
 
 func TestComponent_TekuProposerConfig(t *testing.T) {

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -18,16 +18,14 @@ package signing
 import (
 	"context"
 
-	"github.com/attestantio/go-eth2-client/spec/altair"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/coinbase/kryptology/pkg/core/curves/native/bls12381"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/tracer"
 	"github.com/obolnetwork/charon/eth2util"
-	"github.com/obolnetwork/charon/tbls"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
 // DomainName as defined in eth2 spec.
@@ -94,31 +92,20 @@ func VerifyAggregateAndProofSelection(ctx context.Context, eth2Cl eth2wrap.Clien
 
 	sigRoot, err := eth2util.SlotHashRoot(agg.Aggregate.Data.Slot)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "cannot get hash root of slot")
 	}
 
-	return Verify(ctx, eth2Cl, DomainSelectionProof, epoch, sigRoot, agg.SelectionProof, pubkey)
-}
-
-// VerifySyncContributionAndProof verifies the altair.SignedContributionAndProof with the provided pubkey.
-// Refer get_contribution_and_proof_signature from https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#broadcast-sync-committee-contribution.
-func VerifySyncContributionAndProof(ctx context.Context, eth2Cl eth2wrap.Client, pubkey *bls_sig.PublicKey, contrib *altair.SignedContributionAndProof) error {
-	epoch, err := eth2util.EpochFromSlot(ctx, eth2Cl, contrib.Message.Contribution.Slot)
+	rawKey, err := pubkey.MarshalBinary()
 	if err != nil {
-		return err
+		return errors.Wrap(err, "cannot serialize public key")
 	}
 
-	sigRoot, err := contrib.Message.HashTreeRoot()
-	if err != nil {
-		return err
-	}
-
-	return Verify(ctx, eth2Cl, DomainContributionAndProof, epoch, sigRoot, contrib.Signature, pubkey)
+	return Verify(ctx, eth2Cl, DomainSelectionProof, epoch, sigRoot, agg.SelectionProof, rawKey)
 }
 
 // Verify returns an error if the signature doesn't match the eth2 domain signed root.
 func Verify(ctx context.Context, eth2Cl eth2wrap.Client, domain DomainName, epoch eth2p0.Epoch, sigRoot eth2p0.Root,
-	signature eth2p0.BLSSignature, pubkey *bls_sig.PublicKey,
+	signature eth2p0.BLSSignature, pubkey []byte,
 ) error {
 	ctx, span := tracer.Start(ctx, "eth2util.Verify")
 	defer span.End()
@@ -133,29 +120,11 @@ func Verify(ctx context.Context, eth2Cl eth2wrap.Client, domain DomainName, epoc
 		return errors.New("no signature found")
 	}
 
-	// Convert the signature
-	s, err := sigFromETH2(signature)
-	if err != nil {
-		return errors.Wrap(err, "convert signature")
+	if len(pubkey) != len(tblsv2.PublicKey{}) {
+		return errors.New("wrong length")
 	}
 
 	span.AddEvent("tbls.Verify")
-	ok, err := tbls.Verify(pubkey, sigData[:], s)
-	if err != nil {
-		return err
-	} else if !ok {
-		return errors.New("invalid signature")
-	}
 
-	return nil
-}
-
-// sigFromETH2 converts an eth2 phase0 bls signature into a kryptology bls signature.
-func sigFromETH2(sig eth2p0.BLSSignature) (*bls_sig.Signature, error) {
-	point, err := new(bls12381.G2).FromCompressed((*[96]byte)(sig[:]))
-	if err != nil {
-		return nil, errors.Wrap(err, "uncompress sig")
-	}
-
-	return &bls_sig.Signature{Value: *point}, nil
+	return tblsv2.Verify(*(*tblsv2.PublicKey)(pubkey), sigData[:], tblsv2.Signature(signature))
 }

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -17,6 +17,7 @@ package signing
 
 import (
 	"context"
+	"encoding/hex"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
@@ -24,6 +25,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/tracer"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -126,5 +126,7 @@ func Verify(ctx context.Context, eth2Cl eth2wrap.Client, domain DomainName, epoc
 
 	span.AddEvent("tbls.Verify")
 
-	return tblsv2.Verify(*(*tblsv2.PublicKey)(pubkey), sigData[:], tblsv2.Signature(signature))
+	tbls2Pubkey := *(*tblsv2.PublicKey)(pubkey)
+
+	return tblsv2.Verify(tbls2Pubkey, sigData[:], tblsv2.Signature(signature))
 }

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"testing"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -28,8 +29,15 @@ import (
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestVerifyRegistrationReference(t *testing.T) {
 	bmock, err := beaconmock.New()
@@ -76,6 +84,9 @@ func TestVerifyRegistrationReference(t *testing.T) {
 	pubkey, err := secretShare.GetPublicKey()
 	require.NoError(t, err)
 
-	err = signing.Verify(context.Background(), bmock, signing.DomainApplicationBuilder, 0, sigRoot, tblsconv.SigToETH2(sig), pubkey)
+	rawKey, err := pubkey.MarshalBinary()
+	require.NoError(t, err)
+
+	err = signing.Verify(context.Background(), bmock, signing.DomainApplicationBuilder, 0, sigRoot, tblsconv.SigToETH2(sig), rawKey)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
Kryptology types are still in there, will be refactored later.

category: refactor
ticket: #1744 
feature_flag: herumi_bls
