### PR TITLE
cluster: refactor to use tbls/v2

### DIFF
--- a/app/app_test.go
+++ b/app/app_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"regexp"
 	"sync"
 	"testing"
@@ -45,9 +46,16 @@ import (
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/priority"
 	"github.com/obolnetwork/charon/p2p"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 // TestPingCluster starts a cluster of charon nodes and waits for each node to ping all the others.
 // It relies on discv5 for peer discovery.

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -225,7 +225,7 @@ func TestDefinitionPeers(t *testing.T) {
 	peers, err := lock.Peers()
 	require.NoError(t, err)
 
-	names := []string{"lucky-son", "inexpensive-school", "dark-plant", "dazzling-shape"}
+	names := []string{"remarkable-toy", "talented-sound", "strange-law", "fragile-leg"}
 
 	for i, peer := range peers {
 		require.Equal(t, i, peer.Index)

--- a/cluster/helpers_internal_test.go
+++ b/cluster/helpers_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"testing"
 
@@ -28,8 +29,15 @@ import (
 
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/eth2util"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestLeftPad(t *testing.T) {
 	b := []byte{0x01, 0x02}

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -39,10 +39,17 @@ import (
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 )
 
 //go:generate go test . -run=TestCreateCluster -update -clean
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestCreateCluster(t *testing.T) {
 	defPath := "../cluster/examples/cluster-definition-002.json"

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -18,6 +18,7 @@ package consensus_test
 import (
 	"context"
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/libp2p/go-libp2p"
@@ -36,8 +37,15 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	"github.com/obolnetwork/charon/eth2util/enr"
 	"github.com/obolnetwork/charon/p2p"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestComponent(t *testing.T) {
 	const (

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -41,8 +41,15 @@ import (
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestDKG(t *testing.T) {
 	const (

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -18,6 +18,7 @@ package p2p_test
 import (
 	"context"
 	"math/rand"
+	"os"
 	"testing"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -26,8 +27,15 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util/enr"
 	"github.com/obolnetwork/charon/p2p"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 	"github.com/obolnetwork/charon/testutil"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestNewPeer(t *testing.T) {
 	p2pKey := testutil.GenerateInsecureK1Key(t, rand.New(rand.NewSource(0)))

--- a/tbls/v2/tblsconv/tblsconv.go
+++ b/tbls/v2/tblsconv/tblsconv.go
@@ -18,6 +18,7 @@ package tblsconv
 import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/core"
 	v2 "github.com/obolnetwork/charon/tbls/v2"
 )
@@ -36,4 +37,14 @@ func SigToCore(sig v2.Signature) core.Signature {
 // SigToETH2 converts a tbls.Signature into an eth2 phase0 bls signature.
 func SigToETH2(sig v2.Signature) eth2p0.BLSSignature {
 	return eth2p0.BLSSignature(sig)
+}
+
+// PrivkeyFromBytes returns a v2.PrivateKey from the given compressed private key bytes contained in data.
+// Returns an error if the data isn't of the expected length.
+func PrivkeyFromBytes(data []byte) (v2.PrivateKey, error) {
+	if len(data) != len(v2.PrivateKey{}) {
+		return v2.PrivateKey{}, errors.New("data is not of the correct length")
+	}
+
+	return *(*v2.PrivateKey)(data), nil
 }

--- a/tbls/v2/tblsconv/tblsconv.go
+++ b/tbls/v2/tblsconv/tblsconv.go
@@ -48,3 +48,23 @@ func PrivkeyFromBytes(data []byte) (v2.PrivateKey, error) {
 
 	return *(*v2.PrivateKey)(data), nil
 }
+
+// PubkeyFromBytes returns a v2.PublicKey from the given compressed public key bytes contained in data.
+// Returns an error if the data isn't of the expected length.
+func PubkeyFromBytes(data []byte) (v2.PublicKey, error) {
+	if len(data) != len(v2.PublicKey{}) {
+		return v2.PublicKey{}, errors.New("data is not of the correct length")
+	}
+
+	return *(*v2.PublicKey)(data), nil
+}
+
+// SignatureFromBytes returns a v2.Signature from the given compressed signature bytes contained in data.
+// Returns an error if the data isn't of the expected length.
+func SignatureFromBytes(data []byte) (v2.Signature, error) {
+	if len(data) != len(v2.Signature{}) {
+		return v2.Signature{}, errors.New("data is not of the correct length")
+	}
+
+	return *(*v2.Signature)(data), nil
+}

--- a/testutil/combine/main_internal_test.go
+++ b/testutil/combine/main_internal_test.go
@@ -28,7 +28,14 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	herumiImpl "github.com/obolnetwork/charon/tbls/v2/herumi"
 )
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(herumiImpl.Herumi{})
+	os.Exit(m.Run())
+}
 
 func TestCombine(t *testing.T) {
 	lock, _, shares := cluster.NewForT(t, 1, 3, 4, 0)


### PR DESCRIPTION
Kryptology types are still in there, will be refactored later.

category: refactor
ticket: #1744
feature_flag: herumi_bls
