### PR TITLE
tbls/v2: add AggregatePublicKeys method

### DIFF
--- a/tbls/v2/herumi/herumi.go
+++ b/tbls/v2/herumi/herumi.go
@@ -283,3 +283,18 @@ func (Herumi) VerifyAggregate(publicShares []v2.PublicKey, signature v2.Signatur
 
 	return nil
 }
+
+func (Herumi) AggregatePublicKeys(pubkeys []v2.PublicKey) (v2.PublicKey, error) {
+	hfinal := new(bls.PublicKey)
+
+	for _, key := range pubkeys {
+		final := new(bls.PublicKey)
+		if err := final.Deserialize(key[:]); err != nil {
+			return v2.PublicKey{}, errors.Wrap(err, "herumi pubkey aggregation")
+		}
+
+		hfinal.Add(final)
+	}
+
+	return *(*v2.PublicKey)(hfinal.Serialize()), nil
+}

--- a/tbls/v2/kryptology/kryptology.go
+++ b/tbls/v2/kryptology/kryptology.go
@@ -268,3 +268,27 @@ func (Kryptology) VerifyAggregate(shares []v2.PublicKey, signature v2.Signature,
 
 	return nil
 }
+
+func (Kryptology) AggregatePublicKeys(pubkeys []v2.PublicKey) (v2.PublicKey, error) {
+	var pks []*bls_sig.PublicKey
+
+	for _, key := range pubkeys {
+		final := new(bls_sig.PublicKey)
+		if err := final.UnmarshalBinary(key[:]); err != nil {
+			return v2.PublicKey{}, errors.Wrap(err, "kryptology pubkey unmarshal")
+		}
+		pks = append(pks, final)
+	}
+
+	final, err := bls_sig.NewSigEth2().AggregatePublicKeys(pks...)
+	if err != nil {
+		return v2.PublicKey{}, errors.Wrap(err, "kryptology pubkey aggregation")
+	}
+
+	finalBytes, err := final.MarshalBinary()
+	if err != nil {
+		return v2.PublicKey{}, errors.Wrap(err, "kryptology pubkey marshal")
+	}
+
+	return *(*v2.PublicKey)(finalBytes), nil
+}

--- a/tbls/v2/tbls.go
+++ b/tbls/v2/tbls.go
@@ -67,6 +67,9 @@ type Implementation interface {
 	// Aggregate combines signs in a single Signature with standard BLS signature aggregation,
 	// as defined by the standard: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.8.
 	Aggregate(signs []Signature) (Signature, error)
+
+	// AggregatePublicKeys combines a set of PublicKey into a single one using standard BLS public key aggregation.
+	AggregatePublicKeys(pubkeys []PublicKey) (PublicKey, error)
 }
 
 // SetImplementation sets newImpl as the package backing implementation.
@@ -110,4 +113,8 @@ func VerifyAggregate(shares []PublicKey, signature Signature, data []byte) error
 
 func Aggregate(signs []Signature) (Signature, error) {
 	return impl.Aggregate(signs)
+}
+
+func AggregatePublicKeys(pubkeys []PublicKey) (PublicKey, error) {
+	return impl.AggregatePublicKeys(pubkeys)
 }

--- a/tbls/v2/unimplemented.go
+++ b/tbls/v2/unimplemented.go
@@ -59,3 +59,7 @@ func (Unimplemented) VerifyAggregate(_ []PublicKey, _ Signature, _ []byte) error
 func (Unimplemented) Aggregate(_ []Signature) (Signature, error) {
 	return Signature{}, ErrNotImplemented
 }
+
+func (Unimplemented) AggregatePublicKeys(_ []PublicKey) (PublicKey, error) {
+	return PublicKey{}, ErrNotImplemented
+}


### PR DESCRIPTION
Used to aggregate multiple public keys into a single one.

category: feature 
ticket: none
