### PR TITLE
app: initialize tbls/v2 earlier

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -146,6 +146,13 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	version.LogInfo(ctx, "Charon starting")
 
+	blsv2.SetImplementation(kryptology.Kryptology{})
+
+	if featureset.Enabled(featureset.HerumiBLS) {
+		log.Info(ctx, "Enabling Herumi BLS signature backend")
+		blsv2.SetImplementation(herumi.Herumi{})
+	}
+
 	// Wire processes and their dependencies
 	life := new(lifecycle.Manager)
 
@@ -438,13 +445,6 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		}
 
 		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc)
-	}
-
-	blsv2.SetImplementation(kryptology.Kryptology{})
-
-	if featureset.Enabled(featureset.HerumiBLS) {
-		log.Info(ctx, "Enabling Herumi BLS signature backend")
-		blsv2.SetImplementation(herumi.Herumi{})
 	}
 
 	sigAgg := sigagg.New(lock.Threshold)


### PR DESCRIPTION
Without this commit, lockfile verification would fail with "unimplemented" because tbls/v2 was initialized later.

It's now initialized right after featureset.

category: bug
ticket: none

