### PR TITLE
dkg: add --publish flag to upload lock file

### DIFF
--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -52,6 +52,8 @@ this command at the same time.`,
 	bindNoVerifyFlag(cmd.Flags(), &config.NoVerify)
 	bindP2PFlags(cmd, &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
+	bindLaunchpadAPIAddrFlag(cmd.Flags(), &config.LaunchpadAPIAddr)
+	bindPublishFlag(cmd.Flags(), &config.Publish)
 
 	return cmd
 }
@@ -66,4 +68,12 @@ func bindDefDirFlag(flags *pflag.FlagSet, dataDir *string) {
 
 func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 	flags.StringVar(dataDir, "data-dir", ".charon", "The directory where charon will store all its internal data")
+}
+
+func bindLaunchpadAPIAddrFlag(flags *pflag.FlagSet, addr *string) {
+	flags.StringVar(addr, "launchpad-api-address", "https://obol-api-prod-green.gcp.obol.tech", "The launchpad api URL.")
+}
+
+func bindPublishFlag(flags *pflag.FlagSet, publish *bool) {
+	flags.BoolVar(publish, "publish", false, "Publish lock file to Obol DVT launchpad.")
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -36,6 +36,7 @@ import (
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/deposit"
 	"github.com/obolnetwork/charon/eth2util/keymanager"
+	"github.com/obolnetwork/charon/launchpad"
 	"github.com/obolnetwork/charon/p2p"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
@@ -48,6 +49,9 @@ type Config struct {
 	DataDir        string
 	P2P            p2p.Config
 	Log            log.Config
+
+	LaunchpadAPIAddr string
+	Publish          bool
 
 	TestDef          *cluster.Definition
 	TestSyncCallback func(connected int, id peer.ID)
@@ -208,6 +212,15 @@ func Run(ctx context.Context, conf Config) (err error) {
 			return err
 		}
 		log.Debug(ctx, "Saved keyshares to disk")
+	}
+
+	if conf.Publish {
+		cl := launchpad.New(conf.LaunchpadAPIAddr)
+		if err = cl.PublishLock(ctx, lock); err != nil {
+			log.Warn(ctx, "Publishing lock file", err)
+		} else {
+			log.Debug(ctx, "Published lock file to api")
+		}
 	}
 
 	if err = writeLock(conf.DataDir, lock); err != nil {

--- a/launchpad/api.go
+++ b/launchpad/api.go
@@ -1,0 +1,98 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package launchpad
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/cluster"
+)
+
+// New returns a new Client.
+func New(url string) Client {
+	return Client{
+		baseURL: url,
+	}
+}
+
+// Client is the REST client for launchpad API requests.
+type Client struct {
+	baseURL string // Base launchpad URL
+}
+
+// PublishLock posts the lockfile to obol-api.
+func (c Client) PublishLock(ctx context.Context, lock cluster.Lock) error {
+	if lock.Version != "v1.5.0" {
+		return errors.New("version not supported", z.Str("version", lock.Version))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	addr, err := url.JoinPath(c.baseURL, "/lock")
+	if err != nil {
+		return errors.Wrap(err, "invalid address")
+	}
+
+	url, err := url.Parse(addr)
+	if err != nil {
+		return errors.Wrap(err, "invalid endpoint")
+	}
+
+	b, err := json.MarshalIndent(lock, "", " ")
+	if err != nil {
+		return errors.Wrap(err, "marshal lock")
+	}
+
+	err = httpPost(ctx, url, b)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func httpPost(ctx context.Context, url *url.URL, b []byte) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url.String(), bytes.NewReader(b))
+	if err != nil {
+		return errors.Wrap(err, "new POST request with ctx")
+	}
+
+	res, err := new(http.Client).Do(req)
+	if err != nil {
+		return errors.Wrap(err, "failed to call POST endpoint")
+	}
+	defer res.Body.Close()
+
+	data, err := io.ReadAll(res.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read POST response")
+	}
+
+	if res.StatusCode/100 != 2 {
+		return errors.New("post failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
+	}
+
+	return nil
+}

--- a/launchpad/api_test.go
+++ b/launchpad/api_test.go
@@ -1,0 +1,71 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package launchpad_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/launchpad"
+)
+
+func TestLockPublish(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("2xx response", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			require.Equal(t, r.URL.Path, "/lock")
+
+			data, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			defer r.Body.Close()
+
+			var req cluster.Lock
+			require.NoError(t, json.Unmarshal(data, &req))
+			require.Equal(t, req.Version, "v1.5.0")
+
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		opts := []func(d *cluster.Definition){
+			func(d *cluster.Definition) {
+				d.Version = "v1.5.0"
+			},
+		}
+
+		lock, _, _ := cluster.NewForT(t, 3, 3, 4, 0, opts...)
+
+		cl := launchpad.New(srv.URL)
+		err := cl.PublishLock(ctx, lock)
+		require.NoError(t, err)
+	})
+
+	t.Run("version not supported", func(t *testing.T) {
+		lock, _, _ := cluster.NewForT(t, 3, 3, 4, 0)
+
+		cl := launchpad.New("")
+		err := cl.PublishLock(ctx, lock)
+		require.ErrorContains(t, err, "version not supported")
+	})
+}


### PR DESCRIPTION
Adds publish flag to dkg and create cluster commands to upload the lock file generated to out api. This introduces the new concept of our launchpad api, so added a configurable address with prod as default. 

category: feature
ticket: #1492
