### PR TITLE
eth2util/enr: add backwards compatibility with older versions

### DIFF
--- a/eth2util/enr/enr.go
+++ b/eth2util/enr/enr.go
@@ -53,7 +53,7 @@ func Parse(enrStr string) (Record, error) {
 	}
 
 	// Ensure backwards compatibility with older versions with encoded ENR strings.
-	// Older version ENR strings were base64 padded strings with "=" as padding character.
+	// ENR strings in older versions of charon (<= v0.9.0) were base64 padded strings with "=" as the padding character.
 	// Refer: https://github.com/ObolNetwork/charon/issues/970
 	enrStr = strings.TrimRight(enrStr, "=")
 

--- a/eth2util/enr/enr.go
+++ b/eth2util/enr/enr.go
@@ -52,6 +52,11 @@ func Parse(enrStr string) (Record, error) {
 		return Record{}, errors.New("missing 'enr:' prefix")
 	}
 
+	// Ensure backwards compatibility with older versions with encoded ENR strings.
+	// Older version ENR strings were base64 padded strings with "=" as padding character.
+	// Refer: https://github.com/ObolNetwork/charon/issues/970
+	enrStr = strings.TrimRight(enrStr, "=")
+
 	raw, err := base64.RawURLEncoding.DecodeString(enrStr[4:])
 	if err != nil {
 		return Record{}, errors.Wrap(err, "invalid base64 encoding")

--- a/eth2util/enr/enr_internal_test.go
+++ b/eth2util/enr/enr_internal_test.go
@@ -37,7 +37,7 @@ func TestBackwardsENR(t *testing.T) {
 		record, err := New(key)
 		require.NoError(t, err)
 
-		// Encode ENR string with padding which is supported by v0.9.0 or earlier.
+		// Encode ENR string with padding which is supported by charon versions v0.9.0 or earlier.
 		enrStr := "enr:" + base64.URLEncoding.EncodeToString(encodeElements(record.Signature, record.kvs))
 
 		_, err = Parse(enrStr)

--- a/eth2util/enr/enr_internal_test.go
+++ b/eth2util/enr/enr_internal_test.go
@@ -1,0 +1,46 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package enr
+
+import (
+	"crypto/ecdsa"
+	"encoding/base64"
+	"math/rand"
+	"testing"
+	"time"
+
+	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackwardsENR(t *testing.T) {
+	random := rand.New(rand.NewSource(time.Now().Unix()))
+	for i := 0; i < 100; i++ {
+		k, err := ecdsa.GenerateKey(k1.S256(), random)
+		require.NoError(t, err)
+
+		key := k1.PrivKeyFromBytes(k.D.Bytes())
+
+		record, err := New(key)
+		require.NoError(t, err)
+
+		// Encode ENR string with padding which is supported by v0.9.0 or earlier.
+		enrStr := "enr:" + base64.URLEncoding.EncodeToString(encodeElements(record.Signature, record.kvs))
+
+		_, err = Parse(enrStr)
+		require.NoError(t, err)
+	}
+}

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -808,6 +808,7 @@ func CreateHost(t *testing.T, addr *net.TCPAddr, opts ...libp2p.Option) host.Hos
 
 	h, err := libp2p.New(opts2...)
 
+	SkipIfBindErr(t, err)
 	require.NoError(t, err)
 
 	return h


### PR DESCRIPTION
Adds backwards compatibility in ENR parsing with older versions. Older versions created padded ENRs.

category: bug
ticket: none
