### PR TITLE
eth2util: refactor to use tbls/v2

### DIFF
--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	ssz "github.com/ferranbt/fastssz"
 
@@ -34,9 +33,7 @@ import (
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
-	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 )
 
 // FetchDefinition fetches cluster definition file from a remote URI.
@@ -123,26 +120,11 @@ func signOperator(secret *k1.PrivateKey, def Definition, operator Operator) (Ope
 }
 
 // aggSign returns a bls aggregate signatures of the message signed by all the shares.
-func aggSign(secrets [][]*bls_sig.SecretKeyShare, message []byte) ([]byte, error) {
+func aggSign(secrets [][]tblsv2.PrivateKey, message []byte) ([]byte, error) {
 	var sigs []tblsv2.Signature
 	for _, shares := range secrets {
 		for _, share := range shares {
-			secret, err := tblsconv.ShareToSecret(share)
-			if err != nil {
-				return nil, err
-			}
-
-			secretRaw, err := secret.MarshalBinary()
-			if err != nil {
-				return nil, errors.Wrap(err, "unmarshal error")
-			}
-
-			secretV2, err := tblsconv2.PrivkeyFromBytes(secretRaw)
-			if err != nil {
-				return nil, err
-			}
-
-			sig, err := tblsv2.Sign(secretV2, message)
+			sig, err := tblsv2.Sign(share, message)
 			if err != nil {
 				return nil, err
 			}

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -28,7 +28,6 @@ import (
 	"strings"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -42,8 +41,8 @@ import (
 	"github.com/obolnetwork/charon/eth2util/keymanager"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/p2p"
-	"github.com/obolnetwork/charon/tbls"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 )
 
 const (
@@ -161,13 +160,13 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		return err
 	}
 	// Generate threshold bls key shares
-	dvs, shareSets, err := getTSSShares(secrets, def.Threshold, numNodes)
+	pubkeys, shareSets, err := getTSSShares(secrets, def.Threshold, numNodes)
 	if err != nil {
 		return err
 	}
 
 	// Create validators
-	vals, err := getValidators(dvs)
+	vals, err := getValidators(pubkeys, shareSets)
 	if err != nil {
 		return err
 	}
@@ -220,7 +219,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 }
 
 // signDepositDatas returns Distributed Validator pubkeys and deposit data signatures corresponding to each pubkey.
-func signDepositDatas(secrets []*bls_sig.SecretKey, withdrawalAddresses []string, network string) ([]eth2p0.BLSPubKey, []eth2p0.BLSSignature, error) {
+func signDepositDatas(secrets []tblsv2.PrivateKey, withdrawalAddresses []string, network string) ([]eth2p0.BLSPubKey, []eth2p0.BLSSignature, error) {
 	if len(secrets) != len(withdrawalAddresses) {
 		return nil, nil, errors.New("insufficient withdrawal addresses")
 	}
@@ -235,53 +234,54 @@ func signDepositDatas(secrets []*bls_sig.SecretKey, withdrawalAddresses []string
 			return nil, nil, err
 		}
 
-		pk, err := secret.GetPublicKey()
+		pk, err := tblsv2.SecretToPublicKey(secret)
 		if err != nil {
 			return nil, nil, errors.Wrap(err, "secret to pubkey")
 		}
 
-		pubkey, err := tblsconv.KeyToETH2(pk)
+		msgRoot, err := deposit.GetMessageSigningRoot(eth2p0.BLSPubKey(pk), withdrawalAddr, network)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		msgRoot, err := deposit.GetMessageSigningRoot(pubkey, withdrawalAddr, network)
+		sig, err := tblsv2.Sign(secret, msgRoot[:])
 		if err != nil {
 			return nil, nil, err
 		}
 
-		sig, err := tbls.Sign(secret, msgRoot[:])
-		if err != nil {
-			return nil, nil, err
-		}
-
-		pubkeys = append(pubkeys, pubkey)
-		signatures = append(signatures, tblsconv.SigToETH2(sig))
+		pubkeys = append(pubkeys, eth2p0.BLSPubKey(pk))
+		signatures = append(signatures, tblsconv2.SigToETH2(sig))
 	}
 
 	return pubkeys, signatures, nil
 }
 
 // getTSSShares splits the secrets and returns the threshold key shares.
-func getTSSShares(secrets []*bls_sig.SecretKey, threshold, numNodes int) ([]tbls.TSS, [][]*bls_sig.SecretKeyShare, error) {
+func getTSSShares(secrets []tblsv2.PrivateKey, threshold, numNodes int) ([]tblsv2.PublicKey, [][]tblsv2.PrivateKey, error) {
 	var (
-		dvs    []tbls.TSS
-		splits [][]*bls_sig.SecretKeyShare
+		dvs    []tblsv2.PublicKey
+		splits [][]tblsv2.PrivateKey
 	)
 	for _, secret := range secrets {
-		shares, verifier, err := tbls.SplitSecret(secret, threshold, numNodes, rand.Reader)
+		shares, err := tblsv2.ThresholdSplit(secret, uint(numNodes), uint(threshold))
 		if err != nil {
 			return nil, nil, err
 		}
 
-		splits = append(splits, shares)
+		// preserve order when transforming from map of private shares to array of private keys
+		secretSet := make([]tblsv2.PrivateKey, len(shares))
+		for i := 1; i <= len(shares); i++ {
+			secretSet[i-1] = shares[i]
+		}
 
-		tss, err := tbls.NewTSS(verifier, len(shares))
+		splits = append(splits, secretSet)
+
+		pubkey, err := tblsv2.SecretToPublicKey(secret)
 		if err != nil {
 			return nil, nil, err
 		}
 
-		dvs = append(dvs, tss)
+		dvs = append(dvs, pubkey)
 	}
 
 	return dvs, splits, nil
@@ -301,7 +301,7 @@ func writeWarning(w io.Writer) {
 }
 
 // getKeys fetches secret keys for each distributed validator.
-func getKeys(splitKeys bool, splitKeysDir string, numDVs int) ([]*bls_sig.SecretKey, error) {
+func getKeys(splitKeys bool, splitKeysDir string, numDVs int) ([]tblsv2.PrivateKey, error) {
 	if splitKeys {
 		if splitKeysDir == "" {
 			return nil, errors.New("--split-keys-dir required when splitting keys")
@@ -310,9 +310,9 @@ func getKeys(splitKeys bool, splitKeysDir string, numDVs int) ([]*bls_sig.Secret
 		return keystore.LoadKeys(splitKeysDir)
 	}
 
-	var secrets []*bls_sig.SecretKey
+	var secrets []tblsv2.PrivateKey
 	for i := 0; i < numDVs; i++ {
-		_, secret, err := tbls.KeygenWithSeed(rand.Reader)
+		secret, err := tblsv2.GenerateSecretKey()
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func getKeys(splitKeys bool, splitKeysDir string, numDVs int) ([]*bls_sig.Secret
 }
 
 // writeDepositData writes deposit data to disk for the DVs for all peers in a cluster.
-func writeDepositData(withdrawalAddresses []string, clusterDir string, forkVersion []byte, numNodes int, secrets []*bls_sig.SecretKey) error {
+func writeDepositData(withdrawalAddresses []string, clusterDir string, forkVersion []byte, numNodes int, secrets []tblsv2.PrivateKey) error {
 	if len(secrets) != len(withdrawalAddresses) {
 		return errors.New("insufficient withdrawal addresses")
 	}
@@ -358,7 +358,7 @@ func writeDepositData(withdrawalAddresses []string, clusterDir string, forkVersi
 }
 
 // writeLock creates a cluster lock and writes it to disk for all peers.
-func writeLock(lock cluster.Lock, clusterDir string, numNodes int, shareSets [][]*bls_sig.SecretKeyShare) error {
+func writeLock(lock cluster.Lock, clusterDir string, numNodes int, shareSets [][]tblsv2.PrivateKey) error {
 	var err error
 	lock.SignatureAggregate, err = aggSign(shareSets, lock.LockHash)
 	if err != nil {
@@ -383,26 +383,22 @@ func writeLock(lock cluster.Lock, clusterDir string, numNodes int, shareSets [][
 
 // getValidators returns distributed validators from the provided dv public keys and keyshares.
 // It creates new peers from the provided config and saves validator keys to disk for each peer.
-func getValidators(dvs []tbls.TSS) ([]cluster.DistValidator, error) {
+func getValidators(dvsPubkeys []tblsv2.PublicKey, dvPrivShares [][]tblsv2.PrivateKey) ([]cluster.DistValidator, error) {
 	var vals []cluster.DistValidator
-	for _, dv := range dvs {
-		pk, err := dv.PublicKey().MarshalBinary()
-		if err != nil {
-			return []cluster.DistValidator{}, errors.Wrap(err, "marshal pubkey")
-		}
-
+	for idx, dv := range dvsPubkeys {
+		privShares := dvPrivShares[idx]
 		var pubshares [][]byte
-		for i := 0; i < dv.NumShares(); i++ {
-			share := dv.PublicShare(i + 1) // Shares are 1-indexed.
-			b, err := share.MarshalBinary()
+		for _, ps := range privShares {
+			pubk, err := tblsv2.SecretToPublicKey(ps)
 			if err != nil {
-				return []cluster.DistValidator{}, errors.Wrap(err, "marshal pubshare")
+				return nil, errors.Wrap(err, "public key generation")
 			}
-			pubshares = append(pubshares, b)
+
+			pubshares = append(pubshares, pubk[:])
 		}
 
 		vals = append(vals, cluster.DistValidator{
-			PubKey:    pk,
+			PubKey:    dv[:],
 			PubShares: pubshares,
 		})
 	}
@@ -411,7 +407,7 @@ func getValidators(dvs []tbls.TSS) ([]cluster.DistValidator, error) {
 }
 
 // writeKeysToKeymanager writes validator keys to the provided keymanager addresses.
-func writeKeysToKeymanager(ctx context.Context, addrs []string, numNodes int, shareSets [][]*bls_sig.SecretKeyShare) error {
+func writeKeysToKeymanager(ctx context.Context, addrs []string, numNodes int, shareSets [][]tblsv2.PrivateKey) error {
 	// Ping all keymanager addresses to check if they are accessible to avoid partial writes
 	var clients []keymanager.Client
 	for i := 0; i < numNodes; i++ {
@@ -434,12 +430,7 @@ func writeKeysToKeymanager(ctx context.Context, addrs []string, numNodes int, sh
 			}
 			passwords = append(passwords, password)
 
-			secret, err := tblsconv.ShareToSecret(shares[i])
-			if err != nil {
-				return err
-			}
-
-			store, err := keystore.Encrypt(secret, password, rand.Reader)
+			store, err := keystore.Encrypt(shares[i], password, rand.Reader)
 			if err != nil {
 				return err
 			}
@@ -461,15 +452,11 @@ func writeKeysToKeymanager(ctx context.Context, addrs []string, numNodes int, sh
 }
 
 // writeKeysToDisk writes validator keyshares to disk. It assumes that the directory for each node already exists.
-func writeKeysToDisk(numNodes int, clusterDir string, insecureKeys bool, shareSets [][]*bls_sig.SecretKeyShare) error {
+func writeKeysToDisk(numNodes int, clusterDir string, insecureKeys bool, shareSets [][]tblsv2.PrivateKey) error {
 	for i := 0; i < numNodes; i++ {
-		var secrets []*bls_sig.SecretKey
+		var secrets []tblsv2.PrivateKey
 		for _, shares := range shareSets {
-			secret, err := tblsconv.ShareToSecret(shares[i])
-			if err != nil {
-				return err
-			}
-			secrets = append(secrets, secret)
+			secrets = append(secrets, shares[i])
 		}
 
 		keysDir := path.Join(nodeDir(clusterDir, i), "/validator_keys")
@@ -604,15 +591,11 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 }
 
 // aggSign returns a bls aggregate signatures of the message signed by all the shares.
-func aggSign(secrets [][]*bls_sig.SecretKeyShare, message []byte) ([]byte, error) {
-	var sigs []*bls_sig.Signature
+func aggSign(secrets [][]tblsv2.PrivateKey, message []byte) ([]byte, error) {
+	var sigs []tblsv2.Signature
 	for _, shares := range secrets {
 		for _, share := range shares {
-			secret, err := tblsconv.ShareToSecret(share)
-			if err != nil {
-				return nil, err
-			}
-			sig, err := tbls.Sign(secret, message)
+			sig, err := tblsv2.Sign(share, message)
 			if err != nil {
 				return nil, err
 			}
@@ -620,17 +603,12 @@ func aggSign(secrets [][]*bls_sig.SecretKeyShare, message []byte) ([]byte, error
 		}
 	}
 
-	aggSig, err := tbls.Scheme().AggregateSignatures(sigs...)
+	aggSig, err := tblsv2.Aggregate(sigs)
 	if err != nil {
 		return nil, errors.Wrap(err, "aggregate signatures")
 	}
 
-	b, err := aggSig.MarshalBinary()
-	if err != nil {
-		return nil, errors.Wrap(err, "marshal signature")
-	}
-
-	return b, nil
+	return aggSig[:], nil
 }
 
 // loadDefinition returns the cluster definition from disk or an HTTP URL. It also verifies signatures

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -29,7 +29,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/stretchr/testify/require"
 	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 
@@ -37,9 +36,8 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/keystore"
-	"github.com/obolnetwork/charon/tbls"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -91,12 +89,12 @@ func TestCreateCluster(t *testing.T) {
 
 				keyDir := t.TempDir()
 
-				_, secret1, err := tbls.Keygen()
+				secret1, err := tblsv2.GenerateSecretKey()
 				require.NoError(t, err)
-				_, secret2, err := tbls.Keygen()
+				secret2, err := tblsv2.GenerateSecretKey()
 				require.NoError(t, err)
 
-				err = keystore.StoreKeys([]*bls_sig.SecretKey{secret1, secret2}, keyDir)
+				err = keystore.StoreKeys([]tblsv2.PrivateKey{secret1, secret2}, keyDir)
 				require.NoError(t, err)
 
 				config.SplitKeysDir = keyDir
@@ -272,14 +270,12 @@ func TestKeymanager(t *testing.T) {
 	defer cancel()
 
 	// Create secret
-	_, secret1, err := tbls.Keygen()
-	require.NoError(t, err)
-	originalSecret, err := secret1.MarshalBinary()
+	secret1, err := tblsv2.GenerateSecretKey()
 	require.NoError(t, err)
 
 	// Store secret
 	keyDir := t.TempDir()
-	err = keystore.StoreKeys([]*bls_sig.SecretKey{secret1}, keyDir)
+	err = keystore.StoreKeys([]tblsv2.PrivateKey{secret1}, keyDir)
 	require.NoError(t, err)
 
 	// Create minNodes test servers
@@ -324,26 +320,17 @@ func TestKeymanager(t *testing.T) {
 		require.NoError(t, err)
 
 		// Receive secret shares from all keymanager servers
-		var shares []*bls_sig.SecretKeyShare
+		shares := make(map[int]tblsv2.PrivateKey)
 		for len(shares) < minNodes {
 			res := <-results
-			secretBin, err := res.secret.MarshalBinary()
-			require.NoError(t, err)
-
-			share := new(bls_sig.SecretKeyShare)
-			err = share.UnmarshalBinary(append(secretBin, byte(res.id+1)))
-			require.NoError(t, err)
-
-			shares = append(shares, share)
+			shares[res.id+1] = res.secret
 		}
 
 		// Combine the shares and test equality with original share
-		csb, err := tbls.CombineShares(shares, 3, minNodes)
-		require.NoError(t, err)
-		combinedSecret, err := csb.MarshalBinary()
+		csb, err := tblsv2.RecoverSecret(shares, minNodes, 3)
 		require.NoError(t, err)
 
-		require.Equal(t, combinedSecret, originalSecret)
+		require.EqualValues(t, secret1, csb)
 	})
 
 	t.Run("some unsuccessful", func(t *testing.T) {
@@ -367,21 +354,21 @@ type mockKeymanagerReq struct {
 }
 
 // decrypt returns the secret from the encrypted keystore.
-func decrypt(t *testing.T, store keystore.Keystore, password string) (*bls_sig.SecretKey, error) {
+func decrypt(t *testing.T, store keystore.Keystore, password string) (tblsv2.PrivateKey, error) {
 	t.Helper()
 
 	decryptor := keystorev4.New()
 	secretBytes, err := decryptor.Decrypt(store.Crypto, password)
 	require.NoError(t, err)
 
-	return tblsconv.SecretFromBytes(secretBytes)
+	return tblsconv2.PrivkeyFromBytes(secretBytes)
 }
 
 // result is a struct for receiving secrets along with their id.
 // This is needed as tbls.CombineShares needs shares in the correct (original) order.
 type result struct {
 	id     int
-	secret *bls_sig.SecretKey
+	secret tblsv2.PrivateKey
 }
 
 // newKeymanagerHandler returns http handler for a test keymanager API server.
@@ -391,7 +378,9 @@ func newKeymanagerHandler(ctx context.Context, t *testing.T, id int, results cha
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		data, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		defer r.Body.Close()
+		defer func() {
+			require.NoError(t, r.Body.Close())
+		}()
 
 		var req mockKeymanagerReq
 		require.NoError(t, json.Unmarshal(data, &req))

--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -17,9 +17,9 @@ package core
 
 import (
 	"context"
+
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
-	"github.com/obolnetwork/charon/app/errors"
+
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/signing"
@@ -41,7 +41,7 @@ var (
 )
 
 // VerifyEth2SignedData verifies signature associated with given Eth2SignedData.
-func VerifyEth2SignedData(ctx context.Context, eth2Cl eth2wrap.Client, data Eth2SignedData, pubkey *bls_sig.PublicKey) error {
+func VerifyEth2SignedData(ctx context.Context, eth2Cl eth2wrap.Client, data Eth2SignedData, pubkey tblsv2.PublicKey) error {
 	epoch, err := data.Epoch(ctx, eth2Cl)
 	if err != nil {
 		return err
@@ -52,28 +52,7 @@ func VerifyEth2SignedData(ctx context.Context, eth2Cl eth2wrap.Client, data Eth2
 		return err
 	}
 
-	// TODO(gsora): refactor this to tblsv2.PublicKey
-	pkBytes, err := pubkey.MarshalBinary()
-	if err != nil {
-		return errors.Wrap(err, "cannot serialize public key")
-	}
-
-	pk, err := pubkeyFromBytes(pkBytes)
-	if err != nil {
-		return errors.Wrap(err, "cannot serialize public key")
-	}
-
-	return signing.Verify(ctx, eth2Cl, data.DomainName(), epoch, sigRoot, data.Signature().ToETH2(), pk)
-}
-
-// taken from tbls/v2/tblsconv
-// TODO: refactor so that calling the original method doesn't incur in a import cycle
-func pubkeyFromBytes(data []byte) (tblsv2.PublicKey, error) {
-	if len(data) != len(tblsv2.PublicKey{}) {
-		return tblsv2.PublicKey{}, errors.New("data is not of the correct length")
-	}
-
-	return *(*tblsv2.PublicKey)(data), nil
+	return signing.Verify(ctx, eth2Cl, data.DomainName(), epoch, sigRoot, data.Signature().ToETH2(), pubkey)
 }
 
 // Implement Eth2SignedData for VersionedSignedBeaconBlock.

--- a/core/eth2signeddata_test.go
+++ b/core/eth2signeddata_test.go
@@ -21,14 +21,12 @@ import (
 	"testing"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util/signing"
-	"github.com/obolnetwork/charon/tbls"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
@@ -132,14 +130,17 @@ func TestVerifyEth2SignedData(t *testing.T) {
 	}
 }
 
-func sign(t *testing.T, data []byte) (core.Signature, *bls_sig.PublicKey) {
+func sign(t *testing.T, data []byte) (core.Signature, tblsv2.PublicKey) {
 	t.Helper()
 
-	pk, secret, err := tbls.Keygen()
+	secret, err := tblsv2.GenerateSecretKey()
 	require.NoError(t, err)
 
-	sig, err := tbls.Sign(secret, data)
+	pk, err := tblsv2.SecretToPublicKey(secret)
 	require.NoError(t, err)
 
-	return tblsconv.SigToCore(sig), pk
+	sig, err := tblsv2.Sign(secret, data)
+	require.NoError(t, err)
+
+	return tblsconv2.SigToCore(sig), pk
 }

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"time"
 
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -34,6 +33,7 @@ import (
 	"github.com/obolnetwork/charon/core"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	"github.com/obolnetwork/charon/p2p"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
 const protocolID = "/charon/parsigex/1.0.0"
@@ -149,7 +149,7 @@ func (m *ParSigEx) Subscribe(fn func(context.Context, core.Duty, core.ParSignedD
 }
 
 // NewEth2Verifier returns a partial signature verification function for core workflow eth2 signatures.
-func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey) (func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error, error) {
+func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[int]tblsv2.PublicKey) (func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error, error) {
 	return func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error {
 		pubshares, ok := pubSharesByKey[pubkey]
 		if !ok {

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -18,6 +18,7 @@ package validatorapi
 import (
 	"context"
 	"fmt"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	"runtime"
 	"testing"
 	"time"
@@ -719,12 +720,7 @@ func (c Component) SubmitAggregateAttestations(ctx context.Context, aggregateAnd
 
 		// Verify inner selection proof (outcome of DutyPrepareAggregator).
 		if !c.insecureTest {
-			blsPubkey, err := tblsconv.KeyFromETH2(eth2Pubkey) // Use group pubkey, not pubshare.
-			if err != nil {
-				return err
-			}
-
-			err = signing.VerifyAggregateAndProofSelection(ctx, c.eth2Cl, blsPubkey, agg.Message)
+			err = signing.VerifyAggregateAndProofSelection(ctx, c.eth2Cl, tblsv2.PublicKey(eth2Pubkey), agg.Message)
 			if err != nil {
 				return err
 			}

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -18,7 +18,6 @@ package validatorapi
 import (
 	"context"
 	"fmt"
-	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	"runtime"
 	"testing"
 	"time"
@@ -41,6 +40,7 @@ import (
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
 // PubShareFunc abstracts the mapping of validator root public key to tbls public share.
@@ -58,18 +58,18 @@ func NewComponentInsecure(_ *testing.T, eth2Cl eth2wrap.Client, shareIdx int) (*
 }
 
 // NewComponent returns a new instance of the validator API core workflow component.
-func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[int]*bls_sig.PublicKey,
+func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[int]tblsv2.PublicKey,
 	shareIdx int, feeRecipientFunc func(core.PubKey) string, builderEnabled core.BuilderEnabled, seenPubkeys func(core.PubKey),
 ) (*Component, error) {
 	var (
 		sharesByKey     = make(map[eth2p0.BLSPubKey]eth2p0.BLSPubKey)
 		keysByShare     = make(map[eth2p0.BLSPubKey]eth2p0.BLSPubKey)
-		sharesByCoreKey = make(map[core.PubKey]*bls_sig.PublicKey)
+		sharesByCoreKey = make(map[core.PubKey]tblsv2.PublicKey)
 		coreSharesByKey = make(map[core.PubKey]core.PubKey)
 	)
 	for corePubkey, shares := range allPubSharesByKey {
 		pubshare := shares[shareIdx]
-		coreShare, err := tblsconv.KeyToCore(pubshare)
+		coreShare, err := core.PubKeyFromBytes(pubshare[:])
 		if err != nil {
 			return nil, err
 		}
@@ -81,20 +81,17 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 		if err != nil {
 			return nil, err
 		}
-		eth2Share, err := tblsconv.KeyToETH2(pubshare)
-		if err != nil {
-			return nil, err
-		}
+		eth2Share := eth2p0.BLSPubKey(pubshare)
 		sharesByCoreKey[corePubkey] = pubshare
 		coreSharesByKey[corePubkey] = coreShare
 		sharesByKey[eth2Pubkey] = eth2Share
 		keysByShare[eth2Share] = eth2Pubkey
 	}
 
-	getVerifyShareFunc := func(pubkey core.PubKey) (*bls_sig.PublicKey, error) {
+	getVerifyShareFunc := func(pubkey core.PubKey) (tblsv2.PublicKey, error) {
 		pubshare, ok := sharesByCoreKey[pubkey]
 		if !ok {
-			return nil, errors.New("unknown public key")
+			return tblsv2.PublicKey{}, errors.New("unknown public key")
 		}
 
 		return pubshare, nil
@@ -115,8 +112,7 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 		if !ok {
 			for _, shares := range allPubSharesByKey {
 				for keyshareIdx, pubshare := range shares {
-					eth2key, err := tblsconv.KeyToETH2(pubshare)
-					if err == nil && eth2key == share {
+					if eth2p0.BLSPubKey(pubshare) == share {
 						return eth2p0.BLSPubKey{}, errors.New("mismatching validator client key share index, Mth key share submitted to Nth charon peer",
 							z.Int("key_share_index", keyshareIdx-1), z.Int("charon_peer_index", shareIdx-1)) // 0-indexed
 					}
@@ -154,7 +150,7 @@ type Component struct {
 
 	// getVerifyShareFunc maps public shares (what the VC thinks as its public key)
 	// to public keys (the DV root public key)
-	getVerifyShareFunc func(core.PubKey) (*bls_sig.PublicKey, error)
+	getVerifyShareFunc func(core.PubKey) (tblsv2.PublicKey, error)
 	// getPubShareFunc returns the public share for a root public key.
 	getPubShareFunc func(eth2p0.BLSPubKey) (eth2p0.BLSPubKey, bool)
 	// getPubKeyFunc returns the root public key for a public share.
@@ -844,13 +840,8 @@ func (c Component) SubmitSyncCommitteeContributions(ctx context.Context, contrib
 
 		// Verify inner selection proof.
 		if !c.insecureTest {
-			blsPubkey, err := tblsconv.KeyFromETH2(eth2Pubkey) // Use group pubkey, not pubshare.
-			if err != nil {
-				return err
-			}
-
 			msg := core.NewSyncContributionAndProof(contrib.Message)
-			err = core.VerifyEth2SignedData(ctx, c.eth2Cl, msg, blsPubkey)
+			err = core.VerifyEth2SignedData(ctx, c.eth2Cl, msg, tblsv2.PublicKey(eth2Pubkey))
 			if err != nil {
 				return err
 			}

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -237,14 +237,7 @@ func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 		require.Len(t, keyShares, def.NumValidators)
 
 		for i, key := range keyShares {
-			// convert kryptology keys to tblsv2 keys
-			// TODO(gsora): this needs to go away once keystore is on tblsv2
-			rawKey, err := key.MarshalBinary()
-			require.NoError(t, err)
-
-			v2Key, err := tblsconv2.PrivkeyFromBytes(rawKey)
-			require.NoError(t, err)
-			secretShares[i] = append(secretShares[i], v2Key)
+			secretShares[i] = append(secretShares[i], key)
 		}
 
 		lockFile, err := os.ReadFile(path.Join(dataDir, "cluster-lock.json"))

--- a/eth2util/deposit/deposit.go
+++ b/eth2util/deposit/deposit.go
@@ -28,8 +28,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util"
-	"github.com/obolnetwork/charon/tbls"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
 var (
@@ -95,20 +94,12 @@ func MarshalDepositData(pubkeys []eth2p0.BLSPubKey, depositDataSigs []eth2p0.BLS
 			return nil, err
 		}
 
-		blsSig, err := tblsconv.SigFromETH2(sig)
-		if err != nil {
-			return nil, err
-		}
-		blsPubkey, err := tblsconv.KeyFromETH2(pubkeys[i])
-		if err != nil {
-			return nil, err
-		}
+		blsSig := tblsv2.Signature(sig)
+		blsPubkey := tblsv2.PublicKey(pubkeys[i])
 
-		ok, err := tbls.Verify(blsPubkey, sigData[:], blsSig)
+		err = tblsv2.Verify(blsPubkey, sigData[:], blsSig)
 		if err != nil {
-			return nil, err
-		} else if !ok {
-			return nil, errors.New("invalid deposit data signature")
+			return nil, errors.Wrap(err, "invalid deposit data signature")
 		}
 
 		dd := eth2p0.DepositData{

--- a/eth2util/deposit/deposit_test.go
+++ b/eth2util/deposit/deposit_test.go
@@ -20,13 +20,12 @@ import (
 	"testing"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/deposit"
-	"github.com/obolnetwork/charon/tbls"
-	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -56,10 +55,10 @@ func TestMarshalDepositData(t *testing.T) {
 		msgRoot, err := deposit.GetMessageSigningRoot(pk, withdrawalAddrs[i], eth2util.Goerli.Name)
 		require.NoError(t, err)
 
-		sig, err := tbls.Sign(sk, msgRoot[:])
+		sig, err := tblsv2.Sign(sk, msgRoot[:])
 		require.NoError(t, err)
 
-		sigs = append(sigs, tblsconv.SigToETH2(sig))
+		sigs = append(sigs, tblsconv2.SigToETH2(sig))
 		pubkeys = append(pubkeys, pk)
 	}
 
@@ -70,19 +69,19 @@ func TestMarshalDepositData(t *testing.T) {
 }
 
 // Get the private and public keys in appropriate format for the test.
-func GetKeys(t *testing.T, privKey string) (*bls_sig.SecretKey, eth2p0.BLSPubKey) {
+func GetKeys(t *testing.T, privKey string) (tblsv2.PrivateKey, eth2p0.BLSPubKey) {
 	t.Helper()
 
 	privKeyBytes, err := hex.DecodeString(privKey)
 	require.NoError(t, err)
 
-	sk, err := tblsconv.SecretFromBytes(privKeyBytes)
+	sk, err := tblsconv2.PrivkeyFromBytes(privKeyBytes)
 	require.NoError(t, err)
 
-	pk, err := sk.GetPublicKey()
+	pk, err := tblsv2.SecretToPublicKey(sk)
 	require.NoError(t, err)
 
-	pubkey, err := tblsconv.KeyToETH2(pk)
+	pubkey, err := tblsconv2.PubkeyToETH2(pk)
 	require.NoError(t, err)
 
 	return sk, pubkey

--- a/eth2util/keymanager/keymanager_test.go
+++ b/eth2util/keymanager/keymanager_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
-	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -33,6 +32,7 @@ import (
 	"github.com/obolnetwork/charon/eth2util/keymanager"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
 func TestImportKeystores(t *testing.T) {

--- a/eth2util/keymanager/keymanager_test.go
+++ b/eth2util/keymanager/keymanager_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/obolnetwork/charon/eth2util/keymanager"
 	"github.com/obolnetwork/charon/eth2util/keystore"
-	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
@@ -39,11 +39,11 @@ func TestImportKeystores(t *testing.T) {
 	var (
 		ctx        = context.Background()
 		numSecrets = 4
-		secrets    []*bls_sig.SecretKey
+		secrets    []tblsv2.PrivateKey
 	)
 
 	for i := 0; i < numSecrets; i++ {
-		_, secret, err := tbls.Keygen()
+		secret, err := tblsv2.GenerateSecretKey()
 		require.NoError(t, err)
 		secrets = append(secrets, secret)
 	}
@@ -69,7 +69,9 @@ func TestImportKeystores(t *testing.T) {
 
 			data, err := io.ReadAll(r.Body)
 			require.NoError(t, err)
-			defer r.Body.Close()
+			defer func() {
+				require.NoError(t, r.Body.Close())
+			}()
 
 			var req mockKeymanagerReq
 			require.NoError(t, json.Unmarshal(data, &req))
@@ -96,9 +98,7 @@ func TestImportKeystores(t *testing.T) {
 		// Convert original secrets to strings
 		var originalSecrets []string
 		for _, secret := range secrets {
-			secretBytes, err := secret.MarshalBinary()
-			require.NoError(t, err)
-			originalSecrets = append(originalSecrets, hex.EncodeToString(secretBytes))
+			originalSecrets = append(originalSecrets, hex.EncodeToString(secret[:]))
 		}
 
 		require.Equal(t, originalSecrets, receivedSecrets)

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -19,19 +19,18 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/coinbase/kryptology/pkg/signatures/bls/bls_sig"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/eth2util/keystore"
-	"github.com/obolnetwork/charon/tbls"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 )
 
 func TestStoreLoad(t *testing.T) {
 	dir := t.TempDir()
 
-	var secrets []*bls_sig.SecretKey
+	var secrets []tblsv2.PrivateKey
 	for i := 0; i < 2; i++ {
-		_, secret, err := tbls.Keygen()
+		secret, err := tblsv2.GenerateSecretKey()
 		require.NoError(t, err)
 
 		secrets = append(secrets, secret)
@@ -57,7 +56,5 @@ func TestLoadScrypt(t *testing.T) {
 
 	require.Len(t, secrets, 1)
 
-	b, err := secrets[0].MarshalBinary()
-	require.NoError(t, err)
-	require.Equal(t, "10b16fc552aa607fa1399027f7b86ab789077e470b5653b338693dc2dde02468", fmt.Sprintf("%x", b))
+	require.Equal(t, "10b16fc552aa607fa1399027f7b86ab789077e470b5653b338693dc2dde02468", fmt.Sprintf("%x", secrets[0]))
 }

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -17,7 +17,9 @@ package signing
 
 import (
 	"context"
+
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/tracer"

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -20,16 +20,16 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 	"os"
 	"testing"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/eth2util/signing"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 


### PR DESCRIPTION
This PR is bigger than usual because refactoring eth2util had *a lot* of consequences on other parts of the codebase.

The flip side is we got many packages and their respective tests on tbls/v2.

category: refactor
ticket: #1744
feature_flag: herumi_bls
