### PR TITLE
tbls/v2: add tests to tblsconv, small refactors

### DIFF
--- a/core/sigagg/sigagg.go
+++ b/core/sigagg/sigagg.go
@@ -60,7 +60,11 @@ func (a *Aggregator) Aggregate(ctx context.Context, duty core.Duty, pubkey core.
 	// Get all partial signatures.
 	blsSigs := make(map[int]tblsv2.Signature)
 	for _, parSig := range parSigs {
-		blsSigs[parSig.ShareIdx] = tblsconv2.SigFromCore(parSig.Signature())
+		sig, err := tblsconv2.SigFromCore(parSig.Signature())
+		if err != nil {
+			return errors.Wrap(err, "signature from core")
+		}
+		blsSigs[parSig.ShareIdx] = sig
 	}
 
 	// Aggregate signatures

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -97,7 +97,8 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 		require.Equal(t, expect, aggData.Signature())
-		sig := tblsconv2.SigFromCore(aggData.Signature())
+		sig, err := tblsconv2.SigFromCore(aggData.Signature())
+		require.NoError(t, err)
 
 		require.NoError(t, tblsv2.Verify(pubKey, msg, sig))
 		require.NoError(t, err)
@@ -160,7 +161,8 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 		require.Equal(t, expect, aggData.Signature())
-		sig := tblsconv2.SigFromCore(aggData.Signature())
+		sig, err := tblsconv2.SigFromCore(aggData.Signature())
+		require.NoError(t, err)
 
 		require.NoError(t, tblsv2.Verify(pubKey, msg, sig))
 		require.NoError(t, err)
@@ -227,7 +229,8 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 		require.Equal(t, expect, aggData.Signature())
-		sig := tblsconv2.SigFromCore(aggData.Signature())
+		sig, err := tblsconv2.SigFromCore(aggData.Signature())
+		require.NoError(t, err)
 
 		require.NoError(t, tblsv2.Verify(pubKey, msg, sig))
 		require.NoError(t, err)
@@ -328,7 +331,11 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 				sigCore := tblsconv2.SigToCore(sig)
 				signed, err := block.SetSignature(sigCore)
 				require.NoError(t, err)
-				require.Equal(t, sig, tblsconv2.SigFromCore(signed.Signature()))
+
+				coreSig, err := tblsconv2.SigFromCore(signed.Signature())
+				require.NoError(t, err)
+
+				require.Equal(t, sig, coreSig)
 
 				psigs[idx] = sig
 				parsigs = append(parsigs, core.ParSignedData{
@@ -347,7 +354,8 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 				require.Equal(t, expect, aggData.Signature())
-				sig := tblsconv2.SigFromCore(aggData.Signature())
+				sig, err := tblsconv2.SigFromCore(aggData.Signature())
+				require.NoError(t, err)
 
 				require.NoError(t, tblsv2.Verify(pubKey, msg[:], sig))
 				require.NoError(t, err)
@@ -430,7 +438,11 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 				sigCore := tblsconv2.SigToCore(sig)
 				signed, err := block.SetSignature(sigCore)
 				require.NoError(t, err)
-				require.Equal(t, sig, tblsconv2.SigFromCore(signed.Signature()))
+
+				coreSig, err := tblsconv2.SigFromCore(signed.Signature())
+				require.NoError(t, err)
+
+				require.Equal(t, sig, coreSig)
 
 				psigs[idx] = sig
 				parsigs = append(parsigs, core.ParSignedData{
@@ -449,7 +461,8 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 				require.Equal(t, expect, aggData.Signature())
-				sig := tblsconv2.SigFromCore(aggData.Signature())
+				sig, err := tblsconv2.SigFromCore(aggData.Signature())
+				require.NoError(t, err)
 
 				require.NoError(t, tblsv2.Verify(pubKey, msg[:], sig))
 				require.NoError(t, err)
@@ -522,7 +535,11 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 				sigCore := tblsconv2.SigToCore(sig)
 				signed, err := block.SetSignature(sigCore)
 				require.NoError(t, err)
-				require.Equal(t, sig, tblsconv2.SigFromCore(signed.Signature()))
+
+				coreSig, err := tblsconv2.SigFromCore(signed.Signature())
+				require.NoError(t, err)
+
+				require.Equal(t, sig, coreSig)
 
 				psigs[idx] = sig
 				parsigs = append(parsigs, core.ParSignedData{
@@ -541,7 +558,8 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
 				require.Equal(t, expect, aggData.Signature())
-				sig := tblsconv2.SigFromCore(aggData.Signature())
+				sig, err := tblsconv2.SigFromCore(aggData.Signature())
+				require.NoError(t, err)
 
 				require.NoError(t, tblsv2.Verify(pubKey, msg[:], sig))
 				require.NoError(t, err)

--- a/eth2util/eth2exp/attagg_test.go
+++ b/eth2util/eth2exp/attagg_test.go
@@ -37,7 +37,7 @@ func TestIsAttAggregator(t *testing.T) {
 	// https://github.com/prysmaticlabs/prysm/blob/8627fe72e80009ae162430140bcfff6f209d7a32/beacon-chain/core/helpers/attestation_test.go#L28
 	sig, err := hex.DecodeString("8776a37d6802c4797d113169c5fcfda50e68a32058eb6356a6f00d06d7da64c841a00c7c38b9b94a204751eca53707bd03523ce4797827d9bacff116a6e776a20bbccff4b683bf5201b610797ed0502557a58a65c8395f8a1649b976c3112d15")
 	require.NoError(t, err)
-	blsSig, err := tblsconv2.SigFromBytes(sig)
+	blsSig, err := tblsconv2.SignatureFromBytes(sig)
 	require.NoError(t, err)
 
 	t.Run("aggregator", func(t *testing.T) {

--- a/tbls/v2/tblsconv/tblsconv.go
+++ b/tbls/v2/tblsconv/tblsconv.go
@@ -33,15 +33,6 @@ func SigToCore(sig v2.Signature) core.Signature {
 	return sig[:]
 }
 
-// SigFromBytes converts arbitrary bytes to a v2.Signature.
-func SigFromBytes(sig []byte) (v2.Signature, error) {
-	if len(sig) != len(v2.Signature{}) {
-		return v2.Signature{}, errors.New("data is not of the correct length")
-	}
-
-	return *(*v2.Signature)(sig), nil
-}
-
 // SigToETH2 converts a tbls.Signature into an eth2 phase0 bls signature.
 func SigToETH2(sig v2.Signature) eth2p0.BLSSignature {
 	return eth2p0.BLSSignature(sig)

--- a/tbls/v2/tblsconv/tblsconv.go
+++ b/tbls/v2/tblsconv/tblsconv.go
@@ -24,9 +24,8 @@ import (
 )
 
 // SigFromCore converts a core workflow Signature type into a tbls.Signature.
-func SigFromCore(sig core.Signature) v2.Signature {
-	rawSig := (*[96]byte)(sig.Signature())
-	return *rawSig
+func SigFromCore(sig core.Signature) (v2.Signature, error) {
+	return SignatureFromBytes(sig)
 }
 
 // SigToCore converts a tbls.Signature into a core workflow Signature type.

--- a/tbls/v2/tblsconv/tblsconv_test.go
+++ b/tbls/v2/tblsconv/tblsconv_test.go
@@ -1,0 +1,250 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package tblsconv_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/obolnetwork/charon/tbls/v2"
+	tblsconv2 "github.com/obolnetwork/charon/tbls/v2/tblsconv"
+)
+
+func TestPrivkeyFromBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    v2.PrivateKey
+		wantErr bool
+	}{
+		{
+			"empty input",
+			[]byte{},
+			v2.PrivateKey{},
+			true,
+		},
+		{
+			"more data than expected",
+			bytes.Repeat([]byte{42}, len(v2.PrivateKey{})+1),
+			v2.PrivateKey{},
+			true,
+		},
+		{
+			"less data than expected",
+			bytes.Repeat([]byte{42}, len(v2.PrivateKey{})-1),
+			v2.PrivateKey{},
+			true,
+		},
+		{
+			"enough data",
+			bytes.Repeat([]byte{42}, len(v2.PrivateKey{})),
+			*(*v2.PrivateKey)(bytes.Repeat([]byte{42}, len(v2.PrivateKey{}))),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tblsconv2.PrivkeyFromBytes(tt.data)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPubkeyFromBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    v2.PublicKey
+		wantErr bool
+	}{
+		{
+			"empty input",
+			[]byte{},
+			v2.PublicKey{},
+			true,
+		},
+		{
+			"more data than expected",
+			bytes.Repeat([]byte{42}, len(v2.PublicKey{})+1),
+			v2.PublicKey{},
+			true,
+		},
+		{
+			"less data than expected",
+			bytes.Repeat([]byte{42}, len(v2.PublicKey{})-1),
+			v2.PublicKey{},
+			true,
+		},
+		{
+			"enough data",
+			bytes.Repeat([]byte{42}, len(v2.PublicKey{})),
+			*(*v2.PublicKey)(bytes.Repeat([]byte{42}, len(v2.PublicKey{}))),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tblsconv2.PubkeyFromBytes(tt.data)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestPubkeyToETH2(t *testing.T) {
+	pubkey, err := tblsconv2.PubkeyFromBytes(bytes.Repeat([]byte{42}, len(v2.PublicKey{})))
+	require.NoError(t, err)
+
+	res, err := tblsconv2.PubkeyToETH2(pubkey)
+	require.NoError(t, err)
+
+	require.Equal(t, pubkey[:], res[:])
+}
+
+func TestSignatureFromBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    v2.Signature
+		wantErr bool
+	}{
+		{
+			"empty input",
+			[]byte{},
+			v2.Signature{},
+			true,
+		},
+		{
+			"more data than expected",
+			bytes.Repeat([]byte{42}, len(v2.Signature{})+1),
+			v2.Signature{},
+			true,
+		},
+		{
+			"less data than expected",
+			bytes.Repeat([]byte{42}, len(v2.Signature{})-1),
+			v2.Signature{},
+			true,
+		},
+		{
+			"enough data",
+			bytes.Repeat([]byte{42}, len(v2.Signature{})),
+			*(*v2.Signature)(bytes.Repeat([]byte{42}, len(v2.Signature{}))),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tblsconv2.SignatureFromBytes(tt.data)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSigFromCore(t *testing.T) {
+	tests := []struct {
+		name    string
+		data    []byte
+		want    v2.Signature
+		wantErr bool
+	}{
+		{
+			"empty input",
+			[]byte{},
+			v2.Signature{},
+			true,
+		},
+		{
+			"more data than expected",
+			bytes.Repeat([]byte{42}, len(v2.Signature{})+1),
+			v2.Signature{},
+			true,
+		},
+		{
+			"less data than expected",
+			bytes.Repeat([]byte{42}, len(v2.Signature{})-1),
+			v2.Signature{},
+			true,
+		},
+		{
+			"enough data",
+			bytes.Repeat([]byte{42}, len(v2.Signature{})),
+			*(*v2.Signature)(bytes.Repeat([]byte{42}, len(v2.Signature{}))),
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tblsconv2.SigFromCore(tt.data)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Empty(t, got)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSigToCore(t *testing.T) {
+	sig, err := tblsconv2.SignatureFromBytes(bytes.Repeat([]byte{42}, len(v2.Signature{})))
+	require.NoError(t, err)
+
+	coresig := tblsconv2.SigToCore(sig)
+
+	require.Equal(t, sig[:], []byte(coresig))
+}
+
+func TestSigToETH2(t *testing.T) {
+	sig, err := tblsconv2.SignatureFromBytes(bytes.Repeat([]byte{42}, len(v2.Signature{})))
+	require.NoError(t, err)
+
+	coresig := tblsconv2.SigToETH2(sig)
+
+	require.Equal(t, sig[:], coresig[:])
+}


### PR DESCRIPTION
Added tests to v2 tblsconv, and removed `SigFromBytes` in favor of `SignatureFromBytes`.

Also `SigFromCore` now has bounds checks.

category: refactor
ticket: none