### PR TITLE
p2p: fix connection metrics

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -207,7 +207,6 @@ func RegisterConnectionLogger(ctx context.Context, tcpNode host.Host, peerIDs []
 		events = make(chan logEvent)
 		ticker = time.NewTicker(time.Second * 30)
 	)
-	defer ticker.Stop()
 
 	for _, p := range peerIDs {
 		peers[p] = true
@@ -222,6 +221,7 @@ func RegisterConnectionLogger(ctx context.Context, tcpNode host.Host, peerIDs []
 		for {
 			select {
 			case <-ctx.Done():
+				ticker.Stop()
 				return
 			case <-ticker.C:
 				// Instrument connection counts.


### PR DESCRIPTION
Refactor `p2p_peer_connection_types` metric, calculating it from scratch periodically instead of stateful approach.

category: bug
ticket: #1790