### PR TITLE
cmd: remove deprecated data-dir flag

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"context"
 	"net/url"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -95,27 +94,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 }
 
 func bindPrivKeyFlag(cmd *cobra.Command, privKeyFile *string) {
-	var dataDir string
-
-	cmd.Flags().StringVar(&dataDir, "data-dir", "", "Deprecated, please use 'private-key-file'.")
 	cmd.Flags().StringVar(privKeyFile, "private-key-file", ".charon/charon-enr-private-key", "The path to the charon enr private key file.")
-
-	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
-		ctx := log.WithTopic(cmd.Context(), "cmd")
-		if dataDir != "" {
-			log.Warn(ctx, "Deprecated flag 'data-dir' used, please use new flag 'private-key-file'.", nil)
-		}
-
-		if _, err := os.Open(*privKeyFile); err == nil { //nolint:revive
-			// Ignore data-dir since priv key file is present
-		} else if _, err := os.Open(p2p.KeyPath(dataDir)); err == nil { //nolint:revive
-			*privKeyFile = p2p.KeyPath(dataDir)
-		} else {
-			return errors.New("charon enr private key file not found in either `data-dir` or `private-key-file`")
-		}
-
-		return nil
-	})
 }
 
 func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -44,59 +44,6 @@ func TestBindPrivKeyFlag(t *testing.T) {
 				PrivKeyFile: ".charon/charon-enr-private-key",
 			},
 		},
-		{
-			Name: "privKeyFile and dataDir absent",
-			Args: slice("run"),
-			Envs: map[string]string{
-				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
-			},
-			AppConfig: &app.Config{},
-			WantErr:   true,
-		},
-		{
-			Name: "privKeyFile and dataDir both present and file exists in none",
-			Args: slice("run"),
-			Envs: map[string]string{
-				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
-				"CHARON_DATA_DIR":              ".charon",
-			},
-			AppConfig: &app.Config{
-				PrivKeyFile: ".charon/charon-enr-private-key",
-			},
-			WantErr: true,
-		},
-		{
-			Name: "privKeyFile and dataDir both present and file exists in dataDir",
-			Args: slice("run"),
-			Envs: map[string]string{
-				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
-				"CHARON_DATA_DIR":              ".charon",
-			},
-			AppConfig: &app.Config{
-				PrivKeyFile: ".charon/enr-key",
-			},
-			WantErr: false,
-		},
-		{
-			Name: "dataDir present but file doesn't exist",
-			Args: slice("run"),
-			Envs: map[string]string{
-				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
-				"CHARON_DATA_DIR":              ".charon",
-			},
-			AppConfig: &app.Config{},
-			WantErr:   true,
-		},
-		{
-			Name: "dataDir present and file exists",
-			Args: slice("run"),
-			Envs: map[string]string{
-				"CHARON_BEACON_NODE_ENDPOINTS": "http://beacon.node",
-				"CHARON_DATA_DIR":              ".charon",
-			},
-			AppConfig: &app.Config{},
-			WantErr:   false,
-		},
 	}
 
 	for _, test := range tests {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -122,7 +122,6 @@ Usage:
 Flags:
       --beacon-node-endpoints strings      Comma separated list of one or more beacon node endpoint URLs.
       --builder-api                        Enables the builder api. Will only produce builder blocks. Builder API must also be enabled on the validator client. Beacon node must be connected to a builder-relay to access the builder network.
-      --data-dir string                    Deprecated, please use 'private-key-file'.
       --feature-set string                 Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings        Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings         Comma-separated list of features to enable, overriding the default minimum feature set.


### PR DESCRIPTION
Removes deprecated `data-dir` flag from `charon run` command.

category: refactor
ticket: none
