### PR TITLE
cmd: rescope distributed validator pubkey during slice iteration

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -398,6 +398,7 @@ func writeLock(lock cluster.Lock, clusterDir string, numNodes int, shareSets [][
 func getValidators(dvsPubkeys []tblsv2.PublicKey, dvPrivShares [][]tblsv2.PrivateKey) ([]cluster.DistValidator, error) {
 	var vals []cluster.DistValidator
 	for idx, dv := range dvsPubkeys {
+		dv := dv
 		privShares := dvPrivShares[idx]
 		var pubshares [][]byte
 		for _, ps := range privShares {

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -184,6 +184,14 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition)
 		require.NoError(t, lock.VerifyHashes())
 		require.NoError(t, lock.VerifySignatures())
 
+		// check that there are lock.Definition.NumValidators different public keys in the validator slice
+		vals := make(map[string]struct{})
+		for _, val := range lock.Validators {
+			vals[val.PublicKeyHex()] = struct{}{}
+		}
+
+		require.Equal(t, lock.Definition.NumValidators, len(vals))
+
 		if conf.DefFile != "" {
 			// Config hash and creator should remain the same
 			require.Equal(t, def.ConfigHash, lock.ConfigHash)


### PR DESCRIPTION
Fixes the issue where during a `create cluster` workflow with more than one distributed validator, only the last key in the pubkey slice was used for them all.

This should fix compose tests 500 errors as well.

category: bug
ticket: none
