### PR TITLE
validatorapi: fix content type in http response

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -883,8 +883,6 @@ func getBeaconNodeAddress(ctx context.Context, eth2Cl eth2wrap.Client) (*url.URL
 
 // writeResponse writes the 200 OK response and json response body.
 func writeResponse(ctx context.Context, w http.ResponseWriter, endpoint string, response interface{}) {
-	w.WriteHeader(http.StatusOK)
-
 	if response == nil {
 		return
 	}
@@ -952,8 +950,8 @@ func writeError(ctx context.Context, w http.ResponseWriter, endpoint string, err
 		log.Error(ctx, "Failed marshalling error response", err2)
 	}
 
-	w.WriteHeader(aerr.StatusCode)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(aerr.StatusCode)
 
 	if _, err2 = w.Write(b); err2 != nil {
 		log.Error(ctx, "Failed writing api error", err2)

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -1147,3 +1147,36 @@ type testBeaconAddr struct {
 func (t testBeaconAddr) Address() string {
 	return t.addr
 }
+
+func NewFakeResponse() FakeResponse {
+	fakeHeader := make(http.Header)
+	return FakeResponse{header: fakeHeader}
+}
+
+// FakeResponse represents a fake HTTP response for use in testing. See https://github.com/rs/cors/blob/master/bench_test.go#L8.
+type FakeResponse struct {
+	header http.Header
+}
+
+func (r FakeResponse) Header() http.Header {
+	return r.header
+}
+
+func (r FakeResponse) WriteHeader(_ int) {}
+
+func (r FakeResponse) Write(b []byte) (n int, err error) {
+	return len(b), nil
+}
+
+func TestWriteError(t *testing.T) {
+	w := NewFakeResponse()
+	err := errors.New("errmsg")
+	writeError(context.Background(), w, "", err)
+	require.Equal(t, w.header.Get("Content-Type"), "application/json")
+}
+
+func TestWriteResponse(t *testing.T) {
+	w := NewFakeResponse()
+	writeResponse(context.Background(), w, "", "")
+	require.Equal(t, w.header.Get("Content-Type"), "application/json")
+}

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -1174,36 +1174,3 @@ type testBeaconAddr struct {
 func (t testBeaconAddr) Address() string {
 	return t.addr
 }
-
-func NewFakeResponse() FakeResponse {
-	fakeHeader := make(http.Header)
-	return FakeResponse{header: fakeHeader}
-}
-
-// FakeResponse represents a fake HTTP response for use in testing. See https://github.com/rs/cors/blob/master/bench_test.go#L8.
-type FakeResponse struct {
-	header http.Header
-}
-
-func (r FakeResponse) Header() http.Header {
-	return r.header
-}
-
-func (r FakeResponse) WriteHeader(_ int) {}
-
-func (r FakeResponse) Write(b []byte) (n int, err error) {
-	return len(b), nil
-}
-
-func TestWriteError(t *testing.T) {
-	w := NewFakeResponse()
-	err := errors.New("errmsg")
-	writeError(context.Background(), w, "", err)
-	require.Equal(t, w.header.Get("Content-Type"), "application/json")
-}
-
-func TestWriteResponse(t *testing.T) {
-	w := NewFakeResponse()
-	writeResponse(context.Background(), w, "", "")
-	require.Equal(t, w.header.Get("Content-Type"), "application/json")
-}


### PR DESCRIPTION
Fixes sending incorrect `Content-Type` header in HTTP response. Found this bug while integrating nimbus VC which errored when charon sent `text/plain` instead of `application/json`.

category: bug 
ticket: none 
