### PR TITLE
cmd/relay: fix relay connection limit issue

### DIFF
--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -44,6 +44,9 @@ func startP2P(ctx context.Context, config Config, key *ecdsa.PrivateKey, reporte
 		if err := relaylog.SetLogLevel("relay", config.RelayLogLevel); err != nil {
 			return nil, errors.Wrap(err, "set relay log level")
 		}
+		if err := relaylog.SetLogLevel("rcmgr", config.RelayLogLevel); err != nil {
+			return nil, errors.Wrap(err, "set rcmgr log level")
+		}
 	}
 
 	// Increase resource limits

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -49,6 +49,7 @@ func startP2P(ctx context.Context, config Config, key *ecdsa.PrivateKey, reporte
 	// Increase resource limits
 	limiter := rcmgr.DefaultLimits
 	limiter.SystemBaseLimit.ConnsInbound = config.MaxConns
+	limiter.SystemBaseLimit.Conns = config.MaxConns
 	limiter.SystemBaseLimit.FD = config.MaxConns
 	limiter.TransientBaseLimit = limiter.SystemBaseLimit
 


### PR DESCRIPTION
Fixes relay connection limit issue in v0.13.0.

category: bug
ticket: none
