### PR TITLE
compose: add vouch to compose

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -801,7 +801,10 @@ func createMockValidators(pubkeys []eth2p0.BLSPubKey) beaconmock.ValidatorSet {
 			Status:  eth2v1.ValidatorStateActiveOngoing,
 			Validator: &eth2p0.Validator{
 				WithdrawalCredentials: []byte("12345678901234567890123456789012"),
+				EffectiveBalance:      eth2p0.Gwei(31300000000),
 				PublicKey:             pubkey,
+				ExitEpoch:             18446744073709551615,
+				WithdrawableEpoch:     18446744073709551615,
 			},
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.6.0
 	google.golang.org/protobuf v1.28.2-0.20220831092852-f930b1dc76e8
+	gopkg.in/cenkalti/backoff.v1 v1.1.0
 )
 
 require (
@@ -174,7 +175,6 @@ require (
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/testutil/beaconmock/headproducer.go
+++ b/testutil/beaconmock/headproducer.go
@@ -34,6 +34,11 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 )
 
+const (
+	topicHead  = "head"
+	topicBlock = "block"
+)
+
 func newHeadProducer() *headProducer {
 	return &headProducer{
 		server:         sse.New(),
@@ -131,17 +136,17 @@ func (p *headProducer) updateHead(slot eth2p0.Slot) {
 	}
 
 	// Publish head events.
-	for _, streamID := range p.getStreamIDs("head") {
+	for _, streamID := range p.getStreamIDs(topicHead) {
 		p.server.Publish(streamID, &sse.Event{
-			Event: []byte("head"),
+			Event: []byte(topicHead),
 			Data:  headData,
 		})
 	}
 
 	// Publish block events.
-	for _, streamID := range p.getStreamIDs("block") {
+	for _, streamID := range p.getStreamIDs(topicBlock) {
 		p.server.Publish(streamID, &sse.Event{
-			Event: []byte("block"),
+			Event: []byte(topicBlock),
 			Data:  blockData,
 		})
 	}
@@ -218,8 +223,8 @@ func (p *headProducer) handleEvents(w http.ResponseWriter, r *http.Request) {
 	r.URL.RawQuery = query.Encode()
 
 	for _, topic := range query["topics"] {
-		if topic != "head" && topic != "block" {
-			log.Warn(context.Background(), "Unknown topic requested", nil, z.Str("topic", topic))
+		if topic != topicHead && topic != topicBlock {
+			log.Warn(context.Background(), "Unsupported topic requested", nil, z.Str("topic", topic))
 			w.WriteHeader(http.StatusInternalServerError)
 			resp, err := json.Marshal(errorMsgJSON{
 				Code:    500,

--- a/testutil/beaconmock/headproducer_test.go
+++ b/testutil/beaconmock/headproducer_test.go
@@ -1,0 +1,123 @@
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package beaconmock_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/r3labs/sse/v2"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/cenkalti/backoff.v1"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+func TestHeadProducer(t *testing.T) {
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	defer bmock.Close()
+
+	base, err := url.Parse(bmock.Address())
+	require.NoError(t, err)
+
+	unsupportedTopicErr := errors.New("unknown topic requested")
+
+	tests := []struct {
+		name       string
+		topics     []string
+		statusCode int
+		expectErr  bool
+	}{
+		{
+			name:       "2 supported topics requested",
+			topics:     []string{"head", "block"},
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "head topic",
+			topics:     []string{"head"},
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "block topic",
+			topics:     []string{"block"},
+			statusCode: http.StatusOK,
+		},
+		{
+			name:       "unsupported topic",
+			topics:     []string{"exit"},
+			statusCode: http.StatusInternalServerError,
+			expectErr:  true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			endpoint, err := url.Parse(fmt.Sprintf("eth/v1/events?topics=%s", strings.Join(test.topics, "&topics=")))
+			require.NoError(t, err)
+
+			addr := base.ResolveReference(endpoint).String()
+
+			requiredTopics := make(map[string]bool)
+			for _, topic := range test.topics {
+				requiredTopics[topic] = true
+			}
+
+			client := sse.NewClient(addr, func(c *sse.Client) {
+				c.ResponseValidator = func(c *sse.Client, resp *http.Response) error {
+					require.Equal(t, test.statusCode, resp.StatusCode)
+
+					if resp.StatusCode == http.StatusInternalServerError {
+						data, err := io.ReadAll(resp.Body)
+						require.NoError(t, err)
+						require.Contains(t, string(data), "unknown topic")
+
+						return backoff.Permanent(unsupportedTopicErr)
+					}
+
+					if len(requiredTopics) == 0 {
+						return backoff.Permanent(nil)
+					}
+
+					return nil
+				}
+			})
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if test.expectErr {
+				require.ErrorIs(t, client.SubscribeWithContext(ctx, addr, func(msg *sse.Event) {}), unsupportedTopicErr)
+			} else {
+				require.NoError(t, client.SubscribeWithContext(ctx, addr, func(msg *sse.Event) {
+					require.True(t, requiredTopics[string(msg.Event)])
+					delete(requiredTopics, string(msg.Event))
+					if len(requiredTopics) == 0 {
+						cancel()
+					}
+				}))
+			}
+		})
+	}
+}

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -26,11 +26,14 @@ import (
 
 	eth2client "github.com/attestantio/go-eth2-client"
 	eth2http "github.com/attestantio/go-eth2-client/http"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/gorilla/mux"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 //go:embed static.json
@@ -99,6 +102,38 @@ func newHTTPServer(addr string, optionalHandlers map[string]http.HandlerFunc, ov
 			case <-shutdown:
 			case <-r.Context().Done():
 			}
+		},
+		"/eth/v2/beacon/blocks/{block_id}": func(w http.ResponseWriter, r *http.Request) {
+			type signedBlockResponseJSON struct {
+				Version eth2spec.DataVersion         `json:"version"`
+				Data    *bellatrix.SignedBeaconBlock `json:"data"`
+			}
+
+			resp, err := json.Marshal(signedBlockResponseJSON{
+				Version: eth2spec.DataVersionBellatrix,
+				Data:    testutil.RandomBellatrixSignedBeaconBlock(),
+			})
+			if err != nil {
+				panic(err) // This should never happen and this is test code sorry ;)
+			}
+
+			_, _ = w.Write(resp)
+		},
+		"/eth/v1/beacon/blocks/{block_id}": func(w http.ResponseWriter, r *http.Request) {
+			type signedBlockResponseJSON struct {
+				Version eth2spec.DataVersion         `json:"version"`
+				Data    *bellatrix.SignedBeaconBlock `json:"data"`
+			}
+
+			resp, err := json.Marshal(signedBlockResponseJSON{
+				Version: eth2spec.DataVersionBellatrix,
+				Data:    testutil.RandomBellatrixSignedBeaconBlock(),
+			})
+			if err != nil {
+				panic(err) // This should never happen and this is test code sorry ;)
+			}
+
+			_, _ = w.Write(resp)
 		},
 	}
 

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -105,34 +105,21 @@ func newHTTPServer(addr string, optionalHandlers map[string]http.HandlerFunc, ov
 		},
 		"/eth/v2/beacon/blocks/{block_id}": func(w http.ResponseWriter, r *http.Request) {
 			type signedBlockResponseJSON struct {
-				Version eth2spec.DataVersion         `json:"version"`
+				Version *eth2spec.DataVersion        `json:"version"`
 				Data    *bellatrix.SignedBeaconBlock `json:"data"`
 			}
 
+			version := eth2spec.DataVersionBellatrix
 			resp, err := json.Marshal(signedBlockResponseJSON{
-				Version: eth2spec.DataVersionBellatrix,
+				Version: &version,
 				Data:    testutil.RandomBellatrixSignedBeaconBlock(),
 			})
 			if err != nil {
 				panic(err) // This should never happen and this is test code sorry ;)
 			}
 
-			_, _ = w.Write(resp)
-		},
-		"/eth/v1/beacon/blocks/{block_id}": func(w http.ResponseWriter, r *http.Request) {
-			type signedBlockResponseJSON struct {
-				Version eth2spec.DataVersion         `json:"version"`
-				Data    *bellatrix.SignedBeaconBlock `json:"data"`
-			}
-
-			resp, err := json.Marshal(signedBlockResponseJSON{
-				Version: eth2spec.DataVersionBellatrix,
-				Data:    testutil.RandomBellatrixSignedBeaconBlock(),
-			})
-			if err != nil {
-				panic(err) // This should never happen and this is test code sorry ;)
-			}
-
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
 			_, _ = w.Write(resp)
 		},
 	}

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -50,6 +50,7 @@ const (
 	VCMock       VCType = "mock"
 	VCTeku       VCType = "teku"
 	VCLighthouse VCType = "lighthouse"
+	VCVouch      VCType = "vouch"
 )
 
 // KeyGen defines a key generation process.

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -78,6 +78,10 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 // getVC returns the validator client template data for the provided type and index.
 func getVC(typ VCType, nodeIdx int, numVals int, insecure bool) (TmplVC, error) {
 	vcByType := map[VCType]TmplVC{
+		VCVouch: {
+			Label: string(VCVouch),
+			Build: "vouch",
+		},
 		VCLighthouse: {
 			Label: string(VCLighthouse),
 			Build: "lighthouse",

--- a/testutil/compose/static/vouch/Dockerfile
+++ b/testutil/compose/static/vouch/Dockerfile
@@ -1,0 +1,9 @@
+FROM wealdtech/ethdo:1.25.3 as ethdo
+
+FROM attestant/vouch:1.6.2
+
+COPY --from=ethdo /app/ethdo /app/ethdo
+
+RUN apt-get update && apt-get install -y curl jq wget
+
+ENTRYPOINT ["/compose/vouch/run.sh"]

--- a/testutil/compose/static/vouch/run.sh
+++ b/testutil/compose/static/vouch/run.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# Running vouch VC is split into three steps:
+# 1. Converting keys into a format which vouch understands. This is what ethdo does.
+# 2. Creating configuration for vouch (vouch.yml).
+# 3. Actually running the vouch validator client.
+
+BASE_DIR="/tmp/vouch"
+KEYS_DIR="/tmp/vouch/keys"
+ACCOUNT_PASSPHRASE="secret" # Hardcoded ethdo account passphrase
+
+rm -rf /tmp/vouch || true
+mkdir ${BASE_DIR}
+mkdir ${KEYS_DIR}
+
+cp /compose/vouch/vouch.yml ${BASE_DIR}
+
+# Create an ethdo wallet within the keys folder.
+wallet="validators"
+/app/ethdo --base-dir="${KEYS_DIR}" wallet create --wallet ${wallet}
+
+# Import keys into the ethdo wallet.
+account=0
+for f in /compose/"${NODE}"/validator_keys/keystore-*.json; do
+  accountName="account-${account}"
+  echo "Importing key ${f} into ethdo wallet: ${wallet}/${accountName}"
+
+  KEYSTORE_PASSPHRASE=$(cat "${f//json/txt}")
+  /app/ethdo \
+    --base-dir="${KEYS_DIR}" account import \
+    --account="${wallet}"/"${accountName}" \
+    --keystore="$f" \
+    --passphrase="$ACCOUNT_PASSPHRASE" \
+    --keystore-passphrase="$KEYSTORE_PASSPHRASE" \
+    --allow-weak-passphrases
+
+  # Increment account.
+  # shellcheck disable=SC2003
+  account=$(expr "$account" + 1)
+done
+
+# Log wallet info.
+echo "Starting vouch validator client. Wallet info:"
+/app/ethdo wallet info \
+--wallet="${wallet}" \
+--base-dir="${KEYS_DIR}" \
+--verbose
+
+# Now run vouch.
+exec /app/vouch --base-dir=${BASE_DIR} --beacon-node-address="http://${NODE}:3600"

--- a/testutil/compose/static/vouch/vouch.yml
+++ b/testutil/compose/static/vouch/vouch.yml
@@ -1,0 +1,36 @@
+# This is a sample config to run vouch VC. It is used by the run.sh script
+# to generate a custom config for each vouch VC connected to a charon node.
+# Refer: https://github.com/attestantio/vouch/blob/master/docs/configuration.md.
+
+# The wallet account manager obtains account information from local wallets, and signs locally.
+# It supports wallets created by ethdo.
+accountmanager:
+  wallet:
+    locations: /tmp/vouch/keys
+    accounts: validators
+    passphrases: secret
+
+# metrics is the module that logs metrics, in this case using prometheus. Note that vouch doesn't emit metrics if
+# the following block is not provided.
+metrics:
+  prometheus:
+    # listen-address is the address on which prometheus listens for metrics requests.
+    listen-address: 0.0.0.0:8081
+
+# Allow sufficient time (10s) to block while fetching duties for DVT.
+strategies:
+  beaconblockproposal:
+    timeout: 10s
+  blindedbeaconblockproposal:
+    timeout: 10s
+  attestationdata:
+    timeout: 10s
+  aggregateattestation:
+    timeout: 10s
+  synccommitteecontribution:
+    timeout: 10s
+
+# blockrelay provides information about working with local execution clients and remote relays for block proposals.
+# fallback-fee-recipient is required field for vouch if no execution configuration is provided.
+blockrelay:
+  fallback-fee-recipient: '0x0000000000000000000000000000000000000001'

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -182,6 +182,13 @@ func RandomBellatrixBeaconBlock() *bellatrix.BeaconBlock {
 	}
 }
 
+func RandomBellatrixSignedBeaconBlock() *bellatrix.SignedBeaconBlock {
+	return &bellatrix.SignedBeaconBlock{
+		Message:   RandomBellatrixBeaconBlock(),
+		Signature: RandomEth2Signature(),
+	}
+}
+
 func RandomBellatrixBeaconBlockBody() *bellatrix.BeaconBlockBody {
 	return &bellatrix.BeaconBlockBody{
 		RANDAOReveal: RandomEth2Signature(),


### PR DESCRIPTION
Adds vouch to compose and also made some changes to beaconmock which were needed by vouch specifically.
Note: Vouch doesn't support block proposals because of RANDAO check in go-eth2-client.

category: feature
ticket: #1403 
