### PR TITLE
app: add beacon node version metric

### DIFF
--- a/app/metrics.go
+++ b/app/metrics.go
@@ -79,7 +79,7 @@ var (
 		Namespace: "app",
 		Subsystem: "beacon_node",
 		Name:      "peers",
-		Help:      "Gauge set to the peer count of the beacon node connected to this charon instance",
+		Help:      "Gauge set to the peer count of the upstream beacon node",
 	})
 
 	beaconNodeVersionGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -75,12 +75,19 @@ var (
 			"4 if quorum peers are not connected.",
 	})
 
-	peerCountGauge = promauto.NewGauge(prometheus.GaugeOpts{
+	beaconNodePeerCountGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "app",
 		Subsystem: "beacon_node",
 		Name:      "peers",
-		Help:      "Gauge set to the peer count of the beacon node connected to this charon instance.",
+		Help:      "Gauge set to the peer count of the beacon node connected to this charon instance",
 	})
+
+	beaconNodeVersionGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Subsystem: "beacon_node",
+		Name:      "version",
+		Help:      "Constant gauge with label set to the node version of the upstream beacon node",
+	}, []string{"version"})
 
 	thresholdGauge = promauto.NewGauge(prometheus.GaugeOpts{
 		Namespace: "cluster",

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -53,7 +53,7 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, addr string
 	peerIDs []peer.ID, registry *prometheus.Registry, qbftDebug http.Handler,
 	pubkeys []core.PubKey, seenPubkeys <-chan core.PubKey, vapiCalls <-chan struct{},
 ) {
-	peerCounter(ctx, eth2Cl, clockwork.NewRealClock())
+	beaconNodeMetrics(ctx, eth2Cl, clockwork.NewRealClock())
 
 	mux := http.NewServeMux()
 
@@ -186,17 +186,27 @@ func beaconNodeSyncing(ctx context.Context, eth2Cl eth2client.NodeSyncingProvide
 	return state.IsSyncing, nil
 }
 
-// peerCounter populates the peerCountGauge with the beacon node peer count.
-func peerCounter(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
-	ticker := clock.NewTicker(1 * time.Minute)
-
+// beaconNodeMetrics sets beacon node metrics like the peer count and node version.
+func beaconNodeMetrics(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
+	peerCountTicker := clock.NewTicker(1 * time.Minute)
 	setPeerCount := func() {
-		count, err := beaconNodePeerCount(ctx, eth2Cl)
+		peerCount, err := eth2Cl.NodePeerCount(ctx)
 		if err != nil {
 			log.Error(ctx, "Failed to get beacon node peer count", err)
 			return
 		}
-		peerCountGauge.Set(float64(count))
+		beaconNodePeerCountGauge.Set(float64(peerCount))
+	}
+
+	nodeVersionTicker := clock.NewTicker(10 * time.Minute)
+	setNodeVersion := func() {
+		version, err := eth2Cl.NodeVersion(ctx)
+		if err != nil {
+			log.Error(ctx, "Failed to get beacon node version", err)
+			return
+		}
+
+		beaconNodeVersionGauge.WithLabelValues(version).Set(1)
 	}
 
 	go func() {
@@ -207,23 +217,16 @@ func peerCounter(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Cl
 			select {
 			case <-onStartup:
 				setPeerCount()
-			case <-ticker.Chan():
+				setNodeVersion()
+			case <-peerCountTicker.Chan():
 				setPeerCount()
+			case <-nodeVersionTicker.Chan():
+				setNodeVersion()
 			case <-ctx.Done():
 				return
 			}
 		}
 	}()
-}
-
-// beaconNodePeerCount returns the number of connected peers of the beacon node.
-func beaconNodePeerCount(ctx context.Context, eth2Cl eth2wrap.Client) (int, error) {
-	peerCount, err := eth2Cl.NodePeerCount(ctx)
-	if err != nil {
-		return 0, errors.Wrap(err, "get beacon node peer count")
-	}
-
-	return peerCount, nil
 }
 
 // quorumPeersConnected returns true if quorum peers are currently connected.

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -199,7 +199,7 @@ func beaconNodeMetrics(ctx context.Context, eth2Cl eth2wrap.Client, clock clockw
 	}
 
 	nodeVersionTicker := clock.NewTicker(10 * time.Minute)
-	prevNodeVersion := ""
+	var prevNodeVersion string
 	setNodeVersion := func() {
 		version, err := eth2Cl.NodeVersion(ctx)
 		if err != nil {

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -199,14 +199,22 @@ func beaconNodeMetrics(ctx context.Context, eth2Cl eth2wrap.Client, clock clockw
 	}
 
 	nodeVersionTicker := clock.NewTicker(10 * time.Minute)
+	prevNodeVersion := ""
 	setNodeVersion := func() {
 		version, err := eth2Cl.NodeVersion(ctx)
 		if err != nil {
 			log.Error(ctx, "Failed to get beacon node version", err)
 			return
 		}
+		if version == prevNodeVersion {
+			return
+		}
 
+		if prevNodeVersion != "" {
+			beaconNodeVersionGauge.WithLabelValues(prevNodeVersion).Set(0)
+		}
 		beaconNodeVersionGauge.WithLabelValues(version).Set(1)
+		prevNodeVersion = version
 	}
 
 	go func() {

--- a/testutil/compose/static/grafana/dash_charon_overview.json
+++ b/testutil/compose/static/grafana/dash_charon_overview.json
@@ -86,7 +86,7 @@
         "frameIndex": 0,
         "showHeader": false
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -226,7 +226,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -424,7 +424,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -602,7 +602,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -643,6 +643,95 @@
       "title": "Cluster Info",
       "transformations": [],
       "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Beacon node metrics",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "displayMode": "auto",
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "label"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 116
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 5,
+        "x": 0,
+        "y": 7
+      },
+      "id": 71,
+      "options": {
+        "footer": {
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "9.3.6",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(app_beacon_node_version{cluster_name=\"$cluster_name\",cluster_hash=\"$cluster_hash\",cluster_peer=\"$cluster_peer\"}) by (version)",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Beacon node",
+      "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "rows"
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": {
@@ -922,9 +1011,9 @@
         ]
       },
       "gridPos": {
-        "h": 6,
-        "w": 24,
-        "x": 0,
+        "h": 5,
+        "w": 19,
+        "x": 5,
         "y": 7
       },
       "id": 54,
@@ -945,7 +1034,7 @@
           }
         ]
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -1337,7 +1426,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 13
+        "y": 12
       },
       "id": 7,
       "options": {
@@ -1430,7 +1519,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 13
+        "y": 12
       },
       "id": 67,
       "options": {
@@ -1537,7 +1626,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 20
+        "y": 19
       },
       "id": 62,
       "options": {
@@ -1579,7 +1668,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 20
+        "y": 19
       },
       "id": 66,
       "options": {
@@ -1671,7 +1760,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 25
       },
       "id": 17,
       "options": {
@@ -1764,7 +1853,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 25
       },
       "id": 18,
       "options": {
@@ -1857,7 +1946,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 33
+        "y": 32
       },
       "id": 69,
       "options": {
@@ -1952,7 +2041,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 33
+        "y": 32
       },
       "id": 24,
       "options": {
@@ -2045,7 +2134,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 40
+        "y": 39
       },
       "id": 15,
       "options": {
@@ -2152,7 +2241,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 40
+        "y": 39
       },
       "id": 49,
       "options": {
@@ -2285,7 +2374,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 47
+        "y": 46
       },
       "id": 50,
       "options": {
@@ -2392,7 +2481,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 47
+        "y": 46
       },
       "id": 52,
       "links": [],
@@ -2449,7 +2538,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "light-blue"
+                "color": "light-blue",
+                "value": null
               },
               {
                 "color": "red",
@@ -2541,7 +2631,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 54
+        "y": 53
       },
       "id": 56,
       "options": {
@@ -2560,7 +2650,7 @@
           }
         ]
       },
-      "pluginVersion": "9.3.2",
+      "pluginVersion": "9.3.6",
       "targets": [
         {
           "datasource": {
@@ -2649,7 +2739,7 @@
         "h": 14,
         "w": 24,
         "x": 0,
-        "y": 61
+        "y": 60
       },
       "id": 65,
       "options": {
@@ -2697,6 +2787,11 @@
         },
         "definition": "label_values(app_peer_name, cluster_name)",
         "description": "",
+        "error": {
+          "data": {
+            "message": "Unexpected error"
+          }
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Cluster Name",
@@ -2716,8 +2811,8 @@
       {
         "current": {
           "selected": false,
-          "text": "70260bf",
-          "value": "70260bf"
+          "text": "84a5dac",
+          "value": "84a5dac"
         },
         "datasource": {
           "type": "prometheus",
@@ -2725,6 +2820,11 @@
         },
         "definition": "label_values(app_peer_name{cluster_name=\"$cluster_name\"}, cluster_hash)",
         "description": "",
+        "error": {
+          "data": {
+            "message": "Unexpected error"
+          }
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Cluster Hash",
@@ -2744,8 +2844,8 @@
       {
         "current": {
           "selected": false,
-          "text": "courageous-glass",
-          "value": "courageous-glass"
+          "text": "dazzling-life",
+          "value": "dazzling-life"
         },
         "datasource": {
           "type": "prometheus",
@@ -2753,6 +2853,11 @@
         },
         "definition": "label_values(app_peer_name{cluster_name=\"$cluster_name\",cluster_hash=\"$cluster_hash\"}, cluster_peer)",
         "description": "",
+        "error": {
+          "data": {
+            "message": "Unexpected error"
+          }
+        },
         "hide": 0,
         "includeAll": false,
         "label": "Cluster Peer",
@@ -2781,6 +2886,11 @@
         },
         "definition": "label_values(app_peer_name{cluster_name=\"$cluster_name\",cluster_hash=\"$cluster_hash\",cluster_peer=\"$cluster_peer\"},job)",
         "description": "Prometheus job (can be ignored)",
+        "error": {
+          "data": {
+            "message": "Unexpected error"
+          }
+        },
         "hide": 2,
         "includeAll": false,
         "label": "--",


### PR DESCRIPTION
Adds a constant gauge with label set to the upstream beacon node version. It is refreshed every 10mins. 

Also adds a new panel for beacon node metrics to simnet grafana dashboard.

category: feature
ticket: #1773 
