### PR TITLE
core: fix duty expired context tracker2 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -480,7 +480,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 		opts = []core.WireOption{
 			core.WithTracing(),
-			core.WithTracking(ctx, track),
+			core.WithTracking(track),
 			core.WithAsyncRetry(retryer),
 		}
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -480,7 +480,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 		opts = []core.WireOption{
 			core.WithTracing(),
-			core.WithTracking(track),
+			core.WithTracking(ctx, track),
 			core.WithAsyncRetry(retryer),
 		}
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -176,31 +176,31 @@ type Broadcaster interface {
 // Tracker sends core component events for further analysis and instrumentation.
 type Tracker interface {
 	// FetcherFetched sends Fetcher component's events to tracker.
-	FetcherFetched(context.Context, Duty, DutyDefinitionSet, error)
+	FetcherFetched(Duty, DutyDefinitionSet, error)
 
 	// ConsensusProposed sends Consensus component's events to tracker.
-	ConsensusProposed(context.Context, Duty, UnsignedDataSet, error)
+	ConsensusProposed(Duty, UnsignedDataSet, error)
 
 	// DutyDBStored sends DutyDB component's store events to tracker.
-	DutyDBStored(context.Context, Duty, UnsignedDataSet, error)
+	DutyDBStored(Duty, UnsignedDataSet, error)
 
 	// ParSigDBStoredInternal sends ParSigDB component's store internal events to tracker.
-	ParSigDBStoredInternal(context.Context, Duty, ParSignedDataSet, error)
+	ParSigDBStoredInternal(Duty, ParSignedDataSet, error)
 
 	// ParSigExBroadcasted sends ParSigEx component's broadcast events to tracker.
-	ParSigExBroadcasted(context.Context, Duty, ParSignedDataSet, error)
+	ParSigExBroadcasted(Duty, ParSignedDataSet, error)
 
 	// ParSigDBStoredExternal sends ParSigDB component's store external events to tracker.
-	ParSigDBStoredExternal(context.Context, Duty, ParSignedDataSet, error)
+	ParSigDBStoredExternal(Duty, ParSignedDataSet, error)
 
 	// SigAggAggregated sends SigAgg component's aggregate events to tracker.
-	SigAggAggregated(context.Context, Duty, PubKey, []ParSignedData, error)
+	SigAggAggregated(Duty, PubKey, []ParSignedData, error)
 
 	// AggSigDBStored sends AggSigDB component's store events to tracker.
-	AggSigDBStored(context.Context, Duty, PubKey, SignedData, error)
+	AggSigDBStored(Duty, PubKey, SignedData, error)
 
 	// BroadcasterBroadcast sends Broadcaster component's broadcast events to tracker.
-	BroadcasterBroadcast(context.Context, Duty, PubKey, SignedData, error)
+	BroadcasterBroadcast(Duty, PubKey, SignedData, error)
 }
 
 // wireFuncs defines the core workflow components as a list of input and output functions

--- a/core/tracker/tracker2/tracker.go
+++ b/core/tracker/tracker2/tracker.go
@@ -717,11 +717,9 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 }
 
 // FetcherFetched implements core.Tracker interface.
-func (t *Tracker) FetcherFetched(ctx context.Context, duty core.Duty, set core.DutyDefinitionSet, stepErr error) {
+func (t *Tracker) FetcherFetched(duty core.Duty, set core.DutyDefinitionSet, stepErr error) {
 	for pubkey := range set {
 		select {
-		case <-ctx.Done():
-			return
 		case <-t.quit:
 			return
 		case t.input <- event{
@@ -735,11 +733,9 @@ func (t *Tracker) FetcherFetched(ctx context.Context, duty core.Duty, set core.D
 }
 
 // ConsensusProposed implements core.Tracker interface.
-func (t *Tracker) ConsensusProposed(ctx context.Context, duty core.Duty, set core.UnsignedDataSet, stepErr error) {
+func (t *Tracker) ConsensusProposed(duty core.Duty, set core.UnsignedDataSet, stepErr error) {
 	for pubkey := range set {
 		select {
-		case <-ctx.Done():
-			return
 		case <-t.quit:
 			return
 		case t.input <- event{
@@ -753,11 +749,9 @@ func (t *Tracker) ConsensusProposed(ctx context.Context, duty core.Duty, set cor
 }
 
 // DutyDBStored implements core.Tracker interface.
-func (t *Tracker) DutyDBStored(ctx context.Context, duty core.Duty, set core.UnsignedDataSet, stepErr error) {
+func (t *Tracker) DutyDBStored(duty core.Duty, set core.UnsignedDataSet, stepErr error) {
 	for pubkey := range set {
 		select {
-		case <-ctx.Done():
-			return
 		case <-t.quit:
 			return
 		case t.input <- event{
@@ -771,12 +765,10 @@ func (t *Tracker) DutyDBStored(ctx context.Context, duty core.Duty, set core.Uns
 }
 
 // ParSigDBStoredInternal implements core.Tracker interface.
-func (t *Tracker) ParSigDBStoredInternal(ctx context.Context, duty core.Duty, set core.ParSignedDataSet, stepErr error) {
+func (t *Tracker) ParSigDBStoredInternal(duty core.Duty, set core.ParSignedDataSet, stepErr error) {
 	for pubkey, parSig := range set {
 		parSig := parSig
 		select {
-		case <-ctx.Done():
-			return
 		case <-t.quit:
 			return
 		case t.input <- event{
@@ -791,12 +783,10 @@ func (t *Tracker) ParSigDBStoredInternal(ctx context.Context, duty core.Duty, se
 }
 
 // ParSigExBroadcasted implements core.Tracker interface.
-func (t *Tracker) ParSigExBroadcasted(ctx context.Context, duty core.Duty, set core.ParSignedDataSet, stepErr error) {
+func (t *Tracker) ParSigExBroadcasted(duty core.Duty, set core.ParSignedDataSet, stepErr error) {
 	for pubkey, parSig := range set {
 		parSig := parSig
 		select {
-		case <-ctx.Done():
-			return
 		case <-t.quit:
 			return
 		case t.input <- event{
@@ -811,12 +801,10 @@ func (t *Tracker) ParSigExBroadcasted(ctx context.Context, duty core.Duty, set c
 }
 
 // ParSigDBStoredExternal implements core.Tracker interface.
-func (t *Tracker) ParSigDBStoredExternal(ctx context.Context, duty core.Duty, set core.ParSignedDataSet, stepErr error) {
+func (t *Tracker) ParSigDBStoredExternal(duty core.Duty, set core.ParSignedDataSet, stepErr error) {
 	for pubkey, parSig := range set {
 		parSig := parSig
 		select {
-		case <-ctx.Done():
-			return
 		case <-t.quit:
 			return
 		case t.input <- event{
@@ -831,10 +819,8 @@ func (t *Tracker) ParSigDBStoredExternal(ctx context.Context, duty core.Duty, se
 }
 
 // SigAggAggregated implements core.Tracker interface.
-func (t *Tracker) SigAggAggregated(ctx context.Context, duty core.Duty, pubkey core.PubKey, _ []core.ParSignedData, stepErr error) {
+func (t *Tracker) SigAggAggregated(duty core.Duty, pubkey core.PubKey, _ []core.ParSignedData, stepErr error) {
 	select {
-	case <-ctx.Done():
-		return
 	case <-t.quit:
 		return
 	case t.input <- event{
@@ -847,10 +833,8 @@ func (t *Tracker) SigAggAggregated(ctx context.Context, duty core.Duty, pubkey c
 }
 
 // AggSigSBStored implements core.Tracker interface.
-func (t *Tracker) AggSigDBStored(ctx context.Context, duty core.Duty, pubkey core.PubKey, _ core.SignedData, stepErr error) {
+func (t *Tracker) AggSigDBStored(duty core.Duty, pubkey core.PubKey, _ core.SignedData, stepErr error) {
 	select {
-	case <-ctx.Done():
-		return
 	case <-t.quit:
 		return
 	case t.input <- event{
@@ -863,10 +847,8 @@ func (t *Tracker) AggSigDBStored(ctx context.Context, duty core.Duty, pubkey cor
 }
 
 // BroadcasterBroadcast implements core.Tracker interface.
-func (t *Tracker) BroadcasterBroadcast(ctx context.Context, duty core.Duty, pubkey core.PubKey, _ core.SignedData, stepErr error) {
+func (t *Tracker) BroadcasterBroadcast(duty core.Duty, pubkey core.PubKey, _ core.SignedData, stepErr error) {
 	select {
-	case <-ctx.Done():
-		return
 	case <-t.quit:
 		return
 	case t.input <- event{

--- a/core/tracker/tracker2/tracker_internal_test.go
+++ b/core/tracker/tracker2/tracker_internal_test.go
@@ -71,8 +71,8 @@ func TestTrackerFailedDuty(t *testing.T) {
 
 		go func() {
 			for _, td := range testData {
-				tr.FetcherFetched(ctx, td.duty, td.defSet, nil)
-				tr.ConsensusProposed(ctx, td.duty, td.unsignedDataSet, consensusErr)
+				tr.FetcherFetched(td.duty, td.defSet, nil)
+				tr.ConsensusProposed(td.duty, td.unsignedDataSet, consensusErr)
 
 				// Explicitly mark the current duty as deadlined.
 				analyser.deadlineChan <- td.duty
@@ -111,14 +111,14 @@ func TestTrackerFailedDuty(t *testing.T) {
 
 		go func() {
 			for _, td := range testData {
-				tr.FetcherFetched(ctx, td.duty, td.defSet, nil)
-				tr.ConsensusProposed(ctx, td.duty, td.unsignedDataSet, nil)
-				tr.DutyDBStored(ctx, td.duty, td.unsignedDataSet, nil)
-				tr.ParSigDBStoredInternal(ctx, td.duty, td.parSignedDataSet, nil)
-				tr.ParSigDBStoredExternal(ctx, td.duty, td.parSignedDataSet, nil)
+				tr.FetcherFetched(td.duty, td.defSet, nil)
+				tr.ConsensusProposed(td.duty, td.unsignedDataSet, nil)
+				tr.DutyDBStored(td.duty, td.unsignedDataSet, nil)
+				tr.ParSigDBStoredInternal(td.duty, td.parSignedDataSet, nil)
+				tr.ParSigDBStoredExternal(td.duty, td.parSignedDataSet, nil)
 				for _, pubkey := range pubkeys {
-					tr.SigAggAggregated(ctx, td.duty, pubkey, nil, nil)
-					tr.BroadcasterBroadcast(ctx, td.duty, pubkey, nil, nil)
+					tr.SigAggAggregated(td.duty, pubkey, nil, nil)
+					tr.BroadcasterBroadcast(td.duty, pubkey, nil, nil)
 				}
 
 				// Explicitly mark the current duty as deadlined.
@@ -433,14 +433,14 @@ func TestTrackerParticipation(t *testing.T) {
 
 	go func() {
 		for _, td := range testData {
-			tr.FetcherFetched(ctx, td.duty, td.defSet, nil)
-			tr.ParSigDBStoredInternal(ctx, td.duty, td.parSignedDataSet, nil)
+			tr.FetcherFetched(td.duty, td.defSet, nil)
+			tr.ParSigDBStoredInternal(td.duty, td.parSignedDataSet, nil)
 			for _, data := range psigDataPerDutyPerPeer[td.duty] {
-				tr.ParSigDBStoredExternal(ctx, td.duty, data, nil)
+				tr.ParSigDBStoredExternal(td.duty, data, nil)
 			}
 			for _, pk := range pubkeys {
-				tr.SigAggAggregated(ctx, td.duty, pk, nil, nil)
-				tr.BroadcasterBroadcast(ctx, td.duty, pk, nil, nil)
+				tr.SigAggAggregated(td.duty, pk, nil, nil)
+				tr.BroadcasterBroadcast(td.duty, pk, nil, nil)
 			}
 
 			// Explicitly mark the current duty as deadlined.
@@ -488,7 +488,7 @@ func TestUnexpectedParticipation(t *testing.T) {
 			}
 
 			go func(duty core.Duty) {
-				tr.ParSigDBStoredExternal(ctx, duty, core.ParSignedDataSet{pubkey: data}, nil)
+				tr.ParSigDBStoredExternal(duty, core.ParSignedDataSet{pubkey: data}, nil)
 				analyser.deadlineChan <- duty
 				deleter.deadlineChan <- duty
 			}(d)
@@ -533,8 +533,8 @@ func TestDutyRandaoUnexpected(t *testing.T) {
 	}
 
 	go func() {
-		tr.FetcherFetched(ctx, dutyProposer, core.DutyDefinitionSet{pubkey: core.NewProposerDefinition(testutil.RandomProposerDuty(t))}, errors.New("failed to query randao"))
-		tr.ParSigDBStoredExternal(ctx, dutyRandao, core.ParSignedDataSet{pubkey: data}, nil)
+		tr.FetcherFetched(dutyProposer, core.DutyDefinitionSet{pubkey: core.NewProposerDefinition(testutil.RandomProposerDuty(t))}, errors.New("failed to query randao"))
+		tr.ParSigDBStoredExternal(dutyRandao, core.ParSignedDataSet{pubkey: data}, nil)
 
 		analyser.deadlineChan <- dutyProposer
 		// Trim Proposer events before Randao deadline
@@ -580,8 +580,8 @@ func TestDutyRandaoExpected(t *testing.T) {
 	}
 
 	go func() {
-		tr.FetcherFetched(ctx, dutyProposer, core.DutyDefinitionSet{pubkey: core.NewProposerDefinition(testutil.RandomProposerDuty(t))}, errors.New("failed to query randao"))
-		tr.ParSigDBStoredExternal(ctx, dutyRandao, core.ParSignedDataSet{pubkey: data}, nil)
+		tr.FetcherFetched(dutyProposer, core.DutyDefinitionSet{pubkey: core.NewProposerDefinition(testutil.RandomProposerDuty(t))}, errors.New("failed to query randao"))
+		tr.ParSigDBStoredExternal(dutyRandao, core.ParSignedDataSet{pubkey: data}, nil)
 
 		analyser.deadlineChan <- dutyProposer
 		analyser.deadlineChan <- dutyRandao
@@ -689,9 +689,9 @@ func TestFromSlot(t *testing.T) {
 		close(done)
 	}()
 
-	tr.SigAggAggregated(ctx, core.NewAggregatorDuty(thisSlot), "", nil, nil)
-	tr.ParSigDBStoredInternal(ctx, core.NewProposerDuty(thisSlot), nil, nil)
-	tr.FetcherFetched(ctx, core.NewAggregatorDuty(thisSlot), nil, nil)
+	tr.SigAggAggregated(core.NewAggregatorDuty(thisSlot), "", nil, nil)
+	tr.ParSigDBStoredInternal(core.NewProposerDuty(thisSlot), nil, nil)
+	tr.FetcherFetched(core.NewAggregatorDuty(thisSlot), nil, nil)
 
 	require.Empty(t, tr.events)
 	cancel()

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -20,61 +20,61 @@ import (
 )
 
 // WithTracking wraps component input functions to support tracking of core components.
-func WithTracking(tracker Tracker) WireOption {
+func WithTracking(parentCtx context.Context, tracker Tracker) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
 
 		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
 			err := clone.FetcherFetch(ctx, duty, set)
-			tracker.FetcherFetched(ctx, duty, set, err)
+			tracker.FetcherFetched(parentCtx, duty, set, err)
 
 			return err
 		}
 		w.ConsensusPropose = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
 			err := clone.ConsensusPropose(ctx, duty, set)
-			tracker.ConsensusProposed(ctx, duty, set, err)
+			tracker.ConsensusProposed(parentCtx, duty, set, err)
 
 			return err
 		}
 		w.DutyDBStore = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
 			err := clone.DutyDBStore(ctx, duty, set)
-			tracker.DutyDBStored(ctx, duty, set, err)
+			tracker.DutyDBStored(parentCtx, duty, set, err)
 
 			return err
 		}
 		w.ParSigDBStoreInternal = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			err := clone.ParSigDBStoreInternal(ctx, duty, set)
-			tracker.ParSigDBStoredInternal(ctx, duty, set, err)
+			tracker.ParSigDBStoredInternal(parentCtx, duty, set, err)
 
 			return err
 		}
 		w.ParSigExBroadcast = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			err := clone.ParSigExBroadcast(ctx, duty, set)
-			tracker.ParSigExBroadcasted(ctx, duty, set, err)
+			tracker.ParSigExBroadcasted(parentCtx, duty, set, err)
 
 			return err
 		}
 		w.ParSigDBStoreExternal = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			err := clone.ParSigDBStoreExternal(ctx, duty, set)
-			tracker.ParSigDBStoredExternal(ctx, duty, set, err)
+			tracker.ParSigDBStoredExternal(parentCtx, duty, set, err)
 
 			return err
 		}
 		w.SigAggAggregate = func(ctx context.Context, duty Duty, key PubKey, data []ParSignedData) error {
 			err := clone.SigAggAggregate(ctx, duty, key, data)
-			tracker.SigAggAggregated(ctx, duty, key, data, err)
+			tracker.SigAggAggregated(parentCtx, duty, key, data, err)
 
 			return err
 		}
 		w.AggSigDBStore = func(ctx context.Context, duty Duty, key PubKey, data SignedData) error {
 			err := clone.AggSigDBStore(ctx, duty, key, data)
-			tracker.AggSigDBStored(ctx, duty, key, data, err)
+			tracker.AggSigDBStored(parentCtx, duty, key, data, err)
 
 			return err
 		}
 		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, pubkey PubKey, data SignedData) error {
 			err := clone.BroadcasterBroadcast(ctx, duty, pubkey, data)
-			tracker.BroadcasterBroadcast(ctx, duty, pubkey, data, err)
+			tracker.BroadcasterBroadcast(parentCtx, duty, pubkey, data, err)
 
 			return err
 		}

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -20,61 +20,61 @@ import (
 )
 
 // WithTracking wraps component input functions to support tracking of core components.
-func WithTracking(parentCtx context.Context, tracker Tracker) WireOption {
+func WithTracking(tracker Tracker) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
 
 		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
 			err := clone.FetcherFetch(ctx, duty, set)
-			tracker.FetcherFetched(parentCtx, duty, set, err)
+			tracker.FetcherFetched(duty, set, err)
 
 			return err
 		}
 		w.ConsensusPropose = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
 			err := clone.ConsensusPropose(ctx, duty, set)
-			tracker.ConsensusProposed(parentCtx, duty, set, err)
+			tracker.ConsensusProposed(duty, set, err)
 
 			return err
 		}
 		w.DutyDBStore = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
 			err := clone.DutyDBStore(ctx, duty, set)
-			tracker.DutyDBStored(parentCtx, duty, set, err)
+			tracker.DutyDBStored(duty, set, err)
 
 			return err
 		}
 		w.ParSigDBStoreInternal = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			err := clone.ParSigDBStoreInternal(ctx, duty, set)
-			tracker.ParSigDBStoredInternal(parentCtx, duty, set, err)
+			tracker.ParSigDBStoredInternal(duty, set, err)
 
 			return err
 		}
 		w.ParSigExBroadcast = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			err := clone.ParSigExBroadcast(ctx, duty, set)
-			tracker.ParSigExBroadcasted(parentCtx, duty, set, err)
+			tracker.ParSigExBroadcasted(duty, set, err)
 
 			return err
 		}
 		w.ParSigDBStoreExternal = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			err := clone.ParSigDBStoreExternal(ctx, duty, set)
-			tracker.ParSigDBStoredExternal(parentCtx, duty, set, err)
+			tracker.ParSigDBStoredExternal(duty, set, err)
 
 			return err
 		}
 		w.SigAggAggregate = func(ctx context.Context, duty Duty, key PubKey, data []ParSignedData) error {
 			err := clone.SigAggAggregate(ctx, duty, key, data)
-			tracker.SigAggAggregated(parentCtx, duty, key, data, err)
+			tracker.SigAggAggregated(duty, key, data, err)
 
 			return err
 		}
 		w.AggSigDBStore = func(ctx context.Context, duty Duty, key PubKey, data SignedData) error {
 			err := clone.AggSigDBStore(ctx, duty, key, data)
-			tracker.AggSigDBStored(parentCtx, duty, key, data, err)
+			tracker.AggSigDBStored(duty, key, data, err)
 
 			return err
 		}
 		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, pubkey PubKey, data SignedData) error {
 			err := clone.BroadcasterBroadcast(ctx, duty, pubkey, data)
-			tracker.BroadcasterBroadcast(parentCtx, duty, pubkey, data, err)
+			tracker.BroadcasterBroadcast(duty, pubkey, data, err)
 
 			return err
 		}


### PR DESCRIPTION
Fixes duty expired context in tracker2. This happens when duty is already expired and retryer calls tracker2 with a context which has timed out resulting in closing of ctx.Done() channel. Due to this some events don't get registered in tracker2:
https://github.com/ObolNetwork/charon/blob/eeab76e1f388af478052734eea61803df8f5f38d/core/tracker/tracker2/tracker.go#L741

category: bug
ticket: #1478 
feature_flag: tracker_v2
