### PR TITLE
app: promote `herumi_bls` feature flag to stable

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -134,6 +134,11 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	tblsv2.SetImplementation(tblsv2.Herumi{})
 
+	if !featureset.Enabled(featureset.HerumiBLS) {
+		log.Info(ctx, "Enabling Kryptology BLS signature backend")
+		tblsv2.SetImplementation(tblsv2.Kryptology{})
+	}
+
 	// Wire processes and their dependencies
 	life := new(lifecycle.Manager)
 

--- a/app/app.go
+++ b/app/app.go
@@ -132,10 +132,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	version.LogInfo(ctx, "Charon starting")
 
-	if featureset.Enabled(featureset.HerumiBLS) {
-		log.Info(ctx, "Enabling Herumi BLS signature backend")
-		tblsv2.SetImplementation(tblsv2.Herumi{})
-	}
+	tblsv2.SetImplementation(tblsv2.Herumi{})
 
 	// Wire processes and their dependencies
 	life := new(lifecycle.Manager)

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -50,7 +50,7 @@ var (
 		Priority:       statusStable,
 		MockAlpha:      statusAlpha,
 		RelayDiscovery: statusStable,
-		HerumiBLS:      statusBeta,
+		HerumiBLS:      statusStable,
 		// Add all features and there status here.
 	}
 


### PR DESCRIPTION
`herumi_bls` has been tested in the dev cluster for a while now, works as expected.

This PR moves it as under the stable feature set flag, while flipping the logic around the feature flag presence check: if explicitly disabled, fall back to Kryptology for BLS features.

category: refactor
ticket: #1743 
feature_flag: herumi_bls
