### PR TITLE
core/consensus: swap value vs hash parsing

### DIFF
--- a/core/consensus/msg.go
+++ b/core/consensus/msg.go
@@ -23,12 +23,7 @@ func newMsg(pbMsg *pbv1.QBFTMsg, justification []*pbv1.QBFTMsg, values map[[32]b
 		preparedValueHash [32]byte
 	)
 
-	if hash, ok := toHash32(pbMsg.ValueHash); ok {
-		valueHash = hash
-		if _, ok := values[valueHash]; !ok {
-			return msg{}, errors.New("value hash not found in values")
-		}
-	} else if pbMsg.Value != nil { // Use legacy value inside QBFTMsg.
+	if pbMsg.Value != nil { // Use legacy value inside QBFTMsg.
 		value, err := pbMsg.Value.UnmarshalNew()
 		if err != nil {
 			return msg{}, errors.Wrap(err, "unmarshal any")
@@ -38,14 +33,14 @@ func newMsg(pbMsg *pbv1.QBFTMsg, justification []*pbv1.QBFTMsg, values map[[32]b
 			return msg{}, err
 		}
 		values[valueHash] = pbMsg.Value
+	} else if hash, ok := toHash32(pbMsg.ValueHash); ok {
+		valueHash = hash
+		if _, ok := values[valueHash]; !ok {
+			return msg{}, errors.New("value hash not found in values")
+		}
 	}
 
-	if hash, ok := toHash32(pbMsg.PreparedValueHash); ok {
-		preparedValueHash = hash
-		if _, ok := values[preparedValueHash]; !ok {
-			return msg{}, errors.New("prepared value hash not found in values")
-		}
-	} else if pbMsg.PreparedValue != nil { // Use legacy prepared value inside QBFTMsg.
+	if pbMsg.PreparedValue != nil { // Use legacy prepared value inside QBFTMsg.
 		pv, err := pbMsg.PreparedValue.UnmarshalNew()
 		if err != nil {
 			return msg{}, errors.Wrap(err, "unmarshal any")
@@ -55,6 +50,11 @@ func newMsg(pbMsg *pbv1.QBFTMsg, justification []*pbv1.QBFTMsg, values map[[32]b
 			return msg{}, err
 		}
 		values[valueHash] = pbMsg.PreparedValue
+	} else if hash, ok := toHash32(pbMsg.PreparedValueHash); ok {
+		preparedValueHash = hash
+		if _, ok := values[preparedValueHash]; !ok {
+			return msg{}, errors.New("prepared value hash not found in values")
+		}
 	}
 
 	var justImpls []qbft.Msg[core.Duty, [32]byte]

--- a/core/consensus/msg_internal_test.go
+++ b/core/consensus/msg_internal_test.go
@@ -89,6 +89,28 @@ func TestNewMsg(t *testing.T) {
 	require.EqualValues(t, msg.values, values)
 }
 
+func TestPartialLegacyNewMsg(t *testing.T) {
+	val1 := timestamppb.New(time.Time{})
+	val2 := timestamppb.New(time.Now())
+	hash1, err := hashProto(val1)
+	require.NoError(t, err)
+
+	any1, err := anypb.New(val1)
+	require.NoError(t, err)
+	any2, err := anypb.New(val2)
+	require.NoError(t, err)
+
+	_, err = newMsg(&pbv1.QBFTMsg{
+		PreparedValue: any2,
+	}, []*pbv1.QBFTMsg{
+		{
+			Value:     any1,
+			ValueHash: hash1[:],
+		},
+	}, make(map[[32]byte]*anypb.Any))
+	require.NoError(t, err)
+}
+
 // randomMsg returns a random qbft message.
 func randomMsg(t *testing.T) *pbv1.QBFTMsg {
 	t.Helper()


### PR DESCRIPTION
Fixes `value hash not found in values` issue when a legacy peer sends you a message containing latest justification which would contain the `ValueHash` while the `values` envelope is empty.

category: bug
ticket: none
