### PR TITLE
app/eth2wrap: add proposer index in synthetic blocks

### DIFF
--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -148,20 +148,24 @@ func (h *synthWrapper) syntheticBlock(ctx context.Context, slot eth2p0.Slot, vId
 		block.Phase0 = signedBlock.Phase0.Message
 		block.Phase0.Body.Graffiti = synthGraffiti
 		block.Phase0.Slot = slot
+		block.Phase0.ProposerIndex = vIdx
 	case spec.DataVersionAltair:
 		block.Altair = signedBlock.Altair.Message
 		block.Altair.Body.Graffiti = synthGraffiti
 		block.Altair.Slot = slot
+		block.Altair.ProposerIndex = vIdx
 	case spec.DataVersionBellatrix:
 		block.Bellatrix = signedBlock.Bellatrix.Message
 		block.Bellatrix.Body.Graffiti = synthGraffiti
 		block.Bellatrix.Slot = slot
+		block.Bellatrix.ProposerIndex = vIdx
 		block.Bellatrix.Body.ExecutionPayload.FeeRecipient = feeRecipient
 		block.Bellatrix.Body.ExecutionPayload.Transactions = fraction(block.Bellatrix.Body.ExecutionPayload.Transactions)
 	case spec.DataVersionCapella:
 		block.Capella = signedBlock.Capella.Message
 		block.Capella.Body.Graffiti = synthGraffiti
 		block.Capella.Slot = slot
+		block.Capella.ProposerIndex = vIdx
 		block.Capella.Body.ExecutionPayload.FeeRecipient = feeRecipient
 		block.Capella.Body.ExecutionPayload.Transactions = fraction(block.Capella.Body.ExecutionPayload.Transactions)
 	default:

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -495,7 +495,7 @@ func proposeBlock(p eth2client.BeaconBlockProposalProvider) handlerFunc {
 			}
 
 			return proposeBlockResponsePhase0{
-				Version: "PHASE0",
+				Version: eth2spec.DataVersionPhase0.String(),
 				Data:    block.Phase0,
 			}, nil
 		case eth2spec.DataVersionAltair:
@@ -504,7 +504,7 @@ func proposeBlock(p eth2client.BeaconBlockProposalProvider) handlerFunc {
 			}
 
 			return proposeBlockResponseAltair{
-				Version: "ALTAIR",
+				Version: eth2spec.DataVersionAltair.String(),
 				Data:    block.Altair,
 			}, nil
 		case eth2spec.DataVersionBellatrix:
@@ -513,7 +513,7 @@ func proposeBlock(p eth2client.BeaconBlockProposalProvider) handlerFunc {
 			}
 
 			return proposeBlockResponseBellatrix{
-				Version: "BELLATRIX",
+				Version: eth2spec.DataVersionBellatrix.String(),
 				Data:    block.Bellatrix,
 			}, nil
 		case eth2spec.DataVersionCapella:
@@ -522,7 +522,7 @@ func proposeBlock(p eth2client.BeaconBlockProposalProvider) handlerFunc {
 			}
 
 			return proposeBlockResponseCapella{
-				Version: "CAPELLA",
+				Version: eth2spec.DataVersionCapella.String(),
 				Data:    block.Capella,
 			}, nil
 		default:


### PR DESCRIPTION
Adds proposer index in synthetic blocks which lets lighthouse VC propose synthetic blocks since it checks proposer index: [refer](https://github.com/sigp/lighthouse/blob/319cc61afeb1dbf3692e280dfa18e7b455542b16/validator_client/src/block_service.rs#L398).
Also updates how we return block version in block proposal endpoint which let's us to support block proposals with prysm. 

category: misc
ticket: none
