### PR TITLE
*: update to go1.20.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@master

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -v -test ./...

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.20.1'
+        go-version: '1.20.2'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
       - uses: actions/cache@v3
         with:
           path: |
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
       - uses: actions/cache@v3
         with:
           path: |
@@ -53,7 +53,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/track-pr.yml
+++ b/.github/workflows/track-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
 
       - name: "Track PR"
         run: go run github.com/obolnetwork/charon/testutil/trackpr

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.20.1'
+          go-version: '1.20.2'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.20.1"
+  go: "1.20.2"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -85,7 +85,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.20.1"
+    go: "1.20.2"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v0.0.2
     hooks:
       - id: check-go-version
-        args: [ -v=go1.20.1 ]
+        args: [ -v=go1.20.2 ]
         pass_filenames: false
         additional_dependencies: [ packaging ]
       - id: check-licence-header

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.20.1-bullseye AS builder
+FROM golang:1.20.2-bullseye AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source

--- a/testutil/promrated/Dockerfile
+++ b/testutil/promrated/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.1-alpine AS builder
+FROM golang:1.20.2-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache build-base git

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -869,7 +869,7 @@ func RandomDepositMsg(t *testing.T) eth2p0.DepositMessage {
 
 // constReader is a workaround. It counter-acts the Go library's attempt at
 // making ECDSA signatures non-deterministic.
-// Refer: https://cs.opensource.google/go/go/+/refs/tags/go1.20.1:src/crypto/ecdsa/ecdsa.go;l=155
+// Refer: https://cs.opensource.google/go/go/+/refs/tags/go1.20.2:src/crypto/ecdsa/ecdsa.go;l=155
 type constReader byte
 
 func (c constReader) Read(buf []byte) (int, error) {


### PR DESCRIPTION
Updates repo to [go1.20.2](https://go.dev/doc/devel/release#go1.20.minor). This fixes failing govuln checks.

category: refactor
ticket: none 