### PR TITLE
core: fix data race in scheduler

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -192,8 +192,8 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 			}
 
 			instrumentDuty(duty, defSet)
-			ctx2 := log.WithCtx(ctx, z.Any("duty", duty))
-			ctx2, span := core.StartDutyTrace(ctx2, duty, "core/scheduler.scheduleSlot")
+			dutyCtx := log.WithCtx(ctx, z.Any("duty", duty))
+			dutyCtx, span := core.StartDutyTrace(dutyCtx, duty, "core/scheduler.scheduleSlot")
 			defer span.End()
 
 			for _, sub := range s.dutySubs {
@@ -203,8 +203,8 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 					return
 				}
 
-				if err := sub(ctx2, duty, clone); err != nil {
-					log.Error(ctx2, "Trigger duty subscriber error", err, z.I64("slot", slot.Slot))
+				if err := sub(dutyCtx, duty, clone); err != nil {
+					log.Error(dutyCtx, "Trigger duty subscriber error", err, z.I64("slot", slot.Slot))
 				}
 			}
 		}()

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -199,7 +199,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 			for _, sub := range s.dutySubs {
 				clone, err := defSet.Clone() // Clone for each subscriber.
 				if err != nil {
-					log.Error(ctx, "Cloning duty definition set", err)
+					log.Error(dutyCtx, "Cloning duty definition set", err)
 					return
 				}
 

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -192,8 +192,8 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 			}
 
 			instrumentDuty(duty, defSet)
-			ctx := log.WithCtx(ctx, z.Any("duty", duty))
-			ctx, span := core.StartDutyTrace(ctx, duty, "core/scheduler.scheduleSlot")
+			ctx2 := log.WithCtx(ctx, z.Any("duty", duty))
+			ctx2, span := core.StartDutyTrace(ctx2, duty, "core/scheduler.scheduleSlot")
 			defer span.End()
 
 			for _, sub := range s.dutySubs {
@@ -203,8 +203,8 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 					return
 				}
 
-				if err := sub(ctx, duty, clone); err != nil {
-					log.Error(ctx, "Trigger duty subscriber error", err, z.I64("slot", slot.Slot))
+				if err := sub(ctx2, duty, clone); err != nil {
+					log.Error(ctx2, "Trigger duty subscriber error", err, z.I64("slot", slot.Slot))
 				}
 			}
 		}()

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -192,7 +192,7 @@ func (s *Scheduler) scheduleSlot(ctx context.Context, slot core.Slot) {
 			}
 
 			instrumentDuty(duty, defSet)
-			ctx = log.WithCtx(ctx, z.Any("duty", duty))
+			ctx := log.WithCtx(ctx, z.Any("duty", duty))
 			ctx, span := core.StartDutyTrace(ctx, duty, "core/scheduler.scheduleSlot")
 			defer span.End()
 


### PR DESCRIPTION
Fixes data race in scheduler.go. 

category: fixbuild
ticket: none 
