### PR TITLE
cmd/createcluster: handle multiple addresses with remote definition

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -607,6 +607,10 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 		return errors.New("name not provided")
 	}
 
+	if def.NumValidators == 0 {
+		return errors.New("cannot create cluster with zero validators, specify at least one")
+	}
+
 	if !eth2util.ValidNetwork(network) {
 		return errors.New("unsupported network", z.Str("network", network))
 	}

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -584,6 +584,10 @@ func nodeDir(clusterDir string, i int) string {
 
 // validateDef returns an error if the provided cluster definition is invalid.
 func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []string, def cluster.Definition) error {
+	if def.NumValidators == 0 {
+		return errors.New("cannot create cluster with zero validators, specify at least one")
+	}
+
 	if len(def.Operators) < minNodes {
 		return errors.New("insufficient number of nodes (min = 4)", z.Int("num_nodes", len(def.Operators)))
 	}
@@ -605,10 +609,6 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 
 	if def.Name == "" {
 		return errors.New("name not provided")
-	}
-
-	if def.NumValidators == 0 {
-		return errors.New("cannot create cluster with zero validators, specify at least one")
 	}
 
 	if !eth2util.ValidNetwork(network) {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -114,16 +114,6 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		return errors.New("existing cluster found. Try again with --clean")
 	}
 
-	conf.FeeRecipientAddrs, conf.WithdrawalAddrs, err = validateAddresses(conf.NumDVs, conf.FeeRecipientAddrs, conf.WithdrawalAddrs)
-	if err != nil {
-		return err
-	}
-
-	// Create cluster directory at the given location.
-	if err := os.MkdirAll(conf.ClusterDir, 0o755); err != nil {
-		return errors.Wrap(err, "mkdir")
-	}
-
 	// Map prater to goerli to ensure backwards compatibility with older cluster definitions and cluster locks.
 	// TODO(xenowits): Remove the mapping later.
 	if conf.Network == eth2util.Prater {
@@ -159,6 +149,11 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	pubkeys, shareSets, err := getTSSShares(secrets, def.Threshold, numNodes)
 	if err != nil {
 		return err
+	}
+
+	// Create cluster directory at the given location.
+	if err := os.MkdirAll(conf.ClusterDir, 0o755); err != nil {
+		return errors.Wrap(err, "mkdir")
 	}
 
 	// Create operators
@@ -525,6 +520,11 @@ func getOperators(n int, clusterDir string) ([]cluster.Operator, error) {
 
 // newDefFromConfig returns a new cluster definition using the provided config values.
 func newDefFromConfig(ctx context.Context, conf clusterConfig) (cluster.Definition, error) {
+	feeRecipientAddrs, withdrawalAddrs, err := validateAddresses(conf.NumDVs, conf.FeeRecipientAddrs, conf.WithdrawalAddrs)
+	if err != nil {
+		return cluster.Definition{}, err
+	}
+
 	forkVersion, err := eth2util.NetworkToForkVersion(conf.Network)
 	if err != nil {
 		return cluster.Definition{}, err
@@ -536,8 +536,8 @@ func newDefFromConfig(ctx context.Context, conf clusterConfig) (cluster.Definiti
 	}
 	threshold := safeThreshold(ctx, conf.NumNodes, conf.Threshold)
 
-	def, err := cluster.NewDefinition(conf.Name, conf.NumDVs, threshold, conf.FeeRecipientAddrs,
-		conf.WithdrawalAddrs, forkVersion, cluster.Creator{}, ops, rand.Reader)
+	def, err := cluster.NewDefinition(conf.Name, conf.NumDVs, threshold, feeRecipientAddrs,
+		withdrawalAddrs, forkVersion, cluster.Creator{}, ops, rand.Reader)
 	if err != nil {
 		return cluster.Definition{}, err
 	}

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -263,21 +263,26 @@ func TestValidateDef(t *testing.T) {
 		err = validateDef(ctx, conf.InsecureKeys, conf.KeymanagerAddrs, def)
 		require.ErrorContains(t, err, "name not provided")
 	})
+
+	t.Run("zero validators provided", func(t *testing.T) {
+		def := definition
+		def.NumValidators = 0
+		err = validateDef(ctx, conf.InsecureKeys, conf.KeymanagerAddrs, def)
+		require.ErrorContains(t, err, "cannot create cluster with zero validators, specify at least one")
+	})
 }
 
 func TestMultipleAddresses(t *testing.T) {
 	t.Run("insufficient addresses in config", func(t *testing.T) {
-		expectedErrMsg := "insufficient fee recipient addresses"
 		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{
 			NumDVs:            4,
 			FeeRecipientAddrs: []string{},
 			WithdrawalAddrs:   []string{},
 		})
-		require.ErrorContains(t, err, expectedErrMsg)
+		require.ErrorContains(t, err, "insufficient fee recipient addresses")
 	})
 
 	t.Run("insufficient addresses from remote URL", func(t *testing.T) {
-		expectedErrMsg := "num_validators not matching validators length"
 		lock, _, _ := cluster.NewForT(t, 2, 3, 4, 1, func(d *cluster.Definition) {
 			d.ValidatorAddresses = []cluster.ValidatorAddresses{}
 		})
@@ -295,7 +300,7 @@ func TestMultipleAddresses(t *testing.T) {
 		defer srv.Close()
 
 		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{DefFile: srv.URL, NumNodes: minNodes})
-		require.ErrorContains(t, err, expectedErrMsg)
+		require.ErrorContains(t, err, "num_validators not matching validators length")
 	})
 }
 

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -265,6 +265,40 @@ func TestValidateDef(t *testing.T) {
 	})
 }
 
+func TestMultipleAddresses(t *testing.T) {
+	t.Run("insufficient addresses in config", func(t *testing.T) {
+		expectedErrMsg := "insufficient fee recipient addresses"
+		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{
+			NumDVs:            4,
+			FeeRecipientAddrs: []string{},
+			WithdrawalAddrs:   []string{},
+		})
+		require.ErrorContains(t, err, expectedErrMsg)
+	})
+
+	t.Run("insufficient addresses from remote URL", func(t *testing.T) {
+		expectedErrMsg := "num_validators not matching validators length"
+		lock, _, _ := cluster.NewForT(t, 2, 3, 4, 1, func(d *cluster.Definition) {
+			d.ValidatorAddresses = []cluster.ValidatorAddresses{}
+		})
+
+		def := lock.Definition
+
+		// Serve definition over network
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defBytes, err := def.MarshalJSON()
+			require.NoError(t, err)
+
+			_, err = w.Write(defBytes)
+			require.NoError(t, err)
+		}))
+		defer srv.Close()
+
+		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{DefFile: srv.URL, NumNodes: minNodes})
+		require.ErrorContains(t, err, expectedErrMsg)
+	})
+}
+
 // TestKeymanager tests keymanager support by letting create cluster command split a single secret and then receiving those keyshares using test
 // keymanager servers. These shares are then combined to create the combined share which is then compared to the original secret that was split.
 func TestKeymanager(t *testing.T) {


### PR DESCRIPTION
Handle multiple addresses error in `charon create cluster` command for remote definition.

category: bug
ticket: none
