### PR TITLE
cmd/createcluster: fix split keys bug for multiple validators

### DIFF
--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 func TestCreateCluster(t *testing.T) {
 	defPath := "../cluster/examples/cluster-definition-002.json"
-	def, err := loadDefinition(context.Background(), defPath)
+	def, _, err := loadDefinition(context.Background(), defPath, clusterConfig{})
 	require.NoError(t, err)
 
 	// Serve definition over network
@@ -68,7 +68,6 @@ func TestCreateCluster(t *testing.T) {
 			Config: clusterConfig{
 				NumNodes:  4,
 				Threshold: 3,
-				NumDVs:    2,
 				SplitKeys: true,
 			},
 			Prep: func(t *testing.T, config clusterConfig) clusterConfig {
@@ -117,10 +116,8 @@ func TestCreateCluster(t *testing.T) {
 				test.Config = test.Prep(t, test.Config)
 			}
 
-			for i := 0; i < test.Config.NumDVs; i++ {
-				test.Config.WithdrawalAddrs = append(test.Config.WithdrawalAddrs, defaultWithdrawalAddr)
-				test.Config.FeeRecipientAddrs = append(test.Config.FeeRecipientAddrs, defaultWithdrawalAddr)
-			}
+			test.Config.WithdrawalAddrs = []string{zeroAddress}
+			test.Config.FeeRecipientAddrs = []string{zeroAddress}
 
 			if test.Config.Network == "" {
 				test.Config.Network = defaultNetwork
@@ -207,10 +204,10 @@ func TestValidateDef(t *testing.T) {
 
 	for i := 0; i < conf.NumDVs; i++ {
 		conf.FeeRecipientAddrs = append(conf.FeeRecipientAddrs, testutil.RandomETHAddress())
-		conf.WithdrawalAddrs = append(conf.WithdrawalAddrs, defaultWithdrawalAddr)
+		conf.WithdrawalAddrs = append(conf.WithdrawalAddrs, zeroAddress)
 	}
 
-	definition, err := newDefFromConfig(ctx, conf)
+	definition, _, err := newDefFromConfig(ctx, conf)
 	require.NoError(t, err)
 
 	t.Run("zero address", func(t *testing.T) {
@@ -346,8 +343,8 @@ func TestKeymanager(t *testing.T) {
 		NumDVs:            1,
 		KeymanagerAddrs:   addrs,
 		Network:           defaultNetwork,
-		WithdrawalAddrs:   []string{defaultWithdrawalAddr},
-		FeeRecipientAddrs: []string{defaultWithdrawalAddr},
+		WithdrawalAddrs:   []string{zeroAddress},
+		FeeRecipientAddrs: []string{zeroAddress},
 		Clean:             true,
 	}
 	conf.ClusterDir = t.TempDir()
@@ -410,8 +407,8 @@ func TestPublish(t *testing.T) {
 		NumNodes:          minNodes,
 		NumDVs:            1,
 		Network:           defaultNetwork,
-		WithdrawalAddrs:   []string{defaultWithdrawalAddr},
-		FeeRecipientAddrs: []string{defaultWithdrawalAddr},
+		WithdrawalAddrs:   []string{zeroAddress},
+		FeeRecipientAddrs: []string{zeroAddress},
 		PublishAddr:       addr,
 		Publish:           true,
 	}

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -37,7 +37,7 @@ func TestMain(m *testing.M) {
 
 func TestCreateCluster(t *testing.T) {
 	defPath := "../cluster/examples/cluster-definition-002.json"
-	def, _, err := loadDefinition(context.Background(), defPath, clusterConfig{})
+	def, err := loadDefinition(context.Background(), defPath)
 	require.NoError(t, err)
 
 	// Serve definition over network
@@ -68,6 +68,7 @@ func TestCreateCluster(t *testing.T) {
 			Config: clusterConfig{
 				NumNodes:  4,
 				Threshold: 3,
+				NumDVs:    1, // Default
 				SplitKeys: true,
 			},
 			Prep: func(t *testing.T, config clusterConfig) clusterConfig {
@@ -207,7 +208,7 @@ func TestValidateDef(t *testing.T) {
 		conf.WithdrawalAddrs = append(conf.WithdrawalAddrs, zeroAddress)
 	}
 
-	definition, _, err := newDefFromConfig(ctx, conf)
+	definition, err := newDefFromConfig(ctx, conf)
 	require.NoError(t, err)
 
 	t.Run("zero address", func(t *testing.T) {

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -173,7 +173,7 @@ func validateWithdrawalAddrs(addrs []string, network string) error {
 		}
 
 		// We cannot allow a zero withdrawal address on mainnet or gnosis.
-		if isMainNetwork(network) && addr == defaultWithdrawalAddr {
+		if isMainNetwork(network) && addr == zeroAddress {
 			return errors.New("zero address forbidden on this network", z.Str("network", network))
 		}
 	}

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -18,8 +18,8 @@ func TestCreateDkgValid(t *testing.T) {
 		OutputDir:         temp,
 		NumValidators:     1,
 		Threshold:         3,
-		FeeRecipientAddrs: []string{defaultWithdrawalAddr},
-		WithdrawalAddrs:   []string{defaultWithdrawalAddr},
+		FeeRecipientAddrs: []string{zeroAddress},
+		WithdrawalAddrs:   []string{zeroAddress},
 		Network:           defaultNetwork,
 		DKGAlgo:           "default",
 		OperatorENRs: []string{


### PR DESCRIPTION
Fixes split keys bug when there are more than one validator keystore in split keys directory. This creates definition by reading numDVs cluster config struct rather than creating definition with NumValidators equal to the number of keystores in split keys directory which results in mismatch of NumValidators field in lock file with the number of distributed validators created.
Here's an example:
```json
{
 "cluster_definition": {
  "name": "testobol",
  "creator": {
   "address": "",
   "config_signature": ""
  },
  "operators": [
   {
    "address": "",
    "enr": "enr:-HW4QN-rWB5a12pbRZHOYa2d1sON6_Cg5rXZ_Ft3Tz6fFfNTU9XMZ7un8W6ZyNtuyBHm2v95YxBjvm--SfVgoNTjqJqAgmlkgnY0iXNlY3AyNTZrMaEDeu6WQMO1sw_-GD6J9y_n3fcI97EyJVCvdvMl4832zGs",
    "config_signature": "",
    "enr_signature": ""
   },
   {
    "address": "",
    "enr": "enr:-HW4QKpJiyLtXFbG6e8rgj21h8tAnLCxFnvTQAcWwWP-Pis_XA_d7In2loSvCODftDlovO2edAsk0QT8K7YEwVYk_LaAgmlkgnY0iXNlY3AyNTZrMaECYUXaVUavSrXw0Kf3-KOfAVf4DSjQR47bhYVTL8GsWkw",
    "config_signature": "",
    "enr_signature": ""
   },
   {
    "address": "",
    "enr": "enr:-HW4QM5AyPq-YqeZXLIaeN5t9z1bHRo_jO8GgitJ7wRevGLFD2RnBFrRCfrA2lUSii8ujtZLqrS1WtAqMk85f5_nOdCAgmlkgnY0iXNlY3AyNTZrMaEC1UMC-_bCYQckIvQgkzKA2i_9FnETn7FvR4yKKgz1Nz0",
    "config_signature": "",
    "enr_signature": ""
   },
   {
    "address": "",
    "enr": "enr:-HW4QDKJe5H-8rbp2rMbe9YeDza4WooG7tJAo4TOKojK8MUeBQKIiELNzqapNGGEJlO3RGKBHfAaT5tnxjbtMQhRGxOAgmlkgnY0iXNlY3AyNTZrMaECOPNOYgMMuIJ1DdsEIbskwA7uQzcZbS8_ncWrqtt3TOE",
    "config_signature": "",
    "enr_signature": ""
   },
   {
    "address": "",
    "enr": "enr:-HW4QJXkX-6ZhraHL5pnfg2zYXYDJkr1qRywCLMq-ggzOVlbI4OuvPU49uKwVzIdHg9wDFpafYhQNfahXv-SjiIJY4OAgmlkgnY0iXNlY3AyNTZrMaEDR6nhq7BDl_sutJ3S9O-G0mB-2uAVIyoSnc5tO1WlAN0",
    "config_signature": "",
    "enr_signature": ""
   },
   {
    "address": "",
    "enr": "enr:-HW4QDIaRWrsLg6tKtnPHKy-9wUIRaMg91e2xz1aBqLF3L5eLPwIVPDFvAIOgf_FdwmE2iVgH3Ipq7Ln8Bh8TR1KvzOAgmlkgnY0iXNlY3AyNTZrMaED_o6VDfDyfQrFSBnrXZ1__oMhT_MgXXVrhhYhc6DyKIc",
    "config_signature": "",
    "enr_signature": ""
   }
  ],
  "uuid": "C494F61C-E7C1-D247-2850-AA640AEB9940",
  "version": "v1.4.0",
  "timestamp": "2023-03-09T08:01:59Z",
  "num_validators": 1,
  "threshold": 5,
  "withdrawal_address": "F2a0fb000dA94bD1B4cb0624723F264a87375CD4",
  "dkg_algorithm": "default",
  "fork_version": "0x00001020",
  "config_hash": "0x791fb086fa8667f06fcd57bc18f3e401f64ebacac29376b3d7aa1f44fa8f2e61",
  "definition_hash": "0x5e182493dab7da5a8b0e940ce0d8cfd218ce196284fb33a9a7869970d8171b8e"
 },
 "distributed_validators": [
  {
   "distributed_public_key": "0xb0a72a09e648294f33271876a80f0d221bed33c72fc81713eabbfa7ed8ee497714f0ac615ffa8c71a7b88c052eeac7fc",
   "public_shares": [
    "0xb47661e9a88eb8dfefeb1e005ae90f5e147e9786529c1edccaf7532b91492d53815c54434ef37cb4e164224c8fc15da2",
    "0xb8c54045a14d39e8f9439b35c2158bcfe500e3c1ca83413b9dc2a680706c83753ae39567eed515bb3a9ea20d456a0cbe",
    "0xac032026ce5c0ff1997e316a916adaf981ba62b9f136dc53f9bb988f4bb610c49395bbeafae5fa0cf1228033c58ef99a",
    "0xa3167a6bb9b0d5754de61d5ede81628b5e32962a8300ad7f7032a72d5b93be413b119c2bcdbc2b0e1340db193ed09f31",
    "0x88e984b71847ae5bd072060d6adc90ca4688f4e8e5af9ad6e31959e620e4ed79714fed2be7f8c729757f98b63b1db760",
    "0xabe92a91561593b9e617c090f3cd6a081edbe5e34426d3da5be3ad0b2e35ef85ec986512f3768fdbfa5869d2a4aa1dcb"
   ]
  },
  {
   "distributed_public_key": "0xa9eddfc7f6aa02297b10868261adac18b7a83c454ed37d5bbf781017f1b00f3655b5b457a30485cf8ab4be327d064464",
   "public_shares": [
    "0xb46149dc0b018a7725bac2d673e6900f0e22ffca4de75d81d00da6cf6107fbe14204732b7bbe9665cb45046ab07e5918",
    "0x89610115f90700fadb009af73b96f7f47e7c2a585af9960b9184134715e68191d53c83b87e604a774569a1d226cc7813",
    "0x949181284aa85a4c13d2190dd08a952f70e9e5c90d96c75b8a33b508f418dd9bb73b7627fd8a49f5d40ee0f71dc5d54c",
    "0x904c1f7478ff84bddc2cc2e4c1f3f68c6ee163eed625e3bd15824f36f487011b6ba7f1a2d199b0387119ccda48367868",
    "0x901a0f01e44db9ca93d869f2b0a6852ac84dedfe07319432ba7c643708ee7e19197af8c94899a9e687ba31a704c671f1",
    "0xaa96341b3d1620717ca928837aa52bcd0127954ab3e6128545fbbe23a20d66237e15b1f533adeb081d1cccddb6b7e51c"
   ]
  }
 ],
 "signature_aggregate": "0xa3ad050916efea00dfa42262d71288233526ae95e9e50df984fa9cf99a5dbf5c095b74f2bcebff7e766d91e8d5ebb3cc0d1d81a3fcda65dbc973e43e0afc60d000e9b44647cdd6757af0f56199732084b177a9f48cc6e91d51af54f263994dc5",
 "lock_hash": "0xfd9a1872da10f0c59f301e8f505047c5ac43999dc2424a384819cbc0ccddb46d"
}
```
This bug is reported p2p team: https://discord.com/channels/849256203614945310/1084755971500429372/1084765737782095892

category: bug
ticket: none
