### PR TITLE
k1util: trim newline when decoding `charon-enr-private-key`

### DIFF
--- a/app/k1util/k1util.go
+++ b/app/k1util/k1util.go
@@ -6,6 +6,7 @@ package k1util
 import (
 	"encoding/hex"
 	"os"
+	"strings"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/decred/dcrd/dcrec/secp256k1/v4/ecdsa"
@@ -118,7 +119,7 @@ func Load(file string) (*k1.PrivateKey, error) {
 		return nil, errors.Wrap(err, "read private key from disk", z.Str("file", file))
 	}
 
-	b, err := hex.DecodeString(string(hexStr))
+	b, err := hex.DecodeString(strings.TrimSpace(string(hexStr)))
 	if err != nil {
 		return nil, errors.Wrap(err, "decode private key hex")
 	}

--- a/app/k1util/k1util_test.go
+++ b/app/k1util/k1util_test.go
@@ -113,34 +113,22 @@ func TestLoad(t *testing.T) {
 		require.ErrorContains(t, err, "decode private key hex")
 	})
 
-	t.Run("hex string with a newline", func(t *testing.T) {
-		hexStr := hex.EncodeToString(key.Serialize()) + "\n" // Hex string ending with '\n'
-		err = os.WriteFile(filePath, []byte(hexStr), 0o600)
-		require.NoError(t, err)
+	t.Run("valid hex strings", func(t *testing.T) {
+		hexStrs := []string{
+			hex.EncodeToString(key.Serialize()) + "\n",   // Hex string ending with '\n'
+			hex.EncodeToString(key.Serialize()) + "\r\n", // Hex string ending with '\r\n'
+			hex.EncodeToString(key.Serialize()) + " ",    // Hex string ending with a space
+			hex.EncodeToString(key.Serialize()),          // Hex string
+		}
 
-		pkey, err := k1util.Load(filePath)
-		require.NoError(t, err)
-		require.Equal(t, key, pkey)
-	})
+		for _, hexStr := range hexStrs {
+			err = os.WriteFile(filePath, []byte(hexStr), 0o600)
+			require.NoError(t, err)
 
-	t.Run("hex string with a carriage return and newline", func(t *testing.T) {
-		hexStr := hex.EncodeToString(key.Serialize()) + "\r\n" // Hex string ending with '\r\n'
-		err = os.WriteFile(filePath, []byte(hexStr), 0o600)
-		require.NoError(t, err)
-
-		pkey, err := k1util.Load(filePath)
-		require.NoError(t, err)
-		require.Equal(t, key, pkey)
-	})
-
-	t.Run("valid hex string", func(t *testing.T) {
-		hexStr := hex.EncodeToString(key.Serialize())
-		err = os.WriteFile(filePath, []byte(hexStr), 0o600)
-		require.NoError(t, err)
-
-		pkey, err := k1util.Load(filePath)
-		require.NoError(t, err)
-		require.Equal(t, key, pkey)
+			pkey, err := k1util.Load(filePath)
+			require.NoError(t, err)
+			require.Equal(t, key, pkey)
+		}
 	})
 }
 

--- a/app/k1util/k1util_test.go
+++ b/app/k1util/k1util_test.go
@@ -99,14 +99,14 @@ func TestLoad(t *testing.T) {
 	require.NoError(t, err)
 	filePath := path.Join(t.TempDir(), "charon-enr-private-key")
 
-	t.Run("noexistent file", func(t *testing.T) {
+	t.Run("nonexistent file", func(t *testing.T) {
 		_, err := k1util.Load("nonexistent-file")
 		require.ErrorContains(t, err, "read private key from disk")
 	})
 
 	t.Run("invalid hex encoded file", func(t *testing.T) {
-		hexStr := hex.EncodeToString(key.Serialize()) + "XYZ" // Invalid hex string
-		err = os.WriteFile(filePath, []byte(hexStr), 0o600)
+		invalidHexStr := "abcXYZ123" // Invalid hex string
+		err = os.WriteFile(filePath, []byte(invalidHexStr), 0o600)
 		require.NoError(t, err)
 
 		_, err := k1util.Load(filePath)

--- a/app/k1util/k1util_test.go
+++ b/app/k1util/k1util_test.go
@@ -123,6 +123,16 @@ func TestLoad(t *testing.T) {
 		require.Equal(t, key, pkey)
 	})
 
+	t.Run("hex string with a carriage return and newline", func(t *testing.T) {
+		hexStr := hex.EncodeToString(key.Serialize()) + "\r\n" // Hex string ending with '\r\n'
+		err = os.WriteFile(filePath, []byte(hexStr), 0o600)
+		require.NoError(t, err)
+
+		pkey, err := k1util.Load(filePath)
+		require.NoError(t, err)
+		require.Equal(t, key, pkey)
+	})
+
 	t.Run("valid hex string", func(t *testing.T) {
 		hexStr := hex.EncodeToString(key.Serialize())
 		err = os.WriteFile(filePath, []byte(hexStr), 0o600)


### PR DESCRIPTION
Trims newlines when decoding `charon-enr-private-key`.

category: bug
ticket: none 
