### PR TITLE
combine: explicit output directory, new output keystore directory format

### DIFF
--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -43,7 +43,7 @@ func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force boo
 }
 
 func bindCombineFlags(flags *pflag.FlagSet, clusterDir, outputDir *string, force *bool) {
-	flags.StringVar(clusterDir, "cluster-dir", ".charon/cluster", `Parent directory containing a number of .charon subdirectories from each node in the cluster.`)
+	flags.StringVar(clusterDir, "cluster-dir", ".charon/cluster", `Parent directory containing a number of .charon subdirectories from the required threshold of nodes in the cluster.`)
 	flags.StringVar(outputDir, "output-dir", "./validator_keys", "Directory to output the combined private keys to.")
 	flags.BoolVar(force, "force", false, "Overwrites private keys with the same name if present.")
 }

--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -44,6 +44,6 @@ func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force boo
 
 func bindCombineFlags(flags *pflag.FlagSet, clusterDir, outputDir *string, force *bool) {
 	flags.StringVar(clusterDir, "cluster-dir", ".charon/cluster", `Parent directory containing a number of .charon subdirectories from each node in the cluster.`)
-	flags.StringVar(outputDir, "output-dir", "./validator-keys", "Directory to output the combined private keys to.")
+	flags.StringVar(outputDir, "output-dir", "./validator_keys", "Directory to output the combined private keys to.")
 	flags.BoolVar(force, "force", false, "Overwrites private keys with the same name if present.")
 }

--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -11,9 +11,10 @@ import (
 	"github.com/obolnetwork/charon/combine"
 )
 
-func newCombineCmd(runFunc func(ctx context.Context, clusterDir string, force bool) error) *cobra.Command {
+func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir string, force bool) error) *cobra.Command {
 	var (
 		clusterDir string
+		outputDir  string
 		force      bool
 	)
 
@@ -23,24 +24,26 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir string, force bo
 		Long:  "Combines the private key shares from a threshold of operators in a distributed validator cluster into a set of validator private keys that can be imported into a standard Ethereum validator client.\n\nWarning: running the resulting private keys in a validator alongside the original distributed validator cluster *will* result in slashing.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runFunc(cmd.Context(), clusterDir, force)
+			return runFunc(cmd.Context(), clusterDir, outputDir, force)
 		},
 	}
 
 	bindCombineFlags(
 		cmd.Flags(),
 		&clusterDir,
+		&outputDir,
 		&force,
 	)
 
 	return cmd
 }
 
-func newCombineFunc(ctx context.Context, clusterDir string, force bool) error {
-	return combine.Combine(ctx, clusterDir, force)
+func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force bool) error {
+	return combine.Combine(ctx, clusterDir, outputDir, force)
 }
 
-func bindCombineFlags(flags *pflag.FlagSet, clusterDir *string, force *bool) {
-	flags.StringVar(clusterDir, "cluster-dir", ".charon/", `Parent directory containing a number of .charon subdirectories from each node in the cluster.`)
+func bindCombineFlags(flags *pflag.FlagSet, clusterDir, outputDir *string, force *bool) {
+	flags.StringVar(clusterDir, "cluster-dir", ".charon/cluster", `Parent directory containing a number of .charon subdirectories from each node in the cluster.`)
+	flags.StringVar(outputDir, "output-dir", "./validator-keys", "Directory to output the combined private keys to.")
 	flags.BoolVar(force, "force", false, "Overwrites private keys with the same name if present.")
 }

--- a/combine/combine.go
+++ b/combine/combine.go
@@ -26,11 +26,6 @@ import (
 //
 // Combine will create a new directory named after "outputDir", which will contain Keystore files.
 func Combine(ctx context.Context, inputDir, outputDir string, force bool) error {
-	log.Info(ctx, "Recombining key shares",
-		z.Str("input_dir", inputDir),
-		z.Str("output_dir", outputDir),
-	)
-
 	if !filepath.IsAbs(outputDir) {
 		fp, err := filepath.Abs(outputDir)
 		if err != nil {
@@ -48,6 +43,11 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool) error 
 
 		inputDir = fp
 	}
+
+	log.Info(ctx, "Recombining key shares",
+		z.Str("input_dir", inputDir),
+		z.Str("output_dir", outputDir),
+	)
 
 	lock, possibleKeyPaths, err := loadLockfile(inputDir)
 	if err != nil {

--- a/combine/combine_test.go
+++ b/combine/combine_test.go
@@ -25,7 +25,8 @@ func TestMain(m *testing.M) {
 
 func TestCombineNoLockfile(t *testing.T) {
 	td := t.TempDir()
-	err := combine.Combine(context.Background(), td, false)
+	od := t.TempDir()
+	err := combine.Combine(context.Background(), td, od, false)
 	require.ErrorContains(t, err, "lock file not found")
 }
 
@@ -43,6 +44,7 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	od := t.TempDir()
 
 	// flatten secrets, each validator slice is unpacked in a flat structure
 	var rawSecrets []tblsv2.PrivateKey
@@ -80,7 +82,7 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "node0")))
 
-	err := combine.Combine(context.Background(), dir, false)
+	err := combine.Combine(context.Background(), dir, od, false)
 	require.Error(t, err)
 }
 
@@ -117,6 +119,7 @@ func TestCombine(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	od := t.TempDir()
 
 	// flatten secrets, each validator slice is unpacked in a flat structure
 	var rawSecrets []tblsv2.PrivateKey
@@ -152,14 +155,26 @@ func TestCombine(t *testing.T) {
 		require.NoError(t, json.NewEncoder(lf).Encode(lock))
 	}
 
-	err := combine.Combine(context.Background(), dir, true)
+	err := combine.Combine(context.Background(), dir, od, true)
 	require.NoError(t, err)
 
-	for _, exp := range expectedData {
-		keys, err := keystore.LoadKeys(filepath.Join(dir, exp.pubkey, "validator_keys"))
+	keys, err := keystore.LoadKeys(od)
+	require.NoError(t, err)
+
+	keysMap := make(map[string]string)
+	for _, key := range keys {
+		pk, err := tblsv2.SecretToPublicKey(key)
 		require.NoError(t, err)
-		require.Equal(t, exp.secret, fmt.Sprintf("%#x", keys[0]))
+
+		keysMap[fmt.Sprintf("%#x", pk)] = fmt.Sprintf("%#x", key)
 	}
+
+	for _, exp := range expectedData {
+		require.Contains(t, keysMap, exp.pubkey)
+		require.Equal(t, exp.secret, keysMap[exp.pubkey])
+	}
+
+	require.Len(t, keysMap, len(expectedData))
 }
 
 func TestCombineTwiceWithoutForceFails(t *testing.T) {
@@ -195,6 +210,7 @@ func TestCombineTwiceWithoutForceFails(t *testing.T) {
 	}
 
 	dir := t.TempDir()
+	od := t.TempDir()
 
 	// flatten secrets, each validator slice is unpacked in a flat structure
 	var rawSecrets []tblsv2.PrivateKey
@@ -230,15 +246,27 @@ func TestCombineTwiceWithoutForceFails(t *testing.T) {
 		require.NoError(t, json.NewEncoder(lf).Encode(lock))
 	}
 
-	err := combine.Combine(context.Background(), dir, false)
+	err := combine.Combine(context.Background(), dir, od, false)
 	require.NoError(t, err)
 
-	err = combine.Combine(context.Background(), dir, false)
+	err = combine.Combine(context.Background(), dir, od, false)
 	require.Error(t, err)
 
-	for _, exp := range expectedData {
-		keys, err := keystore.LoadKeys(filepath.Join(dir, exp.pubkey, "validator_keys"))
+	keys, err := keystore.LoadKeys(od)
+	require.NoError(t, err)
+
+	keysMap := make(map[string]string)
+	for _, key := range keys {
+		pk, err := tblsv2.SecretToPublicKey(key)
 		require.NoError(t, err)
-		require.Equal(t, exp.secret, fmt.Sprintf("%#x", keys[0]))
+
+		keysMap[fmt.Sprintf("%#x", pk)] = fmt.Sprintf("%#x", key)
 	}
+
+	for _, exp := range expectedData {
+		require.Contains(t, keysMap, exp.pubkey)
+		require.Equal(t, exp.secret, keysMap[exp.pubkey])
+	}
+
+	require.Len(t, keysMap, len(expectedData))
 }


### PR DESCRIPTION
This PR changes the `combine` command as follows:

- handle relative input paths properly
- make output path explicit with sane defaults
- combine keys in a single directory rather than one directory for each validator

category: refactor
ticket: #1836

Closes #1836.
