### PR TITLE
dockerfile: fix container healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
 
 # Copy final binary into light stage.
 FROM debian:bullseye-slim
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates wget
 ARG GITHUB_SHA=local
 ENV GITHUB_SHA=${GITHUB_SHA}
 COPY --from=builder /app/charon/charon /usr/local/bin/


### PR DESCRIPTION
Wget is needed for the container healthcheck as defined here: https://github.com/ObolNetwork/charon-distributed-validator-node/blob/main/docker-compose.yml  

Moved to slim base in commit 8c1dcc6bfa2e4ba1f2db9b54dfaf8a953a43defa but slim image does not include wget anymore, needs to be added.

category: bug
ticket: #1879 