### PR TITLE
precommit: only check major go version locally

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v0.0.2
     hooks:
       - id: check-go-version
-        args: [ -v=go1.20 ]
+        args: [ -v=go1.20 ] # Only check minor version locally
         pass_filenames: false
         additional_dependencies: [ packaging ]
       - id: check-licence-header

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v0.0.2
     hooks:
       - id: check-go-version
-        args: [ -v=go1.20.2 ]
+        args: [ -v=go1.20 ]
         pass_filenames: false
         additional_dependencies: [ packaging ]
       - id: check-licence-header


### PR DESCRIPTION
Only check minor go-version for pre-commit hooks. Few reasons:
 - Homebrew is slow to support latest versions, so it is pain to upgrade.
 - Local dev patch versions doesn't matter, only local dev minor versions actually matter.
 - Most important is what version we use to build the docker images, that isn't done locally.  

category: misc
ticket: none