### PR TITLE
p2p: always ensure relay connection

### DIFF
--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -52,7 +52,8 @@ func NewRelayReserver(tcpNode host.Host, relay *MutablePeer) lifecycle.HookFunc 
 			// Note a single long-lived reservation (created by server-side) is mapped to
 			// many short-lived limited client-side connections.
 			// When the reservation expires, the server needs to re-reserve.
-			// When the connection expires (stream reset error), then client needs to reconnect.
+			// When the server isn't connected to the relay anymore, it needs to reconnect/re-reserve.
+			// When the client connection expires (stream reset error), then client needs to reconnect.
 
 			refreshDelay := time.Until(resv.Expiration.Add(-2 * time.Minute))
 


### PR DESCRIPTION
Always ensure active connections to relay. This is required since peers can only connect to you via a relay if you are connected to the relay. This reverts the change introduced in #1816. It also mitigates increase in DKG failures and general "not connected to peer" issues.

category: bug
ticket: #1898 
