### PR TITLE
cmd/relay: disable resource manager

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -270,11 +270,6 @@ func wirePeerInfo(life *lifecycle.Manager, tcpNode host.Host, peers []peer.ID, l
 func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	lock cluster.Lock, p2pKey *k1.PrivateKey, lockHashHex string,
 ) (host.Host, error) {
-	peers, err := lock.Peers()
-	if err != nil {
-		return nil, err
-	}
-
 	peerIDs, err := lock.PeerIDs()
 	if err != nil {
 		return nil, err
@@ -310,7 +305,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PPing, p2p.NewPingService(tcpNode, peerIDs, conf.TestConfig.TestPingConfig))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PEventCollector, p2p.NewEventCollector(tcpNode))
-	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewRelayRouter(tcpNode, peers, relays))
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewRelayRouter(tcpNode, peerIDs, relays))
 
 	return tcpNode, nil
 }

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -14,7 +14,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
-	rcmgr "github.com/libp2p/go-libp2p/p2p/host/resource-manager"
 	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
 	ma "github.com/multiformats/go-multiaddr"
 
@@ -40,22 +39,8 @@ func startP2P(ctx context.Context, config Config, key *k1.PrivateKey, reporter m
 		}
 	}
 
-	// Increase resource limits
-	limiter := rcmgr.DefaultLimits
-	limiter.SystemBaseLimit.ConnsInbound = config.MaxConns
-	limiter.SystemBaseLimit.Conns = config.MaxConns
-	limiter.SystemBaseLimit.StreamsInbound = config.MaxConns
-	limiter.SystemBaseLimit.StreamsOutbound = config.MaxConns
-	limiter.SystemBaseLimit.FD = config.MaxConns
-	limiter.TransientBaseLimit = limiter.SystemBaseLimit
-
-	mgr, err := rcmgr.NewResourceManager(rcmgr.NewFixedLimiter(limiter.Scale(1<<30, config.MaxConns))) // 1GB Memory
-	if err != nil {
-		return nil, errors.Wrap(err, "new resource manager")
-	}
-
 	tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(),
-		libp2p.ResourceManager(mgr), libp2p.BandwidthReporter(reporter))
+		libp2p.ResourceManager(&network.NullResourceManager{}), libp2p.BandwidthReporter(reporter))
 	if err != nil {
 		return nil, errors.Wrap(err, "new tcp node")
 	}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -261,7 +261,7 @@ func setupP2P(ctx context.Context, key *k1.PrivateKey, p2pConf p2p.Config, peers
 		}(relay)
 	}
 
-	go p2p.NewRelayRouter(tcpNode, peers, relays)(ctx)
+	go p2p.NewRelayRouter(tcpNode, peerIDs, relays)(ctx)
 
 	return tcpNode, func() {
 		_ = tcpNode.Close()

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -121,9 +121,9 @@ func externalMultiAddrs(cfg Config) ([]ma.Multiaddr, error) {
 	return resp, nil
 }
 
-// MultiAddrsViaRelay returns multiaddrs to the peer via the relay.
+// multiAddrsViaRelay returns multiaddrs to the peer via the relay.
 // See https://github.com/libp2p/go-libp2p/blob/master/examples/relay/main.go.
-func MultiAddrsViaRelay(relayPeer Peer, peerID peer.ID) ([]ma.Multiaddr, error) {
+func multiAddrsViaRelay(relayPeer Peer, peerID peer.ID) ([]ma.Multiaddr, error) {
 	var resp []ma.Multiaddr
 	for _, addr := range relayPeer.Addrs {
 		transportAddr, _ := peer.SplitAddr(addr)

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -121,9 +121,9 @@ func externalMultiAddrs(cfg Config) ([]ma.Multiaddr, error) {
 	return resp, nil
 }
 
-// multiAddrsViaRelay returns multiaddrs to the peer via the relay.
+// MultiAddrsViaRelay returns multiaddrs to the peer via the relay.
 // See https://github.com/libp2p/go-libp2p/blob/master/examples/relay/main.go.
-func multiAddrsViaRelay(relayPeer Peer, peerID peer.ID) ([]ma.Multiaddr, error) {
+func MultiAddrsViaRelay(relayPeer Peer, peerID peer.ID) ([]ma.Multiaddr, error) {
 	var resp []ma.Multiaddr
 	for _, addr := range relayPeer.Addrs {
 		transportAddr, _ := peer.SplitAddr(addr)

--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -120,7 +120,7 @@ func NewRelayRouter(tcpNode host.Host, peers []peer.ID, relays []*MutablePeer) l
 						continue
 					}
 
-					relayAddrs, err := MultiAddrsViaRelay(relay, pID)
+					relayAddrs, err := multiAddrsViaRelay(relay, pID)
 					if err != nil {
 						log.Error(ctx, "Failed discovering peer address", err)
 						continue


### PR DESCRIPTION
Disables the relay's libp2p resource manager so it uses all available resources. Note that the circuitv2 relay resources still apply.

category: feature
ticket: none

