### PR TITLE
dkg: add content type to lock file post

### DIFF
--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -60,6 +60,7 @@ func httpPost(ctx context.Context, url *url.URL, b []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "new POST request with ctx")
 	}
+	req.Header.Add("Content-Type", `application/json`)
 
 	res, err := new(http.Client).Do(req)
 	if err != nil {

--- a/app/obolapi/api_test.go
+++ b/app/obolapi/api_test.go
@@ -23,6 +23,7 @@ func TestLockPublish(t *testing.T) {
 	t.Run("2xx response", func(t *testing.T) {
 		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, r.URL.Path, "/lock")
+			require.Equal(t, r.Header.Get("Content-Type"), "application/json")
 
 			data, err := io.ReadAll(r.Body)
 			require.NoError(t, err)


### PR DESCRIPTION
Adds content type header to api post so that it can be understood.

category: bug
ticket: #1906
