### PR TITLE
dkg: fixes publish arg and signature_aggregate creation

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -243,6 +243,11 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		return err
 	}
 
+	lock.SignatureAggregate, err = aggSign(shareSets, lock.LockHash)
+	if err != nil {
+		return err
+	}
+
 	// Write cluster-lock file
 	if conf.Publish {
 		if err = writeLockToAPI(ctx, conf.PublishAddr, lock); err != nil {
@@ -250,7 +255,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		}
 	}
 
-	if err = writeLock(lock, conf.ClusterDir, numNodes, shareSets); err != nil {
+	if err = writeLock(lock, conf.ClusterDir, numNodes); err != nil {
 		return err
 	}
 
@@ -403,13 +408,7 @@ func writeDepositData(depositDatas []eth2p0.DepositData, network string, cluster
 }
 
 // writeLock creates a cluster lock and writes it to disk for all peers.
-func writeLock(lock cluster.Lock, clusterDir string, numNodes int, shareSets [][]tblsv2.PrivateKey) error {
-	var err error
-	lock.SignatureAggregate, err = aggSign(shareSets, lock.LockHash)
-	if err != nil {
-		return err
-	}
-
+func writeLock(lock cluster.Lock, clusterDir string, numNodes int) error {
 	b, err := json.MarshalIndent(lock, "", " ")
 	if err != nil {
 		return errors.Wrap(err, "marshal cluster lock")

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -41,7 +41,7 @@ this command at the same time.`,
 	bindNoVerifyFlag(cmd.Flags(), &config.NoVerify)
 	bindP2PFlags(cmd, &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
-	bindPublishFlags(cmd.Flags(), config)
+	bindPublishFlags(cmd.Flags(), &config)
 
 	return cmd
 }
@@ -58,7 +58,7 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 	flags.StringVar(dataDir, "data-dir", ".charon", "The directory where charon will store all its internal data")
 }
 
-func bindPublishFlags(flags *pflag.FlagSet, config dkg.Config) {
+func bindPublishFlags(flags *pflag.FlagSet, config *dkg.Config) {
 	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech", "The URL to publish the lock file to.")
 	flags.BoolVar(&config.Publish, "publish", false, "Publish lock file to obol-api.")
 }


### PR DESCRIPTION
There were two bugs:
 - Config flags were not getting set for publish in dkg because it was not getting passed a reference
 - Signature_aggregate was only written at the `writeLock` step of createcluster so was not present when saved to api

category: bug
ticket: #1906
