### PR TITLE
core/validatorapi: add an error log to debug lodestar integration

### DIFF
--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -249,10 +249,8 @@ func (c Component) SubmitAttestations(ctx context.Context, attestations []*eth2p
 
 		pubkey, err := c.pubKeyByAttFunc(ctx, slot, int64(att.Data.Index), int64(indices[0]))
 		if err != nil {
-			log.Error(ctx, "Failed to find pubkey for the given attestation", err, z.I64("slot", slot),
+			return errors.Wrap(err, "failed to find pubkey", z.I64("slot", slot),
 				z.Int("commIdx", int(att.Data.Index)), z.Int("valCommIdx", indices[0]))
-
-			return err
 		}
 
 		parSigData := core.NewPartialAttestation(att, c.shareIdx)

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -249,6 +249,9 @@ func (c Component) SubmitAttestations(ctx context.Context, attestations []*eth2p
 
 		pubkey, err := c.pubKeyByAttFunc(ctx, slot, int64(att.Data.Index), int64(indices[0]))
 		if err != nil {
+			log.Error(ctx, "Failed to find pubkey for the given attestation", err, z.I64("slot", slot),
+				z.Int("commIdx", int(att.Data.Index)), z.Int("valCommIdx", indices[0]))
+
 			return err
 		}
 

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -131,8 +131,6 @@ func writeKeysToDisk(datadir string, shares []share) error {
 }
 
 // writeLock writes the lock file to disk.
-//
-
 func writeLock(datadir string, lock cluster.Lock) error {
 	b, err := json.MarshalIndent(lock, "", " ")
 	if err != nil {


### PR DESCRIPTION
Adds an error log to debug `pubkey not found` error.

category: misc
ticket: none