### PR TITLE
p2p: only advertise public relay addresses 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -284,7 +284,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	// Start libp2p TCP node.
-	tcpNode, err := p2p.NewTCPNode(ctx, conf.P2P, p2pKey, connGater, conf.TestConfig.LibP2POpts...)
+	tcpNode, err := p2p.NewTCPNode(ctx, conf.P2P, p2pKey, connGater, false, conf.TestConfig.LibP2POpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -7,7 +7,6 @@ import (
 
 	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/cmd/relay"
@@ -34,7 +33,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 	}
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
-	bindRelayFlag(cmd.Flags(), &config)
+	bindRelayFlag(cmd, &config)
 	bindP2PFlags(cmd, &config.P2PConfig)
 	bindLogFlags(cmd.Flags(), &config.LogConfig)
 	bindLokiFlags(cmd.Flags(), &config.LogConfig)
@@ -42,13 +41,25 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 	return cmd
 }
 
-func bindRelayFlag(flags *pflag.FlagSet, config *relay.Config) {
-	flags.StringVar(&config.HTTPAddr, "http-address", "127.0.0.1:3640", "Listening address (ip and port) for the relay http server serving runtime ENR.")
-	flags.StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the prometheus and pprof monitoring http server.")
-	flags.BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (secp256k1 private key used for p2p authentication and ENR) if none found in data directory.")
-	flags.StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error.")
+func bindRelayFlag(cmd *cobra.Command, config *relay.Config) {
+	cmd.Flags().StringVar(&config.HTTPAddr, "http-address", "127.0.0.1:3640", "Listening address (ip and port) for the relay http server serving runtime ENR.")
+	cmd.Flags().StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the prometheus and pprof monitoring http server.")
+	cmd.Flags().BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (secp256k1 private key used for p2p authentication and ENR) if none found in data directory.")
+	cmd.Flags().StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error.")
 
 	// Decrease defaults after this has been addressed https://github.com/libp2p/go-libp2p/issues/1713
-	flags.IntVar(&config.MaxResPerPeer, "p2p-max-reservations", 512, "Updates max circuit reservations per peer (each valid for 30min)")
-	flags.IntVar(&config.MaxConns, "p2p-max-connections", 16384, "Libp2p maximum number of peers that can connect to this relay.")
+	cmd.Flags().IntVar(&config.MaxResPerPeer, "p2p-max-reservations", 512, "Updates max circuit reservations per peer (each valid for 30min)")
+	cmd.Flags().IntVar(&config.MaxConns, "p2p-max-connections", 16384, "Libp2p maximum number of peers that can connect to this relay.")
+
+	var advertisePriv bool
+	cmd.Flags().BoolVar(&advertisePriv, "p2p-advertise-private-addresses", false, "Enable advertising of libp2p auto-detected private addresses. This doesn't affect manually provided p2p-external-ip/hostname.")
+
+	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
+		// Invert p2p-advertise-private-addresses flag boolean:
+		// -- Do not ADVERTISE private addresses by default in the binary.
+		// -- Do not FILTER private addresses in unit tests.
+		config.FilterPrivAddrs = !advertisePriv
+
+		return nil
+	})
 }

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -39,7 +39,7 @@ func startP2P(ctx context.Context, config Config, key *k1.PrivateKey, reporter m
 		}
 	}
 
-	tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(),
+	tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(), config.FilterPrivAddrs,
 		libp2p.ResourceManager(&network.NullResourceManager{}), libp2p.BandwidthReporter(reporter))
 	if err != nil {
 		return nil, errors.Wrap(err, "new tcp node")

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -31,15 +31,16 @@ import (
 
 // Config defines the config of the relay.
 type Config struct {
-	DataDir        string
-	HTTPAddr       string
-	MonitoringAddr string
-	P2PConfig      p2p.Config
-	LogConfig      log.Config
-	AutoP2PKey     bool
-	MaxResPerPeer  int
-	MaxConns       int
-	RelayLogLevel  string // TODO(corver): Rename to LibP2PLogLevel.
+	DataDir         string
+	HTTPAddr        string
+	MonitoringAddr  string
+	P2PConfig       p2p.Config
+	LogConfig       log.Config
+	AutoP2PKey      bool
+	MaxResPerPeer   int
+	MaxConns        int
+	FilterPrivAddrs bool
+	RelayLogLevel   string // TODO(corver): Rename to LibP2PLogLevel.
 }
 
 // Run starts an Obol libp2p-tcp-relay and udp-discv5 bootnode.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -107,7 +107,7 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 		for _, relay := range config.Relays {
 			u, err := url.Parse(relay)
 			if err != nil {
-				return errors.Wrap(err, "parse relay address", z.Str("relay", relay))
+				return errors.Wrap(err, "parse relay address", z.Str("address", relay))
 			}
 
 			if u.Scheme == "http" {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -245,7 +245,7 @@ func setupP2P(ctx context.Context, key *k1.PrivateKey, p2pConf p2p.Config, peers
 		return nil, nil, err
 	}
 
-	tcpNode, err := p2p.NewTCPNode(ctx, p2pConf, key, connGater)
+	tcpNode, err := p2p.NewTCPNode(ctx, p2pConf, key, connGater, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/p2p/p2p_internal_test.go
+++ b/p2p/p2p_internal_test.go
@@ -1,0 +1,82 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package p2p
+
+import (
+	"testing"
+
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterAdvertisedAddrs(t *testing.T) {
+	priv1 := "/ip4/192.168.1.1/tcp/80"
+	priv2 := "/ip4/127.0.0.1/udp/123"
+	pub1 := "/ip4/1.1.1.1/tcp/80"
+
+	tests := []struct {
+		name           string
+		internal       []string
+		external       []string
+		excludePrivate bool
+		result         []string
+	}{
+		{
+			name: "empty",
+		},
+		{
+			name:           "drop one private",
+			internal:       []string{pub1, priv1},
+			excludePrivate: true,
+			result:         []string{pub1},
+		},
+		{
+			name:           "keep one private",
+			internal:       []string{pub1, priv1},
+			excludePrivate: false,
+			result:         []string{pub1, priv1},
+		},
+		{
+			name:           "duplicate public",
+			internal:       []string{pub1, priv1},
+			external:       []string{priv1, pub1},
+			excludePrivate: true,
+			result:         []string{priv1, pub1},
+		},
+		{
+			name:           "duplicate private",
+			internal:       []string{priv1, priv2},
+			external:       []string{priv2, priv1},
+			excludePrivate: false,
+			result:         []string{priv2, priv1},
+		},
+		{
+			name:           "drop all private",
+			internal:       []string{priv1, priv2},
+			excludePrivate: true,
+			result:         nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cast := func(addrs []string) []ma.Multiaddr {
+				var resp []ma.Multiaddr
+				for _, addr := range addrs {
+					maddr, err := ma.NewMultiaddr(addr)
+					require.NoError(t, err)
+
+					resp = append(resp, maddr)
+				}
+
+				return resp
+			}
+
+			res := filterAdvertisedAddrs(cast(test.external), cast(test.internal), test.excludePrivate)
+			var resStr []string
+			for _, mAddr := range res {
+				resStr = append(resStr, mAddr.String())
+			}
+			require.EqualValues(t, test.result, resStr)
+		})
+	}
+}

--- a/p2p/peer_test.go
+++ b/p2p/peer_test.go
@@ -38,7 +38,7 @@ func TestNewHost(t *testing.T) {
 	privKey, err := k1.GeneratePrivateKey()
 	require.NoError(t, err)
 
-	_, err = p2p.NewTCPNode(context.Background(), p2p.Config{}, privKey, p2p.NewOpenGater())
+	_, err = p2p.NewTCPNode(context.Background(), p2p.Config{}, privKey, p2p.NewOpenGater(), false)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Adds a `--p2p-advertise-private-addresses` (default false) flag that doesn't advertise auto-detected private addresses by default. This removes noise introduced by charon nodes failing to dial these private addresses which never succeed.

category: bug
ticket: #1898 
