### PR TITLE
testutil/beaconmock: initial PoC for beacon fuzz

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -79,7 +79,7 @@ type Config struct {
 	SimnetSlotDuration      time.Duration
 	SyntheticBlockProposals bool
 	BuilderAPI              bool
-	SimnetBeaconmockFuzz    bool
+	SimnetBMockFuzz         bool
 
 	TestConfig TestConfig
 }
@@ -626,7 +626,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		conf.SimnetSlotDuration = time.Second
 	}
 
-	if conf.SimnetBeaconmockFuzz {
+	if conf.SimnetBMockFuzz {
 		log.Info(ctx, "Beaconmock fuzz configured!")
 		bmock, err := beaconmock.New(beaconmock.WithBeaconMockFuzzer())
 		if err != nil {

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -38,7 +38,6 @@ type Client interface {
 	eth2client.BlindedBeaconBlockSubmitter
 	eth2client.DepositContractProvider
 	eth2client.DomainProvider
-	eth2client.EventsProvider
 	eth2client.ForkProvider
 	eth2client.ForkScheduleProvider
 	eth2client.GenesisProvider
@@ -491,26 +490,6 @@ func (m multi) SubmitValidatorRegistrations(ctx context.Context, registrations [
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
 			return cl.SubmitValidatorRegistrations(ctx, registrations)
-		},
-		m.bestIdx,
-	)
-
-	if err != nil {
-		incError(label)
-		err = wrapError(ctx, err, label)
-	}
-
-	return err
-}
-
-// Events feeds requested events with the given topics to the supplied handler.
-func (m multi) Events(ctx context.Context, topics []string, handler eth2client.EventHandlerFunc) error {
-	const label = "events"
-	defer latency(label)()
-
-	err := submit(ctx, m.clients,
-		func(ctx context.Context, cl Client) error {
-			return cl.Events(ctx, topics, handler)
 		},
 		m.bestIdx,
 	)
@@ -1014,16 +993,6 @@ func (l *lazy) SubmitValidatorRegistrations(ctx context.Context, registrations [
 	}
 
 	return cl.SubmitValidatorRegistrations(ctx, registrations)
-}
-
-// Events feeds requested events with the given topics to the supplied handler.
-func (l *lazy) Events(ctx context.Context, topics []string, handler eth2client.EventHandlerFunc) (err error) {
-	cl, err := l.getClient()
-	if err != nil {
-		return err
-	}
-
-	return cl.Events(ctx, topics, handler)
 }
 
 // Fork fetches fork information for the given state.

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -104,7 +104,6 @@ type Client interface {
 		"BlindedBeaconBlockSubmitter":           true,
 		"DepositContractProvider":               false,
 		"DomainProvider":                        false,
-		"EventsProvider":                        true,
 		"ForkProvider":                          true,
 		"ForkScheduleProvider":                  true,
 		"GenesisProvider":                       false,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,6 +74,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().BoolVar(&config.BuilderAPI, "builder-api", false, "Enables the builder api. Will only produce builder blocks. Builder API must also be enabled on the validator client. Beacon node must be connected to a builder-relay to access the builder network.")
 	cmd.Flags().BoolVar(&config.SyntheticBlockProposals, "synthetic-block-proposals", false, "Enables additional synthetic block proposal duties. Used for testing of rare duties.")
 	cmd.Flags().DurationVar(&config.SimnetSlotDuration, "simnet-slot-duration", time.Second, "Configures slot duration in simnet beacon mock.")
+	cmd.Flags().BoolVar(&config.SimnetBeaconmockFuzz, "simnet-beaconmock-fuzz", false, "Configures simnet beaconmock to return fuzzed responses.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -74,7 +74,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().BoolVar(&config.BuilderAPI, "builder-api", false, "Enables the builder api. Will only produce builder blocks. Builder API must also be enabled on the validator client. Beacon node must be connected to a builder-relay to access the builder network.")
 	cmd.Flags().BoolVar(&config.SyntheticBlockProposals, "synthetic-block-proposals", false, "Enables additional synthetic block proposal duties. Used for testing of rare duties.")
 	cmd.Flags().DurationVar(&config.SimnetSlotDuration, "simnet-slot-duration", time.Second, "Configures slot duration in simnet beacon mock.")
-	cmd.Flags().BoolVar(&config.SimnetBeaconmockFuzz, "simnet-beaconmock-fuzz", false, "Configures simnet beaconmock to return fuzzed responses.")
+	cmd.Flags().BoolVar(&config.SimnetBMockFuzz, "simnet-beacon-mock-fuzz", false, "Configures simnet beaconmock to return fuzzed responses.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ Flags:
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
-      --simnet-beaconmock-fuzz             Configures simnet beaconmock to return fuzzed responses.
+      --simnet-beacon-mock-fuzz            Configures simnet beaconmock to return fuzzed responses.
       --simnet-slot-duration duration      Configures slot duration in simnet beacon mock. (default 1s)
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")
       --simnet-validator-mock              Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,6 +144,7 @@ Flags:
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
+      --simnet-beaconmock-fuzz             Configures simnet beaconmock to return fuzzed responses.
       --simnet-slot-duration duration      Configures slot duration in simnet beacon mock. (default 1s)
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")
       --simnet-validator-mock              Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0
 	github.com/ferranbt/fastssz v0.1.3
 	github.com/golang/snappy v0.0.4
+	github.com/google/gofuzz v1.2.0
 	github.com/gorilla/mux v1.8.0
 	github.com/herumi/bls-eth-go-binary v1.29.1
 	github.com/ipfs/go-log/v2 v2.5.1

--- a/go.sum
+++ b/go.sum
@@ -271,6 +271,8 @@ github.com/google/go-containerregistry v0.13.0/go.mod h1:J9FQ+eSS4a1aC2GNZxvNpbW
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
+github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gopacket v1.1.17/go.mod h1:UdDNZ1OO62aGYVnPhxT1U6aI7ukYtA/kB8vaU0diBUM=
 github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF8=
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -29,7 +29,6 @@ import (
 	"net/http"
 	"time"
 
-	eth2client "github.com/attestantio/go-eth2-client"
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
@@ -123,9 +122,7 @@ type Mock struct {
 	BlockAttestationsFunc                  func(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error)
 	NodePeerCountFunc                      func(ctx context.Context) (int, error)
 	BlindedBeaconBlockProposalFunc         func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2api.VersionedBlindedBeaconBlock, error)
-	BeaconCommitteesFunc                   func(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error)
 	BeaconBlockProposalFunc                func(ctx context.Context, slot eth2p0.Slot, randaoReveal eth2p0.BLSSignature, graffiti []byte) (*eth2spec.VersionedBeaconBlock, error)
-	BeaconBlockRootFunc                    func(ctx context.Context, blockID string) (*eth2p0.Root, error)
 	SignedBeaconBlockFunc                  func(ctx context.Context, blockID string) (*eth2spec.VersionedSignedBeaconBlock, error)
 	ProposerDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error)
 	SubmitAttestationsFunc                 func(context.Context, []*eth2p0.Attestation) error
@@ -136,7 +133,6 @@ type Mock struct {
 	ValidatorsFunc                         func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
 	GenesisTimeFunc                        func(context.Context) (time.Time, error)
 	NodeSyncingFunc                        func(context.Context) (*eth2v1.SyncState, error)
-	EventsFunc                             func(context.Context, []string, eth2client.EventHandlerFunc) error
 	SubmitValidatorRegistrationsFunc       func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error
 	SlotsPerEpochFunc                      func(context.Context) (uint64, error)
 	AggregateBeaconCommitteeSelectionsFunc func(context.Context, []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error)
@@ -189,14 +185,6 @@ func (m Mock) BeaconBlockProposal(ctx context.Context, slot eth2p0.Slot, randaoR
 	return m.BeaconBlockProposalFunc(ctx, slot, randaoReveal, graffiti)
 }
 
-func (m Mock) BeaconBlockRoot(ctx context.Context, blockID string) (*eth2p0.Root, error) {
-	return m.BeaconBlockRootFunc(ctx, blockID)
-}
-
-func (m Mock) BeaconCommittees(ctx context.Context, stateID string) ([]*eth2v1.BeaconCommittee, error) {
-	return m.BeaconCommitteesFunc(ctx, stateID)
-}
-
 func (m Mock) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, validatorIndices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
 	return m.ProposerDutiesFunc(ctx, epoch, validatorIndices)
 }
@@ -219,10 +207,6 @@ func (m Mock) GenesisTime(ctx context.Context) (time.Time, error) {
 
 func (m Mock) NodeSyncing(ctx context.Context) (*eth2v1.SyncState, error) {
 	return m.NodeSyncingFunc(ctx)
-}
-
-func (m Mock) Events(ctx context.Context, topics []string, handler eth2client.EventHandlerFunc) error {
-	return m.EventsFunc(ctx, topics, handler)
 }
 
 func (m Mock) SubmitValidatorRegistrations(ctx context.Context, registrations []*eth2api.VersionedSignedValidatorRegistration) error {

--- a/testutil/beaconmock/beaconmock_fuzz.go
+++ b/testutil/beaconmock/beaconmock_fuzz.go
@@ -1,0 +1,110 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package beaconmock
+
+import (
+	"context"
+
+	eth2api "github.com/attestantio/go-eth2-client/api"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	fuzz "github.com/google/gofuzz"
+)
+
+// WithBeaconMockFuzzer configures the beaconmock to return random responses for the all the functions consumed by charon.
+func WithBeaconMockFuzzer() Option {
+	return func(mock *Mock) {
+		mock.AttesterDutiesFunc = func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
+			var duties []*eth2v1.AttesterDuty
+			fuzz.New().Fuzz(&duties)
+
+			return duties, nil
+		}
+
+		mock.ProposerDutiesFunc = func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+			var duties []*eth2v1.ProposerDuty
+			fuzz.New().Fuzz(&duties)
+
+			return duties, nil
+		}
+
+		mock.AttestationDataFunc = func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error) {
+			var attData *eth2p0.AttestationData
+			fuzz.New().Fuzz(&attData)
+
+			return attData, nil
+		}
+
+		mock.BeaconBlockProposalFunc = func(context.Context, eth2p0.Slot, eth2p0.BLSSignature, []byte) (*eth2spec.VersionedBeaconBlock, error) {
+			var block *eth2spec.VersionedBeaconBlock
+			fuzz.New().Fuzz(&block)
+
+			return block, nil
+		}
+
+		mock.AggregateAttestationFunc = func(ctx context.Context, slot eth2p0.Slot, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error) {
+			var att *eth2p0.Attestation
+			fuzz.New().Fuzz(&att)
+
+			return att, nil
+		}
+
+		mock.ValidatorsFunc = func(context.Context, string, []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+			var vals map[eth2p0.ValidatorIndex]*eth2v1.Validator
+			fuzz.New().Fuzz(&vals)
+
+			return vals, nil
+		}
+
+		mock.BlindedBeaconBlockProposalFunc = func(context.Context, eth2p0.Slot, eth2p0.BLSSignature, []byte) (*eth2api.VersionedBlindedBeaconBlock, error) {
+			var block *eth2api.VersionedBlindedBeaconBlock
+			fuzz.New().Fuzz(&block)
+
+			return block, nil
+		}
+
+		mock.NodePeerCountFunc = func(context.Context) (int, error) {
+			var count int
+			fuzz.New().Fuzz(&count)
+
+			return count, nil
+		}
+
+		mock.ValidatorsByPubKeyFunc = func(_ context.Context, _ string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+			var vals map[eth2p0.ValidatorIndex]*eth2v1.Validator
+			fuzz.New().Fuzz(&vals)
+
+			return vals, nil
+		}
+
+		mock.SlotsPerEpochFunc = func(context.Context) (uint64, error) {
+			var slots uint64
+			fuzz.New().Fuzz(&slots)
+
+			return slots, nil
+		}
+
+		mock.SyncCommitteeDutiesFunc = func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
+			var duties []*eth2v1.SyncCommitteeDuty
+			fuzz.New().Fuzz(&duties)
+
+			return duties, nil
+		}
+
+		mock.SyncCommitteeContributionFunc = func(context.Context, eth2p0.Slot, uint64, eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
+			var contribution *altair.SyncCommitteeContribution
+			fuzz.New().Fuzz(&contribution)
+
+			return contribution, nil
+		}
+
+		mock.BlockAttestationsFunc = func(context.Context, string) ([]*eth2p0.Attestation, error) {
+			var atts []*eth2p0.Attestation
+			fuzz.New().Fuzz(&atts)
+
+			return atts, nil
+		}
+	}
+}

--- a/testutil/beaconmock/headproducer.go
+++ b/testutil/beaconmock/headproducer.go
@@ -231,6 +231,12 @@ func (p *headProducer) handleEvents(w http.ResponseWriter, r *http.Request) {
 	p.server.ServeHTTP(w, r)
 }
 
+func (p *headProducer) BeaconBlockRoot(_ context.Context, _ string) (*eth2p0.Root, error) {
+	blockRoot := p.getCurrentHead().Block
+
+	return &blockRoot, nil
+}
+
 // startSlotTicker returns a blocking channel that will be populated with new slots in real time.
 // It is also populated with the current slot immediately.
 func startSlotTicker(quit chan struct{}, callback func(eth2p0.Slot), genesisTime time.Time, slotDuration time.Duration) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -464,9 +464,6 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		ProposerDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
 			return []*eth2v1.ProposerDuty{}, nil
 		},
-		BeaconCommitteesFunc: func(context.Context, string) ([]*eth2v1.BeaconCommittee, error) {
-			return []*eth2v1.BeaconCommittee{}, nil
-		},
 		AttesterDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
 			return []*eth2v1.AttesterDuty{}, nil
 		},

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -126,6 +126,7 @@ func newNewCmd() *cobra.Command {
 	nodes := cmd.Flags().Int("nodes", conf.NumNodes, "Number of charon nodes in the cluster.")
 	insecureKeys := cmd.Flags().Bool("insecure-keys", conf.InsecureKeys, "To generate keys quickly.")
 	slotDuration := cmd.Flags().Duration("simnet-slot-duration", time.Second, "Configures slot duration in simnet beacon mock.")
+	fuzz := cmd.Flags().Bool("fuzz", false, "Configures simnet beaconmock to return fuzzed responses.")
 
 	cmd.RunE = func(cmd *cobra.Command, _ []string) error {
 		conf.KeyGen = compose.KeyGen(*keygen)
@@ -139,6 +140,7 @@ func newNewCmd() *cobra.Command {
 		conf.Threshold = cluster.Threshold(conf.NumNodes)
 		conf.InsecureKeys = *insecureKeys
 		conf.SlotDuration = *slotDuration
+		conf.Fuzz = *fuzz
 
 		if conf.BuildLocal {
 			conf.ImageTag = "local"

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -108,6 +108,9 @@ type Config struct {
 	// SlotDuration configures slot duration on simnet beacon mock for all the nodes in the cluster.
 	SlotDuration time.Duration `json:"slot_duration"`
 
+	// Fuzz configures simnet beaconmock to return fuzzed responses.
+	Fuzz bool `json:"fuzz"`
+
 	// SyntheticBlockProposals configures use of synthetic block proposals in simnet cluster.
 	SyntheticBlockProposals bool `json:"synthetic_block_proposals"`
 }

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -135,7 +135,7 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		kv{"simnet-validator-mock", fmt.Sprintf(`"%v"`, vcType == VCMock)},
 		kv{"simnet-slot-duration", conf.SlotDuration.String()},
 		kv{"simnet-validator-keys-dir", fmt.Sprintf("/compose/node%d/validator_keys", index)},
-		kv{"simnet-beaconmock-fuzz", fmt.Sprintf(`"%v"`, conf.Fuzz)},
+		kv{"simnet-beacon-mock-fuzz", fmt.Sprintf(`"%v"`, conf.Fuzz)},
 		kv{"loki-addresses", "http://loki:3100/loki/api/v1/push"},
 		kv{"loki-service", fmt.Sprintf("node%d", index)},
 		kv{"synthetic-block-proposals", fmt.Sprintf(`"%v"`, conf.SyntheticBlockProposals)},

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -135,6 +135,7 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		kv{"simnet-validator-mock", fmt.Sprintf(`"%v"`, vcType == VCMock)},
 		kv{"simnet-slot-duration", conf.SlotDuration.String()},
 		kv{"simnet-validator-keys-dir", fmt.Sprintf("/compose/node%d/validator_keys", index)},
+		kv{"simnet-beaconmock-fuzz", fmt.Sprintf(`"%v"`, conf.Fuzz)},
 		kv{"loki-addresses", "http://loki:3100/loki/api/v1/push"},
 		kv{"loki-service", fmt.Sprintf("node%d", index)},
 		kv{"synthetic-block-proposals", fmt.Sprintf(`"%v"`, conf.SyntheticBlockProposals)},

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -74,6 +74,10 @@
      "Value": "/compose/node0/validator_keys"
     },
     {
+     "Key": "simnet-beaconmock-fuzz",
+     "Value": "\"false\""
+    },
+    {
      "Key": "loki-addresses",
      "Value": "http://loki:3100/loki/api/v1/push"
     },
@@ -173,6 +177,10 @@
     {
      "Key": "simnet-validator-keys-dir",
      "Value": "/compose/node1/validator_keys"
+    },
+    {
+     "Key": "simnet-beaconmock-fuzz",
+     "Value": "\"false\""
     },
     {
      "Key": "loki-addresses",
@@ -276,6 +284,10 @@
      "Value": "/compose/node2/validator_keys"
     },
     {
+     "Key": "simnet-beaconmock-fuzz",
+     "Value": "\"false\""
+    },
+    {
      "Key": "loki-addresses",
      "Value": "http://loki:3100/loki/api/v1/push"
     },
@@ -375,6 +387,10 @@
     {
      "Key": "simnet-validator-keys-dir",
      "Value": "/compose/node3/validator_keys"
+    },
+    {
+     "Key": "simnet-beaconmock-fuzz",
+     "Value": "\"false\""
     },
     {
      "Key": "loki-addresses",

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -74,7 +74,7 @@
      "Value": "/compose/node0/validator_keys"
     },
     {
-     "Key": "simnet-beaconmock-fuzz",
+     "Key": "simnet-beacon-mock-fuzz",
      "Value": "\"false\""
     },
     {
@@ -179,7 +179,7 @@
      "Value": "/compose/node1/validator_keys"
     },
     {
-     "Key": "simnet-beaconmock-fuzz",
+     "Key": "simnet-beacon-mock-fuzz",
      "Value": "\"false\""
     },
     {
@@ -284,7 +284,7 @@
      "Value": "/compose/node2/validator_keys"
     },
     {
-     "Key": "simnet-beaconmock-fuzz",
+     "Key": "simnet-beacon-mock-fuzz",
      "Value": "\"false\""
     },
     {
@@ -389,7 +389,7 @@
      "Value": "/compose/node3/validator_keys"
     },
     {
-     "Key": "simnet-beaconmock-fuzz",
+     "Key": "simnet-beacon-mock-fuzz",
      "Value": "\"false\""
     },
     {

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -28,7 +28,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "false"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node0/validator_keys
-      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
+      CHARON_SIMNET_BEACON_MOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node0
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
@@ -62,7 +62,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "false"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node1/validator_keys
-      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
+      CHARON_SIMNET_BEACON_MOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node1
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
@@ -96,7 +96,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "true"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node2/validator_keys
-      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
+      CHARON_SIMNET_BEACON_MOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node2
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
@@ -130,7 +130,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "false"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node3/validator_keys
-      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
+      CHARON_SIMNET_BEACON_MOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node3
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -28,6 +28,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "false"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node0/validator_keys
+      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node0
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
@@ -61,6 +62,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "false"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node1/validator_keys
+      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node1
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
@@ -94,6 +96,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "true"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node2/validator_keys
+      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node2
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
@@ -127,6 +130,7 @@ services:
       CHARON_SIMNET_VALIDATOR_MOCK: "false"
       CHARON_SIMNET_SLOT_DURATION: 1s
       CHARON_SIMNET_VALIDATOR_KEYS_DIR: /compose/node3/validator_keys
+      CHARON_SIMNET_BEACONMOCK_FUZZ: "false"
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node3
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"

--- a/testutil/compose/testdata/TestNewDefaultConfig.golden
+++ b/testutil/compose/testdata/TestNewDefaultConfig.golden
@@ -19,5 +19,6 @@
  "disable_monitoring_ports": false,
  "insecure_keys": false,
  "slot_duration": 1000000000,
+ "fuzz": false,
  "synthetic_block_proposals": true
 }


### PR DESCRIPTION
Adds initial PoC for beacon fuzz to fuzz test charon where beacon mock returns random/malicious responses to charon.

category: feature
ticket: #1848 
