### PR TITLE
app/version: bump version to v0.15.0-dev

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -15,7 +15,7 @@ import (
 const (
 	// Version is the release version of the codebase.
 	// Usually overridden by tag names when building binaries.
-	Version = "v0.14.1"
+	Version = "v0.15.0-dev"
 )
 
 // Supported returns the supported versions in order of precedence.


### PR DESCRIPTION
Bumps version to v0.15.0-dev since main/trunk already includes breaking changes from v0.14 and isn't compatible with v0.13 anymore. So this indicates the compatibility is more aligned with v0.15 rather than v0.14. 

category: misc
ticket: none
