### PR TITLE
dkg: log peer summary at the start of DKG

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -684,12 +684,10 @@ func writeLockToAPI(ctx context.Context, publishAddr string, lock cluster.Lock) 
 // logPeerSummary logs peer summary with peer names and their ethereum addresses.
 func logPeerSummary(ctx context.Context, currentPeer peer.ID, peers []p2p.Peer, operators []cluster.Operator) {
 	for i, p := range peers {
+		opts := []z.Field{z.Str("peer", p.Name), z.Str("address", operators[i].Address), z.Int("index", p.Index)}
 		if p.ID == currentPeer {
-			log.Info(ctx, "Peer summary", z.Str("peer", p.Name), z.Str("address", operators[i].Address),
-				z.Int("index", p.Index), z.Str("you", "⭐️"))
-		} else {
-			log.Info(ctx, "Peer summary", z.Str("peer", p.Name), z.Str("address", operators[i].Address),
-				z.Int("index", p.Index))
+			opts = append(opts, z.Str("you", "⭐️"))
 		}
+		log.Info(ctx, "Peer summary", opts...)
 	}
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -104,6 +104,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	log.Info(ctx, "Starting local P2P networking peer", z.Str("local_peer", p2p.PeerName(pID)))
 
+	logPeerSummary(ctx, pID, peers, def.Operators)
+
 	tcpNode, shutdown, err := setupP2P(ctx, key, conf.P2P, peers, clusterID)
 	if err != nil {
 		return err
@@ -677,4 +679,17 @@ func writeLockToAPI(ctx context.Context, publishAddr string, lock cluster.Lock) 
 	log.Debug(ctx, "Published lock file to api")
 
 	return nil
+}
+
+// logPeerSummary logs peer summary with peer names and their ethereum addresses.
+func logPeerSummary(ctx context.Context, currentPeer peer.ID, peers []p2p.Peer, operators []cluster.Operator) {
+	for i, p := range peers {
+		if p.ID == currentPeer {
+			log.Info(ctx, "Peer summary", z.Str("peer", p.Name), z.Str("address", operators[i].Address),
+				z.Int("index", p.Index), z.Str("you", "⭐️"))
+		} else {
+			log.Info(ctx, "Peer summary", z.Str("peer", p.Name), z.Str("address", operators[i].Address),
+				z.Int("index", p.Index))
+		}
+	}
 }


### PR DESCRIPTION
Logs peer summary at the start of DKG with peer names, ethereum addresses and peer index.

category: feature
ticket: #1912
