### PR TITLE
app/featureset: fix data race in Enabled

### DIFF
--- a/app/featureset/config.go
+++ b/app/featureset/config.go
@@ -87,6 +87,9 @@ func Init(ctx context.Context, config Config) error {
 func EnableForT(t *testing.T, feature Feature) {
 	t.Helper()
 
+	initMu.Lock()
+	defer initMu.Unlock()
+
 	cache := state[feature]
 	t.Cleanup(func() {
 		state[feature] = cache
@@ -98,6 +101,9 @@ func EnableForT(t *testing.T, feature Feature) {
 // DisableForT disables a feature for testing.
 func DisableForT(t *testing.T, feature Feature) {
 	t.Helper()
+
+	initMu.Lock()
+	defer initMu.Unlock()
 
 	cache := state[feature]
 	t.Cleanup(func() {

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -62,5 +62,8 @@ var (
 
 // Enabled returns true if the feature is enabled.
 func Enabled(feature Feature) bool {
+	initMu.Lock()
+	defer initMu.Unlock()
+
 	return state[feature] >= minStatus
 }


### PR DESCRIPTION
Respect `initMu` locking.

category: bug 
ticket: #1867 
