### PR TITLE
p2p: explicitly register fuzzy matched protocols

### DIFF
--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -217,10 +217,13 @@ func (c *Component) SubscribePriority(fn func(ctx context.Context, duty core.Dut
 }
 
 // Start registers the libp2p receive handler and starts a goroutine that cleans state. This should only be called once.
-func (c *Component) Start(ctx context.Context) {
-	p2p.RegisterHandler("qbft", c.tcpNode, protocolID1,
+func (c *Component) Start(ctx context.Context) error {
+	err := p2p.RegisterHandler("qbft", c.tcpNode, protocolID1,
 		func() proto.Message { return new(pbv1.ConsensusMsg) },
 		c.handle, p2p.WithDelimitedProtocol(protocolID2))
+	if err != nil {
+		return err
+	}
 
 	go func() {
 		for {
@@ -232,6 +235,8 @@ func (c *Component) Start(ctx context.Context) {
 			}
 		}
 	}()
+
+	return nil
 }
 
 // Propose participants in a consensus instance proposing the provided unsigned data set.

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -92,7 +92,8 @@ func TestComponent(t *testing.T) {
 			results <- set
 			return nil
 		})
-		c.Start(log.WithCtx(ctx, z.Int("node", i)))
+		err = c.Start(log.WithCtx(ctx, z.Int("node", i)))
+		require.NoError(t, err)
 
 		components = append(components, c)
 	}

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -30,7 +30,10 @@ func Protocols() []protocol.ID {
 	return []protocol.ID{protocolID2, protocolID1}
 }
 
-func NewParSigEx(tcpNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []peer.ID, verifyFunc func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error) *ParSigEx {
+func NewParSigEx(tcpNode host.Host, sendFunc p2p.SendFunc, peerIdx int,
+	peers []peer.ID, verifyFunc func(context.Context, core.Duty,
+		core.PubKey, core.ParSignedData) error,
+) (*ParSigEx, error) {
 	parSigEx := &ParSigEx{
 		tcpNode:    tcpNode,
 		sendFunc:   sendFunc,
@@ -40,9 +43,12 @@ func NewParSigEx(tcpNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []
 	}
 
 	newReq := func() proto.Message { return new(pbv1.ParSigExMsg) }
-	p2p.RegisterHandler("parsigex", tcpNode, protocolID1, newReq, parSigEx.handle, p2p.WithDelimitedProtocol(protocolID2))
+	err := p2p.RegisterHandler("parsigex", tcpNode, protocolID1, newReq, parSigEx.handle, p2p.WithDelimitedProtocol(protocolID2))
+	if err != nil {
+		return nil, err
+	}
 
-	return parSigEx
+	return parSigEx, nil
 }
 
 // ParSigEx exchanges partially signed duty data sets.

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -80,9 +80,11 @@ func TestParSigEx(t *testing.T) {
 	// create ParSigEx components for each host
 	for i := 0; i < n; i++ {
 		wg.Add(n - 1)
-		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error {
+		sigex, err := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error {
 			return nil
 		})
+		require.NoError(t, err)
+
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
 			defer wg.Done()
 

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -67,8 +67,11 @@ func NewComponent(ctx context.Context, tcpNode host.Host, peers []peer.ID, minRe
 
 	deadliner := core.NewDeadliner(ctx, "priority", deadlineFunc)
 
-	prioritiser := newInternal(tcpNode, peers, minRequired, sendFunc, registerHandlerFunc,
+	prioritiser, err := newInternal(tcpNode, peers, minRequired, sendFunc, registerHandlerFunc,
 		consensus, verifier, exchangeTimeout, deadliner)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Component{
 		peerID:       tcpNode.ID(),

--- a/dkg/bcast/impl_test.go
+++ b/dkg/bcast/impl_test.go
@@ -66,11 +66,12 @@ func TestBCast(t *testing.T) {
 	// Create broadcasters
 	for i := 0; i < n; i++ {
 		i := i
-		bcastFunc := bcast.New(tcpNodes[i], peers, secrets[i], allowed,
+		bcastFunc, err := bcast.New(tcpNodes[i], peers, secrets[i], allowed,
 			func(ctx context.Context, peerID peer.ID, msgID string, msg proto.Message) error {
 				results <- result{Source: peerID, MsgID: msgID, Msg: msg, Target: peers[i]}
 				return nil
 			})
+		require.NoError(t, err)
 		bcasts = append(bcasts, bcastFunc)
 	}
 

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -122,7 +122,10 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.Wrap(err, "get peer IDs")
 	}
 
-	ex := newExchanger(tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators)
+	ex, err := newExchanger(tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators)
+	if err != nil {
+		return err
+	}
 
 	// Register Frost libp2p handlers
 	peerMap := make(map[peer.ID]cluster.NodeIdx)
@@ -133,8 +136,10 @@ func Run(ctx context.Context, conf Config) (err error) {
 		}
 		peerMap[p.ID] = nodeIdx
 	}
-	tp := newFrostP2P(tcpNode, peerMap, key)
-
+	tp, err := newFrostP2P(tcpNode, peerMap, key)
+	if err != nil {
+		return nil
+	}
 	log.Info(ctx, "Waiting to connect to all peers...")
 
 	// Improve UX of "context cancelled" errors when sync fails.

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -83,7 +83,8 @@ func TestExchanger(t *testing.T) {
 	}
 
 	for i := 0; i < nodes; i++ {
-		ex := newExchanger(hosts[i], i, peers, dvs)
+		ex, err := newExchanger(hosts[i], i, peers, dvs)
+		require.NoError(t, err)
 		exchangers = append(exchangers, ex)
 	}
 

--- a/p2p/receive_test.go
+++ b/p2p/receive_test.go
@@ -81,7 +81,7 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 	//  - Errors is slot is negative
 	//  - Echos the duty request if slot is even
 	//  - Returns nothing is slot is odd
-	p2p.RegisterHandler("server", server, pID1,
+	err := p2p.RegisterHandler("server", server, pID1,
 		func() proto.Message { return new(pbv1.Duty) },
 		func(ctx context.Context, peerID peer.ID, req proto.Message) (proto.Message, bool, error) {
 			log.Info(ctx, "See protocol logging field")
@@ -100,6 +100,7 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 		},
 		serverOpt...,
 	)
+	require.NoError(t, err)
 
 	sendReceive := func(slot int64) (*pbv1.Duty, error) {
 		resp := new(pbv1.Duty)


### PR DESCRIPTION
#1884 (v0.15.0-dev) introduces support for length-delimited libp2p wire protocols using fuzzy protocol matching. This doesn't explicitly register supported protocols which results in v0.14.0 disabling peerinfo and other protocols since it cannot detect supported protocols.

category: bug
ticket: #1948 