### PR TITLE
core/aggsigdb: refactor concurrent access issue in test

### DIFF
--- a/core/aggsigdb/memory.go
+++ b/core/aggsigdb/memory.go
@@ -31,15 +31,15 @@ func (dm *dataMap) get(key memDBKey) (core.SignedData, bool) {
 }
 
 func (dm *dataMap) set(key memDBKey, value core.SignedData) {
-	dm.Store(key, value)
 	dm.count++
+	dm.Store(key, value)
 }
 
 func (dm *dataMap) delete(key memDBKey) {
-	dm.Delete(key)
 	if dm.count != 0 {
 		dm.count--
 	}
+	dm.Delete(key)
 }
 
 type keysByDutyMap struct {
@@ -63,15 +63,15 @@ func (kdb *keysByDutyMap) get(key core.Duty) ([]memDBKey, bool) {
 }
 
 func (kdb *keysByDutyMap) set(key core.Duty, value []memDBKey) {
-	kdb.Store(key, value)
 	kdb.count++
+	kdb.Store(key, value)
 }
 
 func (kdb *keysByDutyMap) delete(key core.Duty) {
-	kdb.Delete(key)
 	if kdb.count != 0 {
 		kdb.count--
 	}
+	kdb.Delete(key)
 }
 
 var ErrStopped = errors.New("database stopped")

--- a/core/aggsigdb/memory.go
+++ b/core/aggsigdb/memory.go
@@ -5,82 +5,18 @@ package aggsigdb
 import (
 	"bytes"
 	"context"
-	"sync"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/core"
 )
-
-type dataMap struct {
-	sync.Map
-	count uint64
-}
-
-func (dm *dataMap) get(key memDBKey) (core.SignedData, bool) {
-	rawData, ok := dm.Load(key)
-	if !ok {
-		return nil, false
-	}
-
-	sd, canCast := rawData.(core.SignedData)
-	if !canCast {
-		return nil, false
-	}
-
-	return sd, true
-}
-
-func (dm *dataMap) set(key memDBKey, value core.SignedData) {
-	dm.count++
-	dm.Store(key, value)
-}
-
-func (dm *dataMap) delete(key memDBKey) {
-	if dm.count != 0 {
-		dm.count--
-	}
-	dm.Delete(key)
-}
-
-type keysByDutyMap struct {
-	sync.Map
-	count uint64
-}
-
-//nolint:unparam
-func (kdb *keysByDutyMap) get(key core.Duty) ([]memDBKey, bool) {
-	rawData, ok := kdb.Load(key)
-	if !ok {
-		return nil, false
-	}
-
-	sd, canCast := rawData.([]memDBKey)
-	if !canCast {
-		return nil, false
-	}
-
-	return sd, true
-}
-
-func (kdb *keysByDutyMap) set(key core.Duty, value []memDBKey) {
-	kdb.count++
-	kdb.Store(key, value)
-}
-
-func (kdb *keysByDutyMap) delete(key core.Duty) {
-	if kdb.count != 0 {
-		kdb.count--
-	}
-	kdb.Delete(key)
-}
 
 var ErrStopped = errors.New("database stopped")
 
 // NewMemDB creates a basic memory based AggSigDB.
 func NewMemDB(deadliner core.Deadliner) *MemDB {
 	return &MemDB{
-		data:           dataMap{},
-		keysByDuty:     keysByDutyMap{},
+		data:           make(map[memDBKey]core.SignedData),
+		keysByDuty:     make(map[core.Duty][]memDBKey),
 		commands:       make(chan writeCommand),
 		queries:        make(chan readQuery),
 		blockedQueries: []readQuery{},
@@ -92,8 +28,8 @@ func NewMemDB(deadliner core.Deadliner) *MemDB {
 
 // MemDB is a basic memory implementation of core.AggSigDB.
 type MemDB struct {
-	data       dataMap
-	keysByDuty keysByDutyMap // Key index by duty for fast deletion.
+	data       map[memDBKey]core.SignedData
+	keysByDuty map[core.Duty][]memDBKey // Key index by duty for fast deletion.
 
 	commands       chan writeCommand
 	queries        chan readQuery
@@ -182,11 +118,10 @@ func (db *MemDB) Run(ctx context.Context) {
 				db.callbackBlockedQueriesForT()
 			}
 		case duty := <-db.deadliner.C():
-			kbd, _ := db.keysByDuty.get(duty)
-			for _, key := range kbd {
-				db.data.delete(key)
+			for _, key := range db.keysByDuty[duty] {
+				delete(db.data, key)
 			}
-			db.keysByDuty.delete(duty)
+			delete(db.keysByDuty, duty)
 		case <-ctx.Done():
 			return
 		}
@@ -201,7 +136,7 @@ func (db *MemDB) execCommand(command writeCommand) {
 
 	key := memDBKey{command.duty, command.pubKey}
 
-	if existing, ok := db.data.get(key); ok {
+	if existing, ok := db.data[key]; ok {
 		equal, err := dataEqual(existing, command.data)
 		if err != nil {
 			command.response <- err
@@ -209,11 +144,8 @@ func (db *MemDB) execCommand(command writeCommand) {
 			command.response <- errors.New("mismatching data")
 		}
 	} else {
-		db.data.set(key, command.data)
-
-		old, _ := db.keysByDuty.get(command.duty)
-		old = append(old, key)
-		db.keysByDuty.set(command.duty, old)
+		db.data[key] = command.data
+		db.keysByDuty[command.duty] = append(db.keysByDuty[command.duty], key)
 	}
 }
 
@@ -233,7 +165,7 @@ func dataEqual(x core.SignedData, y core.SignedData) (bool, error) {
 // execQuery returns true if the query was successfully executed.
 // If the requested entry is found in the DB it will return it via query.response channel.
 func (db *MemDB) execQuery(query readQuery) bool {
-	data, ok := db.data.get(memDBKey{query.duty, query.pubKey})
+	data, ok := db.data[memDBKey{query.duty, query.pubKey}]
 	if !ok {
 		return false
 	}

--- a/core/aggsigdb/memory.go
+++ b/core/aggsigdb/memory.go
@@ -31,15 +31,15 @@ func (dm *dataMap) get(key memDBKey) (core.SignedData, bool) {
 }
 
 func (dm *dataMap) set(key memDBKey, value core.SignedData) {
-	dm.count++
 	dm.Store(key, value)
+	dm.count++
 }
 
 func (dm *dataMap) delete(key memDBKey) {
+	dm.Delete(key)
 	if dm.count != 0 {
 		dm.count--
 	}
-	dm.Delete(key)
 }
 
 type keysByDutyMap struct {
@@ -63,15 +63,15 @@ func (kdb *keysByDutyMap) get(key core.Duty) ([]memDBKey, bool) {
 }
 
 func (kdb *keysByDutyMap) set(key core.Duty, value []memDBKey) {
-	kdb.count++
 	kdb.Store(key, value)
+	kdb.count++
 }
 
 func (kdb *keysByDutyMap) delete(key core.Duty) {
+	kdb.Delete(key)
 	if kdb.count != 0 {
 		kdb.count--
 	}
-	kdb.Delete(key)
 }
 
 var ErrStopped = errors.New("database stopped")

--- a/core/aggsigdb/memory_internal_test.go
+++ b/core/aggsigdb/memory_internal_test.go
@@ -36,8 +36,8 @@ func TestDutyExpiration(t *testing.T) {
 
 	deadliner.Expire()
 
-	require.Zero(t, db.data.count)
-	require.Zero(t, db.keysByDuty.count)
+	require.Empty(t, db.data)
+	require.Empty(t, db.keysByDuty)
 }
 
 func TestCancelledQuery(t *testing.T) {

--- a/core/aggsigdb/memory_internal_test.go
+++ b/core/aggsigdb/memory_internal_test.go
@@ -36,8 +36,8 @@ func TestDutyExpiration(t *testing.T) {
 
 	deadliner.Expire()
 
-	require.Empty(t, db.data)
-	require.Empty(t, db.keysByDuty)
+	require.Zero(t, db.data.count)
+	require.Zero(t, db.keysByDuty.count)
 }
 
 func TestCancelledQuery(t *testing.T) {


### PR DESCRIPTION
Use sync.Map with a thin abstraction for data and keys by duty maps.

category: bug
ticket: #1867 
