### PR TITLE
ci: run tests with `-race` flag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m ./...
+      - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m -race ./...
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2.1.0
         with:
@@ -44,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: docker pull consensys/teku:latest
-      - run: go test -v -timeout=5m github.com/obolnetwork/charon/app -integration
+      - run: go test -v -timeout=5m -race github.com/obolnetwork/charon/app -integration
 
   compose_tests:
     runs-on: ubuntu-latest
@@ -65,7 +65,7 @@ jobs:
       - run: |
           echo "CHARON_REPO=$(pwd)" >> $GITHUB_ENV
           echo "DOCKER_BUILDKIT=1" >> $GITHUB_ENV
-      - run: go test github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -timeout=20m -log-dir=.
+      - run: go test -race github.com/obolnetwork/charon/testutil/compose/smoke -v -integration -sudo-perms -timeout=20m -log-dir=.
       - uses: actions/upload-artifact@v3
         if: always()
         with:

--- a/.pre-commit/run_tests.sh
+++ b/.pre-commit/run_tests.sh
@@ -4,4 +4,4 @@
 MOD=$(go list -m)
 PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
 
-go test -timeout=2m $PKGS
+go test -race -timeout=2m $PKGS


### PR DESCRIPTION
This PR enables execution of Go tests with the race detector enabled.

Also enables it in `pre-commit` tasks.

Let's merge this once all the data races are solved!

category: feature
ticket: #1867 
