### PR TITLE
p2p: disable dynamic length delimited protocol negotation

### DIFF
--- a/p2p/receive_test.go
+++ b/p2p/receive_test.go
@@ -110,11 +110,7 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("server error", func(t *testing.T) {
 		_, err := sendReceive(-1)
-		if delimitedServer && delimitedClient {
-			require.ErrorContains(t, err, "read response: EOF")
-		} else {
-			require.ErrorContains(t, err, "no response")
-		}
+		require.ErrorContains(t, err, "no response")
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -126,10 +122,6 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("empty response", func(t *testing.T) {
 		_, err := sendReceive(101)
-		if delimitedServer && delimitedClient {
-			require.ErrorContains(t, err, "read response: EOF")
-		} else {
-			require.ErrorContains(t, err, "no response")
-		}
+		require.ErrorContains(t, err, "no response")
 	})
 }


### PR DESCRIPTION
Disable dynamic length delimited protocol negotation, postponing it until v0.16.0-dev release. 

This is because v0.14 still uses the naive `p2p.ProtocolSupported` which doesn't
support dynamically negotiated protocols. It only supports the static advertised protocols.
Our implementation of the length delimited protocol is dynamically negotiated so not supported
by v0.14. The upcoming v0.15.0 release must be compatible with v0.14.

category: bug
ticket: #1948
