### PR TITLE
p2p: support zero length request protos

### DIFF
--- a/app/peerinfo/adhoc_test.go
+++ b/app/peerinfo/adhoc_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package peerinfo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestDoOnce(t *testing.T) {
+	server := testutil.CreateHost(t, testutil.AvailableAddr(t))
+	client := testutil.CreateHost(t, testutil.AvailableAddr(t))
+
+	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), peerstore.PermanentAddrTTL)
+
+	version := "v0"
+	lockHash := []byte("123")
+	gitHash := "abc"
+	// Register the server handler that either
+	_ = peerinfo.New(server, []peer.ID{server.ID(), client.ID()}, version, lockHash, gitHash, p2p.SendReceive)
+
+	info, _, ok, err := peerinfo.DoOnce(context.Background(), client, server.ID())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, version, info.CharonVersion)
+	require.Equal(t, gitHash, info.GitHash)
+	require.Equal(t, lockHash, info.LockHash)
+}

--- a/p2p/receive.go
+++ b/p2p/receive.go
@@ -45,7 +45,7 @@ func RegisterHandler(logTopic string, tcpNode host.Host, pID protocol.ID,
 	}
 
 	matchProtocol := func(pID protocol.ID) bool {
-		return o.readersByProtocol[pID] != nil
+		return o.reqReadersByProtocol[pID] != nil
 	}
 
 	tcpNode.SetStreamHandlerMatch(protocolPrefix(o.protocols...), matchProtocol, func(s network.Stream) {
@@ -68,7 +68,7 @@ func RegisterHandler(logTopic string, tcpNode host.Host, pID protocol.ID,
 			log.Error(ctx, "LibP2P no writer for protocol", nil)
 			return
 		}
-		readFunc, ok := o.readersByProtocol[s.Protocol()]
+		readFunc, ok := o.reqReadersByProtocol[s.Protocol()]
 		if !ok {
 			log.Error(ctx, "LibP2P no reader for protocol", nil)
 			return

--- a/p2p/receive_test.go
+++ b/p2p/receive_test.go
@@ -110,7 +110,7 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("server error", func(t *testing.T) {
 		_, err := sendReceive(-1)
-		require.ErrorContains(t, err, "no response")
+		require.ErrorContains(t, err, "no data")
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -122,6 +122,6 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("empty response", func(t *testing.T) {
 		_, err := sendReceive(101)
-		require.ErrorContains(t, err, "no response")
+		require.ErrorContains(t, err, "no data")
 	})
 }


### PR DESCRIPTION
Fix regression introduced by length-delimited upgrades which assumed that legacy-stream-delimited protocols handled requests and responses the same while it didn't. It allowed zero length requests while it didn't allow zero-length responses. This aligns the new implementation with that.

category: bug
ticket: #1956 
