### PR TITLE
p2p: support zero length request protos

### DIFF
--- a/app/peerinfo/adhoc_test.go
+++ b/app/peerinfo/adhoc_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package peerinfo_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestDoOnce(t *testing.T) {
+	server := testutil.CreateHost(t, testutil.AvailableAddr(t))
+	client := testutil.CreateHost(t, testutil.AvailableAddr(t))
+
+	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), peerstore.PermanentAddrTTL)
+
+	version := "v0"
+	lockHash := []byte("123")
+	gitHash := "abc"
+	// Register the server handler that either
+	_ = peerinfo.New(server, []peer.ID{server.ID(), client.ID()}, version, lockHash, gitHash, p2p.SendReceive)
+
+	info, _, ok, err := peerinfo.DoOnce(context.Background(), client, server.ID())
+	require.NoError(t, err)
+	require.True(t, ok)
+	require.Equal(t, version, info.CharonVersion)
+	require.Equal(t, gitHash, info.GitHash)
+	require.Equal(t, lockHash, info.LockHash)
+}

--- a/p2p/receive_test.go
+++ b/p2p/receive_test.go
@@ -110,7 +110,7 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("server error", func(t *testing.T) {
 		_, err := sendReceive(-1)
-		require.ErrorContains(t, err, "no response")
+		require.ErrorContains(t, err, "no or zero response received")
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -122,6 +122,6 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("empty response", func(t *testing.T) {
 		_, err := sendReceive(101)
-		require.ErrorContains(t, err, "no response")
+		require.ErrorContains(t, err, "no or zero response received")
 	})
 }

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -191,6 +191,10 @@ func defaultSendRecvOpts(pID protocol.ID) sendRecvOpts {
 func SendReceive(ctx context.Context, tcpNode host.Host, peerID peer.ID,
 	req, resp proto.Message, pID protocol.ID, opts ...SendRecvOption,
 ) error {
+	if !isZeroProto(resp) {
+		return errors.New("bug: response proto must be zero value")
+	}
+
 	o := defaultSendRecvOpts(pID)
 	for _, opt := range opts {
 		opt(&o)
@@ -331,4 +335,19 @@ func protocolPrefix(pIDs ...protocol.ID) protocol.ID {
 	}
 
 	return prefix
+}
+
+// isZeroProto returns true if the provided proto message is zero.
+//
+// Note this function is inefficient for the negative case (i.e. when the message is not zero)
+// as it copies the input argument.
+func isZeroProto(m proto.Message) bool {
+	if m == nil {
+		return false
+	}
+
+	clone := proto.Clone(m)
+	proto.Reset(clone)
+
+	return proto.Equal(m, clone)
 }


### PR DESCRIPTION
Fix regression introduced by length-delimited upgrades which assumed that legacy-stream-delimited protocols handled requests and responses the same while it didn't. It allowed zero length requests while it didn't allow zero-length responses. This aligns the new implementation with that.

category: bug
ticket: #1956 
