### PR TITLE
app: fix flapping integration test

### DIFF
--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -479,9 +479,10 @@ func startTeku(t *testing.T, args simnetArgs, node int) simnetArgs {
 	}()
 
 	// Kill the container when done (context cancel is not enough for some reason).
-	t.Cleanup(func() {
+	testutil.EnsureCleanup(t, func() {
 		cancel()
-		_ = exec.Command("docker", "kill", name).Run()
+		t.Log("stopping teku docker container", name)
+		_ = exec.Command("docker", "stop", name).Run()
 	})
 
 	return args

--- a/testutil/timeout.go
+++ b/testutil/timeout.go
@@ -1,0 +1,32 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package testutil
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// EnsureCleanup calls cleanupFunc in one of two cases:
+//   - 100ms before the test deadline is exceeded when it is run with `-timeout`, or
+//   - on test cleanup
+func EnsureCleanup(t *testing.T, cleanupFunc func()) {
+	t.Helper()
+	testDeadline, present := t.Deadline()
+	if !present {
+		t.Cleanup(cleanupFunc)
+		return
+	}
+
+	ctx := context.Background()
+
+	// Adapted from https://github.com/golang/go/issues/24050#issuecomment-1137682781
+	testDeadline = testDeadline.Add(-100 * time.Millisecond)
+	dctx, cancel := context.WithDeadline(ctx, testDeadline)
+	go func() {
+		<-dctx.Done()
+		cancel()
+		cleanupFunc()
+	}()
+}


### PR DESCRIPTION
When a test is killed by timeout, `t.Cleanup()` functions are not called.

Since we relied on them to fully stop Teku Docker containers, they would stick around and make the CI fail because processes were still running.

This commit introduces the `testutil.EnsureCleanup()` function, which calls a function 100ms before the global test timeout.

By calling `docker kill` this way, we always ensure cleanup on test timeout.

category: bug
ticket: none
