### PR TITLE
github/workflows: isolate integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,25 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
 
-  integration_tests:
+  app_tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20.2'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go test -v -timeout=5m -race github.com/obolnetwork/charon/app
+
+  app_docker_tests:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -75,7 +91,7 @@ jobs:
 
   notify_failure:
     runs-on: ubuntu-latest
-    needs: [ unit_tests, integration_tests, compose_tests ]
+    needs: [ unit_tests, app_tests, app_docker_tests, compose_tests ]
     # Syntax ref: https://github.com/actions/runner/issues/1251
     if: always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: docker pull consensys/teku:latest
-      - run: go test -v -timeout=5m -race github.com/obolnetwork/charon/app -integration
+      - run: go test -v -timeout=10m -race github.com/obolnetwork/charon/app -run=TestSimnetDuties -integration
 
   compose_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: unit tests
+name: go tests
 on:
   pull_request:
   push:

--- a/app/simnet_test.go
+++ b/app/simnet_test.go
@@ -123,7 +123,9 @@ func TestSimnetDuties(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			if test.teku && !*integration {
-				t.Skipf("Skipping Teku integration test: %v", t.Name())
+				t.Skipf("Skipping Teku integration test (--integration=false): %v", t.Name())
+			} else if !test.teku && *integration {
+				t.Skipf("Skipping non-integration test (--integration=true): %v", t.Name())
 			}
 			t.Logf("Running test: %v", t.Name())
 


### PR DESCRIPTION
It seems like integration test timeout might be due to tests taking too long to run. So only run explicit integrations tests during the integration test CI step. Prevent other tests from running if `--integration=true`. Also increase timeout. 

category: test
ticket: none
