### PR TITLE
testutil/integration: move app tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.out
 
-  app_tests:
+  integration_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -42,25 +42,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: go test -v -timeout=5m -race github.com/obolnetwork/charon/app
-
-  app_docker_tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
-        with:
-          go-version: '1.20.2'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: docker pull consensys/teku:latest
-      - run: go test -v -timeout=10m -race github.com/obolnetwork/charon/app -run=TestSimnetDuties -integration
+      - run: go test -v -timeout=10m -race github.com/obolnetwork/charon/testutil/integration -integration
 
   compose_tests:
     runs-on: ubuntu-latest
@@ -91,7 +73,7 @@ jobs:
 
   notify_failure:
     runs-on: ubuntu-latest
-    needs: [ unit_tests, app_tests, app_docker_tests, compose_tests ]
+    needs: [ unit_tests, integration_tests, compose_tests ]
     # Syntax ref: https://github.com/actions/runner/issues/1251
     if: always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
     steps:

--- a/testutil/integration/doc.go
+++ b/testutil/integration/doc.go
@@ -1,0 +1,7 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+// Package integration provides integration tests that includes multiple
+// instances communicating via loopback networking.
+//
+// Note all tests are skipped unless the -integration flag is provided.
+package integration

--- a/testutil/integration/helpers_test.go
+++ b/testutil/integration/helpers_test.go
@@ -1,0 +1,158 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package integration_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/cmd/relay"
+	"github.com/obolnetwork/charon/p2p"
+	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+var integration = flag.Bool("integration", false, "Enable this package's integration tests")
+
+func skipIfDisabled(t *testing.T) {
+	t.Helper()
+	if !*integration {
+		t.Skip("Integration tests are disabled")
+	}
+}
+
+func TestMain(m *testing.M) {
+	tblsv2.SetImplementation(tblsv2.Herumi{})
+	os.Exit(m.Run())
+}
+
+// startRelay starts a charon relay and returns its http multiaddr endpoint.
+func startRelay(ctx context.Context, t *testing.T) (string, <-chan error) {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	addr := testutil.AvailableAddr(t).String()
+
+	errChan := make(chan error, 1)
+	go func() {
+		errChan <- relay.Run(ctx, relay.Config{
+			DataDir:  dir,
+			HTTPAddr: addr,
+			P2PConfig: p2p.Config{
+				TCPAddrs: []string{testutil.AvailableAddr(t).String()},
+			},
+			LogConfig: log.Config{
+				Level:  "error",
+				Format: "console",
+			},
+			AutoP2PKey:    true,
+			MaxResPerPeer: 8,
+			MaxConns:      1024,
+		})
+	}()
+
+	endpoint := "http://" + addr
+
+	// Wait for bootnode to become available.
+	for ctx.Err() == nil {
+		_, err := http.Get(endpoint)
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Millisecond * 100)
+	}
+
+	return endpoint, errChan
+}
+
+// asserter provides an abstract callback asserter.
+type asserter struct {
+	Timeout   time.Duration
+	callbacks sync.Map // map[string]bool
+}
+
+// Await waits for all nodes to ping each other or time out.
+func (a *asserter) await(ctx context.Context, t *testing.T, expect int) error {
+	t.Helper()
+
+	var actual map[interface{}]bool
+
+	ok := assert.Eventually(t, func() bool {
+		if ctx.Err() != nil {
+			return true
+		}
+		actual = make(map[interface{}]bool)
+		a.callbacks.Range(func(k, v interface{}) bool {
+			actual[k] = true
+
+			return true
+		})
+
+		return len(actual) >= expect
+	}, a.Timeout, time.Millisecond*10)
+
+	if ctx.Err() != nil {
+		return context.Canceled
+	}
+
+	if !ok {
+		return errors.New(fmt.Sprintf("Timeout waiting for callbacks, expect=%d, actual=%d: %v", expect, len(actual), actual))
+	}
+
+	return nil
+}
+
+// externalIP returns the hosts external IP.
+// Copied from https://stackoverflow.com/questions/23558425/how-do-i-get-the-local-ip-address-in-go.
+func externalIP(t *testing.T) string {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	require.NoError(t, err)
+
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 {
+			continue // interface down
+		}
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue // loopback interface
+		}
+		addrs, err := iface.Addrs()
+		require.NoError(t, err)
+		for _, addr := range addrs {
+			var ip net.IP
+			switch v := addr.(type) {
+			case *net.IPNet:
+				ip = v.IP
+			case *net.IPAddr:
+				ip = v.IP
+			}
+			if ip == nil || ip.IsLoopback() {
+				continue
+			}
+			ip = ip.To4()
+			if ip == nil {
+				continue // not an ipv4 address
+			}
+
+			return ip.String()
+		}
+	}
+
+	t.Fatal("no network?")
+
+	return ""
+}

--- a/testutil/integration/infosync_test.go
+++ b/testutil/integration/infosync_test.go
@@ -1,0 +1,150 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package integration_test
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/obolnetwork/charon/app"
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/featureset"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/version"
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/priority"
+	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+func TestInfoSync(t *testing.T) {
+	skipIfDisabled(t)
+
+	featureset.EnableForT(t, featureset.Priority)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	const n = 3
+	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, 0)
+
+	asserter := &priorityAsserter{
+		asserter: asserter{Timeout: time.Second * 10},
+		N:        n,
+	}
+
+	var tcpNodesLock sync.Mutex
+	var tcpNodes []host.Host
+
+	// Hard code peer addresses and protocols
+	tcpNodeCallback := func(tcpNode host.Host) {
+		tcpNodesLock.Lock()
+		defer tcpNodesLock.Unlock()
+
+		for _, other := range tcpNodes {
+			other.Peerstore().AddAddrs(tcpNode.ID(), tcpNode.Addrs(), peerstore.PermanentAddrTTL)
+			err := other.Peerstore().AddProtocols(tcpNode.ID(), priority.Protocols()...)
+			require.NoError(t, err)
+
+			tcpNode.Peerstore().AddAddrs(other.ID(), other.Addrs(), peerstore.PermanentAddrTTL)
+			err = tcpNode.Peerstore().AddProtocols(other.ID(), priority.Protocols()...)
+			require.NoError(t, err)
+		}
+		tcpNodes = append(tcpNodes, tcpNode)
+	}
+
+	var eg errgroup.Group
+	for i := 0; i < n; i++ {
+		i := i // Copy iteration variable
+		conf := app.Config{
+			Log:              log.DefaultConfig(),
+			Feature:          featureset.DefaultConfig(),
+			SimnetBMock:      true,
+			MonitoringAddr:   testutil.AvailableAddr(t).String(), // Random monitoring address
+			ValidatorAPIAddr: testutil.AvailableAddr(t).String(), // Random validatorapi address
+			TestConfig: app.TestConfig{
+				PrioritiseCallback: asserter.Callback(t, i),
+				Lock:               &lock,
+				P2PKey:             p2pKeys[i],
+				TCPNodeCallback:    tcpNodeCallback,
+				SimnetBMockOpts: []beaconmock.Option{
+					beaconmock.WithNoAttesterDuties(),
+					beaconmock.WithNoProposerDuties(),
+					beaconmock.WithNoSyncCommitteeDuties(),
+					beaconmock.WithSlotsPerEpoch(1),
+				},
+			},
+			P2P: p2p.Config{
+				TCPAddrs: []string{testutil.AvailableAddr(t).String()},
+			},
+		}
+
+		eg.Go(func() error {
+			defer cancel()
+			return app.Run(ctx, conf)
+		})
+	}
+
+	eg.Go(func() error {
+		defer cancel()
+		return asserter.Await(ctx, t)
+	})
+
+	err := eg.Wait()
+	testutil.SkipIfBindErr(t, err)
+	require.NoError(t, err)
+}
+
+// priorityAsserter asserts that all nodes resolved the same priorities.
+type priorityAsserter struct {
+	asserter
+	N int
+}
+
+// Await waits for all nodes to ping each other or time out.
+func (a *priorityAsserter) Await(ctx context.Context, t *testing.T) error {
+	t.Helper()
+	return a.await(ctx, t, a.N)
+}
+
+// Callback returns the PingCallback function for the ith node.
+func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
+	t.Helper()
+
+	return func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
+		expect := map[string]string{
+			"version":  fmt.Sprint(version.Supported()),
+			"protocol": fmt.Sprint(app.Protocols()),
+			"proposal": fmt.Sprint(app.ProposalTypes(false, false)),
+		}
+
+		if !assert.Len(t, results, len(expect)) {
+			return errors.New("unexpected number of results")
+		}
+
+		for _, result := range results {
+			if len(result.Priorities) == 0 {
+				// Some but not all peers participated, ignore this result.
+				return nil
+			}
+
+			if !assert.Equal(t, expect[result.Topic], fmt.Sprint(result.PrioritiesOnly())) {
+				return errors.New("unexpected priorities")
+			}
+		}
+
+		a.callbacks.Store(fmt.Sprint(i), true)
+
+		return nil
+	}
+}

--- a/testutil/integration/ping_test.go
+++ b/testutil/integration/ping_test.go
@@ -1,50 +1,36 @@
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-package app_test
+package integration_test
 
 import (
 	"context"
 	"fmt"
 	"net"
-	"net/http"
-	"os"
 	"regexp"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"github.com/libp2p/go-libp2p/core/peerstore"
 	ma "github.com/multiformats/go-multiaddr"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/obolnetwork/charon/app"
-	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/app/log"
-	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/cluster"
-	"github.com/obolnetwork/charon/cmd/relay"
-	"github.com/obolnetwork/charon/core"
-	"github.com/obolnetwork/charon/core/priority"
 	"github.com/obolnetwork/charon/p2p"
-	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
-func TestMain(m *testing.M) {
-	tblsv2.SetImplementation(tblsv2.Herumi{})
-	os.Exit(m.Run())
-}
-
 // TestPingCluster starts a cluster of charon nodes and waits for each node to ping all the others.
 // It relies on discv5 for peer discovery.
 func TestPingCluster(t *testing.T) {
+	skipIfDisabled(t)
+
 	// Nodes bind to random locahost ports,
 	// use relay,
 	// then upgrade to direct connections.
@@ -186,83 +172,6 @@ func newAddrFactoryFilter(filterStr string) libp2p.Option {
 	}
 }
 
-// startRelay starts a charon relay and returns its http multiaddr endpoint.
-func startRelay(ctx context.Context, t *testing.T) (string, <-chan error) {
-	t.Helper()
-
-	dir := t.TempDir()
-
-	addr := testutil.AvailableAddr(t).String()
-
-	errChan := make(chan error, 1)
-	go func() {
-		errChan <- relay.Run(ctx, relay.Config{
-			DataDir:  dir,
-			HTTPAddr: addr,
-			P2PConfig: p2p.Config{
-				TCPAddrs: []string{testutil.AvailableAddr(t).String()},
-			},
-			LogConfig: log.Config{
-				Level:  "error",
-				Format: "console",
-			},
-			AutoP2PKey:    true,
-			MaxResPerPeer: 8,
-			MaxConns:      1024,
-		})
-	}()
-
-	endpoint := "http://" + addr
-
-	// Wait for bootnode to become available.
-	for ctx.Err() == nil {
-		_, err := http.Get(endpoint)
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Millisecond * 100)
-	}
-
-	return endpoint, errChan
-}
-
-// asserter provides an abstract callback asserter.
-type asserter struct {
-	Timeout   time.Duration
-	callbacks sync.Map // map[string]bool
-}
-
-// Await waits for all nodes to ping each other or time out.
-func (a *asserter) await(ctx context.Context, t *testing.T, expect int) error {
-	t.Helper()
-
-	var actual map[interface{}]bool
-
-	ok := assert.Eventually(t, func() bool {
-		if ctx.Err() != nil {
-			return true
-		}
-		actual = make(map[interface{}]bool)
-		a.callbacks.Range(func(k, v interface{}) bool {
-			actual[k] = true
-
-			return true
-		})
-
-		return len(actual) >= expect
-	}, a.Timeout, time.Millisecond*10)
-
-	if ctx.Err() != nil {
-		return context.Canceled
-	}
-
-	if !ok {
-		return errors.New(fmt.Sprintf("Timeout waiting for callbacks, expect=%d, actual=%d: %v", expect, len(actual), actual))
-	}
-
-	return nil
-}
-
 // pingAsserter asserts that all nodes ping all other nodes.
 type pingAsserter struct {
 	asserter
@@ -311,124 +220,5 @@ func (a *pingAsserter) Callback(t *testing.T, i int) func(peer.ID, host.Host) {
 				a.callbacks.Store(fmt.Sprint(i, "-", j), true)
 			}
 		}
-	}
-}
-
-func TestInfoSync(t *testing.T) {
-	featureset.EnableForT(t, featureset.Priority)
-
-	ctx, cancel := context.WithCancel(context.Background())
-
-	const n = 3
-	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, 0)
-
-	asserter := &priorityAsserter{
-		asserter: asserter{Timeout: time.Second * 10},
-		N:        n,
-	}
-
-	var tcpNodesLock sync.Mutex
-	var tcpNodes []host.Host
-
-	// Hard code peer addresses and protocols
-	tcpNodeCallback := func(tcpNode host.Host) {
-		tcpNodesLock.Lock()
-		defer tcpNodesLock.Unlock()
-
-		for _, other := range tcpNodes {
-			other.Peerstore().AddAddrs(tcpNode.ID(), tcpNode.Addrs(), peerstore.PermanentAddrTTL)
-			err := other.Peerstore().AddProtocols(tcpNode.ID(), priority.Protocols()...)
-			require.NoError(t, err)
-
-			tcpNode.Peerstore().AddAddrs(other.ID(), other.Addrs(), peerstore.PermanentAddrTTL)
-			err = tcpNode.Peerstore().AddProtocols(other.ID(), priority.Protocols()...)
-			require.NoError(t, err)
-		}
-		tcpNodes = append(tcpNodes, tcpNode)
-	}
-
-	var eg errgroup.Group
-	for i := 0; i < n; i++ {
-		i := i // Copy iteration variable
-		conf := app.Config{
-			Log:              log.DefaultConfig(),
-			Feature:          featureset.DefaultConfig(),
-			SimnetBMock:      true,
-			MonitoringAddr:   testutil.AvailableAddr(t).String(), // Random monitoring address
-			ValidatorAPIAddr: testutil.AvailableAddr(t).String(), // Random validatorapi address
-			TestConfig: app.TestConfig{
-				PrioritiseCallback: asserter.Callback(t, i),
-				Lock:               &lock,
-				P2PKey:             p2pKeys[i],
-				TCPNodeCallback:    tcpNodeCallback,
-				SimnetBMockOpts: []beaconmock.Option{
-					beaconmock.WithNoAttesterDuties(),
-					beaconmock.WithNoProposerDuties(),
-					beaconmock.WithNoSyncCommitteeDuties(),
-					beaconmock.WithSlotsPerEpoch(1),
-				},
-			},
-			P2P: p2p.Config{
-				TCPAddrs: []string{testutil.AvailableAddr(t).String()},
-			},
-		}
-
-		eg.Go(func() error {
-			defer cancel()
-			return app.Run(ctx, conf)
-		})
-	}
-
-	eg.Go(func() error {
-		defer cancel()
-		return asserter.Await(ctx, t)
-	})
-
-	err := eg.Wait()
-	testutil.SkipIfBindErr(t, err)
-	require.NoError(t, err)
-}
-
-// priorityAsserter asserts that all nodes resolved the same priorities.
-type priorityAsserter struct {
-	asserter
-	N int
-}
-
-// Await waits for all nodes to ping each other or time out.
-func (a *priorityAsserter) Await(ctx context.Context, t *testing.T) error {
-	t.Helper()
-	return a.await(ctx, t, a.N)
-}
-
-// Callback returns the PingCallback function for the ith node.
-func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
-	t.Helper()
-
-	return func(ctx context.Context, duty core.Duty, results []priority.TopicResult) error {
-		expect := map[string]string{
-			"version":  fmt.Sprint(version.Supported()),
-			"protocol": fmt.Sprint(app.Protocols()),
-			"proposal": fmt.Sprint(app.ProposalTypes(false, false)),
-		}
-
-		if !assert.Len(t, results, len(expect)) {
-			return errors.New("unexpected number of results")
-		}
-
-		for _, result := range results {
-			if len(result.Priorities) == 0 {
-				// Some but not all peers participated, ignore this result.
-				return nil
-			}
-
-			if !assert.Equal(t, expect[result.Topic], fmt.Sprint(result.PrioritiesOnly())) {
-				return errors.New("unexpected priorities")
-			}
-		}
-
-		a.callbacks.Store(fmt.Sprint(i), true)
-
-		return nil
 	}
 }

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/leadercast"
-	"github.com/obolnetwork/charon/core/parsigex"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/p2p"
 	tblsv2 "github.com/obolnetwork/charon/tbls/v2"
@@ -58,7 +57,7 @@ func TestSimnetDuties(t *testing.T) {
 		{
 			name:          "attester with teku",
 			scheduledType: core.DutyAttester,
-			duties:        []core.DutyType{core.DutyAttester}, // Teku doesn't support beacon committee selection.
+			duties:        []core.DutyType{core.DutyAttester}, // Teku does not support beacon committee selection
 			teku:          true,
 		},
 		{
@@ -263,7 +262,6 @@ func testSimnet(t *testing.T, args simnetArgs, expect *simnetExpect) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 
-	parSigExFunc := parsigex.NewMemExFunc()
 	lcastTransportFunc := leadercast.NewMemTransportFunc(ctx)
 	featureConf := featureset.DefaultConfig()
 	featureConf.Disabled = []string{string(featureset.QBFTConsensus)} // TODO(corver): Add support for in-memory transport to QBFT.
@@ -292,7 +290,6 @@ func testSimnet(t *testing.T, args simnetArgs, expect *simnetExpect) {
 				P2PKey:             args.P2PKeys[i],
 				TestPingConfig:     p2p.TestPingConfig{Disable: true},
 				SimnetKeys:         []tblsv2.PrivateKey{args.SimnetKeys[i]},
-				ParSigExFunc:       parSigExFunc,
 				LcastTransportFunc: lcastTransportFunc,
 				BroadcastCallback: func(_ context.Context, duty core.Duty, key core.PubKey, data core.SignedData) error {
 					select {


### PR DESCRIPTION
Move `app` tests to `testutil/integration`, increase timeout.

category: test
ticket: none