### PR TITLE
cmd: fix publish test timeout

### DIFF
--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -515,7 +515,7 @@ func TestPublish(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	result := make(chan struct{}) // Buffered channel
+	result := make(chan struct{}, 1) // Buffered channel
 	defer close(result)
 
 	srv := httptest.NewServer(newObolAPIHandler(ctx, t, result))


### PR DESCRIPTION
Fix timeouts in `TestPublish` by making the channel buffered.

category: test
ticket: none
