### PR TITLE
dkg: improve sync flow test logs

### DIFF
--- a/.pre-commit/run_tests.sh
+++ b/.pre-commit/run_tests.sh
@@ -4,4 +4,4 @@
 MOD=$(go list -m)
 PKGS=$(echo "$@"| xargs -n1 dirname | sort -u | sed -e "s#^#${MOD}/#")
 
-go test -race -timeout=2m $PKGS
+go test -failfast -race -timeout=2m $PKGS

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/cmd/relay"
 	"github.com/obolnetwork/charon/dkg"
@@ -377,8 +378,9 @@ func TestSyncFlow(t *testing.T) {
 
 			// Start DKG for initial peers.
 			for _, idx := range test.connect {
+				t.Logf("Starting initial DKG for peer %d", idx)
 				configs[idx].TestSyncCallback = newCallback(len(test.connect) - 1)
-				stopDkgs[idx] = startNewDKG(t, ctx, configs[idx], dkgErrChan)
+				stopDkgs[idx] = startNewDKG(t, peerCtx(ctx, idx), configs[idx], dkgErrChan)
 			}
 
 			// Wait for initial peers to connect with each other.
@@ -400,6 +402,7 @@ func TestSyncFlow(t *testing.T) {
 
 			// Drop some peers.
 			for _, idx := range test.disconnect {
+				t.Logf("Stopping DKG for peer %d", idx)
 				stopDkgs[idx]()
 
 				// Wait for this dkg process to return.
@@ -409,7 +412,8 @@ func TestSyncFlow(t *testing.T) {
 
 			// Start remaining peers.
 			for _, idx := range test.reconnect {
-				stopDkgs[idx] = startNewDKG(t, ctx, configs[idx], dkgErrChan)
+				t.Logf("Starting remaining DKG for peer %d", idx)
+				stopDkgs[idx] = startNewDKG(t, peerCtx(ctx, idx), configs[idx], dkgErrChan)
 			}
 
 			// Assert DKG results for all DKG processes.
@@ -430,6 +434,10 @@ func TestSyncFlow(t *testing.T) {
 			verifyDKGResults(t, lock.Definition, dir)
 		})
 	}
+}
+
+func peerCtx(ctx context.Context, idx int) context.Context {
+	return log.WithCtx(ctx, z.Int("peer_index", idx))
 }
 
 func getConfigs(t *testing.T, def cluster.Definition, keys []*k1.PrivateKey, dir, bootnode string) []dkg.Config {


### PR DESCRIPTION
Improve DKG `SyncFlow` test to help debugging flapping tests.

category: test 
ticket: none
