### PR TITLE
cmd: change to mainnet by default

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -35,7 +35,8 @@ import (
 
 const (
 	zeroAddress    = "0x0000000000000000000000000000000000000000"
-	defaultNetwork = "goerli"
+	deadAddress    = "0x000000000000000000000000000000000000dead"
+	defaultNetwork = "mainnet"
 	minNodes       = 4
 )
 

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -117,8 +117,8 @@ func TestCreateCluster(t *testing.T) {
 				test.Config = test.Prep(t, test.Config)
 			}
 
-			test.Config.WithdrawalAddrs = []string{zeroAddress}
-			test.Config.FeeRecipientAddrs = []string{zeroAddress}
+			test.Config.WithdrawalAddrs = []string{deadAddress}
+			test.Config.FeeRecipientAddrs = []string{deadAddress}
 
 			if test.Config.Network == "" {
 				test.Config.Network = defaultNetwork
@@ -322,8 +322,8 @@ func TestSplitKeys(t *testing.T) {
 				NumNodes:          minNodes,
 				Threshold:         3,
 				Network:           defaultNetwork,
-				FeeRecipientAddrs: []string{zeroAddress},
-				WithdrawalAddrs:   []string{zeroAddress},
+				FeeRecipientAddrs: []string{deadAddress},
+				WithdrawalAddrs:   []string{deadAddress},
 				ClusterDir:        t.TempDir(),
 			},
 		},
@@ -458,8 +458,8 @@ func TestKeymanager(t *testing.T) {
 		KeymanagerAddrs:      addrs,
 		KeymanagerAuthTokens: authTokens,
 		Network:              defaultNetwork,
-		WithdrawalAddrs:      []string{zeroAddress},
-		FeeRecipientAddrs:    []string{zeroAddress},
+		WithdrawalAddrs:      []string{deadAddress},
+		FeeRecipientAddrs:    []string{deadAddress},
 		Clean:                true,
 	}
 	conf.ClusterDir = t.TempDir()
@@ -531,8 +531,8 @@ func TestPublish(t *testing.T) {
 		NumNodes:          minNodes,
 		NumDVs:            1,
 		Network:           defaultNetwork,
-		WithdrawalAddrs:   []string{zeroAddress},
-		FeeRecipientAddrs: []string{zeroAddress},
+		WithdrawalAddrs:   []string{deadAddress},
+		FeeRecipientAddrs: []string{deadAddress},
 		PublishAddr:       addr,
 		Publish:           true,
 	}

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -18,8 +18,8 @@ func TestCreateDkgValid(t *testing.T) {
 		OutputDir:         temp,
 		NumValidators:     1,
 		Threshold:         3,
-		FeeRecipientAddrs: []string{zeroAddress},
-		WithdrawalAddrs:   []string{zeroAddress},
+		FeeRecipientAddrs: []string{deadAddress},
+		WithdrawalAddrs:   []string{deadAddress},
 		Network:           defaultNetwork,
 		DKGAlgo:           "default",
 		OperatorENRs: []string{


### PR DESCRIPTION
Change `charon create cluster` and `charon create dkg` to default to mainnet. This mitigates the risk of users thinking they generated a mainnet cluster and activiting it, while the actually created a testnet cluster.

category: feature
ticket: #1969