### PR TITLE
eth2util/rlp: add fuzz tests

### DIFF
--- a/eth2util/rlp/rlp_test.go
+++ b/eth2util/rlp/rlp_test.go
@@ -71,7 +71,11 @@ func FuzzEncodeBytesList(f *testing.F) {
 	data := make([]byte, minPayloadSize)
 	d := merge(prefix, data)
 
-	f.Add(0, d, d, d, d, d, d, d, d, d, d)
+	// Add a few different lengths of byte slices
+	for i := 0; i < 10; i++ {
+		f.Add(i, d, d, d, d, d, d, d, d, d, d)
+	}
+
 	f.Fuzz(func(t *testing.T, n int, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9 []byte) {
 		a := [][]byte{d0, d1, d2, d3, d4, d5, d6, d7, d8, d9}
 		if n >= 0 && n < len(a) {

--- a/eth2util/rlp/rlp_test.go
+++ b/eth2util/rlp/rlp_test.go
@@ -1,5 +1,20 @@
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
+// Copyright © 2022 Obol Labs Inc.
+//
+// This program is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+// more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// this program.  If not, see <http://www.gnu.org/licenses/>.
+
 package rlp_test
 
 import (
@@ -17,6 +32,65 @@ var (
 	loremIn  = []byte("Lorem ipsum dolor sit amet, consectetur adipisicing elit")
 	loremOut = []byte{0xb8, 0x38, 'L', 'o', 'r', 'e', 'm', ' ', 'i', 'p', 's', 'u', 'm', ' ', 'd', 'o', 'l', 'o', 'r', ' ', 's', 'i', 't', ' ', 'a', 'm', 'e', 't', ',', ' ', 'c', 'o', 'n', 's', 'e', 'c', 't', 'e', 't', 'u', 'r', ' ', 'a', 'd', 'i', 'p', 'i', 's', 'i', 'c', 'i', 'n', 'g', ' ', 'e', 'l', 'i', 't'}
 )
+
+const (
+	minPrefixSize  = 1
+	minPayloadSize = 0
+)
+
+func FuzzDecodeBytesList(f *testing.F) {
+	prefix := make([]byte, minPrefixSize)
+	data := make([]byte, minPayloadSize)
+
+	f.Add(merge(prefix, data))
+	f.Fuzz(func(t *testing.T, d []byte) {
+		_, err := rlp.DecodeBytesList(d)
+		if err != nil {
+			// only care about panics
+			return
+		}
+	})
+}
+
+func FuzzDecodeBytes(f *testing.F) {
+	prefix := make([]byte, minPrefixSize)
+	data := make([]byte, minPayloadSize)
+
+	f.Add(merge(prefix, data))
+	f.Fuzz(func(t *testing.T, d []byte) {
+		_, err := rlp.DecodeBytes(d)
+		if err != nil {
+			// only care about panics
+			return
+		}
+	})
+}
+
+func FuzzEncodeBytesList(f *testing.F) {
+	prefix := make([]byte, minPrefixSize)
+	data := make([]byte, minPayloadSize)
+	d := merge(prefix, data)
+
+	f.Add(0, d, d, d, d, d, d, d, d, d, d)
+	f.Fuzz(func(t *testing.T, n int, d0, d1, d2, d3, d4, d5, d6, d7, d8, d9 []byte) {
+		a := [][]byte{d0, d1, d2, d3, d4, d5, d6, d7, d8, d9}
+		if n >= 0 && n < len(a) {
+			a = a[:n]
+		}
+
+		rlp.EncodeBytesList(a)
+	})
+}
+
+func FuzzEncodeBytes(f *testing.F) {
+	prefix := make([]byte, minPrefixSize)
+	data := make([]byte, minPayloadSize)
+
+	f.Add(merge(prefix, data))
+	f.Fuzz(func(t *testing.T, d []byte) {
+		rlp.EncodeBytes(d)
+	})
+}
 
 // TestBytesList tests encoding and decoding of lists of byte slices using examples from the RLP spec.
 // See https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp/#examples.
@@ -56,6 +130,14 @@ func TestBytesList(t *testing.T) {
 			}
 		})
 	}
+}
+
+func merge(a, b []byte) []byte {
+	resp := make([]byte, len(a)+len(b))
+	copy(resp, a)
+	copy(resp[len(a):], b)
+
+	return resp
 }
 
 // TestBytes tests encoding and decoding of byte slices using examples from the RLP spec.

--- a/eth2util/rlp/rlp_test.go
+++ b/eth2util/rlp/rlp_test.go
@@ -1,20 +1,5 @@
 // Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-// Copyright © 2022 Obol Labs Inc.
-//
-// This program is free software: you can redistribute it and/or modify it
-// under the terms of the GNU General Public License as published by the Free
-// Software Foundation, either version 3 of the License, or (at your option)
-// any later version.
-//
-// This program is distributed in the hope that it will be useful, but WITHOUT
-// ANY WARRANTY; without even the implied warranty of  MERCHANTABILITY or
-// FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
-// more details.
-//
-// You should have received a copy of the GNU General Public License along with
-// this program.  If not, see <http://www.gnu.org/licenses/>.
-
 package rlp_test
 
 import (


### PR DESCRIPTION
Add fuzz tests to `eth2util/rlp` as identified by sigma-prime audit.

Fixes OBOL-04.

category: bug
ticket: none

