### PR TITLE
*: speed up keystore tests

### DIFF
--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -99,7 +99,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 
 	def, err := NewDefinition("test cluster", dv, k,
 		feeRecipientAddrs, withdrawalAddrs,
-		"0x00000000", creator, ops, random, opts...)
+		eth2util.Goerli.ForkVersionHex, creator, ops, random, opts...)
 	require.NoError(t, err)
 
 	// Definition version prior to v1.3.0 don't support EIP712 signatures.

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -72,7 +72,7 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(ep, 0o755))
 		require.NoError(t, os.Mkdir(vk, 0o755))
-		require.NoError(t, keystore.StoreKeys(keys, vk))
+		require.NoError(t, keystore.StoreKeysInsecure(keys, vk, keystore.ConfirmInsecureKeys))
 
 		lf, err := os.OpenFile(filepath.Join(ep, "cluster-lock.json"), os.O_WRONLY|os.O_CREATE, 0o755)
 		require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestCombine(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(ep, 0o755))
 		require.NoError(t, os.Mkdir(vk, 0o755))
-		require.NoError(t, keystore.StoreKeys(keys, vk))
+		require.NoError(t, keystore.StoreKeysInsecure(keys, vk, keystore.ConfirmInsecureKeys))
 
 		lf, err := os.OpenFile(filepath.Join(ep, "cluster-lock.json"), os.O_WRONLY|os.O_CREATE, 0o755)
 		require.NoError(t, err)
@@ -238,7 +238,7 @@ func TestCombineTwiceWithoutForceFails(t *testing.T) {
 
 		require.NoError(t, os.Mkdir(ep, 0o755))
 		require.NoError(t, os.Mkdir(vk, 0o755))
-		require.NoError(t, keystore.StoreKeys(keys, vk))
+		require.NoError(t, keystore.StoreKeysInsecure(keys, vk, keystore.ConfirmInsecureKeys))
 
 		lf, err := os.OpenFile(filepath.Join(ep, "cluster-lock.json"), os.O_WRONLY|os.O_CREATE, 0o755)
 		require.NoError(t, err)

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -527,6 +527,9 @@ func getConfigs(t *testing.T, def cluster.Definition, keys []*k1.PrivateKey, dir
 			},
 			Log:     log.DefaultConfig(),
 			TestDef: &def,
+			TestStoreKeysFunc: func(secrets []tblsv2.PrivateKey, dir string) error {
+				return keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
+			},
 		}
 		require.NoError(t, os.MkdirAll(conf.DataDir, 0o755))
 


### PR DESCRIPTION
Improve test speed by using `insecure` keystores.

category: test
ticket: none
