### PR TITLE
app: add beacon node far behind metric value to readyz

### DIFF
--- a/app/metrics.go
+++ b/app/metrics.go
@@ -27,6 +27,9 @@ const (
 	// readyzBeaconNodeZeroPeers indicates that readyz is returning 500s since the Beacon Node has zero peers
 	// and hence cannot sync.
 	readyzBeaconNodeZeroPeers = 7
+	// readyzBeaconNodeFarBehind indicates that readyz is returning 500s since the Beacon Node is too far behind
+	// the head slot.
+	readyzBeaconNodeFarBehind = 8
 )
 
 var (

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -140,15 +140,15 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 				if err != nil {
 					err = errReadyBeaconNodeDown
 					readyzGauge.Set(readyzBeaconNodeDown)
+				} else if syncing {
+					err = errReadyBeaconNodeSyncing
+					readyzGauge.Set(readyzBeaconNodeSyncing)
 				} else if bnPeerCount == 0 && bnErr == nil {
 					err = errReadyBeaconNodeZeroPeers
 					readyzGauge.Set(readyzBeaconNodeZeroPeers)
 				} else if syncDistance > bnFarBehindSlots {
 					err = errReadyBeaconNodeFarBehind
 					readyzGauge.Set(readyzBeaconNodeFarBehind)
-				} else if syncing {
-					err = errReadyBeaconNodeSyncing
-					readyzGauge.Set(readyzBeaconNodeSyncing)
 				} else if notConnectedRounds >= minNotConnected {
 					err = errReadyInsufficientPeers
 					readyzGauge.Set(readyzInsufficientPeers)

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -140,15 +140,15 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 				if err != nil {
 					err = errReadyBeaconNodeDown
 					readyzGauge.Set(readyzBeaconNodeDown)
+				} else if bnPeerCount == 0 && bnErr == nil {
+					err = errReadyBeaconNodeZeroPeers
+					readyzGauge.Set(readyzBeaconNodeZeroPeers)
 				} else if syncDistance > bnFarBehindSlots {
 					err = errReadyBeaconNodeFarBehind
 					readyzGauge.Set(readyzBeaconNodeFarBehind)
 				} else if syncing {
 					err = errReadyBeaconNodeSyncing
 					readyzGauge.Set(readyzBeaconNodeSyncing)
-				} else if bnPeerCount == 0 && bnErr == nil {
-					err = errReadyBeaconNodeZeroPeers
-					readyzGauge.Set(readyzBeaconNodeZeroPeers)
 				} else if notConnectedRounds >= minNotConnected {
 					err = errReadyInsufficientPeers
 					readyzGauge.Set(readyzInsufficientPeers)

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	eth2client "github.com/attestantio/go-eth2-client"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/jonboulle/clockwork"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -24,11 +25,16 @@ import (
 	"github.com/obolnetwork/charon/core"
 )
 
+// bnFarBehindSlots is the no of slots that is considered to be too far behind the current beacon chain head.
+// Currently, it is set to 10 epochs (10 * 32 = 320 slots).
+const bnFarBehindSlots = 320
+
 var (
 	errReadyUninitialised       = errors.New("ready check uninitialised")
 	errReadyInsufficientPeers   = errors.New("quorum peers not connected")
-	errReadyBeaconNodeSyncing   = errors.New("beacon node not synced")
 	errReadyBeaconNodeDown      = errors.New("beacon node down")
+	errReadyBeaconNodeFarBehind = errors.New("beacon node far behind")
+	errReadyBeaconNodeSyncing   = errors.New("beacon node not synced")
 	errReadyBeaconNodeZeroPeers = errors.New("beacon node has zero peers")
 	errReadyVCNotConnected      = errors.New("vc not connected")
 	errReadyVCMissingVals       = errors.New("vc missing validators")
@@ -129,11 +135,14 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 					log.Warn(ctx, "Failed to get beacon node peer count", bnErr)
 				}
 
-				syncing, err := beaconNodeSyncing(ctx, eth2Cl)
+				syncing, syncDistance, err := beaconNodeSyncing(ctx, eth2Cl)
 				//nolint:nestif
 				if err != nil {
 					err = errReadyBeaconNodeDown
 					readyzGauge.Set(readyzBeaconNodeDown)
+				} else if syncDistance > bnFarBehindSlots {
+					err = errReadyBeaconNodeFarBehind
+					readyzGauge.Set(readyzBeaconNodeFarBehind)
 				} else if syncing {
 					err = errReadyBeaconNodeSyncing
 					readyzGauge.Set(readyzBeaconNodeSyncing)
@@ -172,14 +181,15 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 	}
 }
 
-// beaconNodeSyncing returns true if the beacon node is still syncing.
-func beaconNodeSyncing(ctx context.Context, eth2Cl eth2client.NodeSyncingProvider) (bool, error) {
+// beaconNodeSyncing returns true if the beacon node is still syncing. It also returns the sync distance, ie, the distance
+// between the node's highest synced slot and the head slot.
+func beaconNodeSyncing(ctx context.Context, eth2Cl eth2client.NodeSyncingProvider) (bool, eth2p0.Slot, error) {
 	state, err := eth2Cl.NodeSyncing(ctx)
 	if err != nil {
-		return false, err
+		return false, 0, err
 	}
 
-	return state.IsSyncing, nil
+	return state.IsSyncing, state.SyncDistance, nil
 }
 
 // beaconNodeMetrics sets beacon node metrics like the peer count and node version.

--- a/testutil/compose/static/grafana/dash_charon_overview.json
+++ b/testutil/compose/static/grafana/dash_charon_overview.json
@@ -385,6 +385,11 @@
                   "color": "light-purple",
                   "index": 8,
                   "text": "BeaconNode has zero peers"
+                },
+                "8": {
+                  "color": "dark-red",
+                  "index": 9,
+                  "text": "BeaconNode far behind"
                 }
               },
               "type": "value"
@@ -2812,8 +2817,8 @@
       {
         "current": {
           "selected": false,
-          "text": "66103ee",
-          "value": "66103ee"
+          "text": "ad1c2dd",
+          "value": "ad1c2dd"
         },
         "datasource": {
           "type": "prometheus",
@@ -2840,8 +2845,8 @@
       {
         "current": {
           "selected": false,
-          "text": "stormy-ring",
-          "value": "stormy-ring"
+          "text": "helpless-state",
+          "value": "helpless-state"
         },
         "datasource": {
           "type": "prometheus",
@@ -2868,8 +2873,8 @@
       {
         "current": {
           "selected": false,
-          "text": "node0",
-          "value": "node0"
+          "text": "node3",
+          "value": "node3"
         },
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
Adds "BeaconNode far behind" metric value to `/readyz`. This would help node operators to monitor their beacon node health if the `Healthy` panel shows `BeaconNode far behind` for a longer time.

category: feature
ticket: #1967 
