### PR TITLE
testutil/beaconmock: speed up head producer tests

### DIFF
--- a/testutil/beaconmock/headproducer_internal_test.go
+++ b/testutil/beaconmock/headproducer_internal_test.go
@@ -104,10 +104,12 @@ func TestHeadProducer(t *testing.T) {
 			if test.expectErr {
 				require.ErrorIs(t, client.SubscribeWithContext(ctx, addr, func(msg *sse.Event) {}), unsupportedTopicErr)
 			} else {
+				actualTopics := make(map[string]bool)
 				require.NoError(t, client.SubscribeWithContext(ctx, addr, func(msg *sse.Event) {
 					require.True(t, requiredTopics[string(msg.Event)])
-					delete(requiredTopics, string(msg.Event))
-					if len(requiredTopics) == 0 {
+
+					actualTopics[string(msg.Event)] = true
+					if len(requiredTopics) == len(actualTopics) {
 						cancel()
 					}
 				}))


### PR DESCRIPTION
Speed up head producer tests by not relying on normally scheduled slots (minimum is 1s), rather refactor to internal tests and update head very fast.

category: test
ticket: none
