### PR TITLE
keystore: speed up tests

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -13,10 +13,12 @@ import (
 	"os"
 	"path"
 	"strings"
+	"testing"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	keystorev4 "github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
@@ -218,7 +220,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 			return err
 		}
 	} else { // Or else save keys to keymanager
-		if err = writeKeysToKeymanager(ctx, conf.KeymanagerAddrs, conf.KeymanagerAuthTokens, numNodes, shareSets); err != nil {
+		if err = writeKeysToKeymanager(ctx, conf, numNodes, shareSets); err != nil {
 			return err
 		}
 	}
@@ -480,11 +482,11 @@ func getValidators(dvsPubkeys []tblsv2.PublicKey, dvPrivShares [][]tblsv2.Privat
 }
 
 // writeKeysToKeymanager writes validator keys to the provided keymanager addresses.
-func writeKeysToKeymanager(ctx context.Context, addrs, authTokens []string, numNodes int, shareSets [][]tblsv2.PrivateKey) error {
+func writeKeysToKeymanager(ctx context.Context, conf clusterConfig, numNodes int, shareSets [][]tblsv2.PrivateKey) error {
 	// Ping all keymanager addresses to check if they are accessible to avoid partial writes
 	var clients []keymanager.Client
 	for i := 0; i < numNodes; i++ {
-		cl := keymanager.New(addrs[i], authTokens[i])
+		cl := keymanager.New(conf.KeymanagerAddrs[i], conf.KeymanagerAuthTokens[i])
 		if err := cl.VerifyConnection(ctx); err != nil {
 			return err
 		}
@@ -503,7 +505,11 @@ func writeKeysToKeymanager(ctx context.Context, addrs, authTokens []string, numN
 			}
 			passwords = append(passwords, password)
 
-			store, err := keystore.Encrypt(shares[i], password, rand.Reader)
+			var opts []keystorev4.Option
+			if conf.InsecureKeys {
+				opts = append(opts, keystorev4.WithCost(new(testing.T), 4))
+			}
+			store, err := keystore.Encrypt(shares[i], password, rand.Reader, opts...)
 			if err != nil {
 				return err
 			}
@@ -512,11 +518,12 @@ func writeKeysToKeymanager(ctx context.Context, addrs, authTokens []string, numN
 
 		err := clients[i].ImportKeystores(ctx, keystores, passwords)
 		if err != nil {
-			log.Error(ctx, "Failed to import keys", err, z.Str("addr", addrs[i]))
+			log.Error(ctx, "Failed to import keys", err, z.Str("addr", conf.KeymanagerAddrs[i]))
 			return err
 		}
 
-		log.Info(ctx, "Imported key shares to keymanager", z.Str("node", fmt.Sprintf("node%d", i)), z.Str("addr", addrs[i]))
+		log.Info(ctx, "Imported key shares to keymanager",
+			z.Str("node", fmt.Sprintf("node%d", i)), z.Str("addr", conf.KeymanagerAddrs[i]))
 	}
 
 	log.Info(ctx, "Imported all validator keys to respective keymanagers")

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -81,7 +81,7 @@ func TestCreateCluster(t *testing.T) {
 				secret2, err := tblsv2.GenerateSecretKey()
 				require.NoError(t, err)
 
-				err = keystore.StoreKeys([]tblsv2.PrivateKey{secret1, secret2}, keyDir)
+				err = keystore.StoreKeysInsecure([]tblsv2.PrivateKey{secret1, secret2}, keyDir, keystore.ConfirmInsecureKeys)
 				require.NoError(t, err)
 
 				config.SplitKeysDir = keyDir
@@ -351,7 +351,7 @@ func TestSplitKeys(t *testing.T) {
 
 			keysDir := t.TempDir()
 
-			err := keystore.StoreKeys(keys, keysDir)
+			err := keystore.StoreKeysInsecure(keys, keysDir, keystore.ConfirmInsecureKeys)
 			require.NoError(t, err)
 
 			test.conf.SplitKeysDir = keysDir
@@ -458,10 +458,11 @@ func TestKeymanager(t *testing.T) {
 		NumDVs:               1,
 		KeymanagerAddrs:      addrs,
 		KeymanagerAuthTokens: authTokens,
-		Network:              defaultNetwork,
+		Network:              eth2util.Goerli.Name,
 		WithdrawalAddrs:      []string{deadAddress},
 		FeeRecipientAddrs:    []string{deadAddress},
 		Clean:                true,
+		InsecureKeys:         true,
 	}
 	conf.ClusterDir = t.TempDir()
 
@@ -531,11 +532,12 @@ func TestPublish(t *testing.T) {
 		Name:              t.Name(),
 		NumNodes:          minNodes,
 		NumDVs:            1,
-		Network:           defaultNetwork,
+		Network:           eth2util.Goerli.Name,
 		WithdrawalAddrs:   []string{deadAddress},
 		FeeRecipientAddrs: []string{deadAddress},
 		PublishAddr:       addr,
 		Publish:           true,
+		InsecureKeys:      true,
 	}
 	conf.ClusterDir = t.TempDir()
 

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -110,6 +110,9 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 		},
 		Log:     log.DefaultConfig(),
 		TestDef: &def,
+		TestStoreKeysFunc: func(secrets []tblsv2.PrivateKey, dir string) error {
+			return keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
+		},
 	}
 
 	allReceivedKeystores := make(chan struct{}) // Receives struct{} for each `numNodes` keystore intercepted by the keymanager server

--- a/eth2util/keymanager/keymanager_test.go
+++ b/eth2util/keymanager/keymanager_test.go
@@ -44,7 +44,7 @@ func TestImportKeystores(t *testing.T) {
 	for _, secret := range secrets {
 		password := randomHex32(t)
 
-		store, err := keystore.Encrypt(secret, password, rand.Reader)
+		store, err := keystore.Encrypt(secret, password, rand.Reader, keystorev4.WithCost(t, 4))
 		require.NoError(t, err)
 
 		keystores = append(keystores, store)

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -23,7 +23,7 @@ func TestStoreLoad(t *testing.T) {
 		secrets = append(secrets, secret)
 	}
 
-	err := keystore.StoreKeys(secrets, dir)
+	err := keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
 	require.NoError(t, err)
 
 	actual, err := keystore.LoadKeys(dir)

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -440,7 +440,7 @@ func startTeku(t *testing.T, args simnetArgs, node int) simnetArgs {
 	}
 
 	// Write private share keystore and password
-	err := keystore.StoreKeys([]tblsv2.PrivateKey{args.SimnetKeys[node]}, tempDir)
+	err := keystore.StoreKeysInsecure([]tblsv2.PrivateKey{args.SimnetKeys[node]}, tempDir, keystore.ConfirmInsecureKeys)
 	require.NoError(t, err)
 	err = os.WriteFile(path.Join(tempDir, "keystore-simnet-0.txt"), []byte("simnet"), 0o644)
 	require.NoError(t, err)


### PR DESCRIPTION
Speed up tests using `keystore` by using insecure keys.

category: test
ticket: none
