### PR TITLE
cmd/combine: add support for insure keys in tests

### DIFF
--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -31,6 +31,7 @@ func TestCombineNoLockfile(t *testing.T) {
 }
 
 func TestCombineCannotLoadKeystore(t *testing.T) {
+	combine.SetInsecureKeysForT(t)
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
 
 	for _, share := range shares {
@@ -87,6 +88,7 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 }
 
 func TestCombine(t *testing.T) {
+	combine.SetInsecureKeysForT(t)
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
 
 	// calculate expected public keys and secrets

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -31,7 +31,6 @@ func TestCombineNoLockfile(t *testing.T) {
 }
 
 func TestCombineCannotLoadKeystore(t *testing.T) {
-	combine.SetInsecureKeysForT(t)
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
 
 	for _, share := range shares {
@@ -83,12 +82,11 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "node0")))
 
-	err := combine.Combine(context.Background(), dir, od, false)
+	err := combine.Combine(context.Background(), dir, od, false, combine.WithInsecureKeysForT(t))
 	require.Error(t, err)
 }
 
 func TestCombine(t *testing.T) {
-	combine.SetInsecureKeysForT(t)
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
 
 	// calculate expected public keys and secrets
@@ -157,7 +155,7 @@ func TestCombine(t *testing.T) {
 		require.NoError(t, json.NewEncoder(lf).Encode(lock))
 	}
 
-	err := combine.Combine(context.Background(), dir, od, true)
+	err := combine.Combine(context.Background(), dir, od, true, combine.WithInsecureKeysForT(t))
 	require.NoError(t, err)
 
 	keys, err := keystore.LoadKeys(od)
@@ -248,10 +246,10 @@ func TestCombineTwiceWithoutForceFails(t *testing.T) {
 		require.NoError(t, json.NewEncoder(lf).Encode(lock))
 	}
 
-	err := combine.Combine(context.Background(), dir, od, false)
+	err := combine.Combine(context.Background(), dir, od, false, combine.WithInsecureKeysForT(t))
 	require.NoError(t, err)
 
-	err = combine.Combine(context.Background(), dir, od, false)
+	err = combine.Combine(context.Background(), dir, od, false, combine.WithInsecureKeysForT(t))
 	require.Error(t, err)
 
 	keys, err := keystore.LoadKeys(od)


### PR DESCRIPTION
Allow `combine` package tests to override keystore with insecure keys for snappier tests.

category: test
ticket: none
