### PR TITLE
gomod: upgrade clockwork to v0.4.0

### DIFF
--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -429,6 +429,8 @@ func (d *delayer) delay(duty core.Duty, deadline time.Time) <-chan time.Time {
 	return resp
 }
 
+var _ clockwork.Clock = (*testClock)(nil)
+
 func newTestClock(now time.Time) *testClock {
 	return &testClock{
 		now:       now,
@@ -499,5 +501,9 @@ func (c *testClock) NewTicker(time.Duration) clockwork.Ticker {
 }
 
 func (c *testClock) NewTimer(time.Duration) clockwork.Timer {
+	panic("not supported")
+}
+
+func (c *testClock) AfterFunc(time.Duration, func()) clockwork.Timer {
 	panic("not supported")
 }

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/herumi/bls-eth-go-binary v1.29.1
 	github.com/ipfs/go-log/v2 v2.5.1
-	github.com/jonboulle/clockwork v0.3.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/jsternberg/zap-logfmt v1.3.0
 	github.com/libp2p/go-libp2p v0.25.1
 	github.com/libp2p/go-msgio v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -338,8 +338,8 @@ github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84 h1:2uT3aivO7NVpUPGcQ
 github.com/jdxcode/netrc v0.0.0-20221124155335-4616370d1a84/go.mod h1:Zi/ZFkEqFHTm7qkjyNJjaWH4LQA9LQhGJyF0lTYGpxw=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
-github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
-github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.9/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=


### PR DESCRIPTION
Upgrade `github.com/jonboulle/clockwork` from `v0.3.0` to  `v0.4.0` . Also fix test.

category: misc
ticket: none