### PR TITLE
p2p: increase relay reserver check freq

### DIFF
--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -69,7 +69,7 @@ func NewRelayReserver(tcpNode host.Host, relay *MutablePeer) lifecycle.HookFuncC
 
 			refresh := time.After(refreshDelay)
 
-			timer := time.NewTimer(time.Second)
+			timer := time.NewTimer(time.Millisecond * 100)
 
 			for {
 				select {


### PR DESCRIPTION
Increase the relay reserve "check if connected" frequency to be more sensitive to failing relay connections so it reconnects quicker. 

category: misc
ticket: none