### PR TITLE
dkg: shutdown race workaround

### DIFF
--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -4,6 +4,7 @@ package cmd
 
 import (
 	"context"
+	"time"
 
 	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
@@ -42,6 +43,7 @@ this command at the same time.`,
 	bindP2PFlags(cmd, &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
 	bindPublishFlags(cmd.Flags(), &config)
+	bindShutdownDelayFlag(cmd.Flags(), &config.ShutdownCallback)
 
 	return cmd
 }
@@ -62,4 +64,14 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 func bindPublishFlags(flags *pflag.FlagSet, config *dkg.Config) {
 	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech", "The URL to publish the lock file to.")
 	flags.BoolVar(&config.Publish, "publish", false, "Publish lock file to obol-api.")
+}
+
+func bindShutdownDelayFlag(flags *pflag.FlagSet, shutdownCallback *func()) {
+	var shutdownDelay time.Duration
+	flags.DurationVar(&shutdownDelay, "shutdown-delay", time.Second, "Graceful shutdown delay.")
+
+	*shutdownCallback = func() {
+		// TODO(corver): Improve graceful shutdown, see https://github.com/ObolNetwork/charon/issues/887
+		time.Sleep(shutdownDelay)
+	}
 }

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -43,7 +43,7 @@ this command at the same time.`,
 	bindP2PFlags(cmd, &config.P2P)
 	bindLogFlags(cmd.Flags(), &config.Log)
 	bindPublishFlags(cmd.Flags(), &config)
-	bindShutdownDelayFlag(cmd.Flags(), &config.ShutdownCallback)
+	bindShutdownDelayFlag(cmd.Flags(), &config.ShutdownDelay)
 
 	return cmd
 }
@@ -66,12 +66,6 @@ func bindPublishFlags(flags *pflag.FlagSet, config *dkg.Config) {
 	flags.BoolVar(&config.Publish, "publish", false, "Publish lock file to obol-api.")
 }
 
-func bindShutdownDelayFlag(flags *pflag.FlagSet, shutdownCallback *func()) {
-	var shutdownDelay time.Duration
-	flags.DurationVar(&shutdownDelay, "shutdown-delay", time.Second, "Graceful shutdown delay.")
-
-	*shutdownCallback = func() {
-		// TODO(corver): Improve graceful shutdown, see https://github.com/ObolNetwork/charon/issues/887
-		time.Sleep(shutdownDelay)
-	}
+func bindShutdownDelayFlag(flags *pflag.FlagSet, shutdownDelay *time.Duration) {
+	flags.DurationVar(shutdownDelay, "shutdown-delay", time.Second, "Graceful shutdown delay.")
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -214,7 +214,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
 	if err = stopSync(ctx); err != nil {
-		return errors.Wrap(err, "sync shutdown") // Consider increasing --shutdown-delay is this occurs often.
+		return errors.Wrap(err, "sync shutdown") // Consider increasing --shutdown-delay if this occurs often.
 	}
 
 	// Write keystores, deposit data and cluster lock files after exchange of partial signatures in order

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -33,11 +33,12 @@ import (
 )
 
 type Config struct {
-	DefFile  string
-	NoVerify bool
-	DataDir  string
-	P2P      p2p.Config
-	Log      log.Config
+	DefFile          string
+	NoVerify         bool
+	DataDir          string
+	P2P              p2p.Config
+	Log              log.Config
+	ShutdownCallback func()
 
 	KeymanagerAddr      string
 	KeymanagerAuthToken string
@@ -212,7 +213,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Debug(ctx, "Aggregated lock hash signatures")
 
 	if err = stopSync(ctx); err != nil {
-		return errors.Wrap(err, "sync shutdown")
+		return errors.Wrap(err, "sync shutdown") // Consider increasing --shutdown-delay is this occurs often.
 	}
 
 	// Write keystores, deposit data and cluster lock files after exchange of partial signatures in order
@@ -245,6 +246,10 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 	log.Debug(ctx, "Saved deposit data file to disk")
+
+	if conf.ShutdownCallback != nil {
+		conf.ShutdownCallback()
+	}
 
 	log.Info(ctx, "Successfully completed DKG ceremony 🎉")
 

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -115,7 +115,7 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 		TestStoreKeysFunc: func(secrets []tblsv2.PrivateKey, dir string) error {
 			return keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
 		},
-		ShutdownCallback: shutdownSync,
+		TestShutdownCallback: shutdownSync,
 	}
 
 	allReceivedKeystores := make(chan struct{}) // Receives struct{} for each `numNodes` keystore intercepted by the keymanager server
@@ -401,7 +401,7 @@ func TestSyncFlow(t *testing.T) {
 				log.Info(ctx, "Starting initial peer", z.Int("peer_index", idx))
 				configs[idx].TestSyncCallback = cTracker.Set
 				if !contains(test.disconnect, idx) {
-					configs[idx].ShutdownCallback = shutdownSync // Only synchronise shutdown for peers that are not disconnected.
+					configs[idx].TestShutdownCallback = shutdownSync // Only synchronise shutdown for peers that are not disconnected.
 				}
 				stopDkgs[idx] = startNewDKG(t, peerCtx(ctx, idx), configs[idx], dkgErrChan)
 			}
@@ -438,7 +438,7 @@ func TestSyncFlow(t *testing.T) {
 			// Start other peers.
 			for _, idx := range test.reconnect {
 				log.Info(ctx, "Starting remaining peer", z.Int("peer_index", idx))
-				configs[idx].ShutdownCallback = shutdownSync
+				configs[idx].TestShutdownCallback = shutdownSync
 				stopDkgs[idx] = startNewDKG(t, peerCtx(ctx, idx), configs[idx], dkgErrChan)
 			}
 

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -67,12 +67,12 @@ func TestDKG(t *testing.T) {
 		},
 		{
 			name:       "dkg with keymanager",
-			dkgAlgo:    "keycast",
+			dkgAlgo:    "frost",
 			keymanager: true,
 		},
 		{
 			name:    "dkg with lockfile publish",
-			dkgAlgo: "keycast",
+			dkgAlgo: "frost",
 			publish: true,
 		},
 	}
@@ -102,6 +102,8 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 	// Start relay.
 	relayAddr := startRelay(ctx, t)
 
+	shutdownSync := newShutdownSync(len(def.Operators))
+
 	// Setup config
 	conf := dkg.Config{
 		DataDir: dir,
@@ -113,6 +115,7 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 		TestStoreKeysFunc: func(secrets []tblsv2.PrivateKey, dir string) error {
 			return keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
 		},
+		ShutdownCallback: shutdownSync,
 	}
 
 	allReceivedKeystores := make(chan struct{}) // Receives struct{} for each `numNodes` keystore intercepted by the keymanager server
@@ -376,6 +379,8 @@ func TestSyncFlow(t *testing.T) {
 			pIDs, err := lock.PeerIDs()
 			require.NoError(t, err)
 
+			shutdownSync := newShutdownSync(test.nodes)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
@@ -395,6 +400,9 @@ func TestSyncFlow(t *testing.T) {
 			for _, idx := range test.connect {
 				log.Info(ctx, "Starting initial peer", z.Int("peer_index", idx))
 				configs[idx].TestSyncCallback = cTracker.Set
+				if !contains(test.disconnect, idx) {
+					configs[idx].ShutdownCallback = shutdownSync // Only synchronise shutdown for peers that are not disconnected.
+				}
 				stopDkgs[idx] = startNewDKG(t, peerCtx(ctx, idx), configs[idx], dkgErrChan)
 			}
 
@@ -430,6 +438,7 @@ func TestSyncFlow(t *testing.T) {
 			// Start other peers.
 			for _, idx := range test.reconnect {
 				log.Info(ctx, "Starting remaining peer", z.Int("peer_index", idx))
+				configs[idx].ShutdownCallback = shutdownSync
 				stopDkgs[idx] = startNewDKG(t, peerCtx(ctx, idx), configs[idx], dkgErrChan)
 			}
 
@@ -568,4 +577,16 @@ func startNewDKG(t *testing.T, parentCtx context.Context, config dkg.Config, dkg
 	}()
 
 	return cancel
+}
+
+// newShutdownSync returns a function that blocks until it is called n times thereby syncing the shutdown of n DKGs.
+// TODO(corver): Remove this once shutdown races have been fixed, https://github.com/ObolNetwork/charon/issues/887.
+func newShutdownSync(n int) func() {
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	return func() {
+		wg.Done()
+		wg.Wait()
+	}
 }


### PR DESCRIPTION
Workaround for the DKG shutdown race issue described in #887. Instead of immediately shutting down after writing artefacts to disk, wait for 1s by default, allowing other peers to also write their artefacts to disk before disconnecting. 

This issue doesn't happen in production that often due to +100ms latency between peers that allow peers to write artefacts to disk before peer disconnects are detected. This does however occur in unit tests and compose tests and could occur in local network DKGs.

category: bug
ticket: #887 
