### PR TITLE
p2p: fix relay conn checker

### DIFF
--- a/p2p/relay.go
+++ b/p2p/relay.go
@@ -69,7 +69,7 @@ func NewRelayReserver(tcpNode host.Host, relay *MutablePeer) lifecycle.HookFuncC
 
 			refresh := time.After(refreshDelay)
 
-			timer := time.NewTimer(time.Millisecond * 100)
+			timer := time.NewTicker(time.Millisecond * 500)
 
 			for {
 				select {


### PR DESCRIPTION
Fix relay connection check, should by regular ticker, not once off timer.

category: bug
ticket: none
