### PR TITLE
testutil/compose: add build-local command

### DIFF
--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -39,6 +39,7 @@ func newRootCmd() *cobra.Command {
 
 	root.AddCommand(newNewCmd())
 	root.AddCommand(newCleanCmd())
+	root.AddCommand(newBuildLocalCmd())
 	root.AddCommand(newAutoCmd())
 	root.AddCommand(newDockerCmd(
 		"define",
@@ -104,6 +105,17 @@ func newAutoCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&conf.PrintYML, "print-yml", false, "Print generated docker-compose.yml files.")
 
 	return cmd
+}
+
+func newBuildLocalCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "build-local",
+		Short: "Builds the obolnetwork/charon:local docker container from the local source code. Note this requires the CHARON_REPO env var.",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return compose.BuildLocal(cmd.Context())
+		},
+	}
 }
 
 func newNewCmd() *cobra.Command {

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -80,7 +80,7 @@ func Define(ctx context.Context, dir string, conf Config) (TmplData, error) {
 	}
 
 	if conf.BuildLocal {
-		if err := buildLocal(ctx); err != nil {
+		if err := BuildLocal(ctx); err != nil {
 			return TmplData{}, err
 		}
 	}
@@ -226,8 +226,8 @@ func pullLatest(ctx context.Context) error {
 	return nil
 }
 
-// buildLocal builds an `obolnetwork/charon:local` docker container from source. Note this requires CHARON_REPO env var.
-func buildLocal(ctx context.Context) error {
+// BuildLocal builds an `obolnetwork/charon:local` docker container from source. Note this requires CHARON_REPO env var.
+func BuildLocal(ctx context.Context) error {
 	repo, ok := os.LookupEnv("CHARON_REPO")
 	if !ok || repo == "" {
 		return errors.New("cannot build local charon binary; CHARON_REPO env var, the path to the charon repo, is not set")


### PR DESCRIPTION
Add a `build-local` command to `compose` to support running new source code without regenerating the whole compose cluster.

category: misc
ticket: none