### PR TITLE
version: bump version to v0.15.0-rc1

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -15,7 +15,7 @@ import (
 const (
 	// Version is the release version of the codebase.
 	// Usually overridden by tag names when building binaries.
-	Version = "v0.15.0-dev"
+	Version = "v0.15.0-rc1"
 )
 
 // Supported returns the supported versions in order of precedence.


### PR DESCRIPTION
Bumps version to `v0.15.0-rc1`

category: misc
ticket: none