### PR TITLE
github/workflows: include release branch in codeql

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main*" ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+    branches: [ "main*" ]
   schedule:
     - cron: '18 19 * * 6'
 


### PR DESCRIPTION
Ensures `codeql` checks also run against release branch commits and PRs.

category: misc
ticket: none
