### PR TITLE
github/workflows: remove release branch check

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -14,12 +14,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: docker/setup-buildx-action@v1
-    # Only allow building docker images from trunk (main) or patch (main/v0.X) protected branches.
-    - name: Check branch
-      run: |
-        # Short name for current branch
-        GIT_BRANCH=${GITHUB_REF#refs/heads/}
-        [[ $GIT_BRANCH = main* ]] || (echo "Not building image for invalid branch: $GIT_BRANCH" && exit 1)
     - name: Define docker image meta data tags
       id: meta
       uses: docker/metadata-action@v3


### PR DESCRIPTION
Removes the `Build and Publish Docker Image` action's "branch check" logic, since one cannot easily map a tagged commit to a branch. Can worry about this later. For now we need to remove the check so that docker tagged images are built for release branch git tags.

category: misc
ticket: none
