### PR TITLE
github/workflows: improve docker image tagging rules

### DIFF
--- a/.github/workflows/build-push-deploy-promrated.yaml
+++ b/.github/workflows/build-push-deploy-promrated.yaml
@@ -22,12 +22,10 @@ jobs:
           obolnetwork/promrated
           ghcr.io/obolnetwork/promrated
         tags: |
-          # Tag "git short sha" on push to branch (main)
-          type=sha,event=branch,prefix=
-          # Tag "latest" on all events
+          # Tag "git short sha" on all git events
+          type=sha,prefix=
+          # Tag "latest" on all git events
           type=raw,value=latest
-          # Tag "tag ref" on tag push events
-          type=ref,event=tag
     - name: Login to Github container registry
       uses: docker/login-action@v2
       with:

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -14,12 +14,6 @@ jobs:
       with:
         fetch-depth: 0
     - uses: docker/setup-buildx-action@v1
-    # Only allow building docker images from trunk (main) or patch (main/v0.X) protected branches.
-    - name: Check branch
-      run: |
-        # Short name for current branch
-        GIT_BRANCH=${GITHUB_REF#refs/heads/}
-        [[ $GIT_BRANCH = main* ]] || (echo "Not building image for invalid branch: $GIT_BRANCH" && exit 1)
     - name: Define docker image meta data tags
       id: meta
       uses: docker/metadata-action@v3
@@ -28,13 +22,13 @@ jobs:
           obolnetwork/charon
           ghcr.io/obolnetwork/charon
         tags: |
-          # Tag "git short sha" on push to branch (main)
-          type=sha,event=branch,prefix=
+          # Tag "git short sha" on all git events
+          type=sha,prefix=
 
-          # Tag "latest" on all events
-          type=raw,value=latest
+          # Tag "latest" on git-push-to-branch (main) events
+          type=raw,value=latest,event=branch
 
-          # Tag "tag ref" on tag push events
+          # Tag "tag ref" on git-tag events
           type=ref,event=tag
 
     - name: Login to Github container registry


### PR DESCRIPTION
Improves docker image tagging rules.

charon:
 - always tag `short sha`
 - only tag `latest` on main branch commits (not on `v0.X` tags)
 - only tag `git tag value` on git tag events
 
 promrated:
  - always tag `short sha`
  - always tag `latest`

category: misc
ticket: none
