### PR TITLE
app/retry: make sure to not enqueue new jobs when shutting down

### DIFF
--- a/app/retry/retry_test.go
+++ b/app/retry/retry_test.go
@@ -88,7 +88,7 @@ func TestRetryer(t *testing.T) {
 
 			retryer := retry.NewForT(t, ctxTimeoutFunc, backoffProvider)
 			var attempt int
-			retryer.DoAsync(ctx, core.NewAttesterDuty(999), "test", "test", func(ctx context.Context) error {
+			_ = retryer.DoAsync(ctx, core.NewAttesterDuty(999), "test", "test", func(ctx context.Context) error {
 				defer func() { attempt++ }()
 				return test.Func(ctx, attempt)
 			})
@@ -103,6 +103,9 @@ func TestRetryer(t *testing.T) {
 func TestShutdown(t *testing.T) {
 	ctx := context.Background()
 	bmock, err := beaconmock.New()
+	defer func() {
+		require.NoError(t, bmock.Close())
+	}()
 	require.NoError(t, err)
 
 	deadlineFunc, err := core.NewDutyDeadlineFunc(ctx, bmock)
@@ -117,13 +120,17 @@ func TestShutdown(t *testing.T) {
 
 	// Start 3 long-running functions
 	for i := 0; i < 3; i++ {
-		go retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", "test", func(ctx context.Context) error {
-			waiting <- struct{}{}
-			<-stop
-			<-ctx.Done()
+		go func() {
+			require.NoError(t,
+				retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", "test", func(ctx context.Context) error {
+					waiting <- struct{}{}
+					<-stop
+					<-ctx.Done()
 
-			return ctx.Err()
-		})
+					return ctx.Err()
+				}),
+			)
+		}()
 	}
 
 	// Wait for functions to block
@@ -145,6 +152,75 @@ func TestShutdown(t *testing.T) {
 		require.Fail(t, "shutdown not blocking")
 	default:
 	}
+
+	close(stop)
+	<-done
+}
+
+func TestRacyShutdown(t *testing.T) {
+	ctx := context.Background()
+	bmock, err := beaconmock.New()
+	defer func() {
+		require.NoError(t, bmock.Close())
+	}()
+	require.NoError(t, err)
+
+	deadlineFunc, err := core.NewDutyDeadlineFunc(ctx, bmock)
+	require.NoError(t, err)
+
+	retryer := retry.New[core.Duty](deadlineFunc)
+
+	const n = 3
+	waiting := make(chan struct{}, n)
+	stop := make(chan struct{})
+	done := make(chan struct{})
+
+	// Start 3 long-running functions
+	for i := 0; i < 3; i++ {
+		go func() {
+			// We're not expecting any errors here, because Shutdown() hasn't been called yet.
+			require.NoError(t,
+				retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", "test", func(ctx context.Context) error {
+					waiting <- struct{}{}
+					<-stop
+					<-ctx.Done()
+
+					return ctx.Err()
+				}),
+			)
+		}()
+	}
+
+	// Wait for functions to block
+	for i := 0; i < n; i++ {
+		<-waiting
+	}
+
+	// Trigger shutdown
+	go func() {
+		go retryer.Shutdown(ctx)
+
+		go func() {
+			// We *might* expect an error here: since Shutdown() is called in a goroutine, the runtime might decide to
+			// schedule its execution *before or after* this one.
+			// So, to test the race condition we expect either no error, or a "shutdown in progress" error.
+			// Both are fine.
+			err := retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", "test", func(ctx context.Context) error {
+				waiting <- struct{}{}
+				<-stop
+				<-ctx.Done()
+
+				return ctx.Err()
+			})
+			if err != nil {
+				require.ErrorContains(t, err, "shutdown in process")
+			}
+		}()
+
+		close(done)
+	}()
+
+	runtime.Gosched()
 
 	close(stop)
 	<-done

--- a/core/retry.go
+++ b/core/retry.go
@@ -13,30 +13,38 @@ func WithAsyncRetry(retryer *retry.Retryer[Duty]) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
 		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
-			go retryer.DoAsync(ctx, duty, "fetcher", "fetch", func(ctx context.Context) error {
-				return clone.FetcherFetch(ctx, duty, set)
-			})
+			go func() {
+				_ = retryer.DoAsync(ctx, duty, "fetcher", "fetch", func(ctx context.Context) error {
+					return clone.FetcherFetch(ctx, duty, set)
+				})
+			}()
 
 			return nil
 		}
 		w.ConsensusPropose = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
-			go retryer.DoAsync(ctx, duty, "consensus", "propose", func(ctx context.Context) error {
-				return clone.ConsensusPropose(ctx, duty, set)
-			})
+			go func() {
+				_ = retryer.DoAsync(ctx, duty, "consensus", "propose", func(ctx context.Context) error {
+					return clone.ConsensusPropose(ctx, duty, set)
+				})
+			}()
 
 			return nil
 		}
 		w.ParSigExBroadcast = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
-			go retryer.DoAsync(ctx, duty, "parsigex", "broadcast", func(ctx context.Context) error {
-				return clone.ParSigExBroadcast(ctx, duty, set)
-			})
+			go func() {
+				_ = retryer.DoAsync(ctx, duty, "parsigex", "broadcast", func(ctx context.Context) error {
+					return clone.ParSigExBroadcast(ctx, duty, set)
+				})
+			}()
 
 			return nil
 		}
 		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, key PubKey, data SignedData) error {
-			go retryer.DoAsync(ctx, duty, "bcast", "broadcast", func(ctx context.Context) error {
-				return clone.BroadcasterBroadcast(ctx, duty, key, data)
-			})
+			go func() {
+				_ = retryer.DoAsync(ctx, duty, "bcast", "broadcast", func(ctx context.Context) error {
+					return clone.BroadcasterBroadcast(ctx, duty, key, data)
+				})
+			}()
 
 			return nil
 		}

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -197,8 +197,8 @@ func newHTTPMock(optionalHandlers map[string]http.HandlerFunc, overrides ...stat
 	// Wait for server to be up
 	for {
 		resp, err := http.Get(addr + "/up") //nolint:noctx // Non-critical code
-		_ = resp.Body.Close()
 		if err == nil && resp.StatusCode == http.StatusOK {
+			_ = resp.Body.Close()
 			break
 		}
 		time.Sleep(time.Millisecond * 100)


### PR DESCRIPTION
This is achieved by adding a lock around r.wg.Wait() and r.wg.Add() calls: you don't want to add a new worker if you're waiting for the existing to finish.

Also added a test case that simulates calling Shutdown() and DoAsync() roughly at the same time.

This test usually exhibits a race condition in the first 10-20 runs on my machine (M1 Pro Mac).

category: bug
ticket: none
