### PR TITLE
core/tracker: unlock mutex

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -149,10 +149,12 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 
 	epoch := duty.Slot / int64(slotsPerEpoch)
 	if !s.isEpochResolved(epoch) {
-		return nil, errors.New("epoch not resolved yet")
+		return nil, errors.New("epoch not resolved yet",
+			z.Any("duty", duty.String()), z.I64("epoch", epoch))
 	}
 	if s.isEpochTrimmed(epoch) {
-		return nil, errors.New("epoch already trimmed")
+		return nil, errors.New("epoch already trimmed",
+			z.Any("duty", duty.String()), z.I64("epoch", epoch))
 	}
 
 	defSet, ok := s.getDutyDefinitionSet(duty)

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -154,7 +154,7 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 	}
 	if s.isEpochTrimmed(epoch) {
 		return nil, errors.New("epoch already trimmed",
-			z.Any("duty", duty.String()), z.I64("epoch", epoch))
+			z.Str("duty", duty.String()), z.I64("epoch", epoch))
 	}
 
 	defSet, ok := s.getDutyDefinitionSet(duty)

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -150,7 +150,7 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 	epoch := duty.Slot / int64(slotsPerEpoch)
 	if !s.isEpochResolved(epoch) {
 		return nil, errors.New("epoch not resolved yet",
-			z.Any("duty", duty.String()), z.I64("epoch", epoch))
+			z.Str("duty", duty.String()), z.I64("epoch", epoch))
 	}
 	if s.isEpochTrimmed(epoch) {
 		return nil, errors.New("epoch already trimmed",

--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -66,10 +66,13 @@ func newInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc, callback fu
 			return err
 		}
 
-		var delays []int64
+		var (
+			delays    []int64
+			startSlot = getStartSlot()
+		)
 		for _, att := range atts {
 			attSlot := att.Data.Slot
-			if int64(attSlot) < getStartSlot() {
+			if int64(attSlot) < startSlot {
 				continue
 			}
 

--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -36,7 +36,7 @@ func newInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc, callback fu
 		dssMutex      sync.Mutex
 	)
 
-	// setStartSlot return a previously set duty start slot and true or it sets it and returns false.
+	// getOrSetStartSlot returns a previously set duty start slot and true or it sets it and returns false.
 	getOrSetStartSlot := func(slot int64) (int64, bool) {
 		dssMutex.Lock()
 		defer dssMutex.Unlock()


### PR DESCRIPTION
Unlock mutex before doing any i/o in core/tracker/incldelay.go.

category: bug
ticket: #2028 
