### PR TITLE
app: fix peer count bn query to occur every min instead of every 10s

### DIFF
--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -127,7 +127,7 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 			if bnPeerCount == nil {
 				bnPeerCount = new(int)
 			}
-			*bnPeerCount = peerCount
+			bnPeerCount = &peerCount
 			beaconNodePeerCountGauge.Set(float64(peerCount))
 		}
 

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -47,7 +47,7 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, addr string
 	peerIDs []peer.ID, registry *prometheus.Registry, qbftDebug http.Handler,
 	pubkeys []core.PubKey, seenPubkeys <-chan core.PubKey, vapiCalls <-chan struct{},
 ) {
-	beaconNodeMetrics(ctx, eth2Cl, clockwork.NewRealClock())
+	beaconNodeVersionMetric(ctx, eth2Cl, clockwork.NewRealClock())
 
 	mux := http.NewServeMux()
 
@@ -106,7 +106,9 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 	)
 	go func() {
 		ticker := clock.NewTicker(10 * time.Second)
+		peerCountTicker := clock.NewTicker(1 * time.Minute)
 		epochTicker := clock.NewTicker(32 * 12 * time.Second) // 32 slots * 12 second slot time
+		var bnPeerCount int
 		currVAPICount := 0
 		prevVAPICount := 1 // Assume connected.
 		currPKs := make(map[core.PubKey]bool)
@@ -123,16 +125,18 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 				// Copy current to previous and clear current.
 				prevPKs, currPKs = currPKs, make(map[core.PubKey]bool)
 				prevVAPICount, currVAPICount = currVAPICount, 0
+			case <-peerCountTicker.Chan():
+				var err error
+				bnPeerCount, err = eth2Cl.NodePeerCount(ctx)
+				if err != nil {
+					log.Warn(ctx, "Failed to get beacon node peer count", err)
+				}
+				beaconNodePeerCountGauge.Set(float64(bnPeerCount))
 			case <-ticker.Chan():
 				if quorumPeersConnected(peerIDs, tcpNode) {
 					notConnectedRounds = 0
 				} else {
 					notConnectedRounds++
-				}
-
-				bnPeerCount, bnErr := eth2Cl.NodePeerCount(ctx)
-				if bnErr != nil {
-					log.Warn(ctx, "Failed to get beacon node peer count", bnErr)
 				}
 
 				syncing, syncDistance, err := beaconNodeSyncing(ctx, eth2Cl)
@@ -143,7 +147,7 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 				} else if syncing {
 					err = errReadyBeaconNodeSyncing
 					readyzGauge.Set(readyzBeaconNodeSyncing)
-				} else if bnPeerCount == 0 && bnErr == nil {
+				} else if bnPeerCount == 0 {
 					err = errReadyBeaconNodeZeroPeers
 					readyzGauge.Set(readyzBeaconNodeZeroPeers)
 				} else if syncDistance > bnFarBehindSlots {
@@ -192,18 +196,8 @@ func beaconNodeSyncing(ctx context.Context, eth2Cl eth2client.NodeSyncingProvide
 	return state.IsSyncing, state.SyncDistance, nil
 }
 
-// beaconNodeMetrics sets beacon node metrics like the peer count and node version.
-func beaconNodeMetrics(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
-	peerCountTicker := clock.NewTicker(1 * time.Minute)
-	setPeerCount := func() {
-		peerCount, err := eth2Cl.NodePeerCount(ctx)
-		if err != nil {
-			log.Error(ctx, "Failed to get beacon node peer count", err)
-			return
-		}
-		beaconNodePeerCountGauge.Set(float64(peerCount))
-	}
-
+// beaconNodeVersionMetric sets the beacon node version gauge.
+func beaconNodeVersionMetric(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
 	nodeVersionTicker := clock.NewTicker(10 * time.Minute)
 	var prevNodeVersion string
 	setNodeVersion := func() {
@@ -230,10 +224,7 @@ func beaconNodeMetrics(ctx context.Context, eth2Cl eth2wrap.Client, clock clockw
 		for {
 			select {
 			case <-onStartup:
-				setPeerCount()
 				setNodeVersion()
-			case <-peerCountTicker.Chan():
-				setPeerCount()
 			case <-nodeVersionTicker.Chan():
 				setNodeVersion()
 			case <-ctx.Done():

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -108,7 +108,7 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 		ticker := clock.NewTicker(10 * time.Second)
 		peerCountTicker := clock.NewTicker(1 * time.Minute)
 		epochTicker := clock.NewTicker(32 * 12 * time.Second) // 32 slots * 12 second slot time
-		var bnPeerCount *int                                  // Beacon node peer count value which is queried on startup & then every minute
+		var bnPeerCount *int                                  // Beacon node peer count value which is queried every minute
 		currVAPICount := 0
 		prevVAPICount := 1 // Assume connected.
 		currPKs := make(map[core.PubKey]bool)

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -108,7 +108,10 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 		ticker := clock.NewTicker(10 * time.Second)
 		peerCountTicker := clock.NewTicker(1 * time.Minute)
 		epochTicker := clock.NewTicker(32 * 12 * time.Second) // 32 slots * 12 second slot time
-		var bnPeerCount int
+		var (
+			bnPeerCount    int   // Beacon node peer count value which is queried on startup & every minute
+			bnPeerCountErr error // Error if the peer count query wasn't successful
+		)
 		currVAPICount := 0
 		prevVAPICount := 1 // Assume connected.
 		currPKs := make(map[core.PubKey]bool)
@@ -117,21 +120,31 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 			prevPKs[pubkey] = true
 		}
 
+		// beaconNodePeerCount queries beacon node peer count and sets the peer count gauge if err is nil.
+		beaconNodePeerCount := func() {
+			bnPeerCount, bnPeerCountErr = eth2Cl.NodePeerCount(ctx)
+			if bnPeerCountErr != nil {
+				log.Error(ctx, "Failed to get beacon node peer count", bnPeerCountErr)
+				return
+			}
+			beaconNodePeerCountGauge.Set(float64(bnPeerCount))
+		}
+
+		onStartup := make(chan struct{}, 1)
+		onStartup <- struct{}{}
+
 		for {
 			select {
 			case <-ctx.Done():
 				return
+			case <-onStartup:
+				beaconNodePeerCount()
 			case <-epochTicker.Chan():
 				// Copy current to previous and clear current.
 				prevPKs, currPKs = currPKs, make(map[core.PubKey]bool)
 				prevVAPICount, currVAPICount = currVAPICount, 0
 			case <-peerCountTicker.Chan():
-				var err error
-				bnPeerCount, err = eth2Cl.NodePeerCount(ctx)
-				if err != nil {
-					log.Warn(ctx, "Failed to get beacon node peer count", err)
-				}
-				beaconNodePeerCountGauge.Set(float64(bnPeerCount))
+				beaconNodePeerCount()
 			case <-ticker.Chan():
 				if quorumPeersConnected(peerIDs, tcpNode) {
 					notConnectedRounds = 0
@@ -147,7 +160,7 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 				} else if syncing {
 					err = errReadyBeaconNodeSyncing
 					readyzGauge.Set(readyzBeaconNodeSyncing)
-				} else if bnPeerCount == 0 {
+				} else if bnPeerCount == 0 && bnPeerCountErr == nil {
 					err = errReadyBeaconNodeZeroPeers
 					readyzGauge.Set(readyzBeaconNodeZeroPeers)
 				} else if syncDistance > bnFarBehindSlots {


### PR DESCRIPTION
Fixes peer count beacon node query to occur every min instead of every 10s. 

Also, fixes it to query only once since we query this both in `startReadyzChecker()` and `beaconNodeMetrics()` and set the `beaconNodeVersionGauge` in `startReadyzChecker` instead.

category: misc 
ticket: none 
