### PR TITLE
core/tracker: unlock mutex

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -149,10 +149,12 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 
 	epoch := duty.Slot / int64(slotsPerEpoch)
 	if !s.isEpochResolved(epoch) {
-		return nil, errors.New("epoch not resolved yet")
+		return nil, errors.New("epoch not resolved yet",
+			z.Str("duty", duty.String()), z.I64("epoch", epoch))
 	}
 	if s.isEpochTrimmed(epoch) {
-		return nil, errors.New("epoch already trimmed")
+		return nil, errors.New("epoch already trimmed",
+			z.Str("duty", duty.String()), z.I64("epoch", epoch))
 	}
 
 	defSet, ok := s.getDutyDefinitionSet(duty)


### PR DESCRIPTION
Unlock mutex before doing any i/o in core/tracker/incldelay.go.

category: bug
ticket: #2028 
cherry-pick: #2027