### PR TITLE
github/workflows: add a branch labeler

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,11 +1,12 @@
 name: Label PR
 on:
   pull_request:
+
 jobs:
-  label_issues:
+  label_pr:
     runs-on: ubuntu-latest
     permissions:
-      issues: write
+      pull-requests: write
     steps:
       - name: Calculate branch label
         id: branch-label
@@ -27,8 +28,7 @@ jobs:
             # Label all other branches as invalid
             LABEL="branch-invalid"
           fi
-          echo "LABEL=$LABEL"
-          echo "::set-output name=label::LABEL"
+          echo "label=$LABEL" >> $GITHUB_OUTPUT
 
       - uses: actions/github-script@v6
         if: steps.branch-label.outputs.label != 'skip'
@@ -38,5 +38,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ["${steps.calc-label.outputs.label}"]
+              labels: ["${steps.branch-label.outputs.label}"]
             })

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,9 +10,12 @@ jobs:
       - name: Calculate branch label
         id: branch-label
         run: |
-          LABEL=""
+
           # Short name for current branch
           GIT_BRANCH=${GITHUB_REF#refs/heads/}
+          echo "GIT_BRANCH=$GIT_BRANCH"
+
+          LABEL=""
           if [[ $GIT_BRANCH = main ]]; then
             # Do not label main branch PRs
           elif [[ $GIT_BRANCH = main* ]]; then
@@ -22,6 +25,7 @@ jobs:
             # Label all other branches as invalid
             LABEL="branch-invalid"
           fi
+          echo "LABEL=$LABEL"
           echo "::set-output name=label::LABEL"
 
       - uses: actions/github-script@v6

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,36 @@
+name: Label PR
+on:
+  pull_request:
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Calculate branch label
+        id: branch-label
+        run: |
+          LABEL=""
+          # Short name for current branch
+          GIT_BRANCH=${GITHUB_REF#refs/heads/}
+          if [[ $GIT_BRANCH = main ]]; then
+            # Do not label main branch PRs
+          elif [[ $GIT_BRANCH = main* ]]; then
+            # Label release branches
+            LABEL="branch-release"
+          else
+            # Label all other branches as invalid
+            LABEL="branch-invalid"
+          fi
+          echo "::set-output name=label::LABEL"
+
+      - uses: actions/github-script@v6
+        if: steps.branch-label.outputs.label != ''
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ["${steps.calc-label.outputs.label}"]
+            })

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -31,7 +31,7 @@ jobs:
           echo "::set-output name=label::LABEL"
 
       - uses: actions/github-script@v6
-        if: steps.branch-label.outputs.label != "skip"
+        if: steps.branch-label.outputs.label != 'skip'
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,6 +1,7 @@
 name: Label PR
 on:
   pull_request:
+    types: [ opened, reopened, edited, synchronize ]
 
 jobs:
   label_pr:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -11,13 +11,15 @@ jobs:
         id: branch-label
         run: |
 
-          # Short name for current branch
-          GIT_BRANCH=${GITHUB_REF#refs/heads/}
+          # Short name for current branch. For PRs, use target branch (base ref)
+          # Reference: https://stackoverflow.com/questions/60300169/how-to-get-branch-name-on-github-action
+          GIT_BRANCH=${GITHUB_BASE_REF:-${GITHUB_REF#refs/heads/}}
           echo "GIT_BRANCH=$GIT_BRANCH"
 
           LABEL=""
           if [[ $GIT_BRANCH = main ]]; then
             # Do not label main branch PRs
+            LABEL="skip"
           elif [[ $GIT_BRANCH = main* ]]; then
             # Label release branches
             LABEL="branch-release"
@@ -29,7 +31,7 @@ jobs:
           echo "::set-output name=label::LABEL"
 
       - uses: actions/github-script@v6
-        if: steps.branch-label.outputs.label != ''
+        if: steps.branch-label.outputs.label != "skip"
         with:
           script: |
             github.rest.issues.addLabels({

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -38,5 +38,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              labels: ["${steps.branch-label.outputs.label}"]
+              labels: ["${{steps.branch-label.outputs.label}}"]
             })


### PR DESCRIPTION
Automatically add labels to PRs that are not on main branch. This makes it obvious and clear if PRs are non-standard.

category: misc
ticket: none