### PR TITLE
app: enable libp2p bandwidth metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -286,7 +286,11 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	// Start libp2p TCP node.
-	tcpNode, err := p2p.NewTCPNode(ctx, conf.P2P, p2pKey, connGater, false, conf.TestConfig.LibP2POpts...)
+	opts := []libp2p.Option{p2p.WithBandwidthReporter()}
+	opts = append(opts, conf.TestConfig.LibP2POpts...)
+
+	tcpNode, err := p2p.NewTCPNode(ctx, conf.P2P, p2pKey, connGater,
+		false, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Enable libp2p built-in bandwidth metrics reporting in `charon run`.

category: feature 
ticket: none
