### PR TITLE
testutil/verifypr: limit PR titles to 60 chars

### DIFF
--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -81,6 +81,13 @@ func verify() error {
 }
 
 func verifyTitle(title string) error {
+	const maxTitleLen = 60
+	if len(title) > maxTitleLen {
+		return errors.New("title too long",
+			z.Int("max", maxTitleLen),
+			z.Int("actual", len(title)))
+	}
+
 	split := strings.SplitN(title, ":", 2)
 	if len(split) < 2 {
 		return errors.New("title isn't prefixed with 'package[/subpackage]:'")

--- a/testutil/verifypr/verify_internal_test.go
+++ b/testutil/verifypr/verify_internal_test.go
@@ -60,6 +60,10 @@ func TestTitle(t *testing.T) {
 			Title: "avoid: Sentence case",
 			Error: "shouldn't start with a capital",
 		},
+		{
+			Title: "foo/bar: this title is too long, the max length is 60 characters",
+			Error: "title too long",
+		},
 	}
 	for i, test := range tests {
 		t.Run(fmt.Sprint(i), func(t *testing.T) {


### PR DESCRIPTION
Limit PR titles to 60 chars. This drives the use of succinct PR titles and more verbose bodies. Commit and PR titles should be glanceable. It should be easy to glance over a long list of PRs and quickly identify and find things "at a glance". This requires short titles. Details about what changed, the types involved, the constants changed all need to be in the body. 

category: misc
ticket: none