### PR TITLE
core: debug clashing aggregator issue

### DIFF
--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -115,8 +115,8 @@ func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.Unsig
 		}
 		db.resolveAttQueriesUnsafe()
 	case core.DutyAggregator:
-		for _, unsignedData := range unsignedSet {
-			err := db.storeAggAttestationUnsafe(unsignedData)
+		for pubkey, unsignedData := range unsignedSet {
+			err := db.storeAggAttestationUnsafe(pubkey, unsignedData)
 			if err != nil {
 				return err
 			}
@@ -367,7 +367,7 @@ func (db *MemDB) storeAttestationUnsafe(pubkey core.PubKey, unsignedData core.Un
 }
 
 // storeAggAttestationUnsafe stores the unsigned aggregated attestation. It is unsafe since it assumes the lock is held.
-func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error {
+func (db *MemDB) storeAggAttestationUnsafe(pubkey core.PubKey, unsignedData core.UnsignedData) error {
 	cloned, err := unsignedData.Clone() // Clone before storing.
 	if err != nil {
 		return err
@@ -403,6 +403,7 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error
 
 		if existingRoot != providedRoot {
 			return errors.New("clashing aggregated attestation",
+				z.Str("pubkey", pubkey.String()),
 				z.U64("commIdx", uint64(aggAtt.Attestation.Data.Index)),
 				z.Hex("existing_aggregation_bits", existing.AggregationBits),
 				z.Hex("provided_aggregation_bits", aggAtt.AggregationBits),

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -402,7 +402,7 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error
 		}
 
 		if existingRoot != providedRoot {
-			return errors.New("clashing aggregated attestation")
+			return errors.New("clashing aggregated attestation", z.U64("commIdx", uint64(aggAtt.Attestation.Data.Index)))
 		}
 	} else {
 		db.aggDuties[key] = aggAtt

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -4,7 +4,6 @@ package dutydb
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -405,10 +404,10 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error
 		if existingRoot != providedRoot {
 			return errors.New("clashing aggregated attestation",
 				z.U64("commIdx", uint64(aggAtt.Attestation.Data.Index)),
-				z.Str("existing_aggregation_bits", fmt.Sprintf("%#x", []byte(existing.AggregationBits))),
-				z.Str("provided_aggregation_bits", fmt.Sprintf("%#x", []byte(aggAtt.AggregationBits))),
-				z.Str("existing_signature", fmt.Sprintf("%#x", existing.Signature)),
-				z.Str("provided_signature", fmt.Sprintf("%#x", aggAtt.Signature)),
+				z.Hex("existing_aggregation_bits", existing.AggregationBits),
+				z.Hex("provided_aggregation_bits", aggAtt.AggregationBits),
+				z.Hex("existing_signature", existing.Signature[:]),
+				z.Hex("provided_signature", aggAtt.Signature[:]),
 			)
 		}
 	} else {

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -4,6 +4,7 @@ package dutydb
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -402,7 +403,13 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error
 		}
 
 		if existingRoot != providedRoot {
-			return errors.New("clashing aggregated attestation", z.U64("commIdx", uint64(aggAtt.Attestation.Data.Index)))
+			return errors.New("clashing aggregated attestation",
+				z.U64("commIdx", uint64(aggAtt.Attestation.Data.Index)),
+				z.Str("existing_aggregation_bits", fmt.Sprintf("%#x", []byte(existing.AggregationBits))),
+				z.Str("provided_aggregation_bits", fmt.Sprintf("%#x", []byte(aggAtt.AggregationBits))),
+				z.Str("existing_signature", fmt.Sprintf("%#x", existing.Signature)),
+				z.Str("provided_signature", fmt.Sprintf("%#x", aggAtt.Signature)),
+			)
 		}
 	} else {
 		db.aggDuties[key] = aggAtt

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -194,7 +194,7 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot int64, defSet co
 			log.Debug(ctx, "Attester not selected for aggregation duty", z.Any("pubkey", pubkey))
 			continue
 		}
-		log.Info(ctx, "Resolved attester aggregation duty", z.Any("pubkey", pubkey))
+		log.Info(ctx, "Resolved attester aggregation duty", z.Any("pubkey", pubkey), z.U64("commIdx", uint64(attDef.CommitteeIndex)))
 
 		// Query DutyDB for Attestation data to get attestation data root.
 		attData, err := f.awaitAttDataFunc(ctx, slot, int64(attDef.CommitteeIndex))


### PR DESCRIPTION
Adds debug logs to debug clashing aggregation attestation error. This error is found in performance cluster, likely to be the case where we have multiple aggregators per slot per committee index but have different aggregated attestation.
![Screenshot 2023-04-07 at 2 13 20 PM](https://user-images.githubusercontent.com/37813203/230582792-4adbb030-0f9d-4544-8ac4-2aa7d5ca5fa3.png)


category: misc
ticket: none
