### PR TITLE
core/fetcher: dedup aggregate attestations

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -199,9 +199,14 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot int64, defSet co
 		}
 		log.Info(ctx, "Resolved attester aggregation duty", z.Any("pubkey", pubkey))
 
-		_, ok = aggAttByCommIdx[attDef.CommitteeIndex]
+		aggAtt, ok := aggAttByCommIdx[attDef.CommitteeIndex]
 		if ok {
-			continue // Skips querying aggregate attestation for aggregators of same committee.
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt,
+			}
+
+			// Skips querying aggregate attestation for aggregators of same committee.
+			continue
 		}
 
 		// Query DutyDB for Attestation data to get attestation data root.
@@ -216,7 +221,7 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot int64, defSet co
 		}
 
 		// Query BN for aggregate attestation.
-		aggAtt, err := f.eth2Cl.AggregateAttestation(ctx, eth2p0.Slot(slot), dataRoot)
+		aggAtt, err = f.eth2Cl.AggregateAttestation(ctx, eth2p0.Slot(slot), dataRoot)
 		if err != nil {
 			return core.UnsignedDataSet{}, err
 		} else if aggAtt == nil {

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -197,16 +197,15 @@ func TestFetchAggregator(t *testing.T) {
 	err = fetch.Fetch(ctx, duty, newDefSet(commLenNoAggregator))
 	require.NoError(t, err)
 
+	// Test for same committee index.
+	sameCommitteeIndex = true
+	err = fetch.Fetch(ctx, duty, newDefSet(commLenAggregator))
+	require.ErrorIs(t, err, done)
+
 	// Test nil, nil AggregateAttestation response.
 	nilAggregate = true
 	err = fetch.Fetch(ctx, duty, newDefSet(commLenAggregator))
 	require.ErrorContains(t, err, "aggregate attestation not found by root (retryable)")
-
-	// Test for same committee index.
-	sameCommitteeIndex = true
-	nilAggregate = false
-	err = fetch.Fetch(ctx, duty, newDefSet(commLenAggregator))
-	require.ErrorIs(t, err, done)
 }
 
 func TestFetchBlocks(t *testing.T) {


### PR DESCRIPTION
Dedup aggregate attestations in fetcher for aggregators of same committee. This solves `clashing aggregated attestation` error in dutydb in case of different aggregate attestations for aggregators of same committee.

category: bug
ticket: none
