### PR TITLE
enr: fix duplicate keys in enr parsing

### DIFF
--- a/eth2util/enr/enr_test.go
+++ b/eth2util/enr/enr_test.go
@@ -119,6 +119,7 @@ func TestParseDuplicateKeys(t *testing.T) {
 	require.ErrorContains(t, err, "duplicate enr key found")
 }
 
+// mockRecord is a mock for enr.Record.
 type mockRecord struct {
 	kvs map[string][]byte
 }
@@ -131,6 +132,7 @@ func (r mockRecord) String() string {
 // encodeElements returns the RLP encoding of a minimal set of record elements adding two duplicate keys.
 func encodeElements(kvs map[string][]byte) []byte {
 	const duplicateKey = "duplicate_key"
+
 	var elements [][]byte
 	elements = append(elements, []byte(keyID), kvs[keyID])
 

--- a/eth2util/enr/enr_test.go
+++ b/eth2util/enr/enr_test.go
@@ -113,19 +113,19 @@ func TestParseDuplicateKeys(t *testing.T) {
 	kvs := map[string][]byte{
 		keyID: []byte(valID),
 	}
-	r := mockRecord{kvs: kvs}
+	r := duplicateRecord{kvs: kvs}
 
 	_, err := enr.Parse(r.String())
 	require.ErrorContains(t, err, "duplicate enr key found")
 }
 
-// mockRecord is a mock for enr.Record.
-type mockRecord struct {
+// duplicateRecord is a duplicate for enr.Record.
+type duplicateRecord struct {
 	kvs map[string][]byte
 }
 
 // String returns the base64 encoded string representation of the record.
-func (r mockRecord) String() string {
+func (r duplicateRecord) String() string {
 	return "enr:" + base64.RawURLEncoding.EncodeToString(encodeElements(r.kvs))
 }
 


### PR DESCRIPTION
Adds a check when duplicate keys are found in ENR parsing. Also adds tests.

category: bug 
ticket: #2054 