### PR TITLE
rlp: fix bug in decodeLength

### DIFF
--- a/eth2util/rlp/rlp.go
+++ b/eth2util/rlp/rlp.go
@@ -125,8 +125,8 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 	}
 
 	length = int(prefix - 0xf7)
-	if length <= 0 { // This is impossible based on outer if else checks
-		panic("length not positive (>=1)")
+	if length > 8 || length <= 0 { // This is impossible based on outer if else checks
+		panic("length not in expected range [1,8]")
 	}
 
 	offset = 1 + length

--- a/eth2util/rlp/rlp.go
+++ b/eth2util/rlp/rlp.go
@@ -102,7 +102,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 
 	if prefix < 0xc0 {
 		length = int(prefix - 0xb7) // length of the string in bytes in binary form
-		if length > 8 || length < 0 {
+		if length > 8 || length <= 0 {
 			return 0, 0, errors.New("invalid length prefix")
 		}
 
@@ -113,7 +113,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 			return 0, 0, err
 		} else if resp < 0 {
 			return 0, 0, errors.New("negative length")
-		} else if offset+resp > len(item) {
+		} else if offset > offset+resp {
 			return 0, 0, errors.New("overflow")
 		}
 
@@ -125,7 +125,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 	}
 
 	length = int(prefix - 0xf7)
-	if length > 8 || length < 0 {
+	if length > 8 || length <= 0 {
 		return 0, 0, errors.New("invalid length prefix")
 	}
 
@@ -136,7 +136,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 		return 0, 0, err
 	} else if resp < 0 {
 		return 0, 0, errors.New("negative length")
-	} else if offset+resp > len(item) {
+	} else if offset > offset+resp {
 		return 0, 0, errors.New("overflow")
 	}
 

--- a/eth2util/rlp/rlp.go
+++ b/eth2util/rlp/rlp.go
@@ -101,9 +101,9 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 	}
 
 	if prefix < 0xc0 {
-		length = int(prefix - 0xb7) // length of the string in bytes in binary form
-		if length > 8 || length <= 0 {
-			return 0, 0, errors.New("invalid length prefix")
+		length = int(prefix - 0xb7)    // length of the string in bytes in binary form
+		if length > 8 || length <= 0 { // This is impossible based on outer if else checks
+			panic("length not in expected range [1,8]")
 		}
 
 		offset := 1 + length
@@ -125,8 +125,8 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 	}
 
 	length = int(prefix - 0xf7)
-	if length > 8 || length <= 0 {
-		return 0, 0, errors.New("invalid length prefix")
+	if length <= 0 { // This is impossible based on outer if else checks
+		panic("length not positive (>=1)")
 	}
 
 	offset = 1 + length

--- a/eth2util/rlp/rlp.go
+++ b/eth2util/rlp/rlp.go
@@ -101,8 +101,8 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 	}
 
 	if prefix < 0xc0 {
-		length = int(prefix - 0xb7)
-		if length > 63 || length < 0 {
+		length = int(prefix - 0xb7) // length of the string in bytes in binary form
+		if length > 8 || length < 0 {
 			return 0, 0, errors.New("invalid length prefix")
 		}
 
@@ -113,7 +113,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 			return 0, 0, err
 		} else if resp < 0 {
 			return 0, 0, errors.New("negative length")
-		} else if offset > offset+resp {
+		} else if offset+resp > len(item) {
 			return 0, 0, errors.New("overflow")
 		}
 
@@ -125,7 +125,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 	}
 
 	length = int(prefix - 0xf7)
-	if length > 63 || length < 0 {
+	if length > 8 || length < 0 {
 		return 0, 0, errors.New("invalid length prefix")
 	}
 
@@ -136,7 +136,7 @@ func decodeLength(item []byte) (offset int, length int, err error) {
 		return 0, 0, err
 	} else if resp < 0 {
 		return 0, 0, errors.New("negative length")
-	} else if offset > offset+resp {
+	} else if offset+resp > len(item) {
 		return 0, 0, errors.New("overflow")
 	}
 

--- a/eth2util/rlp/rlp_internal_test.go
+++ b/eth2util/rlp/rlp_internal_test.go
@@ -27,10 +27,4 @@ func TestDecodeLength(t *testing.T) {
 		_, _, err := decodeLength(items)
 		require.ErrorContains(t, err, "input too short")
 	})
-
-	t.Run("overflow", func(t *testing.T) {
-		items := []byte{0xb8, 0x10, 0x0a}
-		_, _, err := decodeLength(items)
-		require.ErrorContains(t, err, "overflow")
-	})
 }

--- a/eth2util/rlp/rlp_internal_test.go
+++ b/eth2util/rlp/rlp_internal_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package rlp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeLength(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		items := []byte{0xb8, 0x01, 0x0a}
+		offset, length, err := decodeLength(items)
+		require.NoError(t, err)
+		require.Equal(t, 2, offset)
+		require.Equal(t, 1, length)
+	})
+
+	t.Run("prefix absent", func(t *testing.T) {
+		_, _, err := decodeLength(nil)
+		require.ErrorContains(t, err, "input too short")
+	})
+
+	t.Run("prefix provided but length absent", func(t *testing.T) {
+		items := []byte{0xbf}
+		_, _, err := decodeLength(items)
+		require.ErrorContains(t, err, "input too short")
+	})
+
+	t.Run("overflow", func(t *testing.T) {
+		items := []byte{0xb8, 0x10, 0x0a}
+		_, _, err := decodeLength(items)
+		require.ErrorContains(t, err, "overflow")
+	})
+}


### PR DESCRIPTION
Fixes bug in RLP `decodeLength()` by ensuring that calculations of length should use units of bytes instead of bits.

category: bug 
ticket: #2076 
