### PR TITLE
core/tracker: improve ignoring of unsupported duties

### DIFF
--- a/testutil/random.go
+++ b/testutil/random.go
@@ -900,3 +900,8 @@ func GenerateInsecureK1Key(t *testing.T, seed int) *k1.PrivateKey {
 
 	return k1.PrivKeyFromBytes(k.D.Bytes())
 }
+
+// RandomBool returns a random boolean.
+func RandomBool() bool {
+	return rand.Intn(2) == 0
+}


### PR DESCRIPTION
Improves ignoring of unsupported duties, so ignore for both failure and participation logs and metrics. Also fix edge case mentioned in #1348 where aggregation duties succeeded and then later fails.

category: bug
ticket: #1348
