### PR TITLE
beaconmock: remove backoff dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	golang.org/x/time v0.3.0
 	golang.org/x/tools v0.8.0
 	google.golang.org/protobuf v1.30.0
-	gopkg.in/cenkalti/backoff.v1 v1.1.0
 )
 
 require (
@@ -177,6 +176,7 @@ require (
 	golang.org/x/text v0.9.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
+	gopkg.in/cenkalti/backoff.v1 v1.1.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/testutil/beaconmock/headproducer_internal_test.go
+++ b/testutil/beaconmock/headproducer_internal_test.go
@@ -123,6 +123,9 @@ func TestHeadProducer(t *testing.T) {
 }
 
 // Refer https://github.com/cenkalti/backoff/blob/v4/backoff.go#L46 for the following snippet.
+// We don't need the full dependency since we don't want these tests to support exponential backoff.
+// We want simple, fast tests where a single event is sent by the server and is intercepted by the client, or
+// it produces an error.
 
 // Stop indicates that no more retries should be made for use in NextBackOff().
 const Stop time.Duration = -1


### PR DESCRIPTION
Remove `gopkg.in/cenkalti/backoff.v1` direct dependency by removing its usage in `headproducer_internal_test.go`. Though it is still present as an indirect dependency since `sse/v2` uses it.

category: refactor
ticket: https://github.com/ObolNetwork/charon/issues/2083 
