### PR TITLE
core: add nil checks

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -62,6 +62,10 @@ func (m *ParSigEx) handle(ctx context.Context, _ peer.ID, req proto.Message) (pr
 		return nil, false, errors.New("invalid request type")
 	}
 
+	if pb == nil || pb.Duty == nil || pb.DataSet == nil {
+		return nil, false, errors.New("invalid parsigex msg fields", z.Any("msg", pb))
+	}
+
 	duty := core.DutyFromProto(pb.Duty)
 	ctx = log.WithCtx(ctx, z.Any("duty", duty))
 

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -205,6 +205,10 @@ func newMsgVerifier(peers []peer.ID) (func(msg *pbv1.PriorityMsg) error, error) 
 	}
 
 	return func(msg *pbv1.PriorityMsg) error {
+		if msg == nil || msg.Duty == nil {
+			return errors.New("invalid priority msg proto fields", z.Any("msg", msg))
+		}
+
 		key, ok := keys[msg.PeerId]
 		if !ok {
 			return errors.New("unknown peer id")
@@ -246,6 +250,10 @@ func topicProposalToProto(p TopicProposal) (*pbv1.PriorityTopicProposal, error) 
 
 // topicProposalToProto returns a topic proposal from the proto version.
 func topicResultFromProto(p *pbv1.PriorityTopicResult) (TopicResult, error) {
+	if p == nil {
+		return TopicResult{}, errors.New("priority topic result proto cannot be nil")
+	}
+
 	topicVal := new(structpb.Value)
 	if err := p.Topic.UnmarshalTo(topicVal); err != nil {
 		return TopicResult{}, errors.Wrap(err, "anypb topic")

--- a/core/proto.go
+++ b/core/proto.go
@@ -31,6 +31,10 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (ParSignedDa
 	//  For now, it is a good way to catch compatibility issues. But we should
 	//  recover panics and return an error before launching mainnet.
 
+	if data == nil {
+		return ParSignedData{}, errors.New("partial signed data proto cannot be nil")
+	}
+
 	var signedData SignedData
 	switch typ {
 	case DutyAttester:
@@ -147,6 +151,10 @@ func ParSignedDataSetToProto(set ParSignedDataSet) (*pbv1.ParSignedDataSet, erro
 
 // ParSignedDataSetFromProto returns the set from a protobuf.
 func ParSignedDataSetFromProto(typ DutyType, set *pbv1.ParSignedDataSet) (ParSignedDataSet, error) {
+	if set == nil {
+		return nil, errors.New("partial signed data set proto cannot be nil")
+	}
+
 	var (
 		resp = make(ParSignedDataSet)
 		err  error
@@ -179,6 +187,10 @@ func UnsignedDataSetToProto(set UnsignedDataSet) (*pbv1.UnsignedDataSet, error) 
 
 // UnsignedDataSetFromProto returns the set from a protobuf.
 func UnsignedDataSetFromProto(typ DutyType, set *pbv1.UnsignedDataSet) (UnsignedDataSet, error) {
+	if set == nil {
+		return nil, errors.New("unsigned data set proto cannot be nil")
+	}
+
 	resp := make(UnsignedDataSet)
 	for pubkey, data := range set.Set {
 		var err error

--- a/core/proto.go
+++ b/core/proto.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
@@ -151,8 +152,8 @@ func ParSignedDataSetToProto(set ParSignedDataSet) (*pbv1.ParSignedDataSet, erro
 
 // ParSignedDataSetFromProto returns the set from a protobuf.
 func ParSignedDataSetFromProto(typ DutyType, set *pbv1.ParSignedDataSet) (ParSignedDataSet, error) {
-	if set == nil {
-		return nil, errors.New("partial signed data set proto cannot be nil")
+	if set == nil || set.Set == nil {
+		return nil, errors.New("invalid partial signed data set proto fields", z.Any("set", set))
 	}
 
 	var (
@@ -187,8 +188,8 @@ func UnsignedDataSetToProto(set UnsignedDataSet) (*pbv1.UnsignedDataSet, error) 
 
 // UnsignedDataSetFromProto returns the set from a protobuf.
 func UnsignedDataSetFromProto(typ DutyType, set *pbv1.UnsignedDataSet) (UnsignedDataSet, error) {
-	if set == nil {
-		return nil, errors.New("unsigned data set proto cannot be nil")
+	if set == nil || set.Set == nil {
+		return nil, errors.New("invalid unsigned data set fields", z.Any("set", set))
 	}
 
 	resp := make(UnsignedDataSet)

--- a/core/proto.go
+++ b/core/proto.go
@@ -152,7 +152,7 @@ func ParSignedDataSetToProto(set ParSignedDataSet) (*pbv1.ParSignedDataSet, erro
 
 // ParSignedDataSetFromProto returns the set from a protobuf.
 func ParSignedDataSetFromProto(typ DutyType, set *pbv1.ParSignedDataSet) (ParSignedDataSet, error) {
-	if set == nil || set.Set == nil {
+	if set == nil || len(set.Set) == 0 {
 		return nil, errors.New("invalid partial signed data set proto fields", z.Any("set", set))
 	}
 
@@ -188,7 +188,7 @@ func UnsignedDataSetToProto(set UnsignedDataSet) (*pbv1.UnsignedDataSet, error) 
 
 // UnsignedDataSetFromProto returns the set from a protobuf.
 func UnsignedDataSetFromProto(typ DutyType, set *pbv1.UnsignedDataSet) (UnsignedDataSet, error) {
-	if set == nil || set.Set == nil {
+	if set == nil || len(set.Set) == 0 {
 		return nil, errors.New("invalid unsigned data set fields", z.Any("set", set))
 	}
 

--- a/core/proto_test.go
+++ b/core/proto_test.go
@@ -236,3 +236,20 @@ func randomSignedData(t *testing.T) map[core.DutyType]core.SignedData {
 		core.DutySyncContribution:        core.NewSignedSyncContributionAndProof(testutil.RandomSignedSyncContributionAndProof()),
 	}
 }
+
+func TestNilPointerChecks(t *testing.T) {
+	_, err := core.ParSignedDataFromProto(core.DutyAttester, nil)
+	require.ErrorContains(t, err, "partial signed data proto cannot be nil")
+
+	_, err = core.ParSignedDataSetFromProto(core.DutyAttester, nil)
+	require.ErrorContains(t, err, "invalid partial signed data set proto fields")
+
+	_, err = core.ParSignedDataSetFromProto(core.DutyAttester, new(pbv1.ParSignedDataSet))
+	require.ErrorContains(t, err, "invalid partial signed data set proto fields")
+
+	_, err = core.UnsignedDataSetFromProto(core.DutyAttester, nil)
+	require.ErrorContains(t, err, "invalid unsigned data set fields")
+
+	_, err = core.UnsignedDataSetFromProto(core.DutyAttester, new(pbv1.UnsignedDataSet))
+	require.ErrorContains(t, err, "invalid unsigned data set fields")
+}


### PR DESCRIPTION
Adds nil checks before reading proto messages in core package mentioned in audit report.

Refer: OBOL-03

category: misc
ticket: #1997 
