### PR TITLE
testutil/beaconmock: fix fuzz issues

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -834,6 +834,9 @@ func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeReci
 
 		var activeVals []*eth2v1.Validator
 		for _, validator := range vals {
+			if validator == nil {
+				return errors.New("validator data cannot be nil")
+			}
 			if validator.Status != eth2v1.ValidatorStateActiveOngoing {
 				continue
 			}
@@ -846,6 +849,10 @@ func setFeeRecipient(eth2Cl eth2wrap.Client, pubkeys []eth2p0.BLSPubKey, feeReci
 
 		var preps []*eth2v1.ProposalPreparation
 		for _, val := range activeVals {
+			if val == nil || val.Validator == nil {
+				return errors.New("validator data cannot be nil")
+			}
+
 			feeRecipient := feeRecipientFunc(core.PubKeyFrom48Bytes(val.Validator.PublicKey))
 
 			var addr bellatrix.ExecutionAddress

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -284,6 +284,13 @@ func (s *Scheduler) resolveAttDuties(ctx context.Context, slot core.Slot, vals v
 		return err
 	}
 
+	// Check if any of the attester duties returned are nil..
+	for _, duty := range attDuties {
+		if duty == nil {
+			return errors.New("attester duty cannot be nil")
+		}
+	}
+
 	remaining := make(map[eth2p0.ValidatorIndex]bool)
 	for _, index := range vals.Indexes() {
 		remaining[index] = true
@@ -347,6 +354,13 @@ func (s *Scheduler) resolveProDuties(ctx context.Context, slot core.Slot, vals v
 		return err
 	}
 
+	// Check if any of the proposer duties returned are nil.
+	for _, duty := range proDuties {
+		if duty == nil {
+			return errors.New("proposer duty cannot be nil")
+		}
+	}
+
 	for _, proDuty := range proDuties {
 		if proDuty.Slot < eth2p0.Slot(slot.Slot) {
 			// Skip duties for earlier slots in initial epoch.
@@ -387,6 +401,13 @@ func (s *Scheduler) resolveSyncCommDuties(ctx context.Context, slot core.Slot, v
 	duties, err := s.eth2Cl.SyncCommitteeDuties(ctx, eth2p0.Epoch(slot.Epoch()), vals.Indexes())
 	if err != nil {
 		return err
+	}
+
+	// Check if any of the sync committee duties returned are nil.
+	for _, duty := range duties {
+		if duty == nil {
+			return errors.New("sync committee duty cannot be nil")
+		}
 	}
 
 	for _, syncCommDuty := range duties {
@@ -585,6 +606,10 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
 
 	var resp []validator
 	for index, val := range vals {
+		if val == nil || val.Validator == nil {
+			return nil, errors.New("validator data cannot be nil")
+		}
+
 		pubkey, err := core.PubKeyFromBytes(val.Validator.PublicKey[:])
 		if err != nil {
 			return nil, err

--- a/core/tracker/incldelay.go
+++ b/core/tracker/incldelay.go
@@ -67,6 +67,10 @@ func newInclDelayFunc(eth2Cl eth2wrap.Client, dutiesFunc dutiesFunc, callback fu
 
 		var delays []int64
 		for _, att := range atts {
+			if att == nil || att.Data == nil {
+				return errors.New("attestation fields cannot be nil")
+			}
+
 			attSlot := att.Data.Slot
 			if int64(attSlot) < startSlot {
 				continue

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -923,6 +923,10 @@ func (c Component) ProposerDuties(ctx context.Context, epoch eth2p0.Epoch, valid
 
 	// Replace root public keys with public shares
 	for i := 0; i < len(duties); i++ {
+		if duties[i] == nil {
+			return nil, errors.New("proposer duty cannot be nil")
+		}
+
 		pubshare, ok := c.getPubShareFunc(duties[i].PubKey)
 		if !ok {
 			// Ignore unknown validators since ProposerDuties returns ALL proposers for the epoch if validatorIndices is empty.
@@ -942,6 +946,10 @@ func (c Component) AttesterDuties(ctx context.Context, epoch eth2p0.Epoch, valid
 
 	// Replace root public keys with public shares.
 	for i := 0; i < len(duties); i++ {
+		if duties[i] == nil {
+			return nil, errors.New("attester duty cannot be nil")
+		}
+
 		pubshare, ok := c.getPubShareFunc(duties[i].PubKey)
 		if !ok {
 			return nil, errors.New("pubshare not found")
@@ -960,6 +968,10 @@ func (c Component) SyncCommitteeDuties(ctx context.Context, epoch eth2p0.Epoch, 
 
 	// Replace root public keys with public shares.
 	for i := 0; i < len(duties); i++ {
+		if duties[i] == nil {
+			return nil, errors.New("sync committee duty cannot be nil")
+		}
+
 		pubshare, ok := c.getPubShareFunc(duties[i].PubKey)
 		if !ok {
 			return nil, errors.New("pubshare not found")
@@ -1011,6 +1023,10 @@ func (Component) NodeVersion(context.Context) (string, error) {
 func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Validator) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 	resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
 	for vIdx, val := range vals {
+		if val == nil || val.Validator == nil {
+			return nil, errors.New("validator data cannot be nil")
+		}
+
 		var ok bool
 		val.Validator.PublicKey, ok = c.getPubShareFunc(val.Validator.PublicKey)
 		if !ok {

--- a/testutil/compose/fuzz/beacon_fuzz_test.go
+++ b/testutil/compose/fuzz/beacon_fuzz_test.go
@@ -1,0 +1,60 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package fuzz_test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/compose"
+)
+
+//go:generate go test . -run=TestBeaconFuzz -integration -v
+
+var (
+	integration = flag.Bool("integration", false, "Enable docker based integration test")
+	sudoPerms   = flag.Bool("sudo-perms", false, "Enables changing all compose artefacts file permissions using sudo.")
+	logDir      = flag.String("log-dir", "", "Specifies the directory to store test docker-compose logs. Empty defaults to stdout.")
+	fuzzTimeout = flag.Duration("fuzz-timeout", time.Minute*10, "Specifies the duration of the beacon fuzz test.")
+)
+
+func TestBeaconFuzz(t *testing.T) {
+	if !*integration {
+		t.Skip("Skipping beacon fuzz integration test")
+	}
+
+	dir, err := os.MkdirTemp("", "")
+	require.NoError(t, err)
+
+	conf := compose.NewDefaultConfig()
+	conf.SyntheticBlockProposals = true
+	conf.Fuzz = true
+	conf.DisableMonitoringPorts = true
+	conf.BuildLocal = true
+	conf.ImageTag = "local"
+	conf.InsecureKeys = true
+	require.NoError(t, compose.WriteConfig(dir, conf))
+
+	os.Args = []string{"cobra.test"}
+
+	autoConfig := compose.AutoConfig{
+		Dir:          dir,
+		AlertTimeout: *fuzzTimeout,
+		SudoPerms:    *sudoPerms,
+	}
+
+	if *logDir != "" {
+		autoConfig.LogFile = path.Join(*logDir, fmt.Sprintf("%s.log", t.Name()))
+	}
+
+	err = compose.Auto(context.Background(), autoConfig)
+	testutil.RequireNoError(t, err)
+}


### PR DESCRIPTION
Fixes panics found by initial beacon fuzz tests. Also improve efficiency of beacon fuzzer to trigger more panics in charon workflow.

category: test
ticket: #1962 
