### PR TITLE
dkg: verify valIdx in frost dkg messages

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -156,7 +156,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		}
 		peerMap[p.ID] = nodeIdx
 	}
-	tp := newFrostP2P(tcpNode, peerMap, key, def.Threshold)
+	tp := newFrostP2P(tcpNode, peerMap, key, def.Threshold, def.NumValidators)
 
 	log.Info(ctx, "Waiting to connect to all peers...")
 

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -38,6 +38,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 		round1P2PRecv   = make(chan *pb.FrostRound1P2P, len(peers))
 		round2CastsRecv = make(chan *pb.FrostRound2Casts, len(peers))
 
+		mu               sync.Mutex
 		dedupRound1Casts = make(map[peer.ID]bool)
 		dedupRound1P2P   = make(map[peer.ID]bool)
 		dedupRound2Casts = make(map[peer.ID]bool)
@@ -52,12 +53,12 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 
 	// Register reliable broadcast protocol handlers.
 	bcastFunc := bcast.New(tcpNode, peerSlice, secret, []string{round1CastID, round2CastID},
-		bcastCallback(peers, round1CastsRecv, round2CastsRecv, dedupRound1Casts, dedupRound2Casts, threshold, numVals))
+		bcastCallback(peers, &mu, round1CastsRecv, round2CastsRecv, dedupRound1Casts, dedupRound2Casts, threshold, numVals))
 
 	// Register round 1 p2p protocol handlers.
 	p2p.RegisterHandler("frost", tcpNode, round1P2PID,
 		func() proto.Message { return new(pb.FrostRound1P2P) },
-		p2pCallback(tcpNode, peers, dedupRound1P2P, round1P2PRecv, numVals),
+		p2pCallback(tcpNode, peers, &mu, dedupRound1P2P, round1P2PRecv, numVals),
 		p2p.WithDelimitedProtocol(round1P2PID),
 	)
 
@@ -72,11 +73,9 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 }
 
 // bcastCallback returns a callback for broadcast in round 1 and round 2 of frost protocol.
-func bcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *pb.FrostRound1Casts, round2CastsRecv chan *pb.FrostRound2Casts,
+func bcastCallback(peers map[peer.ID]cluster.NodeIdx, mu *sync.Mutex, round1CastsRecv chan *pb.FrostRound1Casts, round2CastsRecv chan *pb.FrostRound2Casts,
 	dedupRound1Casts map[peer.ID]bool, dedupRound2Casts map[peer.ID]bool, threshold, numVals int,
 ) bcast.Callback {
-	var mu sync.Mutex
-
 	return func(ctx context.Context, pID peer.ID, msgID string, m proto.Message) error {
 		switch msgID {
 		case round1CastID:
@@ -147,11 +146,9 @@ func bcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *pb.F
 }
 
 // p2pCallback returns a callback for P2P messages in round 1 of frost protocol.
-func p2pCallback(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx,
+func p2pCallback(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, mu *sync.Mutex,
 	dedupRound1P2P map[peer.ID]bool, round1P2PRecv chan *pb.FrostRound1P2P, numVals int,
 ) p2p.HandlerFunc {
-	var mu sync.Mutex
-
 	return func(ctx context.Context, pID peer.ID, req proto.Message) (proto.Message, bool, error) {
 		mu.Lock()
 		defer mu.Unlock()

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -32,7 +32,7 @@ var (
 )
 
 // newFrostP2P returns a p2p frost transport implementation.
-func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k1.PrivateKey, threshold int) *frostP2P {
+func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k1.PrivateKey, threshold, numVals int) *frostP2P {
 	var (
 		round1CastsRecv = make(chan *pb.FrostRound1Casts, len(peers))
 		round1P2PRecv   = make(chan *pb.FrostRound1P2P, len(peers))
@@ -75,7 +75,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 						return errors.New("invalid round 1 cast source ID")
 					} else if cast.Key.TargetId != 0 {
 						return errors.New("invalid round 1 cast target ID")
-					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= len(peers) {
+					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
 						return errors.New("invalid round 1 cast validator index")
 					}
 
@@ -108,7 +108,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 						return errors.New("invalid round 2 cast source ID")
 					} else if cast.Key.TargetId != 0 {
 						return errors.New("invalid round 2 cast target ID")
-					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= len(peers) {
+					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
 						return errors.New("invalid round 1 cast validator index")
 					}
 				}
@@ -139,7 +139,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 					return nil, false, errors.New("invalid round 1 p2p source ID")
 				} else if int(share.Key.TargetId) != peers[tcpNode.ID()].ShareIdx {
 					return nil, false, errors.New("invalid round 1 p2p target ID")
-				} else if int(share.Key.ValIdx) < 0 || int(share.Key.ValIdx) >= len(peers) {
+				} else if int(share.Key.ValIdx) < 0 || int(share.Key.ValIdx) >= numVals {
 					return nil, false, errors.New("invalid round 1 p2p validator index")
 				}
 			}

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -38,7 +38,6 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 		round1P2PRecv   = make(chan *pb.FrostRound1P2P, len(peers))
 		round2CastsRecv = make(chan *pb.FrostRound2Casts, len(peers))
 
-		mu               sync.Mutex
 		dedupRound1Casts = make(map[peer.ID]bool)
 		dedupRound1P2P   = make(map[peer.ID]bool)
 		dedupRound2Casts = make(map[peer.ID]bool)
@@ -53,107 +52,12 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 
 	// Register reliable broadcast protocol handlers.
 	bcastFunc := bcast.New(tcpNode, peerSlice, secret, []string{round1CastID, round2CastID},
-		func(ctx context.Context, pID peer.ID, msgID string, m proto.Message) error {
-			switch msgID {
-			case round1CastID:
-				mu.Lock()
-				defer mu.Unlock()
-
-				if _, ok := dedupRound1Casts[pID]; ok {
-					log.Debug(ctx, "Ignoring duplicate round 1 message", z.Any("peer", p2p.PeerName(pID)))
-					return nil
-				}
-				dedupRound1Casts[pID] = true
-
-				msg, ok := m.(*pb.FrostRound1Casts)
-				if !ok {
-					return errors.New("invalid round 1 casts message")
-				}
-
-				for _, cast := range msg.Casts {
-					if int(cast.Key.SourceId) != peers[pID].ShareIdx {
-						return errors.New("invalid round 1 cast source ID")
-					} else if cast.Key.TargetId != 0 {
-						return errors.New("invalid round 1 cast target ID")
-					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
-						return errors.New("invalid round 1 cast validator index")
-					}
-
-					if len(cast.Commitments) != threshold {
-						return errors.New("invalid amount of commitments in round 1",
-							z.Int("received", len(cast.Commitments)),
-							z.Int("expected", threshold),
-						)
-					}
-				}
-
-				round1CastsRecv <- msg
-			case round2CastID:
-				mu.Lock()
-				defer mu.Unlock()
-
-				if _, ok := dedupRound2Casts[pID]; ok {
-					log.Debug(ctx, "Ignoring duplicate round 2 message", z.Any("peer", p2p.PeerName(pID)))
-					return nil
-				}
-				dedupRound2Casts[pID] = true
-
-				msg, ok := m.(*pb.FrostRound2Casts)
-				if !ok {
-					return errors.New("invalid round 2 casts message")
-				}
-
-				for _, cast := range msg.Casts {
-					if int(cast.Key.SourceId) != peers[pID].ShareIdx {
-						return errors.New("invalid round 2 cast source ID")
-					} else if cast.Key.TargetId != 0 {
-						return errors.New("invalid round 2 cast target ID")
-					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
-						return errors.New("invalid round 1 cast validator index")
-					}
-				}
-
-				round2CastsRecv <- msg
-			default:
-				return errors.New("bug: unexpected invalid message ID")
-			}
-
-			return nil
-		},
-	)
+		bcastCallback(peers, round1CastsRecv, round2CastsRecv, dedupRound1Casts, dedupRound2Casts, threshold, numVals))
 
 	// Register round 1 p2p protocol handlers.
 	p2p.RegisterHandler("frost", tcpNode, round1P2PID,
 		func() proto.Message { return new(pb.FrostRound1P2P) },
-		func(ctx context.Context, pID peer.ID, req proto.Message) (proto.Message, bool, error) {
-			mu.Lock()
-			defer mu.Unlock()
-
-			msg, ok := req.(*pb.FrostRound1P2P)
-			if !ok {
-				return nil, false, errors.New("invalid round 1 p2p message")
-			}
-
-			for _, share := range msg.Shares {
-				if int(share.Key.SourceId) != peers[pID].ShareIdx {
-					return nil, false, errors.New("invalid round 1 p2p source ID")
-				} else if int(share.Key.TargetId) != peers[tcpNode.ID()].ShareIdx {
-					return nil, false, errors.New("invalid round 1 p2p target ID")
-				} else if int(share.Key.ValIdx) < 0 || int(share.Key.ValIdx) >= numVals {
-					return nil, false, errors.New("invalid round 1 p2p validator index")
-				}
-			}
-
-			if dedupRound1P2P[pID] {
-				log.Debug(ctx, "Ignoring duplicate round 2 message", z.Any("peer", p2p.PeerName(pID)))
-				return nil, false, nil
-			}
-			dedupRound1P2P[pID] = true
-
-			round1P2PRecv <- msg
-
-			return nil, false, nil
-		},
+		p2pCallback(tcpNode, peers, dedupRound1P2P, round1P2PRecv, numVals),
 		p2p.WithDelimitedProtocol(round1P2PID),
 	)
 
@@ -164,6 +68,118 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 		round1CastsRecv: round1CastsRecv,
 		round1P2PRecv:   round1P2PRecv,
 		round2CastsRecv: round2CastsRecv,
+	}
+}
+
+// bcastCallback returns a callback for broadcast in round 1 and round 2 of frost protocol.
+func bcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *pb.FrostRound1Casts, round2CastsRecv chan *pb.FrostRound2Casts,
+	dedupRound1Casts map[peer.ID]bool, dedupRound2Casts map[peer.ID]bool, threshold, numVals int,
+) bcast.Callback {
+	var mu sync.Mutex
+
+	return func(ctx context.Context, pID peer.ID, msgID string, m proto.Message) error {
+		switch msgID {
+		case round1CastID:
+			mu.Lock()
+			defer mu.Unlock()
+
+			if _, ok := dedupRound1Casts[pID]; ok {
+				log.Debug(ctx, "Ignoring duplicate round 1 message", z.Any("peer", p2p.PeerName(pID)))
+				return nil
+			}
+			dedupRound1Casts[pID] = true
+
+			msg, ok := m.(*pb.FrostRound1Casts)
+			if !ok {
+				return errors.New("invalid round 1 casts message")
+			}
+
+			for _, cast := range msg.Casts {
+				if int(cast.Key.SourceId) != peers[pID].ShareIdx {
+					return errors.New("invalid round 1 cast source ID")
+				} else if cast.Key.TargetId != 0 {
+					return errors.New("invalid round 1 cast target ID")
+				} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
+					return errors.New("invalid round 1 cast validator index")
+				}
+
+				if len(cast.Commitments) != threshold {
+					return errors.New("invalid amount of commitments in round 1",
+						z.Int("received", len(cast.Commitments)),
+						z.Int("expected", threshold),
+					)
+				}
+			}
+
+			round1CastsRecv <- msg
+		case round2CastID:
+			mu.Lock()
+			defer mu.Unlock()
+
+			if _, ok := dedupRound2Casts[pID]; ok {
+				log.Debug(ctx, "Ignoring duplicate round 2 message", z.Any("peer", p2p.PeerName(pID)))
+				return nil
+			}
+			dedupRound2Casts[pID] = true
+
+			msg, ok := m.(*pb.FrostRound2Casts)
+			if !ok {
+				return errors.New("invalid round 2 casts message")
+			}
+
+			for _, cast := range msg.Casts {
+				if int(cast.Key.SourceId) != peers[pID].ShareIdx {
+					return errors.New("invalid round 2 cast source ID")
+				} else if cast.Key.TargetId != 0 {
+					return errors.New("invalid round 2 cast target ID")
+				} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
+					return errors.New("invalid round 2 cast validator index")
+				}
+			}
+
+			round2CastsRecv <- msg
+		default:
+			return errors.New("bug: unexpected invalid message ID")
+		}
+
+		return nil
+	}
+}
+
+// p2pCallback returns a callback for P2P messages in round 1 of frost protocol.
+func p2pCallback(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx,
+	dedupRound1P2P map[peer.ID]bool, round1P2PRecv chan *pb.FrostRound1P2P, numVals int,
+) p2p.HandlerFunc {
+	var mu sync.Mutex
+
+	return func(ctx context.Context, pID peer.ID, req proto.Message) (proto.Message, bool, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		msg, ok := req.(*pb.FrostRound1P2P)
+		if !ok {
+			return nil, false, errors.New("invalid round 1 p2p message")
+		}
+
+		for _, share := range msg.Shares {
+			if int(share.Key.SourceId) != peers[pID].ShareIdx {
+				return nil, false, errors.New("invalid round 1 p2p source ID")
+			} else if int(share.Key.TargetId) != peers[tcpNode.ID()].ShareIdx {
+				return nil, false, errors.New("invalid round 1 p2p target ID")
+			} else if int(share.Key.ValIdx) < 0 || int(share.Key.ValIdx) >= numVals {
+				return nil, false, errors.New("invalid round 1 p2p validator index")
+			}
+		}
+
+		if dedupRound1P2P[pID] {
+			log.Debug(ctx, "Ignoring duplicate round 2 message", z.Any("peer", p2p.PeerName(pID)))
+			return nil, false, nil
+		}
+		dedupRound1P2P[pID] = true
+
+		round1P2PRecv <- msg
+
+		return nil, false, nil
 	}
 }
 

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -66,7 +66,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 				dedupRound1Casts[pID] = true
 
 				msg, ok := m.(*pb.FrostRound1Casts)
-				if !ok {
+				if !ok || msg == nil {
 					return errors.New("invalid round 1 casts message")
 				}
 
@@ -75,6 +75,8 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 						return errors.New("invalid round 1 cast source ID")
 					} else if cast.Key.TargetId != 0 {
 						return errors.New("invalid round 1 cast target ID")
+					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= len(peers) {
+						return errors.New("invalid round 1 cast validator index")
 					}
 
 					if len(cast.Commitments) != threshold {
@@ -97,7 +99,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 				dedupRound2Casts[pID] = true
 
 				msg, ok := m.(*pb.FrostRound2Casts)
-				if !ok {
+				if !ok || msg == nil {
 					return errors.New("invalid round 2 casts message")
 				}
 
@@ -106,6 +108,8 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 						return errors.New("invalid round 2 cast source ID")
 					} else if cast.Key.TargetId != 0 {
 						return errors.New("invalid round 2 cast target ID")
+					} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= len(peers) {
+						return errors.New("invalid round 1 cast validator index")
 					}
 				}
 
@@ -126,7 +130,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 			defer mu.Unlock()
 
 			msg, ok := req.(*pb.FrostRound1P2P)
-			if !ok {
+			if !ok || msg == nil {
 				return nil, false, errors.New("invalid round 1 p2p message")
 			}
 
@@ -135,6 +139,8 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 					return nil, false, errors.New("invalid round 1 p2p source ID")
 				} else if int(share.Key.TargetId) != peers[tcpNode.ID()].ShareIdx {
 					return nil, false, errors.New("invalid round 1 p2p target ID")
+				} else if int(share.Key.ValIdx) < 0 || int(share.Key.ValIdx) >= len(peers) {
+					return nil, false, errors.New("invalid round 1 p2p validator index")
 				}
 			}
 

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -48,12 +48,12 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 
 	// Register reliable broadcast protocol handlers.
 	bcastFunc := bcast.New(tcpNode, peerSlice, secret, []string{round1CastID, round2CastID},
-		bcastCallback(peers, round1CastsRecv, round2CastsRecv, threshold, numVals))
+		newBcastCallback(peers, round1CastsRecv, round2CastsRecv, threshold, numVals))
 
 	// Register round 1 p2p protocol handlers.
 	p2p.RegisterHandler("frost", tcpNode, round1P2PID,
 		func() proto.Message { return new(pb.FrostRound1P2P) },
-		p2pCallback(tcpNode, peers, round1P2PRecv, numVals),
+		newP2PCallback(tcpNode, peers, round1P2PRecv, numVals),
 		p2p.WithDelimitedProtocol(round1P2PID),
 	)
 
@@ -67,8 +67,8 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 	}
 }
 
-// bcastCallback returns a callback for broadcast in round 1 and round 2 of frost protocol.
-func bcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *pb.FrostRound1Casts, round2CastsRecv chan *pb.FrostRound2Casts, threshold, numVals int) bcast.Callback {
+// newBcastCallback returns a callback for broadcast in round 1 and round 2 of frost protocol.
+func newBcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *pb.FrostRound1Casts, round2CastsRecv chan *pb.FrostRound2Casts, threshold, numVals int) bcast.Callback {
 	var (
 		mu               sync.Mutex
 		dedupRound1Casts = make(map[peer.ID]bool)
@@ -144,8 +144,8 @@ func bcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *pb.F
 	}
 }
 
-// p2pCallback returns a callback for P2P messages in round 1 of frost protocol.
-func p2pCallback(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, round1P2PRecv chan *pb.FrostRound1P2P, numVals int) p2p.HandlerFunc {
+// newP2PCallback returns a callback for P2P messages in round 1 of frost protocol.
+func newP2PCallback(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, round1P2PRecv chan *pb.FrostRound1P2P, numVals int) p2p.HandlerFunc {
 	var (
 		mu             sync.Mutex
 		dedupRound1P2P = make(map[peer.ID]bool)

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -66,7 +66,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 				dedupRound1Casts[pID] = true
 
 				msg, ok := m.(*pb.FrostRound1Casts)
-				if !ok || msg == nil {
+				if !ok {
 					return errors.New("invalid round 1 casts message")
 				}
 
@@ -99,7 +99,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 				dedupRound2Casts[pID] = true
 
 				msg, ok := m.(*pb.FrostRound2Casts)
-				if !ok || msg == nil {
+				if !ok {
 					return errors.New("invalid round 2 casts message")
 				}
 
@@ -130,7 +130,7 @@ func newFrostP2P(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, secret *k
 			defer mu.Unlock()
 
 			msg, ok := req.(*pb.FrostRound1P2P)
-			if !ok || msg == nil {
+			if !ok {
 				return nil, false, errors.New("invalid round 1 p2p message")
 			}
 

--- a/dkg/frostp2p_internal_test.go
+++ b/dkg/frostp2p_internal_test.go
@@ -83,7 +83,7 @@ func TestBcastCallback(t *testing.T) {
 				Key: &pb.FrostMsgKey{
 					SourceId: 1,
 					TargetId: 0,
-					ValIdx:   3,
+					ValIdx:   3, // Invalid ValIdx since it should be less than numVals
 				},
 			},
 			errorMsg: "invalid round 1 cast validator index",
@@ -125,7 +125,7 @@ func TestBcastCallback(t *testing.T) {
 				Key: &pb.FrostMsgKey{
 					SourceId: 1,
 					TargetId: 0,
-					ValIdx:   3,
+					ValIdx:   numVals, // Invalid ValIdx since it should be less than numVals
 				},
 			},
 			errorMsg: "invalid round 2 cast validator index",
@@ -166,10 +166,10 @@ func TestBcastCallback(t *testing.T) {
 				err = callbackFunc(ctx, peers[0], "invalid/round/id", nil)
 			}
 			if tt.invalidRound1CastMsg {
-				err = callbackFunc(ctx, peers[0], round1CastID, nil)
+				err = callbackFunc(ctx, peers[0], round1CastID, nil) // nil round 1 message
 			}
 			if tt.invalidRound2CastMsg {
-				err = callbackFunc(ctx, peers[0], round2CastID, nil)
+				err = callbackFunc(ctx, peers[0], round2CastID, nil) // nil round 2 message
 			}
 
 			require.Equal(t, err.Error(), tt.errorMsg)

--- a/dkg/frostp2p_internal_test.go
+++ b/dkg/frostp2p_internal_test.go
@@ -147,7 +147,7 @@ func TestBcastCallback(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			callbackFunc := bcastCallback(peerMap, round1CastsRecv, round2CastsRecv, threshold, numVals)
+			callbackFunc := newBcastCallback(peerMap, round1CastsRecv, round2CastsRecv, threshold, numVals)
 
 			var err error
 			if tt.round1Cast != nil {
@@ -243,7 +243,7 @@ func TestP2PCallback(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			round1P2PRecv := make(chan *pb.FrostRound1P2P, len(peers))
 
-			callbackFunc := p2pCallback(tcpNodes[0], peerMap, round1P2PRecv, numVals)
+			callbackFunc := newP2PCallback(tcpNodes[0], peerMap, round1P2PRecv, numVals)
 
 			if tt.invalidRound1P2PMsg {
 				_, _, err := callbackFunc(ctx, peers[0], nil)

--- a/dkg/frostp2p_internal_test.go
+++ b/dkg/frostp2p_internal_test.go
@@ -1,0 +1,273 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package dkg
+
+import (
+	"context"
+	"testing"
+
+	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/cluster"
+	pb "github.com/obolnetwork/charon/dkg/dkgpb/v1"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestBcastCallback(t *testing.T) {
+	const (
+		n         = 4
+		threshold = 3
+		numVals   = 2
+	)
+
+	var (
+		ctx   = context.Background()
+		peers []peer.ID
+	)
+
+	// Create libp2p peers
+	peerMap := make(map[peer.ID]cluster.NodeIdx)
+	for i := 0; i < n; i++ {
+		secret, err := k1.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		tcpNode := testutil.CreateHostWithIdentity(t, testutil.AvailableAddr(t), secret)
+		peers = append(peers, tcpNode.ID())
+		peerMap[tcpNode.ID()] = cluster.NodeIdx{
+			PeerIdx:  i,
+			ShareIdx: i + 1,
+		}
+	}
+
+	var (
+		round1CastsRecv  = make(chan *pb.FrostRound1Casts, len(peerMap))
+		round2CastsRecv  = make(chan *pb.FrostRound2Casts, len(peerMap))
+		dedupRound1Casts = make(map[peer.ID]bool)
+		dedupRound2Casts = make(map[peer.ID]bool)
+	)
+
+	tests := []struct {
+		name                 string
+		round1Cast           *pb.FrostRound1Cast
+		round2Cast           *pb.FrostRound2Cast
+		errorMsg             string
+		invalidRoundCast     bool
+		invalidRound1CastMsg bool
+		invalidRound2CastMsg bool
+	}{
+		{
+			name: "invalid round 1 sourceID",
+			round1Cast: &pb.FrostRound1Cast{
+				Key: &pb.FrostMsgKey{
+					SourceId: 2, // Invalid SourceID since peers[0].ShareIdx is 1
+				},
+			},
+			errorMsg: "invalid round 1 cast source ID",
+		},
+		{
+			name: "invalid round 1 cast target ID",
+			round1Cast: &pb.FrostRound1Cast{
+				Key: &pb.FrostMsgKey{
+					SourceId: 1,
+					TargetId: 1, // Invalid targetID since bcast targetID should always be 0
+				},
+			},
+			errorMsg: "invalid round 1 cast target ID",
+		},
+		{
+			name: "invalid round 1 cast validator index",
+			round1Cast: &pb.FrostRound1Cast{
+				Key: &pb.FrostMsgKey{
+					SourceId: 1,
+					TargetId: 0,
+					ValIdx:   3,
+				},
+			},
+			errorMsg: "invalid round 1 cast validator index",
+		},
+		{
+			name: "invalid round 1 commitments",
+			round1Cast: &pb.FrostRound1Cast{
+				Key: &pb.FrostMsgKey{
+					ValIdx:   0,
+					SourceId: 1,
+					TargetId: 0,
+				},
+				Commitments: nil, // Invalid since len(commitments) should be equal to threshold
+			},
+			errorMsg: "invalid amount of commitments in round 1",
+		},
+		{
+			name: "invalid round 2 cast source ID",
+			round2Cast: &pb.FrostRound2Cast{
+				Key: &pb.FrostMsgKey{
+					SourceId: 2, // Invalid SourceID since peers[0].ShareIdx is 1
+				},
+			},
+			errorMsg: "invalid round 2 cast source ID",
+		},
+		{
+			name: "invalid round 2 cast target ID",
+			round2Cast: &pb.FrostRound2Cast{
+				Key: &pb.FrostMsgKey{
+					SourceId: 1,
+					TargetId: 1, // Invalid targetID since bcast targetID should always be 0
+				},
+			},
+			errorMsg: "invalid round 2 cast target ID",
+		},
+		{
+			name: "invalid round 2 cast validator index",
+			round2Cast: &pb.FrostRound2Cast{
+				Key: &pb.FrostMsgKey{
+					SourceId: 1,
+					TargetId: 0,
+					ValIdx:   3,
+				},
+			},
+			errorMsg: "invalid round 2 cast validator index",
+		},
+		{
+			name:             "invalid cast round",
+			invalidRoundCast: true,
+			errorMsg:         "bug: unexpected invalid message ID",
+		},
+		{
+			name:                 "invalid round 1 casts message",
+			invalidRound1CastMsg: true,
+			errorMsg:             "invalid round 1 casts message",
+		},
+		{
+			name:                 "invalid round 2 casts message",
+			invalidRound2CastMsg: true,
+			errorMsg:             "invalid round 2 casts message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callbackFunc := bcastCallback(peerMap, round1CastsRecv, round2CastsRecv, dedupRound1Casts, dedupRound2Casts, threshold, numVals)
+
+			var err error
+			if tt.round1Cast != nil {
+				msg := pb.FrostRound1Casts{Casts: []*pb.FrostRound1Cast{tt.round1Cast}}
+				err = callbackFunc(ctx, peers[0], round1CastID, &msg)
+			}
+
+			if tt.round2Cast != nil {
+				msg := pb.FrostRound2Casts{Casts: []*pb.FrostRound2Cast{tt.round2Cast}}
+				err = callbackFunc(ctx, peers[0], round2CastID, &msg)
+			}
+
+			if tt.invalidRoundCast {
+				err = callbackFunc(ctx, peers[0], "invalid/round/id", nil)
+			}
+			if tt.invalidRound1CastMsg {
+				err = callbackFunc(ctx, peers[0], round1CastID, nil)
+			}
+			if tt.invalidRound2CastMsg {
+				err = callbackFunc(ctx, peers[0], round2CastID, nil)
+			}
+
+			require.Equal(t, err.Error(), tt.errorMsg)
+		})
+
+		dedupRound1Casts = make(map[peer.ID]bool) // Reset dedup map
+		dedupRound2Casts = make(map[peer.ID]bool) // Reset dedup map
+	}
+}
+
+func TestP2PCallback(t *testing.T) {
+	const (
+		n       = 4
+		numVals = 2
+	)
+
+	var (
+		ctx      = context.Background()
+		peers    []peer.ID
+		tcpNodes []host.Host
+	)
+
+	// Create libp2p peers
+	peerMap := make(map[peer.ID]cluster.NodeIdx)
+	for i := 0; i < n; i++ {
+		secret, err := k1.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		tcpNode := testutil.CreateHostWithIdentity(t, testutil.AvailableAddr(t), secret)
+		peers = append(peers, tcpNode.ID())
+		tcpNodes = append(tcpNodes, tcpNode)
+		peerMap[tcpNode.ID()] = cluster.NodeIdx{
+			PeerIdx:  i,
+			ShareIdx: i + 1,
+		}
+	}
+
+	var (
+		round1P2PRecv  = make(chan *pb.FrostRound1P2P, len(peers))
+		dedupRound1P2P = make(map[peer.ID]bool)
+	)
+
+	tests := []struct {
+		name                string
+		key                 *pb.FrostMsgKey
+		errorMsg            string
+		invalidRound1P2PMsg bool
+	}{
+		{
+			name: "invalid round 1 sourceID",
+			key: &pb.FrostMsgKey{
+				SourceId: 2,
+			},
+			errorMsg: "invalid round 1 p2p source ID",
+		},
+		{
+			name: "invalid round 1 targetID",
+			key: &pb.FrostMsgKey{
+				SourceId: 1,
+				TargetId: 2,
+			},
+			errorMsg: "invalid round 1 p2p target ID",
+		},
+		{
+			name: "invalid round 1 validator index",
+			key: &pb.FrostMsgKey{
+				SourceId: 1,
+				TargetId: 1,
+				ValIdx:   numVals,
+			},
+			errorMsg: "invalid round 1 p2p validator index",
+		},
+		{
+			name:                "invalid p2p message",
+			invalidRound1P2PMsg: true,
+			errorMsg:            "invalid round 1 p2p message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callbackFunc := p2pCallback(tcpNodes[0], peerMap, dedupRound1P2P, round1P2PRecv, numVals)
+
+			if tt.invalidRound1P2PMsg {
+				_, _, err := callbackFunc(ctx, peers[0], nil)
+				require.Equal(t, err.Error(), tt.errorMsg)
+
+				return
+			}
+
+			msg := pb.FrostRound1P2P{Shares: []*pb.FrostRound1ShamirShare{{Key: tt.key}}}
+
+			resp, respBool, err := callbackFunc(ctx, peers[0], &msg)
+			require.Equal(t, resp, nil)
+			require.Equal(t, respBool, false)
+			require.Equal(t, err.Error(), tt.errorMsg)
+		})
+
+		dedupRound1P2P = make(map[peer.ID]bool) // Reset dedup map
+	}
+}


### PR DESCRIPTION
Adds check to ensure validator indexes (`ValIdx`) in frost DKG messages are in the range `[0, num_validators)`.

Also refactors out broadcast and p2p callbacks and adds tests for them.

category: feature
ticket: #1888 
