### PR TITLE
*: implement pidfile for run and dkg

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/hex"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -31,6 +32,7 @@ import (
 	"github.com/obolnetwork/charon/app/lifecycle"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/app/pidfile"
 	"github.com/obolnetwork/charon/app/promauto"
 	"github.com/obolnetwork/charon/app/retry"
 	"github.com/obolnetwork/charon/app/tracer"
@@ -121,6 +123,17 @@ func Run(ctx context.Context, conf Config) (err error) {
 	defer func() {
 		if err != nil {
 			log.Error(ctx, "Fatal run error", err)
+		}
+	}()
+
+	pidfileDeleteFunc, err := pidfile.New(filepath.Dir(conf.LockFile), "run")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := pidfileDeleteFunc(); err != nil {
+			log.Error(ctx, "Cannot delete pidfile", err)
 		}
 	}()
 

--- a/app/pidfile/pidfile.go
+++ b/app/pidfile/pidfile.go
@@ -1,0 +1,105 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package pidfile
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+const (
+	filename = "charon-pidfile"
+)
+
+// New creates a pidfile called "charon-pidfile" in dataDir, writing contextStr in it.
+// If a pidfile exists already in dataDir New returns an error, a clean-up function otherwise.
+// New also registers a SIGINT signal handler so that it cleans its state if CTRL-C is called.
+func New(dataDir, contextStr string) (func() error, error) {
+	pfPath := filepath.Join(dataDir, filename)
+
+	if _, err := os.Stat(pfPath); err == nil {
+		readCtxStr, err := os.ReadFile(pfPath)
+		if err != nil {
+			return nil, errors.Wrap(err, "could not read pidfile content even if present")
+		}
+
+		return nil, errors.New(
+			"another instance of charon is running on the selected data directory",
+			z.Str("data_directory", dataDir),
+			z.Str("context", string(readCtxStr)),
+		)
+	} else if errors.Is(err, os.ErrNotExist) {
+		return createPidfile(pfPath, contextStr)
+	} else {
+		return nil, errors.Wrap(err, "fatal error while handling pidfile", z.Str("path", pfPath))
+	}
+}
+
+func createPidfile(path, contextStr string) (func() error, error) {
+	f, err := os.Create(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot create pidfile", z.Str("path", path))
+	}
+
+	amt, err := f.WriteString(contextStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "cannot write context string in pidfile", z.Str("path", path))
+	}
+
+	if amt != len(contextStr) {
+		return nil, errors.New(
+			"could not write entirety of context string in pidfile",
+			z.Str("path", path),
+			z.Int("expected", len(contextStr)),
+			z.Int("got", amt),
+		)
+	}
+
+	alreadyDeleted := atomic.Bool{}
+	alreadyDeleted.Store(false)
+
+	ctx := context.Background()
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		<-c
+
+		defer os.Exit(0)
+
+		if alreadyDeleted.Load() {
+			log.Debug(ctx, "Pidfile already deleted, not deleting from ctrl-c handler")
+			return
+		}
+
+		alreadyDeleted.Store(true)
+
+		log.Debug(ctx, "Deleting pidfile from SIGINT")
+		if err := os.Remove(path); err != nil {
+			log.Error(ctx, "Cannot delete pidfile", err)
+			return
+		}
+	}()
+
+	return func() error {
+		if alreadyDeleted.Load() {
+			log.Debug(ctx, "Pidfile already deleted, not deleting from closure")
+			return nil
+		}
+
+		alreadyDeleted.Store(true)
+
+		if err := os.Remove(path); err != nil {
+			return errors.Wrap(err, "cannot remove pidfile")
+		}
+
+		return nil
+	}, nil
+}

--- a/app/pidfile/pidfile_test.go
+++ b/app/pidfile/pidfile_test.go
@@ -1,0 +1,36 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package pidfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/pidfile"
+)
+
+func TestNewInitsAndDelete(t *testing.T) {
+	temp := t.TempDir()
+	cleanFunc, err := pidfile.New(temp, "test")
+	require.NoError(t, err)
+	require.NotNil(t, cleanFunc)
+	require.NoError(t, cleanFunc())
+	_, openErr := os.Open(filepath.Join(temp, "charon-pidfile"))
+	require.ErrorContains(t, openErr, "no such file or directory")
+}
+
+func TestNewTwoInitsAndDelete(t *testing.T) {
+	temp := t.TempDir()
+	cleanFunc, err := pidfile.New(temp, "test")
+	require.NoError(t, err)
+	require.NotNil(t, cleanFunc)
+
+	cleanFunc2, err2 := pidfile.New(temp, "test")
+	require.ErrorContains(t, err2, "another instance of charon is running on the selected data directory")
+	require.Nil(t, cleanFunc2)
+
+	require.NoError(t, cleanFunc())
+}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -19,6 +19,7 @@ import (
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/obolapi"
 	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/app/pidfile"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
@@ -72,7 +73,20 @@ func Run(ctx context.Context, conf Config) (err error) {
 		}
 	}()
 
+	pidfileDeleteFunc, err := pidfile.New(conf.DataDir, "dkg")
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if err := pidfileDeleteFunc(); err != nil {
+			log.Error(ctx, "cannot delete pidfile", err)
+		}
+	}()
+
 	version.LogInfo(ctx, "Charon DKG starting")
+
+	time.Sleep(1 * time.Minute)
 
 	def, err := loadDefinition(ctx, conf)
 	if err != nil {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -80,13 +80,11 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	defer func() {
 		if err := pidfileDeleteFunc(); err != nil {
-			log.Error(ctx, "cannot delete pidfile", err)
+			log.Error(ctx, "Cannot delete pidfile", err)
 		}
 	}()
 
 	version.LogInfo(ctx, "Charon DKG starting")
-
-	time.Sleep(1 * time.Minute)
 
 	def, err := loadDefinition(ctx, conf)
 	if err != nil {


### PR DESCRIPTION
Pidfile allows multiple instances of charon to run on the same data directory, effectively avoiding that users run e.g. `dkg` while having `run` running in the background.

Closes #1918.

category: feature
ticket: #1918 
