### PR TITLE
core/tracker: improve participation

### DIFF
--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -746,19 +746,19 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 
 		var absentPeers []string
 		for _, peer := range peers {
+			participationSuccess.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(participatedShares[peer.ShareIdx()]))
+			participationSuccessLegacy.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(participatedShares[peer.ShareIdx()]))
+			participationExpect.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(totalParticipationExpected))
+			participationMissed.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(totalParticipationExpected - participatedShares[peer.ShareIdx()]))
+
 			if participatedShares[peer.ShareIdx()] > 0 {
 				participationGauge.WithLabelValues(duty.Type.String(), peer.Name).Set(1)
-				participationSuccess.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(participatedShares[peer.ShareIdx()]))
-				participationSuccessLegacy.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(participatedShares[peer.ShareIdx()]))
-				participationExpect.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(totalParticipationExpected - participatedShares[peer.ShareIdx()]))
 			} else if unexpectedShares[peer.ShareIdx()] > 0 {
 				log.Warn(ctx, "Unexpected event found", nil, z.Str("peer", peer.Name), z.Str("duty", duty.String()))
 				unexpectedEventsCounter.WithLabelValues(peer.Name).Add(float64(unexpectedShares[peer.ShareIdx()]))
 			} else {
 				absentPeers = append(absentPeers, peer.Name)
 				participationGauge.WithLabelValues(duty.Type.String(), peer.Name).Set(0)
-				participationMissed.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(totalParticipationExpected))
-				participationExpect.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(totalParticipationExpected))
 			}
 		}
 

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -749,7 +749,7 @@ func newParticipationReporter(peers []p2p.Peer) func(context.Context, core.Duty,
 			if participatedShares[peer.ShareIdx()] > 0 {
 				participationGauge.WithLabelValues(duty.Type.String(), peer.Name).Set(1)
 				participationSuccess.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(participatedShares[peer.ShareIdx()]))
-				participationSuccessLegacy.WithLabelValues(duty.Type.String(), peer.Name).Inc()
+				participationSuccessLegacy.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(participatedShares[peer.ShareIdx()]))
 				participationExpect.WithLabelValues(duty.Type.String(), peer.Name).Add(float64(totalParticipationExpected - participatedShares[peer.ShareIdx()]))
 			} else if unexpectedShares[peer.ShareIdx()] > 0 {
 				log.Warn(ctx, "Unexpected event found", nil, z.Str("peer", peer.Name), z.Str("duty", duty.String()))


### PR DESCRIPTION
Improves participation metric to count multiple duties per slot. For example, we can have multiple attester duties per slot.

category: feature
ticket: #2034 
