### PR TITLE
compose/smoke: add vouch in smoke tests

### DIFF
--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -123,6 +123,12 @@ func TestSmoke(t *testing.T) {
 				}
 			},
 		},
+		{
+			Name: "cluster_with_vouch",
+			ConfigFunc: func(conf *compose.Config) {
+				conf.VCs = []compose.VCType{compose.VCVouch}
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/testutil/compose/static/vouch/Dockerfile
+++ b/testutil/compose/static/vouch/Dockerfile
@@ -1,6 +1,6 @@
-FROM wealdtech/ethdo:1.25.3 as ethdo
+FROM wealdtech/ethdo:1.30.0 as ethdo
 
-FROM attestant/vouch:1.6.2
+FROM attestant/vouch:1.7.5
 
 COPY --from=ethdo /app/ethdo /app/ethdo
 


### PR DESCRIPTION
Adds a smoke test which uses vouch as VC.

category: misc
ticket: none
