### PR TITLE
app/eth2wrap: implement and wire validator cache

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -486,7 +486,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 	core.Wire(sched, fetch, cons, dutyDB, vapi, parSigDB, parSigEx, sigAgg, aggSigDB, broadcaster, opts...)
 
-	err = wireValidatorMock(conf, pubshares, sched, valCache)
+	err = wireValidatorMock(conf, pubshares, sched)
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -697,7 +697,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 
 		if conf.SyntheticBlockProposals {
 			log.Info(ctx, "Synthetic block proposals enabled")
-			wrap = eth2wrap.WithSyntheticDuties(wrap, pubkeys)
+			wrap = eth2wrap.WithSyntheticDuties(wrap)
 		}
 
 		life.RegisterStop(lifecycle.StopBeaconMock, lifecycle.HookFuncErr(bmock.Close))
@@ -716,7 +716,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 
 	if conf.SyntheticBlockProposals {
 		log.Info(ctx, "Synthetic block proposals enabled")
-		eth2Cl = eth2wrap.WithSyntheticDuties(eth2Cl, pubkeys)
+		eth2Cl = eth2wrap.WithSyntheticDuties(eth2Cl)
 	}
 
 	// Check BN chain/network.

--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -111,7 +111,7 @@ func TestSetFeeRecipient(t *testing.T) {
 			return nil
 		}
 
-		fn := setFeeRecipient(bmock, clone.PublicKeys(), func(core.PubKey) string {
+		fn := setFeeRecipient(bmock, func(core.PubKey) string {
 			return "0xdead"
 		})
 		err = fn(context.Background(), core.Slot{SlotsPerEpoch: 1})

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -59,10 +59,10 @@ func Instrument(clients ...Client) (Client, error) {
 }
 
 // WithSyntheticDuties wraps the provided client adding synthetic duties.
-func WithSyntheticDuties(cl Client, pubkeys []eth2p0.BLSPubKey) Client {
+func WithSyntheticDuties(cl Client) Client {
 	return &synthWrapper{
 		Client:             cl,
-		synthProposerCache: newSynthProposerCache(pubkeys),
+		synthProposerCache: newSynthProposerCache(),
 		feeRecipients:      make(map[eth2p0.ValidatorIndex]bellatrix.ExecutionAddress),
 	}
 }

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -25,6 +25,9 @@ type Client interface {
 	BlockAttestationsProvider
 	NodePeerCountProvider
 
+	ActiveValidatorsProvider
+	SetValidatorCache(func(context.Context) (ActiveValidators, error))
+
 	eth2client.AggregateAttestationProvider
 	eth2client.AggregateAttestationsSubmitter
 	eth2client.AttestationDataProvider

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -47,6 +47,9 @@ type Client interface {
     BlockAttestationsProvider
     NodePeerCountProvider
 
+    ActiveValidatorsProvider
+    SetValidatorCache(func(context.Context) (ActiveValidators, error))
+
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
 }

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -37,34 +37,6 @@ type NodePeerCountProvider interface {
 	NodePeerCount(ctx context.Context) (int, error)
 }
 
-type ActiveValidators map[eth2p0.ValidatorIndex]eth2p0.BLSPubKey
-
-// Pubkeys returns a list of active validator pubkeys.
-func (m ActiveValidators) Pubkeys() []eth2p0.BLSPubKey {
-	var pubkeys []eth2p0.BLSPubKey
-	for _, pubkey := range m {
-		pubkeys = append(pubkeys, pubkey)
-	}
-
-	return pubkeys
-}
-
-// Indices returns a list of active validator indices.
-func (m ActiveValidators) Indices() []eth2p0.ValidatorIndex {
-	var indices []eth2p0.ValidatorIndex
-	for index := range m {
-		indices = append(indices, index)
-	}
-
-	return indices
-}
-
-// ActiveValidatorsProvider is the interface for providing current epoch's cached active validator
-// identity information.
-type ActiveValidatorsProvider interface {
-	ActiveValidators(context.Context) (ActiveValidators, error)
-}
-
 // NewHTTPAdapterForT returns a http adapter for testing non-eth2service methods as it is nil.
 func NewHTTPAdapterForT(_ *testing.T, address string, timeout time.Duration) Client {
 	return newHTTPAdapter(nil, address, timeout)

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -36,6 +36,34 @@ type NodePeerCountProvider interface {
 	NodePeerCount(ctx context.Context) (int, error)
 }
 
+type ActiveValidators map[eth2p0.ValidatorIndex]eth2p0.BLSPubKey
+
+// Pubkeys returns a list of active validator pubkeys.
+func (m ActiveValidators) Pubkeys() []eth2p0.BLSPubKey {
+	var pubkeys []eth2p0.BLSPubKey
+	for _, pubkey := range m {
+		pubkeys = append(pubkeys, pubkey)
+	}
+
+	return pubkeys
+}
+
+// Indices returns a list of active validator indices.
+func (m ActiveValidators) Indices() []eth2p0.ValidatorIndex {
+	var indices []eth2p0.ValidatorIndex
+	for index := range m {
+		indices = append(indices, index)
+	}
+
+	return indices
+}
+
+// ActiveValidatorsProvider is the interface for providing current epoch's cached active validator
+// identity information.
+type ActiveValidatorsProvider interface {
+	ActiveValidators(context.Context) (ActiveValidators, error)
+}
+
 // NewHTTPAdapterForT returns a http adapter for testing non-eth2service methods as it is nil.
 func NewHTTPAdapterForT(_ *testing.T, address string, timeout time.Duration) Client {
 	return newHTTPAdapter(nil, address, timeout)
@@ -61,8 +89,21 @@ func newHTTPAdapter(ethSvc *eth2http.Service, address string, timeout time.Durat
 //   - experimental interfaces
 type httpAdapter struct {
 	*eth2http.Service
-	address string
-	timeout time.Duration
+	address  string
+	timeout  time.Duration
+	valCache func(context.Context) (ActiveValidators, error)
+}
+
+func (h *httpAdapter) SetValidatorCache(valCache func(context.Context) (ActiveValidators, error)) {
+	h.valCache = valCache
+}
+
+func (h *httpAdapter) ActiveValidators(ctx context.Context) (ActiveValidators, error) {
+	if h.valCache == nil {
+		return nil, errors.New("no active validator cache")
+	}
+
+	return h.valCache(ctx)
 }
 
 // AggregateBeaconCommitteeSelections implements eth2exp.BeaconCommitteeSelectionAggregator.

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -89,16 +90,22 @@ func newHTTPAdapter(ethSvc *eth2http.Service, address string, timeout time.Durat
 //   - experimental interfaces
 type httpAdapter struct {
 	*eth2http.Service
-	address  string
-	timeout  time.Duration
-	valCache func(context.Context) (ActiveValidators, error)
+	address    string
+	timeout    time.Duration
+	valCacheMu sync.RWMutex
+	valCache   func(context.Context) (ActiveValidators, error)
 }
 
 func (h *httpAdapter) SetValidatorCache(valCache func(context.Context) (ActiveValidators, error)) {
+	h.valCacheMu.Lock()
 	h.valCache = valCache
+	h.valCacheMu.Unlock()
 }
 
 func (h *httpAdapter) ActiveValidators(ctx context.Context) (ActiveValidators, error) {
+	h.valCacheMu.RLock()
+	defer h.valCacheMu.RUnlock()
+
 	if h.valCache == nil {
 		return nil, errors.New("no active validator cache")
 	}

--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -108,14 +108,13 @@ func (l *lazy) ActiveValidators(ctx context.Context) (ActiveValidators, error) {
 }
 
 func (l *lazy) SetValidatorCache(valCache func(context.Context) (ActiveValidators, error)) {
+	l.clientMu.Lock()
+	l.valCache = valCache
+	l.clientMu.Unlock()
+
 	if cl, ok := l.getClient(); ok {
 		cl.SetValidatorCache(valCache)
 	}
-
-	l.clientMu.Lock()
-	defer l.clientMu.Unlock()
-
-	l.valCache = valCache
 }
 
 func (l *lazy) AggregateBeaconCommitteeSelections(ctx context.Context, partialSelections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -241,9 +241,8 @@ func IsSyntheticBlock(block *spec.VersionedSignedBeaconBlock) bool {
 }
 
 // synthProposerCache returns a new cache for synthetic proposer duties.
-func newSynthProposerCache(pubkeys []eth2p0.BLSPubKey) *synthProposerCache {
+func newSynthProposerCache() *synthProposerCache {
 	return &synthProposerCache{
-		pubkeys:     pubkeys,
 		duties:      make(map[eth2p0.Epoch][]*eth2v1.ProposerDuty),
 		synths:      make(map[eth2p0.Epoch]map[eth2p0.Slot]eth2p0.ValidatorIndex),
 		shuffleFunc: eth2Shuffle,
@@ -255,7 +254,6 @@ func newSynthProposerCache(pubkeys []eth2p0.BLSPubKey) *synthProposerCache {
 // Since only a single validator can be a proposer per slot, we require all
 // validators to calculate the synthetic duties for the whole set.
 type synthProposerCache struct {
-	pubkeys []eth2p0.BLSPubKey
 	// shuffleFunc deterministically shuffles the validator indices for the epoch.
 	shuffleFunc func(eth2p0.Epoch, []eth2p0.ValidatorIndex) []eth2p0.ValidatorIndex
 

--- a/app/eth2wrap/synthproposer_test.go
+++ b/app/eth2wrap/synthproposer_test.go
@@ -30,7 +30,7 @@ func TestSynthProposer(t *testing.T) {
 		epoch         eth2p0.Epoch = 100
 		realBlockSlot              = eth2p0.Slot(slotsPerEpoch) * eth2p0.Slot(epoch)
 		done                       = make(chan struct{})
-		valsByPubkey               = 0
+		activeVals                 = 0
 	)
 	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(set), beaconmock.WithSlotsPerEpoch(slotsPerEpoch))
 	require.NoError(t, err)
@@ -52,10 +52,10 @@ func TestSynthProposer(t *testing.T) {
 			},
 		}, nil
 	}
-	cached := bmock.ValidatorsByPubKey
-	bmock.ValidatorsByPubKeyFunc = func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
-		valsByPubkey++
-		return cached(ctx, stateID, pubkeys)
+	cached := bmock.ActiveValidatorsFunc
+	bmock.ActiveValidatorsFunc = func(ctx context.Context) (eth2wrap.ActiveValidators, error) {
+		activeVals++
+		return cached(ctx)
 	}
 	signedBeaconBlock := bmock.SignedBeaconBlock
 	bmock.SignedBeaconBlockFunc = func(ctx context.Context, blockID string) (*spec.VersionedSignedBeaconBlock, error) {
@@ -81,13 +81,13 @@ func TestSynthProposer(t *testing.T) {
 	duties, err := eth2Cl.ProposerDuties(ctx, epoch, nil)
 	require.NoError(t, err)
 	require.Len(t, duties, len(set))
-	require.Equal(t, 1, valsByPubkey)
+	require.Equal(t, 1, activeVals)
 
 	// Get synthetic duties again
 	duties2, err := eth2Cl.ProposerDuties(ctx, epoch, nil)
 	require.NoError(t, err)
 	require.Equal(t, duties, duties2) // Identical
-	require.Equal(t, 1, valsByPubkey) // Cached
+	require.Equal(t, 1, activeVals)   // Cached
 
 	// Submit blocks
 	for _, duty := range duties {

--- a/app/eth2wrap/synthproposer_test.go
+++ b/app/eth2wrap/synthproposer_test.go
@@ -66,7 +66,7 @@ func TestSynthProposer(t *testing.T) {
 		return signedBeaconBlock(ctx, blockID)
 	}
 
-	eth2Cl := eth2wrap.WithSyntheticDuties(bmock, set.PublicKeys())
+	eth2Cl := eth2wrap.WithSyntheticDuties(bmock)
 
 	var preps []*eth2v1.ProposalPreparation
 	for vIdx := range set {

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -1,0 +1,83 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import (
+	"context"
+	"sync"
+
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+// NewValidatorCache creates a new validator cache.
+func NewValidatorCache(eth2Cl Client, pubkeys []eth2p0.BLSPubKey) *ValidatorCache {
+	return &ValidatorCache{
+		eth2Cl:  eth2Cl,
+		pubkeys: pubkeys,
+	}
+}
+
+// ValidatorCache caches active validators.
+type ValidatorCache struct {
+	eth2Cl  Client
+	pubkeys []eth2p0.BLSPubKey
+
+	mu     sync.RWMutex
+	active ActiveValidators
+}
+
+// Trim trims the cache.
+// This should be called on epoch boundary.
+func (c *ValidatorCache) Trim() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.active = nil
+}
+
+// cached returns the cached validators and true if they are available.
+func (c *ValidatorCache) cached() (ActiveValidators, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.active, c.active != nil
+}
+
+// Get returns the cached active validators, or fetches them if not available populating the cache.
+func (c *ValidatorCache) Get(ctx context.Context) (ActiveValidators, error) {
+	if cached, ok := c.cached(); ok {
+		return cached, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check again in case another goroutine updated the cache while we were waiting for the lock.
+	if c.active != nil {
+		return c.active, nil
+	}
+
+	vals, err := c.eth2Cl.ValidatorsByPubKey(ctx, "head", c.pubkeys)
+	if err != nil {
+		return nil, err
+	}
+
+	resp := make(ActiveValidators)
+	for _, val := range vals {
+		if val == nil || val.Validator == nil {
+			return nil, errors.New("validator data cannot be nil")
+		}
+
+		if !val.Status.IsActive() {
+			continue
+		}
+
+		resp[val.Index] = val.Validator.PublicKey
+	}
+
+	c.active = resp
+
+	return resp, nil
+}

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -11,6 +11,35 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 )
 
+// ActiveValidators is a map of active validator indices to pubkeys.
+type ActiveValidators map[eth2p0.ValidatorIndex]eth2p0.BLSPubKey
+
+// Pubkeys returns a list of active validator pubkeys.
+func (m ActiveValidators) Pubkeys() []eth2p0.BLSPubKey {
+	var pubkeys []eth2p0.BLSPubKey
+	for _, pubkey := range m {
+		pubkeys = append(pubkeys, pubkey)
+	}
+
+	return pubkeys
+}
+
+// Indices returns a list of active validator indices.
+func (m ActiveValidators) Indices() []eth2p0.ValidatorIndex {
+	var indices []eth2p0.ValidatorIndex
+	for index := range m {
+		indices = append(indices, index)
+	}
+
+	return indices
+}
+
+// ActiveValidatorsProvider is the interface for providing current epoch's cached active validator
+// identity information.
+type ActiveValidatorsProvider interface {
+	ActiveValidators(context.Context) (ActiveValidators, error)
+}
+
 // NewValidatorCache creates a new validator cache.
 func NewValidatorCache(eth2Cl Client, pubkeys []eth2p0.BLSPubKey) *ValidatorCache {
 	return &ValidatorCache{

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -1,0 +1,83 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+func TestValidatorCache(t *testing.T) {
+	var (
+		expected = make(eth2wrap.ActiveValidators)
+		set      = make(beaconmock.ValidatorSet)
+		pubkeys  []eth2p0.BLSPubKey
+	)
+
+	// Create a set of validators, half active, half random state.
+	for i := 0; i < 10; i++ {
+		val := testutil.RandomValidator(t)
+		if rand.Intn(2) == 0 {
+			val.Status = eth2v1.ValidatorState(rand.Intn(10))
+		}
+		if val.Status.IsActive() {
+			expected[val.Index] = val.Validator.PublicKey
+		}
+		set[val.Index] = val
+		pubkeys = append(pubkeys, val.Validator.PublicKey)
+	}
+
+	// Create a mock client.
+	eth2Cl, err := beaconmock.New()
+	require.NoError(t, err)
+
+	// Configure it to return the set of validators if queried.
+	var queried int
+	eth2Cl.ValidatorsByPubKeyFunc = func(ctx context.Context, stateID string, keys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+		queried++
+		require.Equal(t, "head", stateID)
+		require.Equal(t, pubkeys, keys)
+
+		return set, nil
+	}
+
+	// Create a cache.
+	valCache := eth2wrap.NewValidatorCache(eth2Cl, pubkeys)
+	ctx := context.Background()
+
+	// Check cache is populated.
+	actual, err := valCache.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	require.Equal(t, 1, queried)
+
+	// Check cache is used.
+	actual, err = valCache.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	require.Equal(t, 1, queried)
+
+	// Trim cache.
+	valCache.Trim()
+
+	// Check cache is populated again.
+	actual, err = valCache.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	require.Equal(t, 2, queried)
+
+	// Check cache is used again.
+	actual, err = valCache.Get(ctx)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+	require.Equal(t, 2, queried)
+}

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -83,6 +83,7 @@ func (s *Scheduler) SubscribeDuties(fn func(context.Context, core.Duty, core.Dut
 
 // SubscribeSlots subscribes a callback function for triggered slots.
 // Note this should be called *before* Start.
+// TODO(corver): Add subscriber names for improved logging.
 func (s *Scheduler) SubscribeSlots(fn func(context.Context, core.Slot) error) {
 	s.slotSubs = append(s.slotSubs, fn)
 }
@@ -598,7 +599,6 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
 		e2pks = append(e2pks, e2pk)
 	}
 
-	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
 	vals, err := eth2Cl.ValidatorsByPubKey(ctx, "head", e2pks)
 	if err != nil {
 		return nil, err

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1609,10 +1609,6 @@ func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {
 		valSet = beaconmock.ValidatorSetA
 	)
 
-	// Construct beaconmock.
-	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(valSet))
-	require.NoError(t, err)
-
 	// Sync committee selection 1.
 	secret1, err := tbls.GenerateSecretKey()
 	require.NoError(t, err)
@@ -1628,7 +1624,6 @@ func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {
 	selection1 := testutil.RandomSyncCommitteeSelection()
 	selection1.ValidatorIndex = valSet[1].Index
 	selection1.Slot = slot
-	selection1.SelectionProof = syncCommSelectionProof(t, bmock, secret1, slot, selection1.SubcommitteeIndex)
 
 	// Sync committee selection 2.
 	secret2, err := tbls.GenerateSecretKey()
@@ -1645,6 +1640,12 @@ func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {
 	selection2 := testutil.RandomSyncCommitteeSelection()
 	selection2.ValidatorIndex = valSet[2].Index
 	selection2.Slot = slot
+
+	// Construct beaconmock.
+	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(valSet))
+	require.NoError(t, err)
+
+	selection1.SelectionProof = syncCommSelectionProof(t, bmock, secret1, slot, selection1.SubcommitteeIndex)
 	selection2.SelectionProof = syncCommSelectionProof(t, bmock, secret2, slot, selection2.SubcommitteeIndex)
 
 	selections := []*eth2exp.SyncCommitteeSelection{selection1, selection2}

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -117,6 +117,7 @@ type Mock struct {
 	clock        clockwork.Clock
 	headProducer *headProducer
 
+	ActiveValidatorsFunc                   func(ctx context.Context) (eth2wrap.ActiveValidators, error)
 	AttestationDataFunc                    func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
 	AttesterDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
 	BlockAttestationsFunc                  func(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error)
@@ -146,7 +147,14 @@ type Mock struct {
 	SyncCommitteeContributionFunc          func(ctx context.Context, slot eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
 	SubmitSyncCommitteeSubscriptionsFunc   func(ctx context.Context, subscriptions []*eth2v1.SyncCommitteeSubscription) error
 	SubmitProposalPreparationsFunc         func(ctx context.Context, preparations []*eth2v1.ProposalPreparation) error
-	getAllValidatorsFunc                   func(ctx context.Context) []*eth2v1.Validator
+}
+
+func (Mock) SetValidatorCache(func(context.Context) (eth2wrap.ActiveValidators, error)) {
+	panic("unsupported")
+}
+
+func (m Mock) ActiveValidators(ctx context.Context) (eth2wrap.ActiveValidators, error) {
+	return m.ActiveValidatorsFunc(ctx)
 }
 
 func (m Mock) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
@@ -286,8 +294,4 @@ func (m Mock) Close() error {
 	}
 
 	return nil
-}
-
-func (m Mock) getAllValidators(ctx context.Context) []*eth2v1.Validator {
-	return m.getAllValidatorsFunc(ctx)
 }

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -150,7 +150,7 @@ type Mock struct {
 }
 
 func (Mock) SetValidatorCache(func(context.Context) (eth2wrap.ActiveValidators, error)) {
-	panic("unsupported")
+	// Ignore this, only rely on WithValidator functional option.
 }
 
 func (m Mock) ActiveValidators(ctx context.Context) (eth2wrap.ActiveValidators, error) {

--- a/testutil/validatormock/validatormock.go
+++ b/testutil/validatormock/validatormock.go
@@ -29,10 +29,9 @@ type SignFunc func(pubshare eth2p0.BLSPubKey, data []byte) (eth2p0.BLSSignature,
 
 // ProposeBlock proposes block for the given slot.
 func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
-	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
+	slot eth2p0.Slot,
 ) error {
-	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
-	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys)
+	valMap, err := eth2Cl.ActiveValidators(ctx)
 	if err != nil {
 		return err
 	}
@@ -44,10 +43,7 @@ func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
 
 	var indexes []eth2p0.ValidatorIndex
-	for index, val := range valMap {
-		if !val.Status.IsActive() {
-			continue
-		}
+	for index := range valMap {
 		indexes = append(indexes, index)
 	}
 
@@ -143,10 +139,9 @@ func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc
 
 // ProposeBlindedBlock proposes blinded block for the given slot.
 func ProposeBlindedBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc,
-	slot eth2p0.Slot, pubkeys ...eth2p0.BLSPubKey,
+	slot eth2p0.Slot,
 ) error {
-	// TODO(corver): Use cache instead of using head to try to mitigate this expensive call.
-	valMap, err := eth2Cl.ValidatorsByPubKey(ctx, "head", pubkeys)
+	valMap, err := eth2Cl.ActiveValidators(ctx)
 	if err != nil {
 		return err
 	}
@@ -159,10 +154,7 @@ func ProposeBlindedBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc S
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
 
 	var indexes []eth2p0.ValidatorIndex
-	for index, val := range valMap {
-		if !val.Status.IsActive() {
-			continue
-		}
+	for index := range valMap {
 		indexes = append(indexes, index)
 	}
 

--- a/testutil/validatormock/validatormock_test.go
+++ b/testutil/validatormock/validatormock_test.go
@@ -153,7 +153,7 @@ func TestProposeBlock(t *testing.T) {
 	}
 
 	// Call propose block function
-	err = validatormock.ProposeBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch), valSet.PublicKeys()...)
+	err = validatormock.ProposeBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch))
 	require.NoError(t, err)
 }
 
@@ -201,7 +201,7 @@ func TestProposeBlindedBlock(t *testing.T) {
 	}
 
 	// Call propose block function
-	err = validatormock.ProposeBlindedBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch), valSet.PublicKeys()...)
+	err = validatormock.ProposeBlindedBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch))
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
This is a second attempt at caching active validators. Instead of caching the `eth2client.ValidatorProvider` endpoints which return full `Validator` objects that are not actually immutable by epoch, rather implement a new set of client endpoint specifically for cached immutable active validators by current epoch that only return the validator index and pubkey which are immutable. The only race condition is the fact that we query this by "head", so could be for another slot that what we think is current, although this was already the case previously, so no new races are introdcued.

This should significantly decrease BN load, especially if using the validatormock.  

category: feature
ticket: #1396
