### PR TITLE
core/sigagg: verify aggregated signature

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -444,7 +444,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc)
 	}
 
-	sigAgg, err := sigagg.New(lock.Threshold)
+	sigAgg, err := sigagg.New(lock.Threshold, sigagg.NewSigAggVerifier(eth2Cl))
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -444,7 +444,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc)
 	}
 
-	sigAgg, err := sigagg.New(lock.Threshold, sigagg.NewSigAggVerifier(eth2Cl))
+	sigAgg, err := sigagg.New(lock.Threshold, sigagg.NewVerifier(eth2Cl))
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -444,7 +444,10 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		parSigEx = parsigex.NewParSigEx(tcpNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc)
 	}
 
-	sigAgg := sigagg.New(lock.Threshold)
+	sigAgg, err := sigagg.New(lock.Threshold)
+	if err != nil {
+		return err
+	}
 
 	aggSigDB := aggsigdb.NewMemDB(deadlinerFunc("aggsigdb"))
 

--- a/core/sigagg/sigagg.go
+++ b/core/sigagg/sigagg.go
@@ -101,8 +101,8 @@ func (a *Aggregator) Aggregate(ctx context.Context, duty core.Duty, pubkey core.
 	return nil
 }
 
-// NewSigAggVerifier returns a signature verification function for aggregated signatures.
-func NewSigAggVerifier(eth2Cl eth2wrap.Client) func(context.Context, core.PubKey, core.SignedData) error {
+// NewVerifier returns a signature verification function for aggregated signatures.
+func NewVerifier(eth2Cl eth2wrap.Client) func(context.Context, core.PubKey, core.SignedData) error {
 	return func(ctx context.Context, pubkey core.PubKey, data core.SignedData) error {
 		tblsPubkey, err := tblsconv.PubkeyFromCore(pubkey)
 		if err != nil {

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -110,10 +110,9 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 		sig, err := tbls.Sign(secret, msg[:])
 		require.NoError(t, err)
 
-		x, err := att.SetSignature(sig[:])
-		require.NoError(t, err)
-		newAtt := x.(core.Attestation)
-		parsig := core.NewPartialAttestation(&newAtt.Attestation, shareIdx)
+		partialAtt := att.Attestation
+		partialAtt.Signature = eth2p0.BLSSignature(sig)
+		parsig := core.NewPartialAttestation(&partialAtt, shareIdx)
 
 		psigs[shareIdx] = sig
 		parsigs = append(parsigs, parsig)

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -19,10 +19,11 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/sigagg"
-	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
 func TestSigAgg(t *testing.T) {
@@ -33,13 +34,16 @@ func TestSigAgg(t *testing.T) {
 		peers     = 4
 	)
 
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
 	t.Run("invalid threshold", func(t *testing.T) {
-		_, err := sigagg.New(0)
+		_, err := sigagg.New(0, sigagg.NewSigAggVerifier(bmock))
 		require.ErrorContains(t, err, "invalid threshold")
 	})
 
 	t.Run("threshold sigs", func(t *testing.T) {
-		agg, err := sigagg.New(threshold)
+		agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 		require.NoError(t, err)
 		err = agg.Aggregate(ctx, core.Duty{}, "", nil)
 		require.ErrorContains(t, err, "require threshold signatures")
@@ -55,7 +59,7 @@ func TestSigAgg(t *testing.T) {
 			parsigs = append(parsigs, parsig)
 		}
 
-		agg, err := sigagg.New(threshold)
+		agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 		require.NoError(t, err)
 		err = agg.Aggregate(ctx, core.Duty{}, "", parsigs)
 		require.ErrorContains(t, err, "number of partial signatures less than threshold")
@@ -70,10 +74,18 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 		peers     = 4
 	)
 
-	att := testutil.RandomAttestation()
-	att.Signature = eth2p0.BLSSignature{}
+	att := core.NewAttestation(testutil.RandomAttestation())
 
-	msg, err := att.Data.HashTreeRoot()
+	msgRoot, err := att.MessageRoot()
+	require.NoError(t, err)
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	epoch, err := att.Epoch(ctx, bmock)
+	require.NoError(t, err)
+
+	msg, err := signing.GetDataRoot(ctx, bmock, att.DomainName(), epoch, msgRoot)
 	require.NoError(t, err)
 
 	// Generate private shares
@@ -98,8 +110,10 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 		sig, err := tbls.Sign(secret, msg[:])
 		require.NoError(t, err)
 
-		att.Signature = tblsconv.SigToETH2(sig)
-		parsig := core.NewPartialAttestation(att, shareIdx)
+		x, err := att.SetSignature(sig[:])
+		require.NoError(t, err)
+		newAtt := x.(core.Attestation)
+		parsig := core.NewPartialAttestation(&newAtt.Attestation, shareIdx)
 
 		psigs[shareIdx] = sig
 		parsigs = append(parsigs, parsig)
@@ -110,7 +124,7 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg, err := sigagg.New(threshold)
+	agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 	require.NoError(t, err)
 
 	// Assert output
@@ -134,18 +148,19 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	ctx := context.Background()
 
 	const (
-		epoch     = 123
 		threshold = 3
 		peers     = 4
+		epoch     = 123
 	)
 
-	msgRandao := core.SignedRandao{
-		SignedEpoch: eth2util.SignedEpoch{
-			Epoch: epoch,
-		},
-	}
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
 
-	msg, err := msgRandao.HashTreeRoot()
+	randao := core.NewSignedRandao(epoch, eth2p0.BLSSignature{})
+	randaoRoot, err := randao.MessageRoot()
+	require.NoError(t, err)
+
+	msg, err := signing.GetDataRoot(ctx, bmock, randao.DomainName(), epoch, randaoRoot)
 	require.NoError(t, err)
 
 	// Generate private shares
@@ -182,7 +197,7 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg, err := sigagg.New(threshold)
+	agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 	require.NoError(t, err)
 
 	// Assert output
@@ -208,7 +223,11 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	const (
 		threshold = 3
 		peers     = 4
+		epoch     = 123
 	)
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
 
 	// Generate private shares
 	secretKey, err := tbls.GenerateSecretKey()
@@ -220,8 +239,14 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	secrets, err := tbls.ThresholdSplit(secretKey, peers, threshold)
 	require.NoError(t, err)
 
-	exit := testutil.RandomExit()
-	msg, err := exit.Message.HashTreeRoot()
+	exitMsg := testutil.RandomExit()
+	exitMsg.Message.Epoch = epoch
+
+	volexit := core.NewSignedVoluntaryExit(exitMsg)
+	exitRoot, err := volexit.MessageRoot()
+	require.NoError(t, err)
+
+	msg, err := signing.GetDataRoot(ctx, bmock, volexit.DomainName(), epoch, exitRoot)
 	require.NoError(t, err)
 
 	// Create partial signatures (in two formats)
@@ -239,7 +264,7 @@ func TestSigAgg_DutyExit(t *testing.T) {
 
 		eth2Sig := tblsconv.SigToETH2(sig)
 		parsig := core.NewPartialSignedVoluntaryExit(&eth2p0.SignedVoluntaryExit{
-			Message:   exit.Message,
+			Message:   volexit.Message,
 			Signature: eth2Sig,
 		}, idx)
 
@@ -251,7 +276,7 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg, err := sigagg.New(threshold)
+	agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 	require.NoError(t, err)
 
 	// Assert output
@@ -278,6 +303,9 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 		threshold = 3
 		peers     = 4
 	)
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
 
 	// Generate private shares
 	secretKey, err := tbls.GenerateSecretKey()
@@ -337,8 +365,16 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Ignoring Domain for this test
-			msg, err := test.block.Root()
+			block, err := core.NewVersionedSignedBeaconBlock(test.block)
+			require.NoError(t, err)
+
+			msgRoot, err := block.MessageRoot()
+			require.NoError(t, err)
+
+			epoch, err := block.Epoch(ctx, bmock)
+			require.NoError(t, err)
+
+			msg, err := signing.GetDataRoot(ctx, bmock, block.DomainName(), epoch, msgRoot)
 			require.NoError(t, err)
 
 			// Create partial signatures (in two formats)
@@ -377,7 +413,7 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg, err := sigagg.New(threshold)
+			agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 			require.NoError(t, err)
 
 			// Assert output
@@ -406,6 +442,9 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 		threshold = 3
 		peers     = 4
 	)
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
 
 	// Generate private shares
 	secretKey, err := tbls.GenerateSecretKey()
@@ -445,8 +484,16 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Ignoring Domain for this test
-			msg, err := test.block.Root()
+			block, err := core.NewVersionedSignedBlindedBeaconBlock(test.block)
+			require.NoError(t, err)
+
+			msgRoot, err := block.MessageRoot()
+			require.NoError(t, err)
+
+			epoch, err := block.Epoch(ctx, bmock)
+			require.NoError(t, err)
+
+			msg, err := signing.GetDataRoot(ctx, bmock, block.DomainName(), epoch, msgRoot)
 			require.NoError(t, err)
 
 			// Create partial signatures (in two formats)
@@ -485,7 +532,7 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg, err := sigagg.New(threshold)
+			agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 			require.NoError(t, err)
 
 			// Assert output
@@ -513,7 +560,11 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 	const (
 		threshold = 3
 		peers     = 4
+		epoch     = 123
 	)
+
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
 
 	// Generate private shares
 	secretKey, err := tbls.GenerateSecretKey()
@@ -543,8 +594,13 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Ignoring Domain for this test
-			msg, err := test.registration.Root()
+			reg, err := core.NewVersionedSignedValidatorRegistration(test.registration)
+			require.NoError(t, err)
+
+			msgRoot, err := reg.MessageRoot()
+			require.NoError(t, err)
+
+			msg, err := signing.GetDataRoot(ctx, bmock, reg.DomainName(), epoch, msgRoot)
 			require.NoError(t, err)
 
 			// Create partial signatures (in two formats)
@@ -583,7 +639,7 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg, err := sigagg.New(threshold)
+			agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
 			require.NoError(t, err)
 
 			// Assert output

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/sigagg"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 	"github.com/obolnetwork/charon/testutil"
@@ -32,18 +33,33 @@ func TestSigAgg(t *testing.T) {
 		peers     = 4
 	)
 
-	var (
-		parsigs []core.ParSignedData
-		att     = testutil.RandomAttestation()
-	)
-	for i := 0; i < peers; i++ {
-		parsig := core.NewPartialAttestation(att, 0) // All partial sig with the same shareIdx (0)
-		parsigs = append(parsigs, parsig)
-	}
+	t.Run("invalid threshold", func(t *testing.T) {
+		_, err := sigagg.New(0)
+		require.ErrorContains(t, err, "invalid threshold")
+	})
 
-	agg := sigagg.New(threshold)
-	err := agg.Aggregate(ctx, core.Duty{}, "", parsigs)
-	require.ErrorContains(t, err, "number of partial signatures less than threshold")
+	t.Run("threshold sigs", func(t *testing.T) {
+		agg, err := sigagg.New(threshold)
+		require.NoError(t, err)
+		err = agg.Aggregate(ctx, core.Duty{}, "", nil)
+		require.ErrorContains(t, err, "require threshold signatures")
+	})
+
+	t.Run("partial sigs", func(t *testing.T) {
+		var (
+			parsigs []core.ParSignedData
+			att     = testutil.RandomAttestation()
+		)
+		for i := 0; i < peers; i++ {
+			parsig := core.NewPartialAttestation(att, 0) // All partial sig with the same shareIdx (0)
+			parsigs = append(parsigs, parsig)
+		}
+
+		agg, err := sigagg.New(threshold)
+		require.NoError(t, err)
+		err = agg.Aggregate(ctx, core.Duty{}, "", parsigs)
+		require.ErrorContains(t, err, "number of partial signatures less than threshold")
+	})
 }
 
 func TestSigAgg_DutyAttester(t *testing.T) {
@@ -55,9 +71,9 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 	)
 
 	att := testutil.RandomAttestation()
+	att.Signature = eth2p0.BLSSignature{}
 
-	// Sign the attestation directly (spec domain not required for test)
-	msg, err := att.MarshalSSZ()
+	msg, err := att.Data.HashTreeRoot()
 	require.NoError(t, err)
 
 	// Generate private shares
@@ -78,14 +94,14 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 
 	psigs = make(map[int]tbls.Signature)
 
-	for idx, secret := range secrets {
-		sig, err := tbls.Sign(secret, msg)
+	for shareIdx, secret := range secrets {
+		sig, err := tbls.Sign(secret, msg[:])
 		require.NoError(t, err)
 
 		att.Signature = tblsconv.SigToETH2(sig)
-		parsig := core.NewPartialAttestation(att, idx)
+		parsig := core.NewPartialAttestation(att, shareIdx)
 
-		psigs[idx] = sig
+		psigs[shareIdx] = sig
 		parsigs = append(parsigs, parsig)
 	}
 
@@ -94,7 +110,8 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg := sigagg.New(threshold)
+	agg, err := sigagg.New(threshold)
+	require.NoError(t, err)
 
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
@@ -102,14 +119,14 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 		sig, err := tblsconv.SigFromCore(aggData.Signature())
 		require.NoError(t, err)
 
-		require.NoError(t, tbls.Verify(pubKey, msg, sig))
+		require.NoError(t, tbls.Verify(pubKey, msg[:], sig))
 		require.NoError(t, err)
 
 		return nil
 	})
 
 	// Run aggregation
-	err = agg.Aggregate(ctx, core.Duty{Type: core.DutyAttester}, "", parsigs)
+	err = agg.Aggregate(ctx, core.Duty{Type: core.DutyAttester}, core.PubKeyFrom48Bytes(pubKey), parsigs)
 	require.NoError(t, err)
 }
 
@@ -122,7 +139,14 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 		peers     = 4
 	)
 
-	msg := []byte("RANDAO reveal")
+	msgRandao := core.SignedRandao{
+		SignedEpoch: eth2util.SignedEpoch{
+			Epoch: epoch,
+		},
+	}
+
+	msg, err := msgRandao.HashTreeRoot()
+	require.NoError(t, err)
 
 	// Generate private shares
 	secretKey, err := tbls.GenerateSecretKey()
@@ -143,7 +167,7 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	psigs = make(map[int]tbls.Signature)
 
 	for idx, secret := range secrets {
-		sig, err := tbls.Sign(secret, msg)
+		sig, err := tbls.Sign(secret, msg[:])
 		require.NoError(t, err)
 
 		eth2Sig := tblsconv.SigToETH2(sig)
@@ -158,7 +182,8 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg := sigagg.New(threshold)
+	agg, err := sigagg.New(threshold)
+	require.NoError(t, err)
 
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
@@ -166,14 +191,14 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 		sig, err := tblsconv.SigFromCore(aggData.Signature())
 		require.NoError(t, err)
 
-		require.NoError(t, tbls.Verify(pubKey, msg, sig))
+		require.NoError(t, tbls.Verify(pubKey, msg[:], sig))
 		require.NoError(t, err)
 
 		return nil
 	})
 
 	// Run aggregation
-	err = agg.Aggregate(ctx, core.Duty{Type: core.DutyRandao}, "", parsigs)
+	err = agg.Aggregate(ctx, core.Duty{Type: core.DutyRandao}, core.PubKeyFrom48Bytes(pubKey), parsigs)
 	require.NoError(t, err)
 }
 
@@ -196,7 +221,7 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	require.NoError(t, err)
 
 	exit := testutil.RandomExit()
-	msg, err := exit.Message.MarshalSSZ()
+	msg, err := exit.Message.HashTreeRoot()
 	require.NoError(t, err)
 
 	// Create partial signatures (in two formats)
@@ -209,7 +234,7 @@ func TestSigAgg_DutyExit(t *testing.T) {
 
 	for idx, secret := range secrets {
 		// Ignoring domain for this test
-		sig, err := tbls.Sign(secret, msg)
+		sig, err := tbls.Sign(secret, msg[:])
 		require.NoError(t, err)
 
 		eth2Sig := tblsconv.SigToETH2(sig)
@@ -226,7 +251,8 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg := sigagg.New(threshold)
+	agg, err := sigagg.New(threshold)
+	require.NoError(t, err)
 
 	// Assert output
 	agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
@@ -234,14 +260,14 @@ func TestSigAgg_DutyExit(t *testing.T) {
 		sig, err := tblsconv.SigFromCore(aggData.Signature())
 		require.NoError(t, err)
 
-		require.NoError(t, tbls.Verify(pubKey, msg, sig))
+		require.NoError(t, tbls.Verify(pubKey, msg[:], sig))
 		require.NoError(t, err)
 
 		return nil
 	})
 
 	// Run aggregation
-	err = agg.Aggregate(ctx, core.Duty{Type: core.DutyExit}, "", parsigs)
+	err = agg.Aggregate(ctx, core.Duty{Type: core.DutyExit}, core.PubKeyFrom48Bytes(pubKey), parsigs)
 	require.NoError(t, err)
 }
 
@@ -351,7 +377,8 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg := sigagg.New(threshold)
+			agg, err := sigagg.New(threshold)
+			require.NoError(t, err)
 
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
@@ -366,7 +393,7 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			})
 
 			// Run aggregation
-			err = agg.Aggregate(ctx, core.Duty{Type: core.DutyProposer}, "", parsigs)
+			err = agg.Aggregate(ctx, core.Duty{Type: core.DutyProposer}, core.PubKeyFrom48Bytes(pubKey), parsigs)
 			require.NoError(t, err)
 		})
 	}
@@ -458,7 +485,8 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg := sigagg.New(threshold)
+			agg, err := sigagg.New(threshold)
+			require.NoError(t, err)
 
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
@@ -473,7 +501,7 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			})
 
 			// Run aggregation
-			err = agg.Aggregate(ctx, core.Duty{Type: core.DutyBuilderProposer}, "", parsigs)
+			err = agg.Aggregate(ctx, core.Duty{Type: core.DutyBuilderProposer}, core.PubKeyFrom48Bytes(pubKey), parsigs)
 			require.NoError(t, err)
 		})
 	}
@@ -555,7 +583,8 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg := sigagg.New(threshold)
+			agg, err := sigagg.New(threshold)
+			require.NoError(t, err)
 
 			// Assert output
 			agg.Subscribe(func(_ context.Context, _ core.Duty, _ core.PubKey, aggData core.SignedData) error {
@@ -570,7 +599,7 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 			})
 
 			// Run aggregation
-			err = agg.Aggregate(ctx, core.Duty{Type: core.DutyBuilderRegistration}, "", parsigs)
+			err = agg.Aggregate(ctx, core.Duty{Type: core.DutyBuilderRegistration}, core.PubKeyFrom48Bytes(pubKey), parsigs)
 			require.NoError(t, err)
 		})
 	}

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -38,12 +38,12 @@ func TestSigAgg(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("invalid threshold", func(t *testing.T) {
-		_, err := sigagg.New(0, sigagg.NewSigAggVerifier(bmock))
+		_, err := sigagg.New(0, sigagg.NewVerifier(bmock))
 		require.ErrorContains(t, err, "invalid threshold")
 	})
 
 	t.Run("threshold sigs", func(t *testing.T) {
-		agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+		agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 		require.NoError(t, err)
 		err = agg.Aggregate(ctx, core.Duty{}, "", nil)
 		require.ErrorContains(t, err, "require threshold signatures")
@@ -59,7 +59,7 @@ func TestSigAgg(t *testing.T) {
 			parsigs = append(parsigs, parsig)
 		}
 
-		agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+		agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 		require.NoError(t, err)
 		err = agg.Aggregate(ctx, core.Duty{}, "", parsigs)
 		require.ErrorContains(t, err, "number of partial signatures less than threshold")
@@ -123,7 +123,7 @@ func TestSigAgg_DutyAttester(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+	agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 	require.NoError(t, err)
 
 	// Assert output
@@ -196,7 +196,7 @@ func TestSigAgg_DutyRandao(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+	agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 	require.NoError(t, err)
 
 	// Assert output
@@ -275,7 +275,7 @@ func TestSigAgg_DutyExit(t *testing.T) {
 	require.NoError(t, err)
 	expect := tblsconv.SigToCore(aggSig)
 
-	agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+	agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 	require.NoError(t, err)
 
 	// Assert output
@@ -412,7 +412,7 @@ func TestSigAgg_DutyProposer(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+			agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 			require.NoError(t, err)
 
 			// Assert output
@@ -531,7 +531,7 @@ func TestSigAgg_DutyBuilderProposer(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+			agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 			require.NoError(t, err)
 
 			// Assert output
@@ -638,7 +638,7 @@ func TestSigAgg_DutyBuilderRegistration(t *testing.T) {
 			require.NoError(t, err)
 			expect := tblsconv.SigToCore(aggSig)
 
-			agg, err := sigagg.New(threshold, sigagg.NewSigAggVerifier(bmock))
+			agg, err := sigagg.New(threshold, sigagg.NewVerifier(bmock))
 			require.NoError(t, err)
 
 			// Assert output

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -718,6 +718,16 @@ func (r *VersionedSignedValidatorRegistration) UnmarshalJSON(input []byte) error
 	return nil
 }
 
+// NewSignedRandao is a convenience function that returns a new signed Randao Reveal.
+func NewSignedRandao(epoch eth2p0.Epoch, randao eth2p0.BLSSignature) SignedRandao {
+	return SignedRandao{
+		SignedEpoch: eth2util.SignedEpoch{
+			Epoch:     epoch,
+			Signature: randao,
+		},
+	}
+}
+
 // NewPartialSignedRandao is a convenience function that returns a new partially signed Randao Reveal.
 func NewPartialSignedRandao(epoch eth2p0.Epoch, randao eth2p0.BLSSignature, shareIdx int) ParSignedData {
 	return ParSignedData{


### PR DESCRIPTION
Verify reconstructed aggregated signature.

Fixes OBOL-17 of sigp audit.

category: feature 
ticket: #2122 
