### PR TITLE
core/tracker: check aggbits for inclusion

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -468,7 +468,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	opts := []core.WireOption{
 		core.WithTracing(),
-		core.WithTracking(track, inclusion.Submitted),
+		core.WithTracking(track, inclusion),
 		core.WithAsyncRetry(retryer),
 	}
 	core.Wire(sched, fetch, cons, dutyDB, vapi, parSigDB, parSigEx, sigAgg, aggSigDB, broadcaster, opts...)

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -443,7 +443,7 @@ func TestFetchSyncContribution(t *testing.T) {
 				Slot:              slot,
 				BeaconBlockRoot:   beaconBlockRoot,
 				SubcommitteeIndex: subcommitteeIndex,
-				AggregationBits:   bitfield.Bitvector128(testutil.RandomBitList()),
+				AggregationBits:   bitfield.Bitvector128(testutil.RandomBitList(1)),
 				Signature:         testutil.RandomEth2Signature(),
 			}, nil
 		}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -160,6 +160,13 @@ type Broadcaster interface {
 	Broadcast(context.Context, Duty, PubKey, SignedData) error
 }
 
+// InclusionChecker checks whether duties have been included on-chain.
+// TODO(corver): Merge this with tracker below as a compose multi tracker.
+type InclusionChecker interface {
+	// Submitted is called when a duty has been submitted.
+	Submitted(duty Duty, pubkey PubKey, data SignedData) error
+}
+
 // Tracker sends core component events for further analysis and instrumentation.
 type Tracker interface {
 	// FetcherFetched sends Fetcher component's events to tracker.

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -160,7 +160,7 @@ type Broadcaster interface {
 	Broadcast(context.Context, Duty, PubKey, SignedData) error
 }
 
-// InclusionChecker checks whether duties have been included on-chain.
+// InclusionChecker checks whether submitted duties have been included on-chain.
 // TODO(corver): Merge this with tracker below as a compose multi tracker.
 type InclusionChecker interface {
 	// Submitted is called when a duty has been submitted.

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -364,7 +364,7 @@ func (a *InclusionChecker) checkBlock(ctx context.Context, slot int64) error {
 	attsMap := make(map[eth2p0.Root]*eth2p0.Attestation)
 	for _, att := range atts {
 		if att == nil || att.Data == nil {
-			return errors.New("nil attestation")
+			return errors.New("invalid attestation")
 		}
 
 		root, err := att.Data.HashTreeRoot()

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -4,9 +4,11 @@ package tracker
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/eth2wrap"
@@ -39,7 +41,7 @@ func TestInclusion(t *testing.T) {
 	block5.Capella.Message.Body.Graffiti = eth2wrap.GetSyntheticGraffiti() // Ignored, not included or missed.
 	block5Duty := core.NewBuilderProposerDuty(int64(block5.Capella.Message.Slot))
 
-	// Submit the duties
+	// Submit all duties
 	err := incl.Submitted(att1Duty, "", core.NewAttestation(att1), 0)
 	require.NoError(t, err)
 	err = incl.Submitted(agg2Duty, "", core.NewSignedAggregateAndProof(agg2), 0)
@@ -54,25 +56,37 @@ func TestInclusion(t *testing.T) {
 	err = incl.Submitted(block5Duty, "", block5, 0)
 	require.NoError(t, err)
 
-	// Create a mock block with the first two attestations.
-	att1Root, err := att1.HashTreeRoot()
+	// Create a mock block with the 1st and 2nd attestations.
+	att1Root, err := att1.Data.HashTreeRoot()
 	require.NoError(t, err)
-	att2Root, err := agg2.Message.Aggregate.HashTreeRoot()
+	att2Root, err := agg2.Message.Aggregate.Data.HashTreeRoot()
 	require.NoError(t, err)
+	// Add some random aggregation bits to the attestation
+	addRandomBits(att1.AggregationBits)
+	addRandomBits(agg2.Message.Aggregate.AggregationBits)
 
-	// Check the block
-	incl.CheckBlock(context.Background(), block{
+	block := block{
 		Slot: block4Duty.Slot,
 		Attestations: map[eth2p0.Root]*eth2p0.Attestation{
 			att1Root: att1,
 			att2Root: agg2.Message.Aggregate,
 		},
-	})
-	// Assert that the first two duties were included
+	}
+
+	// Check the block
+	incl.CheckBlock(context.Background(), block)
+
+	// Assert that the 1st and 2nd duty was included
 	require.Equal(t, []core.Duty{att1Duty, agg2Duty}, included)
 
 	// Trim the duties
 	incl.Trim(context.Background(), att3Duty.Slot)
-	// Assert that the third duty was missed
+	// Assert that the 3rd duty was missed
 	require.Equal(t, []core.Duty{att3Duty}, missed)
+}
+
+func addRandomBits(list bitfield.Bitlist) {
+	for i := 0; i < rand.Intn(4); i++ {
+		list.SetBitAt(uint64(rand.Intn(int(list.Len()))), true)
+	}
 }

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -67,7 +67,7 @@ func TestInclusion(t *testing.T) {
 
 	block := block{
 		Slot: block4Duty.Slot,
-		Attestations: map[eth2p0.Root]*eth2p0.Attestation{
+		AttestationsByDataRoot: map[eth2p0.Root]*eth2p0.Attestation{
 			att1Root: att1,
 			att2Root: agg2.Message.Aggregate,
 		},

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -9,7 +9,7 @@ import (
 )
 
 // WithTracking wraps component input functions to support tracking of core components.
-func WithTracking(tracker Tracker, submittedFunc func(Duty, PubKey, SignedData) error) WireOption {
+func WithTracking(tracker Tracker, inclusion InclusionChecker) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
 
@@ -68,8 +68,8 @@ func WithTracking(tracker Tracker, submittedFunc func(Duty, PubKey, SignedData) 
 				return err
 			}
 
-			if err := submittedFunc(duty, pubkey, data); err != nil {
-				log.Error(ctx, "Failed to submit duty", err)
+			if err := inclusion.Submitted(duty, pubkey, data); err != nil {
+				log.Error(ctx, "Bug: failed to submit duty to inclusion checker", err)
 			}
 
 			return nil

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -87,7 +87,15 @@ func RandomValidator(t *testing.T) *eth2v1.Validator {
 
 func RandomAttestation() *eth2p0.Attestation {
 	return &eth2p0.Attestation{
-		AggregationBits: RandomBitList(),
+		AggregationBits: RandomBitList(1),
+		Data:            RandomAttestationData(),
+		Signature:       RandomEth2Signature(),
+	}
+}
+
+func RandomAggregateAttestation() *eth2p0.Attestation {
+	return &eth2p0.Attestation{
+		AggregationBits: RandomBitList(64),
 		Data:            RandomAttestationData(),
 		Signature:       RandomEth2Signature(),
 	}
@@ -459,7 +467,7 @@ func RandomSignedAggregateAndProof() *eth2p0.SignedAggregateAndProof {
 func RandomAggregateAndProof() *eth2p0.AggregateAndProof {
 	return &eth2p0.AggregateAndProof{
 		AggregatorIndex: RandomVIdx(),
-		Aggregate:       RandomAttestation(),
+		Aggregate:       RandomAggregateAttestation(),
 		SelectionProof:  RandomEth2Signature(),
 	}
 }
@@ -703,11 +711,12 @@ func RandomArray32() [32]byte {
 	return resp
 }
 
-func RandomBitList() bitfield.Bitlist {
+func RandomBitList(maxBits int) bitfield.Bitlist {
 	size := 256
-	index := rand.Intn(size)
 	resp := bitfield.NewBitlist(uint64(size))
-	resp.SetBitAt(uint64(index), true)
+	for i := 0; i < rand.Intn(maxBits); i++ {
+		resp.SetBitAt(uint64(rand.Intn(size)), true)
+	}
 
 	return resp
 }

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -711,10 +711,10 @@ func RandomArray32() [32]byte {
 	return resp
 }
 
-func RandomBitList(maxBits int) bitfield.Bitlist {
+func RandomBitList(length int) bitfield.Bitlist {
 	size := 256
 	resp := bitfield.NewBitlist(uint64(size))
-	for i := 0; i < rand.Intn(maxBits); i++ {
+	for i := 0; i < length; i++ {
 		resp.SetBitAt(uint64(rand.Intn(size)), true)
 	}
 


### PR DESCRIPTION
When checking attestation and aggregation inclusion, check whether our submissions's aggbits are included in the block attestation aggbits. Also fix matching using attestation data root (not attestation root which changes on additional aggregation). 

category: feature 
ticket: #1538 
