### PR TITLE
app: refactor lockfile fork version mismatch error

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -732,7 +732,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		}
 	}
 	if !ok {
-		return nil, errors.Wrap(err, "lock file fork version not in beacon node fork schedule (probably wrong chain/network)")
+		return nil, errors.New("lock file fork version not in beacon node fork schedule (probably wrong chain/network)")
 	}
 
 	return eth2Cl, nil

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -266,7 +266,7 @@ func (db *MemDB) AwaitAggAttestation(ctx context.Context, slot int64, attestatio
 		}
 		aggAtt, ok := clone.(core.AggregatedAttestation)
 		if !ok {
-			return nil, errors.Wrap(err, "invalid aggregated attestation")
+			return nil, errors.New("invalid aggregated attestation")
 		}
 
 		return &aggAtt.Attestation, nil


### PR DESCRIPTION
Don't wrap old, nil error when a lockfile fork mismatch one is being created.

category: refactor
ticket: none