### PR TITLE
core/consensus: refactor alpha timer AB testing

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -753,7 +753,7 @@ func newConsensus(conf Config, lock cluster.Lock, tcpNode host.Host, p2pKey *k1.
 	}
 
 	if featureset.Enabled(featureset.QBFTConsensus) {
-		comp, err := consensus.New(tcpNode, sender, peers, p2pKey, deadliner, qbftSniffer, featureset.Enabled(featureset.QBFTDoubleLeadTimer))
+		comp, err := consensus.New(tcpNode, sender, peers, p2pKey, deadliner, qbftSniffer)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -39,18 +39,19 @@ const (
 	//   - Those are added to the peer store so libp2p will try to use them.
 	RelayDiscovery Feature = "relay_discovery"
 
-	// QBFTDoubleLeadTimer enables double round duration is leader is online (if pre-prepare received).
-	QBFTDoubleLeadTimer Feature = "qbft_double_lead_timer"
+	// QBFTTimersABTest enables a round-robin mixed timer selection for A/B testing
+	// the affects of different round timers.
+	QBFTTimersABTest Feature = "qbft_timers_ab_test"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		QBFTConsensus:       statusStable,
-		Priority:            statusStable,
-		MockAlpha:           statusAlpha,
-		RelayDiscovery:      statusStable,
-		QBFTDoubleLeadTimer: statusAlpha,
+		QBFTConsensus:    statusStable,
+		Priority:         statusStable,
+		MockAlpha:        statusAlpha,
+		RelayDiscovery:   statusStable,
+		QBFTTimersABTest: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -79,7 +79,7 @@ func TestComponent(t *testing.T) {
 			sniffed <- len(msgs.Msgs)
 		}
 
-		c, err := consensus.New(hosts[i], new(p2p.Sender), peers, p2pkeys[i], testDeadliner{}, sniffer, true)
+		c, err := consensus.New(hosts[i], new(p2p.Sender), peers, p2pkeys[i], testDeadliner{}, sniffer)
 		require.NoError(t, err)
 		c.Subscribe(func(_ context.Context, _ core.Duty, set core.UnsignedDataSet) error {
 			results <- set

--- a/core/consensus/metrics.go
+++ b/core/consensus/metrics.go
@@ -17,7 +17,7 @@ var (
 		Subsystem: "consensus",
 		Name:      "decided_rounds",
 		Help:      "Number of rounds it took to decide consensus instances by duty type.",
-	}, []string{"duty"}) // Using gauge since the value changes slowly, once per slot.
+	}, []string{"duty", "timerType"}) // Using gauge since the value changes slowly, once per slot.
 
 	consensusDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "core",
@@ -25,14 +25,14 @@ var (
 		Name:      "duration_seconds",
 		Help:      "Duration of a consensus instance in seconds by duty",
 		Buckets:   []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60},
-	}, []string{"duty"})
+	}, []string{"duty", "timerType"})
 
 	consensusTimeout = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "core",
 		Subsystem: "consensus",
 		Name:      "timeout_total",
 		Help:      "Total count of consensus timeouts by duty",
-	}, []string{"duty"})
+	}, []string{"duty", "timerType"})
 
 	consensusError = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "core",
@@ -42,7 +42,7 @@ var (
 	})
 )
 
-func instrumentConsensus(duty core.Duty, round int64, startTime time.Time) {
-	decidedRoundsGauge.WithLabelValues(duty.Type.String()).Set(float64(round))
-	consensusDuration.WithLabelValues(duty.Type.String()).Observe(time.Since(startTime).Seconds())
+func instrumentConsensus(duty core.Duty, round int64, startTime time.Time, typ timerType) {
+	decidedRoundsGauge.WithLabelValues(duty.Type.String(), string(typ)).Set(float64(round))
+	consensusDuration.WithLabelValues(duty.Type.String(), string(typ)).Observe(time.Since(startTime).Seconds())
 }

--- a/core/consensus/roundtimer.go
+++ b/core/consensus/roundtimer.go
@@ -7,11 +7,49 @@ import (
 	"time"
 
 	"github.com/jonboulle/clockwork"
+
+	"github.com/obolnetwork/charon/app/featureset"
+	"github.com/obolnetwork/charon/core"
 )
 
 const (
 	incRoundStart    = time.Millisecond * 750
 	incRoundIncrease = time.Millisecond * 250
+)
+
+// timerFunc is a function that returns a round timer.
+type timerFunc func(core.Duty) roundTimer
+
+// getTimerFunc returns a timer function based on the enabled features.
+func getTimerFunc() timerFunc {
+	if featureset.Enabled(featureset.QBFTTimersABTest) {
+		return func(duty core.Duty) roundTimer {
+			switch (duty.Slot + int64(duty.Type)) % 3 {
+			case 0:
+				return newIncreasingRoundTimer()
+			case 1:
+				return newDoubleLeadRoundTimer()
+			case 2:
+				return newExponentialRoundTimer()
+			default:
+				panic("unreachable")
+			}
+		}
+	}
+
+	// Default to increasing round timer.
+	return func(core.Duty) roundTimer {
+		return newIncreasingRoundTimer()
+	}
+}
+
+// timerType is the type of round timer.
+type timerType string
+
+const (
+	timerIncreasing  timerType = "inc"
+	timerDoubleLead  timerType = "double"
+	timerExponential timerType = "exp"
 )
 
 // increasingRoundTimeout returns the duration for a round that starts at incRoundStart in round 1
@@ -24,27 +62,32 @@ func increasingRoundTimeout(round int64) time.Duration {
 type roundTimer interface {
 	// Timer returns a channel that will be closed when the round expires and a stop function.
 	Timer(round int64) (<-chan time.Time, func())
+	// Type returns the type of the round timerType.
+	Type() timerType
 }
 
-// newTimeoutRoundTimer returns a new increasing round timer.
+// newTimeoutRoundTimer returns a new increasing round timerType.
 func newIncreasingRoundTimer() *increasingRoundTimer {
 	return &increasingRoundTimer{
 		clock: clockwork.NewRealClock(),
 	}
 }
 
-// increasingRoundTimer implements a linear increasing round timer.
-// It ignores the Cancel call.
+// increasingRoundTimer implements a linear increasing round timerType.
 type increasingRoundTimer struct {
 	clock clockwork.Clock
 }
 
-func (t increasingRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
-	timer := t.clock.NewTimer(increasingRoundTimeout(round))
-	return timer.Chan(), func() {}
+func (increasingRoundTimer) Type() timerType {
+	return timerIncreasing
 }
 
-// newDoubleLeadRoundTimer returns a new double lead round timer.
+func (t increasingRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
+	timer := t.clock.NewTimer(increasingRoundTimeout(round))
+	return timer.Chan(), func() { timer.Stop() }
+}
+
+// newDoubleLeadRoundTimer returns a new double lead round timerType.
 func newDoubleLeadRoundTimer() *doubleLeadRoundTimer {
 	return &doubleLeadRoundTimer{
 		clock:          clockwork.NewRealClock(),
@@ -52,8 +95,8 @@ func newDoubleLeadRoundTimer() *doubleLeadRoundTimer {
 	}
 }
 
-// doubleLeadRoundTimer implements a round timer that double the round duration when a leader is active.
-// Instead of resetting the round timer on justified pre-prepare, rather double the timeout.
+// doubleLeadRoundTimer implements a round timerType that double the round duration when a leader is active.
+// Instead of resetting the round timerType on justified pre-prepare, rather double the timeout.
 // This ensures all peers round end-times remain aligned with round start times.
 //
 // The original solution is to reset the round time on justified pre-prepare, but this causes
@@ -67,6 +110,10 @@ type doubleLeadRoundTimer struct {
 
 	mu             sync.Mutex
 	firstDeadlines map[int64]time.Time
+}
+
+func (*doubleLeadRoundTimer) Type() timerType {
+	return timerDoubleLead
 }
 
 func (t *doubleLeadRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
@@ -84,6 +131,32 @@ func (t *doubleLeadRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
 	}
 
 	timer := t.clock.NewTimer(deadline.Sub(t.clock.Now()))
+
+	return timer.Chan(), func() { timer.Stop() }
+}
+
+// newExponentialRoundTimer returns a new exponential round timerType.
+func newExponentialRoundTimer() *exponentialRoundTimer {
+	return &exponentialRoundTimer{
+		clock: clockwork.NewRealClock(),
+	}
+}
+
+// exponentialRoundTimer implements a exponential increasing round timerType.
+type exponentialRoundTimer struct {
+	clock clockwork.Clock
+}
+
+func (exponentialRoundTimer) Type() timerType {
+	return timerExponential
+}
+
+func (t exponentialRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
+	duration := incRoundStart
+	for i := 1; i < int(round); i++ {
+		duration *= 2
+	}
+	timer := t.clock.NewTimer(duration)
 
 	return timer.Chan(), func() { timer.Stop() }
 }

--- a/core/consensus/roundtimer.go
+++ b/core/consensus/roundtimer.go
@@ -142,7 +142,8 @@ func newExponentialRoundTimer() *exponentialRoundTimer {
 	}
 }
 
-// exponentialRoundTimer implements a exponential increasing round timerType.
+// exponentialRoundTimer implements a exponential increasing round timer
+// starting at incRoundStart and doubling each subsequent round.
 type exponentialRoundTimer struct {
 	clock clockwork.Clock
 }
@@ -152,9 +153,9 @@ func (exponentialRoundTimer) Type() timerType {
 }
 
 func (t exponentialRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
-	duration := incRoundStart
+	duration := incRoundStart // Duration starts at incRoundStart.
 	for i := 1; i < int(round); i++ {
-		duration *= 2
+		duration *= 2 // Duration doubles each subsequent round.
 	}
 	timer := t.clock.NewTimer(duration)
 

--- a/core/consensus/roundtimer_internal_test.go
+++ b/core/consensus/roundtimer_internal_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/featureset"
+	"github.com/obolnetwork/charon/core"
 )
 
 func TestIncreasingRoundTimer(t *testing.T) {
@@ -39,20 +42,20 @@ func TestIncreasingRoundTimer(t *testing.T) {
 		timer.clock = fakeClock
 
 		t.Run(tt.name, func(t *testing.T) {
-			// Start the timer
+			// Start the timerType
 			timerC, stop := timer.Timer(tt.round)
 
 			// Advance the fake clock
 			fakeClock.Advance(tt.want)
 
-			// Check if the timer fires
+			// Check if the timerType fires
 			select {
 			case <-timerC:
 			default:
 				require.Fail(t, "Fail", "Timer(round %d) did not fire, want %v", tt.round, tt.want)
 			}
 
-			// Stop the timer
+			// Stop the timerType
 			stop()
 		})
 	}
@@ -69,7 +72,7 @@ func TestDoubleLeadRoundTimer(t *testing.T) {
 		// Advance the fake clock
 		fakeClock.Advance(d)
 
-		// Check if the timer fired as expected
+		// Check if the timerType fired as expected
 		select {
 		case <-ch:
 			if !expect {
@@ -82,27 +85,94 @@ func TestDoubleLeadRoundTimer(t *testing.T) {
 		}
 	}
 
-	// Get round 1 timer.
+	// Get round 1 timerType.
 	timerC, stop := timer.Timer(1)
 	// Assert it times out after 1000ms
 	assert(t, timerC, 1000*time.Millisecond, true)
 	stop()
 
-	// Get round 1 timer again.
+	// Get round 1 timerType again.
 	timerC, stop = timer.Timer(1)
 	// Assert it times out after 1000ms again
 	assert(t, timerC, 1000*time.Millisecond, true)
 	stop()
 
-	// Get round 2 timer.
+	// Get round 2 timerType.
 	timerC, stop = timer.Timer(2)
 	// Advance time by 250ms (1s remains).
 	assert(t, timerC, 250*time.Millisecond, false)
 	stop()
 
-	// Get round 2 timer again.
+	// Get round 2 timerType again.
 	timerC, stop = timer.Timer(2)
 	// Assert it times out after 1s+1250ms
 	assert(t, timerC, time.Second+1250*time.Millisecond, true)
 	stop()
+}
+
+func TestExponentialRoundTimer(t *testing.T) {
+	tests := []struct {
+		name  string
+		round int64
+		want  time.Duration
+	}{
+		{
+			name:  "round 1",
+			round: 1,
+			want:  750 * time.Millisecond,
+		},
+		{
+			name:  "round 2",
+			round: 2,
+			want:  1500 * time.Millisecond,
+		},
+		{
+			name:  "round 3",
+			round: 3,
+			want:  3000 * time.Millisecond,
+		},
+		{
+			name:  "round 4",
+			round: 4,
+			want:  6000 * time.Millisecond,
+		},
+		{
+			name:  "round 5",
+			round: 5,
+			want:  12000 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		fakeClock := clockwork.NewFakeClock()
+		timer := newExponentialRoundTimer()
+		timer.clock = fakeClock
+
+		t.Run(tt.name, func(t *testing.T) {
+			// Start the timerType
+			timerC, stop := timer.Timer(tt.round)
+
+			// Advance the fake clock
+			fakeClock.Advance(tt.want)
+
+			// Check if the timerType fires
+			select {
+			case <-timerC:
+			default:
+				require.Fail(t, "Fail", "Timer(round %d) did not fire, want %v", tt.round, tt.want)
+			}
+
+			// Stop the timerType
+			stop()
+		})
+	}
+}
+
+func TestGetTimerFunc(t *testing.T) {
+	featureset.EnableForT(t, featureset.QBFTTimersABTest)
+
+	timerFunc := getTimerFunc()
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(4)).Type())
+	require.Equal(t, timerDoubleLead, timerFunc(core.NewAttesterDuty(5)).Type())
+	require.Equal(t, timerExponential, timerFunc(core.NewAttesterDuty(6)).Type())
 }

--- a/core/consensus/strategysim_internal_test.go
+++ b/core/consensus/strategysim_internal_test.go
@@ -69,7 +69,7 @@ var (
 	}
 
 	expTimer = func(clock clockwork.Clock) roundTimer {
-		return expRoundTimer{clock: clock}
+		return exponentialRoundTimer{clock: clock}
 	}
 )
 
@@ -633,25 +633,14 @@ type incRoundTimer2 struct {
 	clock clockwork.Clock
 }
 
+func (t incRoundTimer2) Type() timerType {
+	return "inc2"
+}
+
 func (t incRoundTimer2) Timer(round int64) (<-chan time.Time, func()) {
 	duration := incRoundStart
 	for i := 1; i < int(round); i++ {
 		duration += incRoundStart
-	}
-
-	timer := t.clock.NewTimer(duration)
-
-	return timer.Chan(), func() {}
-}
-
-type expRoundTimer struct {
-	clock clockwork.Clock
-}
-
-func (t expRoundTimer) Timer(round int64) (<-chan time.Time, func()) {
-	duration := incRoundStart
-	for i := 1; i < int(round); i++ {
-		duration *= 2
 	}
 
 	timer := t.clock.NewTimer(duration)


### PR DESCRIPTION
Refactors the timer selection alpha feature to AB test 3 different timers using a round-robin selection. This allows much better 1-to-1 comparison using metrics.  Note this introduces a 3rd timer, the exponential timer that the simulator showed is very robust and as performant as the increasing timer.

category: feature
ticket: #2092 