### PR TITLE
core/consensus: fix metric labels

### DIFF
--- a/core/consensus/metrics.go
+++ b/core/consensus/metrics.go
@@ -16,23 +16,23 @@ var (
 		Namespace: "core",
 		Subsystem: "consensus",
 		Name:      "decided_rounds",
-		Help:      "Number of rounds it took to decide consensus instances by duty type.",
-	}, []string{"duty", "timerType"}) // Using gauge since the value changes slowly, once per slot.
+		Help:      "Number of rounds it took to decide consensus instances by duty and timer type.",
+	}, []string{"duty", "timer"}) // Using gauge since the value changes slowly, once per slot.
 
 	consensusDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 		Namespace: "core",
 		Subsystem: "consensus",
 		Name:      "duration_seconds",
-		Help:      "Duration of a consensus instance in seconds by duty",
+		Help:      "Duration of a consensus instance in seconds by duty and timer type.",
 		Buckets:   []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60},
-	}, []string{"duty", "timerType"})
+	}, []string{"duty", "timer"})
 
 	consensusTimeout = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "core",
 		Subsystem: "consensus",
 		Name:      "timeout_total",
-		Help:      "Total count of consensus timeouts by duty",
-	}, []string{"duty", "timerType"})
+		Help:      "Total count of consensus timeouts by duty and timer type.",
+	}, []string{"duty", "timer"})
 
 	consensusError = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: "core",


### PR DESCRIPTION
Fix typo in new consensus metric label names.

category: misc
ticket: none
