### PR TITLE
cmd: disable private key locking by default

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -70,6 +70,7 @@ type Config struct {
 	LockFile                string
 	NoVerify                bool
 	PrivKeyFile             string
+	PrivKeyLocking          bool
 	MonitoringAddr          string
 	ValidatorAPIAddr        string
 	BeaconNodeAddrs         []string
@@ -82,7 +83,6 @@ type Config struct {
 	SyntheticBlockProposals bool
 	BuilderAPI              bool
 	SimnetBMockFuzz         bool
-	PrivkeyLockingEnabled   bool
 
 	TestConfig TestConfig
 }
@@ -126,7 +126,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		}
 	}()
 
-	if conf.PrivkeyLockingEnabled {
+	if conf.PrivKeyLocking {
 		cleanPrivkeyLock, err := privkeylock.New(conf.PrivKeyFile+".lock", "charon run")
 		if err != nil {
 			return err

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -76,6 +76,7 @@ func TestCmdFlags(t *testing.T) {
 				},
 				LockFile:               ".charon/cluster-lock.json",
 				PrivKeyFile:            ".charon/charon-enr-private-key",
+				PrivKeyLocking:         false,
 				SimnetValidatorKeysDir: ".charon/validator_keys",
 				SimnetSlotDuration:     time.Second,
 				MonitoringAddr:         "127.0.0.1:3620",
@@ -83,7 +84,6 @@ func TestCmdFlags(t *testing.T) {
 				BeaconNodeAddrs:        []string{"http://beacon.node"},
 				JaegerAddr:             "",
 				JaegerService:          "charon",
-				PrivkeyLockingEnabled:  true,
 			},
 		},
 		{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,7 +38,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error) *cobra.Command {
 		},
 	}
 
-	bindPrivKeyFlag(cmd, &conf.PrivKeyFile, &conf.PrivkeyLockingEnabled)
+	bindPrivKeyFlag(cmd, &conf.PrivKeyFile, &conf.PrivKeyLocking)
 	bindRunFlags(cmd, &conf)
 	bindNoVerifyFlag(cmd.Flags(), &conf.NoVerify)
 	bindP2PFlags(cmd, &conf.P2P)
@@ -87,7 +87,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 
 func bindPrivKeyFlag(cmd *cobra.Command, privKeyFile *string, privkeyLockEnabled *bool) {
 	cmd.Flags().StringVar(privKeyFile, "private-key-file", ".charon/charon-enr-private-key", "The path to the charon enr private key file.")
-	cmd.Flags().BoolVar(privkeyLockEnabled, "private-key-file-lock", true, "Whether or not to enable private key locking. When enabled, Charon will not run if the private key is used by another instance.")
+	cmd.Flags().BoolVar(privkeyLockEnabled, "private-key-file-lock", false, "Enables private key locking to prevent multiple instances using the same key.")
 }
 
 func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -144,7 +144,7 @@ Flags:
       --p2p-relays strings                 Comma-separated list of libp2p relay URLs or multiaddrs. (default [https://0.relay.obol.tech])
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
-      --private-key-file-lock              Whether or not to enable private key locking. When enabled, Charon will not run if the private key is used by another instance. (default true)
+      --private-key-file-lock              Enables private key locking to prevent multiple instances using the same key.
       --simnet-beacon-mock                 Enables an internal mock beacon node for running a simnet.
       --simnet-beacon-mock-fuzz            Configures simnet beaconmock to return fuzzed responses.
       --simnet-slot-duration duration      Configures slot duration in simnet beacon mock. (default 1s)


### PR DESCRIPTION
Disables private key locking by default for `charon run`.

category: misc
ticket: none
