### PR TITLE
app: fix flapping test

### DIFF
--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -161,7 +161,7 @@ func TestStartChecker(t *testing.T) {
 			// Advance clock for first epoch tick.
 			advanceClock(clock, 32*12*time.Second)
 
-			waitFor := time.Second
+			waitFor := 1 * time.Second
 			tickInterval := 10 * time.Millisecond
 			if tt.err != nil {
 				require.Eventually(t, func() bool {

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -161,6 +161,8 @@ func TestStartChecker(t *testing.T) {
 			// Advance clock for first epoch tick.
 			advanceClock(clock, 32*12*time.Second)
 
+			waitFor := time.Second
+			tickInterval := 10 * time.Millisecond
 			if tt.err != nil {
 				require.Eventually(t, func() bool {
 					advanceClock(clock, 10*time.Second)
@@ -171,12 +173,12 @@ func TestStartChecker(t *testing.T) {
 					}
 
 					return true
-				}, time.Second, 100*time.Millisecond)
+				}, waitFor, tickInterval)
 			} else {
 				require.Eventually(t, func() bool {
 					advanceClock(clock, 12*time.Second)
 					return readyErrFunc() == nil
-				}, time.Second, 100*time.Millisecond)
+				}, waitFor, tickInterval)
 			}
 		})
 	}

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -162,7 +162,7 @@ func TestStartChecker(t *testing.T) {
 			advanceClock(clock, 32*12*time.Second)
 
 			waitFor := 1 * time.Second
-			tickInterval := 10 * time.Millisecond
+			tickInterval := 1 * time.Millisecond
 			if tt.err != nil {
 				require.Eventually(t, func() bool {
 					advanceClock(clock, 10*time.Second)


### PR DESCRIPTION
Increases tick frequency to 1ms to fix flapping test in monitoringapi.

Now the condition is checked every 1ms in a 1s window, ie, 1000 times in a second. This should fix the flapping behaviour.

category: fixbuild 
ticket: #2125 
