### PR TITLE
core/qbft: add support for lazy input values

### DIFF
--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -319,7 +319,7 @@ func (c *Component) propose(ctx context.Context, duty core.Duty, value proto.Mes
 	}
 
 	// Run the algo, blocking until the context is cancelled.
-	err = qbft.Run[core.Duty, [32]byte](ctx, def, qt, duty, peerIdx, hash)
+	err = qbft.Run[core.Duty, [32]byte](ctx, def, qt, duty, peerIdx, qbft.InputValue(hash))
 	if err != nil && !isContextErr(err) {
 		consensusError.Inc()
 		return err // Only return non-context errors.

--- a/core/consensus/sniffed_internal_test.go
+++ b/core/consensus/sniffed_internal_test.go
@@ -108,7 +108,7 @@ func testSniffedInstance(ctx context.Context, t *testing.T, instance *pbv1.Sniff
 	}
 
 	// Run the algo, blocking until the context is cancelled.
-	err := qbft.Run[core.Duty, [32]byte](ctx, def, qt, duty, instance.PeerIdx, [32]byte{1})
+	err := qbft.Run[core.Duty, [32]byte](ctx, def, qt, duty, instance.PeerIdx, qbft.InputValue([32]byte{1}))
 	if expectDecided {
 		require.ErrorIs(t, err, context.Canceled)
 	} else {

--- a/core/consensus/strategysim_internal_test.go
+++ b/core/consensus/strategysim_internal_test.go
@@ -317,7 +317,7 @@ func testStrategySimulator(t *testing.T, conf ssConfig, verbose bool, syncer zap
 		if verbose {
 			log.Debug(ctx, "Starting peer", z.Any("delayed", conf.startByPeer[p.Idx]))
 		}
-		err := qbft.Run(ctx, def, transports[p.Idx], core.Duty{Slot: int64(conf.seed)}, p.Idx, val)
+		err := qbft.Run(ctx, def, transports[p.Idx], core.Duty{Slot: int64(conf.seed)}, p.Idx, qbft.InputValue(val))
 		if err != nil && !errors.Is(err, context.Canceled) {
 			return res, err
 		}

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -10,6 +10,8 @@ import (
 	"math"
 	"strings"
 	"time"
+
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 // Transport abstracts the transport layer between processes in the consensus system.
@@ -273,6 +275,9 @@ func Run[I any, V comparable](ctx context.Context, d Definition[I, V], t Transpo
 		var err error
 		select {
 		case inputValue = <-inputValueCh:
+			if isZeroVal(inputValue) {
+				return errors.New("zero input value not supported")
+			}
 			if ppjCache != nil {
 				// Broadcast the pre-prepare now that we have a input value using the cached justification.
 				err = broadcastMsg(MsgPrePrepare, inputValue, ppjCache)


### PR DESCRIPTION
Adds support for lazy QBFT input values that are not necessarily provided at the start of the instance. Next step is to add support for this consensus component.

category: feature
ticket: #928 
