### PR TITLE
core/consensus: add support for eager consensus

### DIFF
--- a/core/consensus/component_internal_test.go
+++ b/core/consensus/component_internal_test.go
@@ -369,10 +369,9 @@ func TestComponent_handle(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tc := Component{
-				deadliner:   testDeadliner{},
-				recvBuffers: make(map[core.Duty]chan msg),
-			}
+			var tc Component
+			tc.deadliner = testDeadliner{}
+			tc.mutable.recvBuffers = make(map[core.Duty]chan msg)
 
 			msg := &pbv1.ConsensusMsg{
 				Msg: randomMsg(t),

--- a/core/consensus/roundtimer.go
+++ b/core/consensus/roundtimer.go
@@ -47,8 +47,8 @@ func getTimerFunc() timerFunc {
 // timerType is the type of round timer.
 type timerType string
 
-// EagerStart returns true if the timerType requires an eager start (before proposal values are present).
-func (t timerType) EagerStart() bool {
+// Eager returns true if the timer type requires an eager start (before proposal values are present).
+func (t timerType) Eager() bool {
 	return strings.Contains(string(t), "eager")
 }
 

--- a/core/consensus/roundtimer.go
+++ b/core/consensus/roundtimer.go
@@ -3,6 +3,7 @@
 package consensus
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -45,6 +46,11 @@ func getTimerFunc() timerFunc {
 
 // timerType is the type of round timer.
 type timerType string
+
+// EagerStart returns true if the timerType requires an eager start (before proposal values are present).
+func (t timerType) EagerStart() bool {
+	return strings.Contains(string(t), "eager")
+}
 
 const (
 	timerIncreasing  timerType = "inc"

--- a/core/leadercast/leadercast.go
+++ b/core/leadercast/leadercast.go
@@ -78,6 +78,9 @@ func (l *LeaderCast) Subscribe(fn func(ctx context.Context, duty core.Duty, set 
 	l.subs = append(l.subs, fn)
 }
 
+// Participate is a no-op for leader cast. Only Propose is used.
+func (*LeaderCast) Participate(context.Context, core.Duty) error { return nil }
+
 // Propose proposes an unsigned duty data object for consensus. If this peer is the leader, then it is
 // broadcasted to all peers (including self), else the proposal is ignored.
 func (l *LeaderCast) Propose(ctx context.Context, duty core.Duty, data core.UnsignedDataSet) error {

--- a/core/retry.go
+++ b/core/retry.go
@@ -19,13 +19,6 @@ func WithAsyncRetry(retryer *retry.Retryer[Duty]) WireOption {
 
 			return nil
 		}
-		w.ConsensusPropose = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
-			go retryer.DoAsync(ctx, duty, "consensus", "propose", func(ctx context.Context) error {
-				return clone.ConsensusPropose(ctx, duty, set)
-			})
-
-			return nil
-		}
 		w.ParSigExBroadcast = func(ctx context.Context, duty Duty, set ParSignedDataSet) error {
 			go retryer.DoAsync(ctx, duty, "parsigex", "broadcast", func(ctx context.Context) error {
 				return clone.ParSigExBroadcast(ctx, duty, set)

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -59,6 +59,12 @@ func WithTracing() WireOption {
 
 			return clone.FetcherFetch(ctx, duty, set)
 		}
+		w.ConsensusParticipate = func(parent context.Context, duty Duty) error {
+			ctx, span := tracer.Start(parent, "core/consensus.Participate")
+			defer span.End()
+
+			return clone.ConsensusParticipate(ctx, duty)
+		}
 		w.ConsensusPropose = func(parent context.Context, duty Duty, set UnsignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/consensus.Propose")
 			defer span.End()

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -19,6 +19,7 @@ func WithTracking(tracker Tracker, inclusion InclusionChecker) WireOption {
 
 			return err
 		}
+		// TODO(corver): Should we track the new ConsensusParticipate function?
 		w.ConsensusPropose = func(ctx context.Context, duty Duty, set UnsignedDataSet) error {
 			err := clone.ConsensusPropose(ctx, duty, set)
 			tracker.ConsensusProposed(duty, set, err)


### PR DESCRIPTION
Adds support for eager consensus if timer contains `eager` substring. This starts consensus via scheduler without waiting for fetcher.  

category: feature
ticket: #928 
