### PR TITLE
app/log: force color for loki pretty field

### DIFF
--- a/app/log/config.go
+++ b/app/log/config.go
@@ -176,8 +176,12 @@ func InitLogger(config Config) error {
 		loggers := multiLogger{logger}
 		for _, address := range config.LokiAddresses {
 			lokiCl := loki.New(address, config.LokiService, logFunc, getLokiLabels)
+			// Direct-to-loki logger is opinionated: debug level, logfmt format, colored pretty field.
 			lokiLogger, err := newStructuredLogger("logfmt",
-				zapcore.DebugLevel, color, lokiWriter{cl: lokiCl}, callerSkip)
+				zapcore.DebugLevel,
+				true,
+				lokiWriter{cl: lokiCl},
+				callerSkip)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Forces color for `pretty` field when using the opinionated loki logger that pusher directly to loki.

category: misc
ticket: none
