### PR TITLE
precommit: lint importing of testutil

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,8 @@ repos:
         entry: .pre-commit/run_regexp.sh
         types: [ file, go ]
         exclude: "_test.go"
+      - id: run-testutil
+        name: run-testutil
+        language: script
+        entry: .pre-commit/run_testutil.sh
+        types: [ file, go ]

--- a/.pre-commit/run_testutil.sh
+++ b/.pre-commit/run_testutil.sh
@@ -12,16 +12,17 @@ function exclude_names() {
      FILES=$(echo $FILES | tr ' ' '\n' | grep -vE "$1" | tr '\n' ' ')
 }
 
-# exclude_names excludes files with content matching the given regex from the list of files
+# exclude_content excludes files with content matching the given regex from the list of files
 function exclude_content() {
       FILES=$(echo $FILES | tr ' ' '\n' | xargs grep -LZE "$1" | tr '\n' ' ')
 }
 
 # Exclude all file names with 'test' in the path.
 exclude_names 'test'
-# Exclude all files with 'Allow testutil' string.
+# Exclude all files with 'Allow testutil' content.
 exclude_content 'Allow testutil'
 
+# Chck any remaining files for testutil imports.
 check 'Testutil package may only be imported by tests' 'github.com/obolnetwork/charon/testutil' && exit 1
 
 true

--- a/.pre-commit/run_testutil.sh
+++ b/.pre-commit/run_testutil.sh
@@ -19,9 +19,9 @@ function exclude_content() {
 
 # Exclude all file names with 'test' in the path.
 exclude_names 'test'
-exclude_content '// Allow testutil'
+# Exclude all files with 'Allow testutil' string.
+exclude_content 'Allow testutil'
 
-# These checks apply to all non-test files
 check 'Testutil package may only be imported by tests' 'github.com/obolnetwork/charon/testutil' && exit 1
 
 true

--- a/.pre-commit/run_testutil.sh
+++ b/.pre-commit/run_testutil.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+FILES=$@
+
+# check runs a regexp check on the given files
+function check() {
+    grep -HnE "$2" $FILES && printf "\n❌ Regexp check failed: %s\n\n" "$1"
+}
+
+# exclude_names excludes file names matching the given regex from the list of files
+function exclude_names() {
+     FILES=$(echo $FILES | tr ' ' '\n' | grep -vE "$1" | tr '\n' ' ')
+}
+
+# exclude_names excludes files with content matching the given regex from the list of files
+function exclude_content() {
+      FILES=$(echo $FILES | tr ' ' '\n' | xargs grep -LZE "$1" | tr '\n' ' ')
+}
+
+# Exclude all file names with 'test' in the path.
+exclude_names 'test'
+exclude_content '// Allow testutil'
+
+# These checks apply to all non-test files
+check 'Testutil package may only be imported by tests' 'github.com/obolnetwork/charon/testutil' && exit 1
+
+true

--- a/app/app.go
+++ b/app/app.go
@@ -58,7 +58,7 @@ import (
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
-	"github.com/obolnetwork/charon/testutil/beaconmock"
+	"github.com/obolnetwork/charon/testutil/beaconmock" // Allow testutil
 )
 
 const eth2ClientTimeout = time.Second * 2

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -18,7 +18,7 @@ import (
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/keystore"
-	"github.com/obolnetwork/charon/testutil/validatormock"
+	"github.com/obolnetwork/charon/testutil/validatormock" // Allow testutil
 )
 
 // wireValidatorMock wires the validator mock if enabled. It connects via http validatorapi.Router.

--- a/tools.go
+++ b/tools.go
@@ -8,6 +8,8 @@ package main
 // This file contains build time developer tools used in the charon repo.
 // To install all the tools run: go generate tools.go
 
+// Allow testutil
+
 import (
 	_ "github.com/bufbuild/buf/cmd/buf"
 	_ "golang.org/x/tools/cmd/stringer"


### PR DESCRIPTION
Extend the `run_regexp.sh` linter to check for `testutil` imports in any non-test package.

category: misc
ticket: #1683 