### PR TITLE
eth2util/keystore: order keystores by index

### DIFF
--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -66,7 +66,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 	privkeys := make(map[int][]tbls.PrivateKey)
 
 	for _, pkp := range possibleKeyPaths {
-		secrets, err := keystore.LoadKeys(pkp)
+		secrets, err := keystore.LoadKeysSequential(pkp)
 		if err != nil {
 			return errors.Wrap(err, "cannot load keystore", z.Str("path", pkp))
 		}

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -53,7 +53,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 		inputDir = fp
 	}
 
-	log.Info(ctx, "Recombining key shares",
+	log.Info(ctx, "Recombining private key shares",
 		z.Str("input_dir", inputDir),
 		z.Str("output_dir", outputDir),
 	)
@@ -68,7 +68,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 	for _, pkp := range possibleKeyPaths {
 		secrets, err := keystore.LoadKeysSequential(pkp)
 		if err != nil {
-			return errors.Wrap(err, "cannot load keystore", z.Str("path", pkp))
+			return errors.Wrap(err, "cannot load private key share", z.Str("path", pkp))
 		}
 
 		for idx, secret := range secrets {
@@ -81,14 +81,14 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 	for idx, pkSet := range privkeys {
 		if len(pkSet) != len(lock.Operators) {
 			return errors.New(
-				"amount of private keys read doesn't match the current validator index",
-				z.Int("validator_number", idx),
-				z.Int("required_amount", len(lock.Operators)),
-				z.Int("got", len(pkSet)),
+				"not all private keys found for validator",
+				z.Int("validator_index", idx),
+				z.Int("expected", len(lock.Operators)),
+				z.Int("actual", len(pkSet)),
 			)
 		}
 
-		log.Info(ctx, "Recombining key share", z.Int("validator_number", idx))
+		log.Info(ctx, "Recombining private key shares", z.Int("validator_index", idx))
 		shares, err := secretsToShares(lock, pkSet)
 		if err != nil {
 			return err
@@ -96,7 +96,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 
 		secret, err := tbls.RecoverSecret(shares, uint(len(lock.Operators)), uint(lock.Threshold))
 		if err != nil {
-			return errors.Wrap(err, "cannot recover shares", z.Int("validator_number", idx))
+			return errors.Wrap(err, "cannot recover private key share", z.Int("validator_index", idx))
 		}
 
 		// require that the generated secret pubkey matches what's in the lockfile for the idx validator
@@ -104,16 +104,16 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 
 		valPk, err := val.PublicKey()
 		if err != nil {
-			return errors.Wrap(err, "public key for validator from lockfile", z.Int("validator_number", idx))
+			return errors.Wrap(err, "public key for validator from lockfile", z.Int("validator_index", idx))
 		}
 
 		genPubkey, err := tbls.SecretToPublicKey(secret)
 		if err != nil {
-			return errors.Wrap(err, "public key for validator from generated secret", z.Int("validator_number", idx))
+			return errors.Wrap(err, "public key for validator from generated secret", z.Int("validator_index", idx))
 		}
 
 		if valPk != genPubkey {
-			return errors.New("generated and lockfile public key for validator DO NOT match", z.Int("validator_number", idx))
+			return errors.New("generated and lockfile public key for validator DO NOT match", z.Int("validator_index", idx))
 		}
 
 		combinedKeys = append(combinedKeys, secret)

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -81,8 +81,19 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 	require.Error(t, err)
 }
 
+// This test exists because of https://github.com/ObolNetwork/charon/issues/2151.
+func TestCombineLotsOfVals(t *testing.T) {
+	lock, _, shares := cluster.NewForT(t, 100, 3, 4, 0)
+	combineTest(t, lock, shares)
+}
+
 func TestCombine(t *testing.T) {
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
+	combineTest(t, lock, shares)
+}
+
+func combineTest(t *testing.T, lock cluster.Lock, shares [][]tbls.PrivateKey) {
+	t.Helper()
 
 	// calculate expected public keys and secrets
 	type expected struct {

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -88,8 +88,8 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 // loadFiles loads EIP-2335 keystore files from dir, with the given glob.
 // If sortKeyfiles is not nil, it will run it passing the file list as input, and
 // its output will be used as the source of file names to read keystores from.
-func loadFiles(dir string, glob string, sortKeyfiles func([]string) ([]string, error)) ([]tbls.PrivateKey, error) {
-	files, err := filepath.Glob(path.Join(dir, glob))
+func loadFiles(dir string, sortKeyfiles func([]string) ([]string, error)) ([]tbls.PrivateKey, error) {
+	files, err := filepath.Glob(path.Join(dir, "keystore-*.json"))
 	if err != nil {
 		return nil, errors.Wrap(err, "read files")
 	}
@@ -140,7 +140,7 @@ func loadFiles(dir string, glob string, sortKeyfiles func([]string) ([]string, e
 // Note that the index sequence must be incremental, and the difference between consecutive indices must be exactly
 // 1.
 func LoadKeysSequential(dir string) ([]tbls.PrivateKey, error) {
-	return loadFiles(dir, "keystore-*.json", func(files []string) ([]string, error) {
+	return loadFiles(dir, func(files []string) ([]string, error) {
 		newFiles, indices, err := orderByKeystoreNum(files)
 		if err != nil {
 			return nil, err
@@ -177,7 +177,7 @@ func LoadKeysSequential(dir string) ([]tbls.PrivateKey, error) {
 // using password stored in dir/keystore-*.txt.
 // Keystore files are read in lexicographic order from disk, based on their file name.
 func LoadKeys(dir string) ([]tbls.PrivateKey, error) {
-	return loadFiles(dir, "keystore-*.json", nil)
+	return loadFiles(dir, nil)
 }
 
 // orderByKeystoreNum orders keystore file names by their index in ascending order.

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -135,7 +135,10 @@ func loadFiles(dir string, glob string, sortKeyfiles func([]string) ([]string, e
 
 // LoadKeysSequential returns all secrets stored in dir/keystore-([0-9]*).json 2335 Keystore files
 // using password stored in dir/keystore-([0-9]*).txt.
-// The keystore files are read based on their index, and the returned slice is sorted accordingly.
+// The keystore files are read sequentially based on their index starting from 0,
+// and the returned slice is sorted accordingly.
+// Note that the index sequence must be incremental, and the difference between consecutive indices must be exactly
+// 1.
 func LoadKeysSequential(dir string) ([]tbls.PrivateKey, error) {
 	return loadFiles(dir, "keystore-*.json", func(files []string) ([]string, error) {
 		newFiles, indices, err := orderByKeystoreNum(files)

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -85,7 +85,7 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 	return nil
 }
 
-// loadFiles loads keystore files from dir, with the given glob.
+// loadFiles loads EIP-2335 keystore files from dir, with the given glob.
 // If sortKeyfiles is not nil, it will run it passing the file list as input, and
 // its output will be used as the source of file names to read keystores from.
 func loadFiles(dir string, glob string, sortKeyfiles func([]string) ([]string, error)) ([]tbls.PrivateKey, error) {
@@ -133,7 +133,7 @@ func loadFiles(dir string, glob string, sortKeyfiles func([]string) ([]string, e
 	return resp, nil
 }
 
-// LoadKeysSequential returns all secrets stored in dir/keystore-([0-9]*).json 2335 Keystore files
+// LoadKeysSequential returns all secrets stored in dir/keystore-([0-9]*).json EIP-2335 Keystore files
 // using password stored in dir/keystore-([0-9]*).txt.
 // The keystore files are read sequentially based on their index starting from 0,
 // and the returned slice is sorted accordingly.
@@ -173,7 +173,7 @@ func LoadKeysSequential(dir string) ([]tbls.PrivateKey, error) {
 	})
 }
 
-// LoadKeys returns all secrets stored in dir/keystore-*.json 2335 Keystore files
+// LoadKeys returns all secrets stored in dir/keystore-*.json EIP-2335 Keystore files
 // using password stored in dir/keystore-*.txt.
 // Keystore files are read in lexicographic order from disk, based on their file name.
 func LoadKeys(dir string) ([]tbls.PrivateKey, error) {

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -194,8 +194,21 @@ func orderByKeystoreNum(files []string) ([]string, []int, error) {
 		first := strings.TrimPrefix(files[i], prefix)
 		second := strings.TrimPrefix(files[j], prefix)
 
-		if !extractor.MatchString(first) || !extractor.MatchString(second) {
-			sortErr = errors.New("keystore filenames do not match expected pattern")
+		if !extractor.MatchString(first) {
+			sortErr = errors.New(
+				"keystore filenames do not match expected pattern 'keystore-%d.json' or 'keystore-insecure-%d.json'",
+				z.Str("filename", first),
+			)
+
+			return false
+		}
+
+		if !extractor.MatchString(second) {
+			sortErr = errors.New(
+				"keystore filenames do not match expected pattern 'keystore-%d.json' or 'keystore-insecure-%d.json'",
+				z.Str("filename", second),
+			)
+
 			return false
 		}
 

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -175,6 +175,7 @@ func LoadKeysSequential(dir string) ([]tbls.PrivateKey, error) {
 
 // LoadKeys returns all secrets stored in dir/keystore-*.json 2335 Keystore files
 // using password stored in dir/keystore-*.txt.
+// Keystore files are read in lexicographic order from disk, based on their file name.
 func LoadKeys(dir string) ([]tbls.PrivateKey, error) {
 	return loadFiles(dir, "keystore-*.json", nil)
 }

--- a/eth2util/keystore/keystore_internal_test.go
+++ b/eth2util/keystore/keystore_internal_test.go
@@ -70,7 +70,7 @@ func Test_orderByKeystoreNum(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := orderByKeystoreNum(tt.files)
+			got, _, err := orderByKeystoreNum(tt.files)
 
 			tt.errCheck(t, err)
 			require.Equal(t, tt.want, got)

--- a/eth2util/keystore/keystore_internal_test.go
+++ b/eth2util/keystore/keystore_internal_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package keystore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_orderByKeystoreNum(t *testing.T) {
+	tests := []struct {
+		name     string
+		files    []string
+		want     []string
+		errCheck require.ErrorAssertionFunc
+	}{
+		{
+			"keystore secure files",
+			[]string{
+				"/keystore-10.json",
+				"/keystore-1.json",
+				"/keystore-3.json",
+				"/keystore-2.json",
+			},
+			[]string{
+				"/keystore-1.json",
+				"/keystore-2.json",
+				"/keystore-3.json",
+				"/keystore-10.json",
+			},
+			require.NoError,
+		},
+		{
+			"keystore insecure files",
+			[]string{
+				"/keystore-insecure-10.json",
+				"/keystore-insecure-1.json",
+				"/keystore-insecure-3.json",
+				"/keystore-insecure-2.json",
+			},
+			[]string{
+				"/keystore-insecure-1.json",
+				"/keystore-insecure-2.json",
+				"/keystore-insecure-3.json",
+				"/keystore-insecure-10.json",
+			},
+			require.NoError,
+		},
+		{
+			"filenames that do not pass regex error early",
+			[]string{
+				"/keystore-insecure-fail.json",
+				"/keystore-insecure-failtoo.json",
+			},
+			nil,
+			require.Error,
+		},
+		{
+			"single file path yields the exact same thing",
+			[]string{
+				"/keystore-0.json",
+			},
+			[]string{
+				"/keystore-0.json",
+			},
+			require.NoError,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := orderByKeystoreNum(tt.files)
+
+			tt.errCheck(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,49 @@ func TestStoreLoad(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, secrets, actual)
+}
+
+func TestStoreLoadNonCharonNames(t *testing.T) {
+	dir := t.TempDir()
+
+	filenames := []string{
+		"keystore-bar-1",
+		"keystore-bar-2",
+		"keystore-bar-10",
+		"keystore-foo",
+	}
+
+	sort.Strings(filenames)
+
+	var secrets []tbls.PrivateKey
+
+	for i := 0; i < len(filenames); i++ {
+		secret, err := tbls.GenerateSecretKey()
+		require.NoError(t, err)
+
+		secrets = append(secrets, secret)
+	}
+
+	err := keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
+	require.NoError(t, err)
+
+	// rename according to filenames slice
+	for idx := 0; idx < len(filenames); idx++ {
+		oldPath := filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.json", idx))
+		newPath := filepath.Join(dir, fmt.Sprintf("%s.json", filenames[idx]))
+		require.NoError(t, os.Rename(oldPath, newPath))
+
+		oldPath = filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.txt", idx))
+		newPath = filepath.Join(dir, fmt.Sprintf("%s.txt", filenames[idx]))
+		require.NoError(t, os.Rename(oldPath, newPath))
+	}
+
+	actual, err := keystore.LoadKeys(dir)
+	require.NoError(t, err)
+
+	for idx, genpk := range secrets {
+		require.Equal(t, genpk, actual[idx])
+	}
 }
 
 func TestStoreLoadKeysAll(t *testing.T) {
@@ -75,6 +119,46 @@ func TestStoreLoadKeysAllNonSequentialIdx(t *testing.T) {
 	actual, err := keystore.LoadKeysSequential(dir)
 	require.ErrorContains(t, err, "keyfile sorting: indices are non sequential")
 
+	require.Empty(t, actual)
+}
+
+func TestStoreLoadSequentialNonCharonNames(t *testing.T) {
+	dir := t.TempDir()
+
+	filenames := []string{
+		"keystore-bar-1",
+		"keystore-bar-2",
+		"keystore-bar-10",
+		"keystore-foo",
+	}
+
+	sort.Strings(filenames)
+
+	var secrets []tbls.PrivateKey
+
+	for i := 0; i < len(filenames); i++ {
+		secret, err := tbls.GenerateSecretKey()
+		require.NoError(t, err)
+
+		secrets = append(secrets, secret)
+	}
+
+	err := keystore.StoreKeysInsecure(secrets, dir, keystore.ConfirmInsecureKeys)
+	require.NoError(t, err)
+
+	// rename according to filenames slice
+	for idx := 0; idx < len(filenames); idx++ {
+		oldPath := filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.json", idx))
+		newPath := filepath.Join(dir, fmt.Sprintf("%s.json", filenames[idx]))
+		require.NoError(t, os.Rename(oldPath, newPath))
+
+		oldPath = filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.txt", idx))
+		newPath = filepath.Join(dir, fmt.Sprintf("%s.txt", filenames[idx]))
+		require.NoError(t, os.Rename(oldPath, newPath))
+	}
+
+	actual, err := keystore.LoadKeysSequential(dir)
+	require.ErrorContains(t, err, "keystore filenames do not match expected pattern 'keystore-%d.json' or 'keystore-insecure-%d.json'")
 	require.Empty(t, actual)
 }
 


### PR DESCRIPTION
Fixes an error in `cmd/combine` where the i'th combined key was different than expected one if the amount of validator in the lock file is greater than 10.

`filepath.Glob()` orders its input in lexicographical order, so that the following output is obtained:

```
├── keystore-insecure-0.json
├── keystore-insecure-0.txt
├── keystore-insecure-1.json
├── keystore-insecure-1.txt
├── keystore-insecure-10.json
├── keystore-insecure-10.txt
├── keystore-insecure-2.json
├── keystore-insecure-2.txt
```

In this instance, keystore 10 comes before keystore 2.

`cmd/combine` uses the lock file keys order to orchestrate its logic and given the mismatch between that and the `LoadKeys()` output, a key mismatch error will result: `combine` expected key at index 2 to be what's contained in `keystore-insecure-2.json`, but it obtained `keystore-insecure-10.json`.

Ordering the keys path before reading the keystores fixes this issue.

Also added a test in `cmd/combine` which combines 100 validator keys among 4 operators.

category: bug
ticket: #2151

Closes #2151
