### PR TITLE
cmd: improve error logs

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -120,11 +120,6 @@ type TestConfig struct {
 // to the life cycle manager which handles starting and graceful shutdown.
 func Run(ctx context.Context, conf Config) (err error) {
 	ctx = log.WithTopic(ctx, "app-start")
-	defer func() {
-		if err != nil {
-			log.Error(ctx, "Fatal run error", err)
-		}
-	}()
 
 	_, _ = maxprocs.Set()
 

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -113,7 +113,8 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 		}
 
 		if valPk != genPubkey {
-			return errors.New("generated and lockfile public key for validator DO NOT match", z.Int("validator_index", idx))
+			return errors.New("actual generated and expected lockfile public key for validator DO NOT match",
+				z.Int("validator_index", idx), z.Hex("actual", genPubkey[:]), z.Hex("expected", valPk[:]))
 		}
 
 		combinedKeys = append(combinedKeys, secret)

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -113,7 +113,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force bool, opts .
 		}
 
 		if valPk != genPubkey {
-			return errors.New("mismatching resulting combined validator public key vs expected",
+			return errors.New("unexpected resulting combined validator public key",
 				z.Int("validator_index", idx), z.Hex("actual", genPubkey[:]), z.Hex("expected", valPk[:]))
 		}
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -13,7 +13,5 @@ func newCreateCmd(cmds ...*cobra.Command) *cobra.Command {
 
 	root.AddCommand(cmds...)
 
-	titledHelp(root)
-
 	return root
 }

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -73,12 +73,6 @@ func mustMarkFlagRequired(cmd *cobra.Command, flag string) {
 }
 
 func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
-	defer func() {
-		if err != nil {
-			log.Error(ctx, "Fatal run error", err)
-		}
-	}()
-
 	// Map prater to goerli to ensure backwards compatibility with older cluster definitions.
 	// TODO(xenowits): Remove the mapping later.
 	if conf.Network == eth2util.Prater {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -106,7 +106,6 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
-		ctx := log.WithTopic(cmd.Context(), "cmd")
 		for _, relay := range config.Relays {
 			u, err := url.Parse(relay)
 			if err != nil {
@@ -114,7 +113,7 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 			}
 
 			if u.Scheme == "http" {
-				log.Warn(ctx, "Insecure relay address provided, not HTTPS", nil, z.Str("address", relay))
+				log.Warn(cmd.Context(), "Insecure relay address provided, not HTTPS", nil, z.Str("address", relay))
 			}
 		}
 

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -74,12 +74,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ctx = log.WithTopic(ctx, "charon dkg")
-	defer func() {
-		if err != nil {
-			log.Error(ctx, "Fatal error", err)
-		}
-	}()
+	ctx = log.WithTopic(ctx, "dkg")
 
 	lockSvc, err := privkeylock.New(p2p.KeyPath(conf.DataDir)+".lock", "charon dkg")
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -4,17 +4,24 @@ package main
 
 import (
 	"context"
+	"os"
 	"os/signal"
 	"syscall"
 
-	"github.com/spf13/cobra"
-
+	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/cmd"
 )
 
 func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer cancel()
+	ctx = log.WithTopic(ctx, "cmd")
 
-	cobra.CheckErr(cmd.New().ExecuteContext(ctx))
+	err := cmd.New().ExecuteContext(ctx)
+
+	cancel()
+
+	if err != nil {
+		log.Error(ctx, "Fatal error", err)
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Improve all command fatal error logs:
 - Remove duplicates
 - Use app/log to print errors, so structured fields are included.
 - Only show usage on flag parsing errors.  
 
 Also improve `combine` mismatch error logs.

category: misc
ticket: #2151 
