### PR TITLE
eth2util/keystore: concurrently read/write keystore files

### DIFF
--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -149,7 +149,7 @@ func loadFiles(dir string, sortKeyfiles func([]string) ([]string, error)) ([]tbl
 			}
 
 			// PSA: this is a concurrent array write, and it works because we're not
-			// appending, rather we're accessing individual elements of it in a concurrent matter.
+			// appending, rather we're accessing individual elements of it in a concurrent way.
 			// Concurrent access to a variable must be synchronized if at least one of them involves a write.
 			// Spec says:
 			//     Structured variables of array, slice, and struct types have elements and fields

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -148,6 +148,14 @@ func loadFiles(dir string, sortKeyfiles func([]string) ([]string, error)) ([]tbl
 				return errors.Wrap(err, "keystore decryption", z.Str("filename", f))
 			}
 
+			// PSA: this is a concurrent array write, and it works because we're not
+			// appending, rather we're accessing individual elements of it in a concurrent matter.
+			// Concurrent access to a variable must be synchronized if at least one of them involves a write.
+			// Spec says:
+			//     Structured variables of array, slice, and struct types have elements and fields
+			//     that may be addressed individually. Each such element acts like a variable.
+			// So each element effectively is a different variable, which is being written only by a single goroutine:
+			// no synchronization required.
 			resp[idx] = secret
 
 			return nil

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -55,7 +55,7 @@ func StoreKeys(secrets []tbls.PrivateKey, dir string) error {
 }
 
 func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string, opts ...keystorev4.Option) error {
-	eg := errgroup.Group{}
+	var eg errgroup.Group
 
 	for i, secret := range secrets {
 		i := i
@@ -93,7 +93,7 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 	}
 
 	if err := eg.Wait(); err != nil {
-		return errors.Wrap(eg.Wait(), "store keys")
+		return errors.Wrap(err, "store keys")
 	}
 
 	return nil
@@ -119,7 +119,7 @@ func loadFiles(dir string, sortKeyfiles func([]string) ([]string, error)) ([]tbl
 		}
 	}
 
-	eg := errgroup.Group{}
+	var eg errgroup.Group
 
 	resp := make([]tbls.PrivateKey, len(files))
 


### PR DESCRIPTION
Miga Labs testing revealed that loading a huge amount of keys (1000 in their case) takes an unbearable amount of time.

Manual debugging with a similar amount of secure keys also revealed that writing them is slow.

Use `errgroup` to make the reading/writing process concurrent, utilising as much host resources as possible, reducing the time needed to execute those operations.

category: feature
ticket: none
