### PR TITLE
app/genssz: support transform funcs

### DIFF
--- a/app/genssz/template.go
+++ b/app/genssz/template.go
@@ -23,14 +23,14 @@ func ({{$abbr}} {{.Name}}) HashTreeRootWith(hw ssz.HashWalker) (err error) {
 {{range .Fields}}
 	// Field {{.Index}}: '{{.Name}}' ssz:"{{.SSZTag}}"
 	{{- if .IsUint64}}
-	hw.PutUint64(uint64({{$abbr}}.{{.Name}}))
+	hw.PutUint64(uint64({{$abbr}}.{{.Name}}{{.Transform}}))
 	{{else if .IsByteList}}
-	err = putByteList(hw, []byte({{$abbr}}.{{.Name}}[:]), {{.Size}}, "{{.Name}}")
+	err = putByteList(hw, []byte({{$abbr}}.{{.Name}}{{.Transform}}[:]), {{.Size}}, "{{.Name}}")
 	if err != nil {
 		return err
 	}
 	{{else if .IsBytesN}}
-	err = putBytesN(hw, []byte({{$abbr}}.{{.Name}}[:]), {{.Size}})
+	err = putBytesN(hw, []byte({{$abbr}}.{{.Name}}{{.Transform}}[:]), {{.Size}})
 	if err != nil {
 		return err
 	}

--- a/app/genssz/testdata/example.go
+++ b/app/genssz/testdata/example.go
@@ -2,16 +2,19 @@
 
 package testdata
 
+import "time"
+
 //go:generate go install github.com/obolnetwork/charon/app/genssz
 //go:generate genssz
 
 type Foo struct {
-	ByteList []byte  `ssz:"ByteList[32]"`
-	Number   int     `ssz:"uint64"`
-	Bytes4   [4]byte `ssz:"Bytes4"`
-	Bytes2   []byte  `ssz:"Bytes2"`
-	Bar      Bar     `ssz:"Composite"`
-	Quxes    []Qux   `ssz:"CompositeList[256]"`
+	ByteList []byte    `ssz:"ByteList[32]"`
+	Number   int       `ssz:"uint64"`
+	Bytes4   [4]byte   `ssz:"Bytes4"`
+	Bytes2   []byte    `ssz:"Bytes2"`
+	Bar      Bar       `ssz:"Composite"`
+	Quxes    []Qux     `ssz:"CompositeList[256]"`
+	UnixTime time.Time `ssz:"uint64,Unix"`
 }
 
 type Bar struct {
@@ -20,4 +23,10 @@ type Bar struct {
 
 type Qux struct {
 	Number int `ssz:"uint64"`
+}
+
+type ignored struct {
+	Foo `json:"foo"`
+	Bar Bar `json:"bar"`
+	Qux Qux `json:"qux"`
 }

--- a/app/genssz/testdata/ssz_gen.go
+++ b/app/genssz/testdata/ssz_gen.go
@@ -6,6 +6,7 @@ package testdata
 
 import (
 	ssz "github.com/ferranbt/fastssz"
+
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/z"
 )
@@ -53,6 +54,9 @@ func (f Foo) HashTreeRootWith(hw ssz.HashWalker) (err error) {
 
 		hw.MerkleizeWithMixin(listIdx, uint64(len(f.Quxes)), uint64(256))
 	}
+
+	// Field 6: 'UnixTime' ssz:"uint64"
+	hw.PutUint64(uint64(f.UnixTime.Unix()))
 
 	hw.Merkleize(indx)
 

--- a/app/genssz/types.go
+++ b/app/genssz/types.go
@@ -35,9 +35,10 @@ func (t Type) Abbr() string {
 }
 
 type Field struct {
-	Index  int
-	Name   string
-	SSZTag string
+	Index     int
+	Name      string
+	Transform string
+	SSZTag    string
 }
 
 func (f Field) IsComposite() bool {


### PR DESCRIPTION
Add support for optional transform functions when auto-generating ssz hashing. This allows transformation of `time.Time` into `uint64` by specifying `ssz:"uint64,Unix"` which would result in `uint64(m.Timestamp.Unix())`.

Also skip structs with tags but without ssz tags.

category: misc
ticket: none