### PR TITLE
cmd/relay: properly skip test on bind issue

### DIFF
--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -53,6 +53,7 @@ func TestComponent(t *testing.T) {
 
 		priv := (*libp2pcrypto.Secp256k1PrivateKey)(p2pkeys[i])
 		h, err := libp2p.New(libp2p.Identity(priv), libp2p.ListenAddrs(mAddr))
+		testutil.SkipIfBindErr(t, err)
 		require.NoError(t, err)
 
 		record, err := enr.Parse(lock.Operators[i].ENR)


### PR DESCRIPTION
Fixes flapping test when binding to port fails sporadically. 

category: test
ticket: none