### PR TITLE
cluster/state: implement load and materialise

### DIFF
--- a/cluster/state/load.go
+++ b/cluster/state/load.go
@@ -1,0 +1,42 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package state
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/cluster"
+)
+
+// Load loads a cluster state from disk. It supports both legacy lock files and raw DAG files.
+func Load(file string) (Cluster, error) {
+	b, err := os.ReadFile(file)
+	if err != nil {
+		return Cluster{}, errors.Wrap(err, "read file")
+	}
+
+	var rawDAG RawDAG
+	if err := json.Unmarshal(b, &rawDAG); err != nil {
+		return loadLegacyLock(b)
+	}
+
+	return Materialise(rawDAG)
+}
+
+func loadLegacyLock(input []byte) (Cluster, error) {
+	var lock cluster.Lock
+	if err := json.Unmarshal(input, &lock); err != nil {
+		return Cluster{}, errors.Wrap(err, "unmarshal legacy lock")
+	}
+
+	// TODO(corver): Verify the lock with support for no-verify.
+
+	legacy, err := NewLegacyLock(lock)
+	if err != nil {
+		return Cluster{}, errors.Wrap(err, "create legacy lock")
+	}
+
+	return legacy.Transform(Cluster{})
+}

--- a/cluster/state/materialise.go
+++ b/cluster/state/materialise.go
@@ -1,0 +1,17 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package state
+
+// Materialise transforms a raw DAG and returns the resulting cluster state.
+func Materialise(rawDAG RawDAG) (Cluster, error) {
+	var cluster Cluster
+	for _, signed := range rawDAG {
+		var err error
+		cluster, err = signed.Transform(cluster)
+		if err != nil {
+			return Cluster{}, err
+		}
+	}
+
+	return cluster, nil
+}

--- a/cluster/state/mutation.go
+++ b/cluster/state/mutation.go
@@ -30,8 +30,6 @@ func (t MutationType) Unmarshal(input []byte) (MutationData, error) {
 
 // Transform returns a transformed cluster state with the given mutation.
 func (t MutationType) Transform(cluster Cluster, signed SignedMutation) (Cluster, error) {
-	// TODO(corver): Verify signature
-
 	return mutationDefs[t].TransformFunc(cluster, signed)
 }
 

--- a/cluster/state/mutationlegacylock.go
+++ b/cluster/state/mutationlegacylock.go
@@ -3,6 +3,7 @@
 package state
 
 import (
+	"reflect"
 	"time"
 
 	ssz "github.com/ferranbt/fastssz"
@@ -84,7 +85,12 @@ func verifyLegacyLock(signed SignedMutation) error {
 }
 
 // transformLegacyLock transforms the cluster state with the provided legacy lock mutation.
-func transformLegacyLock(_ Cluster, signed SignedMutation) (Cluster, error) {
+func transformLegacyLock(input Cluster, signed SignedMutation) (Cluster, error) {
+	if !reflect.ValueOf(input).IsZero() {
+		// TODO(corver): Find a better way to verify input cluster is zero.
+		return Cluster{}, errors.New("legacy lock not first mutation")
+	}
+
 	if err := verifyLegacyLock(signed); err != nil {
 		return Cluster{}, errors.Wrap(err, "verify legacy lock")
 	}

--- a/cluster/state/types.go
+++ b/cluster/state/types.go
@@ -13,8 +13,8 @@ import (
 
 //go:generate genssz
 
-// RawDAG is a list of mutations that constitute the raw cluster state DAG.
-type RawDAG []Mutation
+// RawDAG is a list of signed mutations that constitute the raw cluster state DAG.
+type RawDAG []SignedMutation
 
 // rootHasher indicates that a type can be hashed with a ssz.HashWalker.
 type rootHasher interface {
@@ -107,6 +107,15 @@ type SignedMutation struct {
 	Signer []byte `ssz:"ByteList[256]"`
 	// Signature is the signature of the mutation.
 	Signature []byte `ssz:"ByteList[256]"`
+}
+
+// Transform returns a transformed cluster state by applying this mutation.
+func (m SignedMutation) Transform(cluster Cluster) (Cluster, error) {
+	if !m.Mutation.Type.Valid() {
+		return cluster, errors.New("invalid mutation type")
+	}
+
+	return m.Mutation.Type.Transform(cluster, m)
 }
 
 func (m SignedMutation) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Implement a basic materialise logic as well as loading either a legacy lock or raw DAG from disk.

category: feature
ticket: #1886 