### PR TITLE
core/validatorapi: get all validators

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1152,10 +1152,6 @@ func getValidatorIDs(query url.Values) []string {
 
 // getValidatorsByID returns the validators with ids being either pubkeys or validator indexes.
 func getValidatorsByID(ctx context.Context, p eth2client.ValidatorsProvider, stateID string, ids ...string) ([]v1Validator, error) {
-	if len(ids) == 0 {
-		return nil, errors.New("no validator ids provided")
-	}
-
 	flatten := func(kvs map[eth2p0.ValidatorIndex]*eth2v1.Validator) []v1Validator {
 		var vals []v1Validator
 		for _, v := range kvs {
@@ -1165,7 +1161,7 @@ func getValidatorsByID(ctx context.Context, p eth2client.ValidatorsProvider, sta
 		return vals
 	}
 
-	if strings.HasPrefix(ids[0], "0x") {
+	if len(ids) > 0 && strings.HasPrefix(ids[0], "0x") {
 		var pubkeys []eth2p0.BLSPubKey
 		for _, id := range ids {
 			coreBytes, err := core.PubKey(id).Bytes()

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -1000,11 +1000,10 @@ func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Vali
 		pubshare, ok := c.getPubShareFunc(val.Validator.PublicKey)
 		if !ok && !ignoreNotFound {
 			return nil, errors.New("pubshare not found")
-		}
-
-		if ok {
+		} else if ok {
 			val.Validator.PublicKey = pubshare
 		}
+
 		resp[vIdx] = val
 	}
 

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -958,7 +958,7 @@ func (c Component) Validators(ctx context.Context, stateID string, validatorIndi
 		return nil, err
 	}
 
-	return c.convertValidators(vals, validatorIndices == nil)
+	return c.convertValidators(vals, len(validatorIndices) == 0)
 }
 
 func (c Component) ValidatorsByPubKey(ctx context.Context, stateID string, pubshares []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
@@ -979,7 +979,7 @@ func (c Component) ValidatorsByPubKey(ctx context.Context, stateID string, pubsh
 	}
 
 	// Then convert back.
-	return c.convertValidators(valMap, pubkeys == nil)
+	return c.convertValidators(valMap, len(pubkeys) == 0)
 }
 
 // NodeVersion returns the current version of charon.
@@ -990,7 +990,7 @@ func (Component) NodeVersion(context.Context) (string, error) {
 }
 
 // convertValidators returns the validator map with root public keys replaced by public shares for all validators that are part of the cluster.
-func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Validator, allVals bool) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Validator, ignoreNotFound bool) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 	resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
 	for vIdx, val := range vals {
 		if val == nil || val.Validator == nil {
@@ -998,7 +998,7 @@ func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Vali
 		}
 
 		pubshare, ok := c.getPubShareFunc(val.Validator.PublicKey)
-		if !ok && !allVals {
+		if !ok && !ignoreNotFound {
 			return nil, errors.New("pubshare not found")
 		}
 

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -958,7 +958,7 @@ func (c Component) Validators(ctx context.Context, stateID string, validatorIndi
 		return nil, err
 	}
 
-	return c.convertValidators(vals)
+	return c.convertValidators(vals, validatorIndices == nil)
 }
 
 func (c Component) ValidatorsByPubKey(ctx context.Context, stateID string, pubshares []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
@@ -979,7 +979,7 @@ func (c Component) ValidatorsByPubKey(ctx context.Context, stateID string, pubsh
 	}
 
 	// Then convert back.
-	return c.convertValidators(valMap)
+	return c.convertValidators(valMap, pubkeys == nil)
 }
 
 // NodeVersion returns the current version of charon.
@@ -989,18 +989,21 @@ func (Component) NodeVersion(context.Context) (string, error) {
 	return fmt.Sprintf("obolnetwork/charon/%s-%s/%s-%s", version.Version, commitSHA, runtime.GOARCH, runtime.GOOS), nil
 }
 
-// convertValidators returns the validator map with all root public keys replaced by public shares.
-func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Validator) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+// convertValidators returns the validator map with root public keys replaced by public shares for all validators that are part of the cluster.
+func (c Component) convertValidators(vals map[eth2p0.ValidatorIndex]*eth2v1.Validator, allVals bool) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 	resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
 	for vIdx, val := range vals {
 		if val == nil || val.Validator == nil {
 			return nil, errors.New("validator data cannot be nil")
 		}
 
-		var ok bool
-		val.Validator.PublicKey, ok = c.getPubShareFunc(val.Validator.PublicKey)
-		if !ok {
+		pubshare, ok := c.getPubShareFunc(val.Validator.PublicKey)
+		if !ok && !allVals {
 			return nil, errors.New("pubshare not found")
+		}
+
+		if ok {
+			val.Validator.PublicKey = pubshare
 		}
 		resp[vIdx] = val
 	}

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1655,6 +1655,29 @@ func TestComponent_GetAllValidators(t *testing.T) {
 	}
 }
 
+func TestComponent_GetClusterValidatorsWithError(t *testing.T) {
+	const (
+		numClusterVals = 4
+		shareIdx       = 1
+	)
+
+	validatorSet := testutil.RandomValidatorSet(t, numClusterVals)
+	var indices []eth2p0.ValidatorIndex
+	for vidx := range validatorSet {
+		indices = append(indices, vidx)
+	}
+
+	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(validatorSet))
+	require.NoError(t, err)
+
+	// Construct validatorapi component.
+	vapi, err := validatorapi.NewComponent(bmock, make(map[core.PubKey]map[int]tbls.PublicKey), shareIdx, nil, testutil.BuilderFalse, nil)
+	require.NoError(t, err)
+
+	_, err = vapi.Validators(context.Background(), "head", indices)
+	require.ErrorContains(t, err, "pubshare not found")
+}
+
 func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {
 	const (
 		slot     = 0

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/eth2util/signing"
 	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/tbls/tblsconv"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 	"github.com/obolnetwork/charon/testutil/validatormock"
@@ -1598,6 +1599,60 @@ func TestComponent_SubmitSyncCommitteeContributionsVerify(t *testing.T) {
 	err = vapi.SubmitSyncCommitteeContributions(ctx, []*altair.SignedContributionAndProof{signedContribAndProof})
 	require.NoError(t, err)
 	<-done
+}
+
+func TestComponent_GetAllValidators(t *testing.T) {
+	const (
+		totalVals      = 10
+		numClusterVals = 4
+		shareIdx       = 1
+	)
+
+	validatorSet := testutil.RandomValidatorSet(t, totalVals)
+
+	// Pick numClusterVals from validator set.
+	var (
+		clusterVals       []*eth2v1.Validator
+		allPubSharesByKey = make(map[core.PubKey]map[int]tbls.PublicKey)
+		keyByPubshare     = make(map[tbls.PublicKey]core.PubKey)
+	)
+	i := numClusterVals
+	for _, val := range validatorSet {
+		i--
+
+		clusterVals = append(clusterVals, val)
+		pubshare, err := tblsconv.PubkeyFromCore(testutil.RandomCorePubKey(t))
+		require.NoError(t, err)
+
+		corePubkey := core.PubKeyFrom48Bytes(val.Validator.PublicKey)
+		allPubSharesByKey[corePubkey] = make(map[int]tbls.PublicKey)
+		allPubSharesByKey[core.PubKeyFrom48Bytes(val.Validator.PublicKey)][shareIdx] = pubshare
+		keyByPubshare[pubshare] = corePubkey
+
+		if i == 0 {
+			break
+		}
+	}
+
+	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(validatorSet))
+	require.NoError(t, err)
+
+	// Construct validatorapi component.
+	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
+	require.NoError(t, err)
+
+	vals, err := vapi.Validators(context.Background(), "head", nil)
+	require.NoError(t, err)
+	require.Len(t, vals, totalVals)
+
+	for _, val := range clusterVals {
+		pubshare, err := tblsconv.PubkeyFromBytes(vals[val.Index].Validator.PublicKey[:])
+		require.NoError(t, err)
+
+		eth2Pubkey, err := keyByPubshare[pubshare].ToETH2()
+		require.NoError(t, err)
+		require.Equal(t, validatorSet[val.Index].Validator.PublicKey, eth2Pubkey)
+	}
 }
 
 func TestComponent_AggregateSyncCommitteeSelectionsVerify(t *testing.T) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -149,6 +149,12 @@ func WithValidatorSet(set ValidatorSet) Option {
 				}
 			}
 
+			if len(resp) == 0 {
+				for idx, val := range set {
+					resp[idx] = cloneValidator(val)
+				}
+			}
+
 			return resp, nil
 		}
 
@@ -160,6 +166,12 @@ func WithValidatorSet(set ValidatorSet) Option {
 					resp[index] = cloneValidator(val)
 				} else {
 					log.Debug(ctx, "Index not found")
+				}
+			}
+
+			if len(resp) == 0 {
+				for idx, val := range set {
+					resp[idx] = cloneValidator(val)
 				}
 			}
 

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -140,6 +140,14 @@ func WithValidatorSet(set ValidatorSet) Option {
 	return func(mock *Mock) {
 		mock.ValidatorsByPubKeyFunc = func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 			resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
+			if len(pubkeys) == 0 {
+				for idx, val := range set {
+					resp[idx] = cloneValidator(val)
+				}
+
+				return resp, nil
+			}
+
 			for _, pubkey := range pubkeys {
 				val, ok := set.ByPublicKey(pubkey)
 				if ok {
@@ -149,29 +157,25 @@ func WithValidatorSet(set ValidatorSet) Option {
 				}
 			}
 
-			if len(resp) == 0 {
-				for idx, val := range set {
-					resp[idx] = cloneValidator(val)
-				}
-			}
-
 			return resp, nil
 		}
 
 		mock.ValidatorsFunc = func(ctx context.Context, stateID string, indexes []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 			resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
+			if len(indexes) == 0 {
+				for idx, val := range set {
+					resp[idx] = cloneValidator(val)
+				}
+
+				return resp, nil
+			}
+
 			for _, index := range indexes {
 				val, ok := set[index]
 				if ok {
 					resp[index] = cloneValidator(val)
 				} else {
 					log.Debug(ctx, "Index not found")
-				}
-			}
-
-			if len(resp) == 0 {
-				for idx, val := range set {
-					resp[idx] = cloneValidator(val)
 				}
 			}
 

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -86,6 +86,18 @@ func RandomValidator(t *testing.T) *eth2v1.Validator {
 	}
 }
 
+func RandomValidatorSet(t *testing.T, vals int) map[eth2p0.ValidatorIndex]*eth2v1.Validator {
+	t.Helper()
+
+	resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
+	for i := 0; i < vals; i++ {
+		val := RandomValidator(t)
+		resp[val.Index] = val
+	}
+
+	return resp
+}
+
 func RandomAttestation() *eth2p0.Attestation {
 	return &eth2p0.Attestation{
 		AggregationBits: RandomBitList(1),


### PR DESCRIPTION
Adds support to get all validators from validatorapi if no validator index or pubkey is provided. This issue came up while testing with prysm VC which needs to query beacon node to get the information of total validators active on beacon chain.
Refer: https://github.com/prysmaticlabs/prysm/blob/5c00fcb84ffef6e85d3d105d7288281ae44b44b2/validator/client/wait_for_activation.go#L139

category: misc
ticket: none
