### PR TITLE
tbls: support deterministic key gen for testing

### DIFF
--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -39,7 +39,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 	}
 
 	for i := 0; i < dv; i++ {
-		rootSecret, err := tbls.GenerateSecretKey()
+		rootSecret, err := tbls.GenerateInsecureKey(t, random)
 		require.NoError(t, err)
 
 		rootPublic, err := tbls.SecretToPublicKey(rootSecret)

--- a/tbls/tbls.go
+++ b/tbls/tbls.go
@@ -2,7 +2,11 @@
 
 package tbls
 
-import "sync"
+import (
+	"io"
+	"sync"
+	"testing"
+)
 
 var (
 	impl     Implementation = Herumi{}
@@ -24,6 +28,10 @@ type (
 type Implementation interface {
 	// GenerateSecretKey generates a secret key and returns its compressed serialized representation.
 	GenerateSecretKey() (PrivateKey, error)
+
+	// GenerateInsecureKey generates a insecure deterministic secret key using the provided random number generator
+	// and returns its compressed serialized representation.
+	GenerateInsecureKey(t *testing.T, random io.Reader) (PrivateKey, error)
 
 	// SecretToPublicKey extracts the public key associated with the secret passed in input, and returns its
 	// compressed serialized representation.
@@ -63,38 +71,60 @@ func SetImplementation(newImpl Implementation) {
 	impl = newImpl
 }
 
+// GenerateSecretKey generates a secret key and returns its compressed serialized representation.
 func GenerateSecretKey() (PrivateKey, error) {
 	return impl.GenerateSecretKey()
 }
 
+// GenerateInsecureKey generates a insecure deterministic secret key using the provided random number generator
+// and returns its compressed serialized representation.
+func GenerateInsecureKey(t *testing.T, random io.Reader) (PrivateKey, error) {
+	t.Helper()
+	return impl.GenerateInsecureKey(t, random)
+}
+
+// SecretToPublicKey extracts the public key associated with the secret passed in input, and returns its
+// compressed serialized representation.
 func SecretToPublicKey(secret PrivateKey) (PublicKey, error) {
 	return impl.SecretToPublicKey(secret)
 }
 
+// ThresholdSplit splits a compressed secret into total units of secret keys, with the given threshold.
+// It returns a map that associates each private, compressed private key to its ID.
 func ThresholdSplit(secret PrivateKey, total uint, threshold uint) (map[int]PrivateKey, error) {
 	return impl.ThresholdSplit(secret, total, threshold)
 }
 
+// RecoverSecret recovers the original secret off the input shares.
 func RecoverSecret(shares map[int]PrivateKey, total uint, threshold uint) (PrivateKey, error) {
 	return impl.RecoverSecret(shares, total, threshold)
 }
 
+// ThresholdAggregate aggregates the partial signatures passed in input in the final original signature.
 func ThresholdAggregate(partialSignaturesByIndex map[int]Signature) (Signature, error) {
 	return impl.ThresholdAggregate(partialSignaturesByIndex)
 }
 
+// Verify verifies that signature has been produced with the private key associated with compressedPublicKey, on
+// the provided data.
 func Verify(compressedPublicKey PublicKey, data []byte, signature Signature) error {
 	return impl.Verify(compressedPublicKey, data, signature)
 }
 
+// Sign signs data with the provided private key, and returns the resulting signature.
+// This function works on both shares of private keys, and complete private keys.
 func Sign(privateKey PrivateKey, data []byte) (Signature, error) {
 	return impl.Sign(privateKey, data)
 }
 
+// VerifyAggregate is the BLS standard FastAggregateVerify call, as defined by the standard:
+// https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-3.3.4.
 func VerifyAggregate(shares []PublicKey, signature Signature, data []byte) error {
 	return impl.VerifyAggregate(shares, signature, data)
 }
 
+// Aggregate combines signs in a single Signature with standard BLS signature aggregation,
+// as defined by the standard: https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.8.
 func Aggregate(signs []Signature) (Signature, error) {
 	return impl.Aggregate(signs)
 }

--- a/tbls/tbls_test.go
+++ b/tbls/tbls_test.go
@@ -4,6 +4,7 @@ package tbls_test
 
 import (
 	"crypto/rand"
+	"io"
 	"math/big"
 	"testing"
 
@@ -243,6 +244,17 @@ func (r randomizedImpl) GenerateSecretKey() (tbls.PrivateKey, error) {
 	}
 
 	return impl.GenerateSecretKey()
+}
+
+func (r randomizedImpl) GenerateInsecureKey(t *testing.T, random io.Reader) (tbls.PrivateKey, error) {
+	t.Helper()
+
+	impl, err := r.selectImpl()
+	if err != nil {
+		return tbls.PrivateKey{}, err
+	}
+
+	return impl.GenerateInsecureKey(t, random)
 }
 
 func (r randomizedImpl) SecretToPublicKey(key tbls.PrivateKey) (tbls.PublicKey, error) {


### PR DESCRIPTION
Adds support for deterministic tbls key generation for use in golden file tests.

category: test
ticket: none