### PR TITLE
app/genssz: transforms for composite list types

### DIFF
--- a/app/genssz/template.go
+++ b/app/genssz/template.go
@@ -43,7 +43,7 @@ func ({{$abbr}} {{.Name}}) HashTreeRootWith(hw ssz.HashWalker) (err error) {
 	{
 		listIdx := hw.Index()
 		for _, item := range {{$abbr}}.{{.Name}} {
-			err = item.HashTreeRootWith(hw)
+			err = item{{.Transform}}.HashTreeRootWith(hw)
 			if err != nil {
 				return err
 			}

--- a/app/genssz/testdata/example.go
+++ b/app/genssz/testdata/example.go
@@ -2,7 +2,10 @@
 
 package testdata
 
-import "time"
+import (
+	"strconv"
+	"time"
+)
 
 //go:generate go install github.com/obolnetwork/charon/app/genssz
 //go:generate genssz
@@ -14,6 +17,7 @@ type Foo struct {
 	Bytes2   []byte    `ssz:"Bytes2"`
 	Bar      Bar       `ssz:"Composite"`
 	Quxes    []Qux     `ssz:"CompositeList[256]"`
+	QuxStrs  []Qux     `ssz:"CompositeList[256],toQuxStr"`
 	UnixTime time.Time `ssz:"uint64,Unix"`
 }
 
@@ -23,6 +27,14 @@ type Bar struct {
 
 type Qux struct {
 	Number int `ssz:"uint64"`
+}
+
+func (q Qux) toQuxStr() QuxStr {
+	return QuxStr{Str: strconv.Itoa(q.Number)}
+}
+
+type QuxStr struct {
+	Str string `ssz:"ByteList[32]"`
 }
 
 type ignored struct {

--- a/app/genssz/testdata/ssz_gen.go
+++ b/app/genssz/testdata/ssz_gen.go
@@ -55,7 +55,20 @@ func (f Foo) HashTreeRootWith(hw ssz.HashWalker) (err error) {
 		hw.MerkleizeWithMixin(listIdx, uint64(len(f.Quxes)), uint64(256))
 	}
 
-	// Field 6: 'UnixTime' ssz:"uint64"
+	// Field 6: 'QuxStrs' ssz:"CompositeList[256]"
+	{
+		listIdx := hw.Index()
+		for _, item := range f.QuxStrs {
+			err = item.toQuxStr().HashTreeRootWith(hw)
+			if err != nil {
+				return err
+			}
+		}
+
+		hw.MerkleizeWithMixin(listIdx, uint64(len(f.QuxStrs)), uint64(256))
+	}
+
+	// Field 7: 'UnixTime' ssz:"uint64"
 	hw.PutUint64(uint64(f.UnixTime.Unix()))
 
 	hw.Merkleize(indx)
@@ -84,6 +97,21 @@ func (q Qux) HashTreeRootWith(hw ssz.HashWalker) (err error) {
 
 	// Field 0: 'Number' ssz:"uint64"
 	hw.PutUint64(uint64(q.Number))
+
+	hw.Merkleize(indx)
+
+	return nil
+}
+
+// HashTreeRootWith ssz hashes the QuxStr object with a hasher
+func (s QuxStr) HashTreeRootWith(hw ssz.HashWalker) (err error) {
+	indx := hw.Index()
+
+	// Field 0: 'Str' ssz:"ByteList[32]"
+	err = putByteList(hw, []byte(s.Str[:]), 32, "Str")
+	if err != nil {
+		return err
+	}
 
 	hw.Merkleize(indx)
 


### PR DESCRIPTION
Supports transform functions for composite list types. This aims to support SSZ hashing of `[][]byte` via simple `[]sszPubkey `ssz:"CompositeList[256],toSSZ"` custom type and override.

category: misc
ticket: none