### PR TITLE
dkg: pre-generate validator registration messages

### DIFF
--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -45,7 +45,7 @@ const (
 
 	// PregenValidatorRegistrations enables pre-generation of validator registrations data, signed at
 	// DKG time from the validator's cluster private keys.
-	PregenValidatorRegistrations Feature = "pregen_validator_registrations"
+	PregenValidatorRegistrations Feature = "pregen_registrations"
 )
 
 var (

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -42,16 +42,21 @@ const (
 	// QBFTTimersABTest enables a round-robin mixed timer selection for A/B testing
 	// the affects of different round timers.
 	QBFTTimersABTest Feature = "qbft_timers_ab_test"
+
+	// PregenValidatorRegistrations enables pre-generation of validator registrations data, signed at
+	// DKG time from the validator's cluster private keys.
+	PregenValidatorRegistrations Feature = "pregen_validator_registrations"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		QBFTConsensus:    statusStable,
-		Priority:         statusStable,
-		MockAlpha:        statusAlpha,
-		RelayDiscovery:   statusStable,
-		QBFTTimersABTest: statusAlpha,
+		QBFTConsensus:                statusStable,
+		Priority:                     statusStable,
+		MockAlpha:                    statusAlpha,
+		RelayDiscovery:               statusStable,
+		QBFTTimersABTest:             statusAlpha,
+		PregenValidatorRegistrations: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -44,6 +44,7 @@ this command at the same time.`,
 	bindLogFlags(cmd.Flags(), &config.Log)
 	bindPublishFlags(cmd.Flags(), &config)
 	bindShutdownDelayFlag(cmd.Flags(), &config.ShutdownDelay)
+	bindFeatureFlags(cmd.Flags(), &config.Feature)
 
 	return cmd
 }

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -25,6 +25,8 @@ const (
 	sigLock sigType = 101
 	// dutyDepositData is responsible for deposit data signed partial signatures exchange and aggregation.
 	sigDepositData sigType = 102
+	// sigValidatorRegistration is responsible for the pre-generated validator registration exchange and aggregation.
+	sigValidatorRegistration sigType = 103
 )
 
 // sigData includes the fields obtained from sigdb when threshold is reached.

--- a/eth2util/registration/registration.go
+++ b/eth2util/registration/registration.go
@@ -1,0 +1,92 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package registration
+
+import (
+	"encoding/hex"
+	"strings"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/eth2util"
+)
+
+// DOMAIN_APPLICATION_BUILDER. See https://github.com/ethereum/builder-specs/blob/7b269305e1e54f22ddb84b3da2f222e20adf6e4f/specs/bellatrix/builder.md#domain-types.
+var registrationDomainType = eth2p0.DomainType([4]byte{0x00, 0x00, 0x00, 0x01})
+
+// NewMessage returns a v1.ValidatorRegistration message with the provided pubkey, feeRecipient, gasLimit and timestamp.
+func NewMessage(pubkey eth2p0.BLSPubKey, feeRecipient string, gasLimit uint64, timestamp time.Time) (eth2v1.ValidatorRegistration, error) {
+	execAddr, err := executionAddressFromStr(feeRecipient)
+	if err != nil {
+		return eth2v1.ValidatorRegistration{}, err
+	}
+
+	return eth2v1.ValidatorRegistration{
+		FeeRecipient: execAddr,
+		GasLimit:     gasLimit,
+		Timestamp:    timestamp,
+		Pubkey:       pubkey,
+	}, nil
+}
+
+// executionAddressFromStr returns the address corresponding to a '0x01' Ethereum withdrawal address.
+func executionAddressFromStr(addr string) ([20]byte, error) {
+	// Check for validity of address.
+	if _, err := eth2util.ChecksumAddress(addr); err != nil {
+		return [20]byte{}, errors.Wrap(err, "invalid address", z.Str("addr", addr))
+	}
+
+	addrBytes, err := hex.DecodeString(strings.TrimPrefix(addr, "0x"))
+	if err != nil {
+		return [20]byte{}, errors.Wrap(err, "decode address")
+	}
+
+	if len(addrBytes) > 20 {
+		return [20]byte{}, errors.New("address has wrong length", z.Int("length", len(addrBytes)))
+	}
+
+	return [20]byte(addrBytes), nil
+}
+
+// getRegistrationDomain returns the validator registration signature domain.
+func getRegistrationDomain() (eth2p0.Domain, error) {
+	forkData := &eth2p0.ForkData{
+		CurrentVersion:        eth2p0.Version{}, // CurrentVersion is zero for validator registration,
+		GenesisValidatorsRoot: eth2p0.Root{},    // GenesisValidatorsRoot is zero for validator registration.
+	}
+
+	root, err := forkData.HashTreeRoot()
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "hash fork data")
+	}
+
+	var domain eth2p0.Domain
+	copy(domain[0:], registrationDomainType[:])
+	copy(domain[4:], root[:])
+
+	return domain, nil
+}
+
+// GetMessageSigningRoot returns the validator registration message signing root created by the provided parameters.
+func GetMessageSigningRoot(msg eth2v1.ValidatorRegistration) ([32]byte, error) {
+	msgRoot, err := msg.HashTreeRoot()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "validator registration message root")
+	}
+
+	domain, err := getRegistrationDomain()
+	if err != nil {
+		return [32]byte{}, err
+	}
+
+	resp, err := (&eth2p0.SigningData{ObjectRoot: msgRoot, Domain: domain}).HashTreeRoot()
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "signing data root")
+	}
+
+	return resp, nil
+}

--- a/eth2util/registration/registration.go
+++ b/eth2util/registration/registration.go
@@ -19,13 +19,13 @@ import (
 var registrationDomainType = eth2p0.DomainType([4]byte{0x00, 0x00, 0x00, 0x01})
 
 // NewMessage returns a v1.ValidatorRegistration message with the provided pubkey, feeRecipient, gasLimit and timestamp.
-func NewMessage(pubkey eth2p0.BLSPubKey, feeRecipient string, gasLimit uint64, timestamp time.Time) (eth2v1.ValidatorRegistration, error) {
+func NewMessage(pubkey eth2p0.BLSPubKey, feeRecipient string, gasLimit uint64, timestamp time.Time) (*eth2v1.ValidatorRegistration, error) {
 	execAddr, err := executionAddressFromStr(feeRecipient)
 	if err != nil {
-		return eth2v1.ValidatorRegistration{}, err
+		return nil, err
 	}
 
-	return eth2v1.ValidatorRegistration{
+	return &eth2v1.ValidatorRegistration{
 		FeeRecipient: execAddr,
 		GasLimit:     gasLimit,
 		Timestamp:    timestamp,
@@ -45,7 +45,7 @@ func executionAddressFromStr(addr string) ([20]byte, error) {
 		return [20]byte{}, errors.Wrap(err, "decode address")
 	}
 
-	if len(addrBytes) > 20 {
+	if len(addrBytes) != 20 {
 		return [20]byte{}, errors.New("address has wrong length", z.Int("length", len(addrBytes)))
 	}
 
@@ -72,7 +72,7 @@ func getRegistrationDomain() (eth2p0.Domain, error) {
 }
 
 // GetMessageSigningRoot returns the validator registration message signing root created by the provided parameters.
-func GetMessageSigningRoot(msg eth2v1.ValidatorRegistration) ([32]byte, error) {
+func GetMessageSigningRoot(msg *eth2v1.ValidatorRegistration) ([32]byte, error) {
 	msgRoot, err := msg.HashTreeRoot()
 	if err != nil {
 		return [32]byte{}, errors.Wrap(err, "validator registration message root")

--- a/eth2util/registration/registration_test.go
+++ b/eth2util/registration/registration_test.go
@@ -1,0 +1,78 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package registration_test
+
+import (
+	"testing"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/eth2util/registration"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestNewMessage(t *testing.T) {
+	gasLimit := uint64(30000000)
+
+	timestamp, err := time.Parse("Jan 2, 2006", "Jan 1, 2000")
+	require.NoError(t, err)
+
+	pubk := testutil.RandomEth2PubKey(t)
+
+	expected := eth2v1.ValidatorRegistration{
+		GasLimit:  gasLimit,
+		Timestamp: timestamp,
+		Pubkey:    pubk,
+		FeeRecipient: bellatrix.ExecutionAddress{
+			50, 29, 203, 82, 159, 57, 69, 188, 148, 254, 206, 169, 211, 188, 92, 175, 53, 37, 59, 148,
+		},
+	}
+
+	feeRecipient := "0x321dcb529f3945bc94fecea9d3bc5caf35253b94"
+
+	result, err := registration.NewMessage(pubk, feeRecipient, gasLimit, timestamp)
+	require.NoError(t, err)
+	require.Equal(t, expected, result)
+}
+
+func TestNewMessageBadAddress(t *testing.T) {
+	gasLimit := uint64(30000000)
+
+	timestamp, err := time.Parse("Jan 2, 2006", "Jan 1, 2000")
+	require.NoError(t, err)
+
+	pubk := testutil.RandomEth2PubKey(t)
+
+	feeRecipient := "0x321dcb529f3945bc94fecea9d3bc5caf35253b9"
+
+	result, err := registration.NewMessage(pubk, feeRecipient, gasLimit, timestamp)
+
+	require.ErrorContains(t, err, "invalid address")
+	require.Empty(t, result)
+}
+
+func TestGetMessageSigningRoot(t *testing.T) {
+	gasLimit := uint64(30000000)
+
+	timestamp, err := time.Parse("Jan 2, 2006", "Jan 1, 2000")
+	require.NoError(t, err)
+
+	pubk := testutil.RandomEth2PubKey(t)
+
+	msg := eth2v1.ValidatorRegistration{
+		GasLimit:  gasLimit,
+		Timestamp: timestamp,
+		Pubkey:    pubk,
+		FeeRecipient: bellatrix.ExecutionAddress{
+			50, 29, 203, 82, 159, 57, 69, 188, 148, 254, 206, 169, 211, 188, 92, 175, 53, 37, 59, 148,
+		},
+	}
+
+	res, err := registration.GetMessageSigningRoot(msg)
+	require.NoError(t, err)
+	require.NotEmpty(t, res)
+	require.Len(t, res, 32)
+}

--- a/eth2util/registration/registration_test.go
+++ b/eth2util/registration/registration_test.go
@@ -22,7 +22,7 @@ func TestNewMessage(t *testing.T) {
 
 	pubk := testutil.RandomEth2PubKey(t)
 
-	expected := eth2v1.ValidatorRegistration{
+	expected := &eth2v1.ValidatorRegistration{
 		GasLimit:  gasLimit,
 		Timestamp: timestamp,
 		Pubkey:    pubk,
@@ -62,7 +62,7 @@ func TestGetMessageSigningRoot(t *testing.T) {
 
 	pubk := testutil.RandomEth2PubKey(t)
 
-	msg := eth2v1.ValidatorRegistration{
+	msg := &eth2v1.ValidatorRegistration{
 		GasLimit:  gasLimit,
 		Timestamp: timestamp,
 		Pubkey:    pubk,


### PR DESCRIPTION
This functionality lives behind the `pregen_validator_registrations` feature flag.

This PR is only concerned with the DKG pre-generation section of the design document (https://docs.google.com/document/d/1lCYiEv7JmVYymp4CBrEvExj3WNmSqWVvZwl9dwATCmA/edit#).

A follow-up PR will implement the lock file changes and wire it accordingly.

category: feature
ticket: #2172 
feature_flag: pregen_registrations
