### PR TITLE
testutil/integration: add DKG test with 5000 validators 

### DIFF
--- a/.github/workflows/nightly-dkg.yml
+++ b/.github/workflows/nightly-dkg.yml
@@ -1,5 +1,5 @@
-# This runs long wait DKG test once a day at 12:00 noon.
-name: long wait dkg
+# This runs DKG tests that assert edge cases and long execution times once a day at 12:00 noon.
+name: nightly dkg
 on:
   schedule:
     - cron: '00 12 * * *'
@@ -20,4 +20,4 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      - run: go test -v -timeout=60m -race github.com/obolnetwork/charon/testutil/integration -long-wait
+      - run: go test -v -timeout=60m -race github.com/obolnetwork/charon/testutil/integration -nightly

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -44,7 +44,6 @@ this command at the same time.`,
 	bindLogFlags(cmd.Flags(), &config.Log)
 	bindPublishFlags(cmd.Flags(), &config)
 	bindShutdownDelayFlag(cmd.Flags(), &config.ShutdownDelay)
-	bindFeatureFlags(cmd.Flags(), &config.Feature)
 
 	return cmd
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -19,7 +19,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/obolnetwork/charon/app/errors"
-	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/obolapi"
 	"github.com/obolnetwork/charon/app/peerinfo"
@@ -62,7 +61,6 @@ type Config struct {
 	P2P           p2p.Config
 	Log           log.Config
 	ShutdownDelay time.Duration
-	Feature       featureset.Config
 
 	KeymanagerAddr      string
 	KeymanagerAuthToken string

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 
-	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
@@ -590,7 +589,6 @@ func getConfigs(t *testing.T, def cluster.Definition, keys []*k1.PrivateKey, dir
 				},
 				TCPNodeCallback: tcpNodeCallback,
 			},
-			Feature: featureset.DefaultConfig(),
 		}
 		require.NoError(t, os.MkdirAll(conf.DataDir, 0o755))
 


### PR DESCRIPTION
Also rename longwait_dkg_test.go to nightly_dkg_test.go, since it contains more than a DKG long-wait test.

category: test
ticket: none