### PR TITLE
cmd: generate validator builder registrations

### DIFF
--- a/cluster/examples/cluster-definition-004.json
+++ b/cluster/examples/cluster-definition-004.json
@@ -1,0 +1,52 @@
+{
+  "name": "solo flow",
+  "creator": {
+    "address": "",
+    "config_signature": ""
+  },
+  "operators": [
+    {
+      "address": "",
+      "enr": "enr:-HW4QArFuw57YniRTZLfq1qQ_jQiGRJyyi4mAXML_72eZHF7B5pAnP1Up1LZ5WYrtSjG1296N1J_G1BaN1oh9jJCfs2AgmlkgnY0iXNlY3AyNTZrMaEDDpHYRvdi0Hhjtr22axvltIQ8aSk_YMk1-E8WtgARmFE",
+      "config_signature": "",
+      "enr_signature": ""
+    },
+    {
+      "address": "",
+      "enr": "enr:-HW4QNdov7ccgDm4yNatX2Jt_A9OHBJRTJzZY2JQ1CuLoTqhbQz1sP6gXeJPNLEjonLxyZucBIDOdwkbYx7DA81-MXSAgmlkgnY0iXNlY3AyNTZrMaED-fsjV6DVtsVcaiAmG8lXY7egWSDUDfWb-EvNx5RBCTk",
+      "config_signature": "",
+      "enr_signature": ""
+    },
+    {
+      "address": "",
+      "enr": "enr:-HW4QPIrxXfdbvLpjHA-HmTaXepfUxNolSQQ4yC5UK7smdI_Ddf8fitZy1uPCmnMYUqUO3Xsikui0iaG2P4p3lk0OrGAgmlkgnY0iXNlY3AyNTZrMaEDvkyXqcyF7DNrS8_GFvP4TnKkm_0303KBw2RM2CifO_0",
+      "config_signature": "",
+      "enr_signature": ""
+    },
+    {
+      "address": "",
+      "enr": "enr:-HW4QNU1ASUEFj0YMOwv94o-Ku17SBn1Bc_MaYHOOThLbDiUSJWB6_EoTZZLPrEmDVR16zkfoGGsh3I0bb9qIjb5i-iAgmlkgnY0iXNlY3AyNTZrMaECZyldhbKm0cqAneYqXTo_KLyYPDadBKchEyiNby5tzXg",
+      "config_signature": "",
+      "enr_signature": ""
+    }
+  ],
+  "uuid": "B6AE17B3-78F5-147B-2C37-2572B93437DF",
+  "version": "v1.7.0",
+  "timestamp": "2023-05-18T15:12:46+02:00",
+  "num_validators": 2,
+  "threshold": 3,
+  "validators": [
+    {
+      "fee_recipient_address": "0x0D941218c10b055f0907FE1BbE486ccdAa7e332A",
+      "withdrawal_address": "0x0D941218c10b055f0907FE1BbE486ccdAa7e332A"
+    },
+    {
+      "fee_recipient_address": "0x0D941218c10b055f0907FE1BbE486ccdAa7e332A",
+      "withdrawal_address": "0x0D941218c10b055f0907FE1BbE486ccdAa7e332A"
+    }
+  ],
+  "dkg_algorithm": "default",
+  "fork_version": "0x00001020",
+  "config_hash": "0x8e93aedb37a29bda13e81c779724108e97904d0180c5fd7358a006cffd051dd3",
+  "definition_hash": "0x188630980aea16d9693326ee56c0dee7614c3866c28abe05aafb13b36a56d56e"
+}

--- a/cluster/version.go
+++ b/cluster/version.go
@@ -5,11 +5,11 @@ package cluster
 import "testing"
 
 const (
-	currentVersion = v1_6
+	currentVersion = v1_7
 	dkgAlgo        = "default"
 
-	v1_7 = "v1.7.0" // Draft
-	v1_6 = "v1.6.0" // Default
+	v1_7 = "v1.7.0" // Default
+	v1_6 = "v1.6.0"
 	v1_5 = "v1.5.0"
 	v1_4 = "v1.4.0"
 	v1_3 = "v1.3.0"

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -31,7 +31,7 @@ import (
 //go:generate go test . -run=TestCreateCluster -update -clean
 
 func TestCreateCluster(t *testing.T) {
-	defPath := "../cluster/examples/cluster-definition-002.json"
+	defPath := "../cluster/examples/cluster-definition-004.json"
 	def, err := loadDefinition(context.Background(), defPath)
 	require.NoError(t, err)
 
@@ -185,6 +185,10 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition)
 				// ENRs should be populated
 				require.NotEqual(t, lock.Operators[i].ENR, "")
 			}
+		}
+
+		for _, val := range lock.Validators {
+			require.NotEmpty(t, val.BuilderRegistration)
 		}
 	})
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -38,23 +38,6 @@ import (
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
-const (
-	// valRegGasLimit is the default gas limit used in validator registration pre-generation.
-	valRegGasLimit = 30000000
-)
-
-// registrationTime is the registration time used to pre-generate validator registrations.
-var registrationTime = time.Date(
-	2000,
-	1,
-	1,
-	0,
-	0,
-	0,
-	0,
-	time.UTC,
-)
-
 type Config struct {
 	DefFile       string
 	NoVerify      bool
@@ -251,7 +234,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		ex,
 		shares,
 		def.FeeRecipientAddresses(),
-		valRegGasLimit,
+		registration.DefaultGasLimit,
 		nodeIdx,
 	)
 	if err != nil {
@@ -678,7 +661,7 @@ func signValidatorRegistrations(shares []share, shareIdx int, feeRecipients []st
 			return nil, nil, err
 		}
 
-		regMsg, err := registration.NewMessage(pubkey, feeRecipients[idx], gasLimit, registrationTime)
+		regMsg, err := registration.NewMessage(pubkey, feeRecipients[idx], gasLimit, registration.DefaultRegistrationTime)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -279,17 +279,6 @@ func startRelay(parentCtx context.Context, t *testing.T) string {
 func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 	t.Helper()
 
-	expectedRegistrationTime := time.Date(
-		2000,
-		1,
-		1,
-		0,
-		0,
-		0,
-		0,
-		time.UTC,
-	)
-
 	// Read generated lock and keystores from disk
 	var (
 		secretShares = make([][]tbls.PrivateKey, def.NumValidators)
@@ -320,8 +309,8 @@ func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 
 			// Assert Builder Registration
 			require.EqualValues(t, val.PubKey, val.BuilderRegistration.Message.PubKey)
-			require.EqualValues(t, 30000000, val.BuilderRegistration.Message.GasLimit)
-			require.EqualValues(t, expectedRegistrationTime, val.BuilderRegistration.Message.Timestamp)
+			require.EqualValues(t, registration.DefaultGasLimit, val.BuilderRegistration.Message.GasLimit)
+			require.EqualValues(t, registration.DefaultRegistrationTime, val.BuilderRegistration.Message.Timestamp)
 
 			// Verify registration signatures
 			eth2Reg, err := registration.NewMessage(eth2p0.BLSPubKey(val.BuilderRegistration.Message.PubKey),

--- a/eth2util/registration/registration.go
+++ b/eth2util/registration/registration.go
@@ -15,6 +15,23 @@ import (
 	"github.com/obolnetwork/charon/eth2util"
 )
 
+const (
+	// DefaultGasLimit is the default gas limit used in validator registration pre-generation.
+	DefaultGasLimit = 30000000
+)
+
+// DefaultRegistrationTime is the registration time used to pre-generate validator registrations.
+var DefaultRegistrationTime = time.Date(
+	2000,
+	1,
+	1,
+	0,
+	0,
+	0,
+	0,
+	time.UTC,
+)
+
 // DOMAIN_APPLICATION_BUILDER. See https://github.com/ethereum/builder-specs/blob/7b269305e1e54f22ddb84b3da2f222e20adf6e4f/specs/bellatrix/builder.md#domain-types.
 var registrationDomainType = eth2p0.DomainType([4]byte{0x00, 0x00, 0x00, 0x01})
 


### PR DESCRIPTION
Generate validator builder registrations when running `charon create cluster` manually.

category: feature
ticket: #2172 