### PR TITLE
core: support ssz unmarshalling in protos

### DIFF
--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -15,6 +15,7 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
@@ -37,6 +38,22 @@ var (
 	_ SignedData = SyncContributionAndProof{}
 	_ SignedData = SignedSyncContributionAndProof{}
 	_ SignedData = SyncCommitteeSelection{}
+
+	// Some types support SSZ marshalling and unmarshalling.
+	_ ssz.Marshaler   = VersionedSignedBeaconBlock{}
+	_ ssz.Marshaler   = Attestation{}
+	_ ssz.Marshaler   = VersionedSignedBlindedBeaconBlock{}
+	_ ssz.Marshaler   = SignedAggregateAndProof{}
+	_ ssz.Marshaler   = SignedSyncMessage{}
+	_ ssz.Marshaler   = SyncContributionAndProof{}
+	_ ssz.Marshaler   = SignedSyncContributionAndProof{}
+	_ ssz.Unmarshaler = new(VersionedSignedBeaconBlock)
+	_ ssz.Unmarshaler = new(Attestation)
+	_ ssz.Unmarshaler = new(VersionedSignedBlindedBeaconBlock)
+	_ ssz.Unmarshaler = new(SignedAggregateAndProof)
+	_ ssz.Unmarshaler = new(SignedSyncMessage)
+	_ ssz.Unmarshaler = new(SyncContributionAndProof)
+	_ ssz.Unmarshaler = new(SignedSyncContributionAndProof)
 )
 
 // SigFromETH2 returns a new signature from eth2 phase0 BLSSignature.
@@ -68,7 +85,6 @@ func (s Signature) Clone() (SignedData, error) {
 
 // clone returns a copy of the Signature.
 // It is similar to Clone that returns the SignedData interface.
-
 func (s Signature) clone() Signature {
 	resp := make([]byte, len(s))
 	copy(resp, s)
@@ -528,6 +544,22 @@ func (a *Attestation) UnmarshalJSON(b []byte) error {
 	return a.Attestation.UnmarshalJSON(b)
 }
 
+func (a Attestation) MarshalSSZ() ([]byte, error) {
+	return a.Attestation.MarshalSSZ()
+}
+
+func (a Attestation) MarshalSSZTo(dst []byte) ([]byte, error) {
+	return a.Attestation.MarshalSSZTo(dst)
+}
+
+func (a Attestation) SizeSSZ() int {
+	return a.Attestation.SizeSSZ()
+}
+
+func (a *Attestation) UnmarshalSSZ(b []byte) error {
+	return a.Attestation.UnmarshalSSZ(b)
+}
+
 // NewSignedVoluntaryExit is a convenience function that returns a new signed voluntary exit.
 func NewSignedVoluntaryExit(exit *eth2p0.SignedVoluntaryExit) SignedVoluntaryExit {
 	return SignedVoluntaryExit{SignedVoluntaryExit: *exit}
@@ -555,7 +587,6 @@ func (e SignedVoluntaryExit) Clone() (SignedData, error) {
 
 // clone returns a copy of the SignedVoluntaryExit.
 // It is similar to Clone that returns the SignedData interface.
-
 func (e SignedVoluntaryExit) clone() (SignedVoluntaryExit, error) {
 	var resp SignedVoluntaryExit
 	err := cloneJSONMarshaler(e, &resp)
@@ -981,6 +1012,22 @@ func (s *SignedAggregateAndProof) UnmarshalJSON(input []byte) error {
 	return s.SignedAggregateAndProof.UnmarshalJSON(input)
 }
 
+func (s SignedAggregateAndProof) MarshalSSZ() ([]byte, error) {
+	return s.SignedAggregateAndProof.MarshalSSZ()
+}
+
+func (s SignedAggregateAndProof) MarshalSSZTo(dst []byte) ([]byte, error) {
+	return s.SignedAggregateAndProof.MarshalSSZTo(dst)
+}
+
+func (s SignedAggregateAndProof) SizeSSZ() int {
+	return s.SignedAggregateAndProof.SizeSSZ()
+}
+
+func (s *SignedAggregateAndProof) UnmarshalSSZ(b []byte) error {
+	return s.SignedAggregateAndProof.UnmarshalSSZ(b)
+}
+
 // SyncCommitteeMessage: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#synccommitteemessage.
 
 // NewSignedSyncMessage is a convenience function which returns new signed SignedSyncMessage.
@@ -1040,6 +1087,22 @@ func (s SignedSyncMessage) MarshalJSON() ([]byte, error) {
 
 func (s *SignedSyncMessage) UnmarshalJSON(input []byte) error {
 	return s.SyncCommitteeMessage.UnmarshalJSON(input)
+}
+
+func (s SignedSyncMessage) MarshalSSZ() ([]byte, error) {
+	return s.SyncCommitteeMessage.MarshalSSZ()
+}
+
+func (s SignedSyncMessage) MarshalSSZTo(dst []byte) ([]byte, error) {
+	return s.SyncCommitteeMessage.MarshalSSZTo(dst)
+}
+
+func (s SignedSyncMessage) SizeSSZ() int {
+	return s.SyncCommitteeMessage.SizeSSZ()
+}
+
+func (s *SignedSyncMessage) UnmarshalSSZ(b []byte) error {
+	return s.SyncCommitteeMessage.UnmarshalSSZ(b)
 }
 
 // ContributionAndProof: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#contributionandproof.
@@ -1118,6 +1181,22 @@ func (s SyncContributionAndProof) Epoch(ctx context.Context, eth2Cl eth2wrap.Cli
 	return eth2util.EpochFromSlot(ctx, eth2Cl, s.Contribution.Slot)
 }
 
+func (s SyncContributionAndProof) MarshalSSZ() ([]byte, error) {
+	return s.ContributionAndProof.MarshalSSZ()
+}
+
+func (s SyncContributionAndProof) MarshalSSZTo(dst []byte) ([]byte, error) {
+	return s.ContributionAndProof.MarshalSSZTo(dst)
+}
+
+func (s SyncContributionAndProof) SizeSSZ() int {
+	return s.ContributionAndProof.SizeSSZ()
+}
+
+func (s *SyncContributionAndProof) UnmarshalSSZ(b []byte) error {
+	return s.ContributionAndProof.UnmarshalSSZ(b)
+}
+
 // SignedContributionAndProof: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#signedcontributionandproof.
 
 // NewSignedSyncContributionAndProof is a convenience function that returns a new signed altair.SignedContributionAndProof.
@@ -1181,8 +1260,24 @@ func (s *SignedSyncContributionAndProof) UnmarshalJSON(input []byte) error {
 	return s.SignedContributionAndProof.UnmarshalJSON(input)
 }
 
+func (s SignedSyncContributionAndProof) MarshalSSZ() ([]byte, error) {
+	return s.SignedContributionAndProof.MarshalSSZ()
+}
+
+func (s SignedSyncContributionAndProof) MarshalSSZTo(dst []byte) ([]byte, error) {
+	return s.SignedContributionAndProof.MarshalSSZTo(dst)
+}
+
+func (s SignedSyncContributionAndProof) SizeSSZ() int {
+	return s.SignedContributionAndProof.SizeSSZ()
+}
+
+func (s *SignedSyncContributionAndProof) UnmarshalSSZ(b []byte) error {
+	return s.SignedContributionAndProof.UnmarshalSSZ(b)
+}
+
 // cloneJSONMarshaler clones the marshaler by serialising to-from json
-// since eth2 types contain pointers. The result is stored in the value pointed to by v.
+// since eth2 types contain pointers. The result is stored in the sszValFromVersion pointed to by v.
 func cloneJSONMarshaler(data json.Marshaler, v any) error {
 	bytes, err := data.MarshalJSON()
 	if err != nil {

--- a/core/ssz.go
+++ b/core/ssz.go
@@ -1,0 +1,373 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package core
+
+import (
+	"testing"
+
+	eth2bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
+	eth2capella "github.com/attestantio/go-eth2-client/api/v1/capella"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+type sszType interface {
+	ssz.Marshaler
+	ssz.Unmarshaler
+}
+
+// MarshalSSZ ssz marshals the VersionedSignedBeaconBlock object.
+func (b VersionedSignedBeaconBlock) MarshalSSZ() ([]byte, error) {
+	resp, err := ssz.MarshalSSZ(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal VersionedSignedBeaconBlock")
+	}
+
+	return resp, nil
+}
+
+// MarshalSSZTo ssz marshals the VersionedSignedBeaconBlock object to a target array.
+func (b VersionedSignedBeaconBlock) MarshalSSZTo(buf []byte) ([]byte, error) {
+	return marshalSSZVersionedTo(buf, b.Version, b.sszValFromVersion)
+}
+
+// UnmarshalSSZ ssz unmarshals the VersionedSignedBeaconBlock object.
+func (b *VersionedSignedBeaconBlock) UnmarshalSSZ(buf []byte) error {
+	version, err := unmarshalSSZVersioned(buf, b.sszValFromVersion)
+	if err != nil {
+		return errors.Wrap(err, "unmarshal VersionedSignedBeaconBlock")
+	}
+
+	b.Version = version
+
+	return nil
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the VersionedSignedBeaconBlock object.
+func (b VersionedSignedBeaconBlock) SizeSSZ() int {
+	val, err := b.sszValFromVersion(b.Version)
+	if err != nil {
+		// SSZMarshaller interface doesn't return an error, so we can't either.
+		return 0
+	}
+
+	return sizeSSZVersioned(val)
+}
+
+// sszValFromVersion returns the internal value of the VersionedSignedBeaconBlock object for a given version.
+func (b *VersionedSignedBeaconBlock) sszValFromVersion(version eth2spec.DataVersion) (sszType, error) {
+	switch version {
+	case eth2spec.DataVersionPhase0:
+		if b.Phase0 == nil {
+			b.Phase0 = new(eth2p0.SignedBeaconBlock)
+		}
+
+		return b.Phase0, nil
+	case eth2spec.DataVersionAltair:
+		if b.Altair == nil {
+			b.Altair = new(altair.SignedBeaconBlock)
+		}
+
+		return b.Altair, nil
+	case eth2spec.DataVersionBellatrix:
+		if b.Bellatrix == nil {
+			b.Bellatrix = new(bellatrix.SignedBeaconBlock)
+		}
+
+		return b.Bellatrix, nil
+	case eth2spec.DataVersionCapella:
+		if b.Capella == nil {
+			b.Capella = new(capella.SignedBeaconBlock)
+		}
+
+		return b.Capella, nil
+	case eth2spec.DataVersionDeneb:
+		if b.Deneb == nil {
+			b.Deneb = new(deneb.SignedBeaconBlock)
+		}
+
+		return b.Deneb, nil
+	default:
+		return nil, errors.New("invalid version")
+	}
+}
+
+// ================== VersionedSignedBeaconBlock ===================
+
+// MarshalSSZ ssz marshals the VersionedBeaconBlock object.
+func (b VersionedBeaconBlock) MarshalSSZ() ([]byte, error) {
+	resp, err := ssz.MarshalSSZ(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal VersionedBeaconBlock")
+	}
+
+	return resp, nil
+}
+
+// MarshalSSZTo ssz marshals the VersionedBeaconBlock object to a target array.
+func (b VersionedBeaconBlock) MarshalSSZTo(buf []byte) ([]byte, error) {
+	return marshalSSZVersionedTo(buf, b.Version, b.sszValFromVersion)
+}
+
+// UnmarshalSSZ ssz unmarshals the VersionedBeaconBlock object.
+func (b *VersionedBeaconBlock) UnmarshalSSZ(buf []byte) error {
+	version, err := unmarshalSSZVersioned(buf, b.sszValFromVersion)
+	if err != nil {
+		return errors.Wrap(err, "unmarshal VersionedSignedBeaconBlock")
+	}
+
+	b.Version = version
+
+	return nil
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the VersionedBeaconBlock object.
+func (b VersionedBeaconBlock) SizeSSZ() int {
+	val, err := b.sszValFromVersion(b.Version)
+	if err != nil {
+		// SSZMarshaller interface doesn't return an error, so we can't either.
+		return 0
+	}
+
+	return sizeSSZVersioned(val)
+}
+
+// sszValFromVersion returns the internal value of the VersionedBeaconBlock object for a given version.
+func (b *VersionedBeaconBlock) sszValFromVersion(version eth2spec.DataVersion) (sszType, error) {
+	switch version {
+	case eth2spec.DataVersionPhase0:
+		if b.Phase0 == nil {
+			b.Phase0 = new(eth2p0.BeaconBlock)
+		}
+
+		return b.Phase0, nil
+	case eth2spec.DataVersionAltair:
+		if b.Altair == nil {
+			b.Altair = new(altair.BeaconBlock)
+		}
+
+		return b.Altair, nil
+	case eth2spec.DataVersionBellatrix:
+		if b.Bellatrix == nil {
+			b.Bellatrix = new(bellatrix.BeaconBlock)
+		}
+
+		return b.Bellatrix, nil
+	case eth2spec.DataVersionCapella:
+		if b.Capella == nil {
+			b.Capella = new(capella.BeaconBlock)
+		}
+
+		return b.Capella, nil
+	case eth2spec.DataVersionDeneb:
+		if b.Deneb == nil {
+			b.Deneb = new(deneb.BeaconBlock)
+		}
+
+		return b.Deneb, nil
+	default:
+		return nil, errors.New("invalid version")
+	}
+}
+
+// ================== VersionedSignedBlindedBeaconBlock ===================
+
+// MarshalSSZ ssz marshals the VersionedSignedBlindedBeaconBlock object.
+func (b VersionedSignedBlindedBeaconBlock) MarshalSSZ() ([]byte, error) {
+	resp, err := ssz.MarshalSSZ(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal VersionedSignedBlindedBeaconBlock")
+	}
+
+	return resp, nil
+}
+
+// MarshalSSZTo ssz marshals the VersionedSignedBlindedBeaconBlock object to a target array.
+func (b VersionedSignedBlindedBeaconBlock) MarshalSSZTo(buf []byte) ([]byte, error) {
+	return marshalSSZVersionedTo(buf, b.Version, b.sszValFromVersion)
+}
+
+// UnmarshalSSZ ssz unmarshals the VersionedSignedBlindedBeaconBlock object.
+func (b *VersionedSignedBlindedBeaconBlock) UnmarshalSSZ(buf []byte) error {
+	version, err := unmarshalSSZVersioned(buf, b.sszValFromVersion)
+	if err != nil {
+		return errors.Wrap(err, "unmarshal VersionedSignedBeaconBlock")
+	}
+
+	b.Version = version
+
+	return nil
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the VersionedSignedBlindedBeaconBlock object.
+func (b VersionedSignedBlindedBeaconBlock) SizeSSZ() int {
+	val, err := b.sszValFromVersion(b.Version)
+	if err != nil {
+		// SSZMarshaller interface doesn't return an error, so we can't either.
+		return 0
+	}
+
+	return sizeSSZVersioned(val)
+}
+
+// sszValFromVersion returns the internal value of the VersionedSignedBlindedBeaconBlock object for a given version.
+func (b *VersionedSignedBlindedBeaconBlock) sszValFromVersion(version eth2spec.DataVersion) (sszType, error) {
+	switch version {
+	case eth2spec.DataVersionBellatrix:
+		if b.Bellatrix == nil {
+			b.Bellatrix = new(eth2bellatrix.SignedBlindedBeaconBlock)
+		}
+
+		return b.Bellatrix, nil
+	case eth2spec.DataVersionCapella:
+		if b.Capella == nil {
+			b.Capella = new(eth2capella.SignedBlindedBeaconBlock)
+		}
+
+		return b.Capella, nil
+
+	//	if b.Deneb == nil {
+	//		b.Deneb = new(v1deneb.SignedBlindedBeaconBlock)
+	//	}
+	//	return b.Deneb, nil
+	default:
+		return nil, errors.New("invalid version")
+	}
+}
+
+// ================== VersionedBlindedBeaconBlock ===================
+
+// MarshalSSZ ssz marshals the VersionedBlindedBeaconBlock object.
+func (b VersionedBlindedBeaconBlock) MarshalSSZ() ([]byte, error) {
+	resp, err := ssz.MarshalSSZ(b)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal VersionedSignedBlindedBeaconBlock")
+	}
+
+	return resp, nil
+}
+
+// MarshalSSZTo ssz marshals the VersionedBlindedBeaconBlock object to a target array.
+func (b VersionedBlindedBeaconBlock) MarshalSSZTo(buf []byte) ([]byte, error) {
+	return marshalSSZVersionedTo(buf, b.Version, b.sszValFromVersion)
+}
+
+// UnmarshalSSZ ssz unmarshals the VersionedBlindedBeaconBlock object.
+func (b *VersionedBlindedBeaconBlock) UnmarshalSSZ(buf []byte) error {
+	version, err := unmarshalSSZVersioned(buf, b.sszValFromVersion)
+	if err != nil {
+		return errors.Wrap(err, "unmarshal VersionedSignedBeaconBlock")
+	}
+
+	b.Version = version
+
+	return nil
+}
+
+// SizeSSZ returns the ssz encoded size in bytes for the VersionedBlindedBeaconBlock object.
+func (b VersionedBlindedBeaconBlock) SizeSSZ() int {
+	val, err := b.sszValFromVersion(b.Version)
+	if err != nil {
+		// SSZMarshaller interface doesn't return an error, so we can't either.
+		return 0
+	}
+
+	return sizeSSZVersioned(val)
+}
+
+// sszValFromVersion returns the internal value of the VersionedBlindedBeaconBlock object for a given version.
+func (b *VersionedBlindedBeaconBlock) sszValFromVersion(version eth2spec.DataVersion) (sszType, error) {
+	switch version {
+	case eth2spec.DataVersionBellatrix:
+		if b.Bellatrix == nil {
+			b.Bellatrix = new(eth2bellatrix.BlindedBeaconBlock)
+		}
+
+		return b.Bellatrix, nil
+	case eth2spec.DataVersionCapella:
+		if b.Capella == nil {
+			b.Capella = new(eth2capella.BlindedBeaconBlock)
+		}
+
+		return b.Capella, nil
+	//	if b.Deneb == nil {
+	//		b.Deneb = new(v1deneb.SignedBlindedBeaconBlock)
+	//	}
+	//	return b.Deneb, nil
+	default:
+		return nil, errors.New("invalid version")
+	}
+}
+
+const versionedOffset = 8 + 4 // version (uint64) + offset (uint32)
+
+func marshalSSZVersionedTo(dst []byte, version eth2spec.DataVersion, valFunc func(eth2spec.DataVersion) (sszType, error)) ([]byte, error) {
+	// Field (0) 'Version'
+	dst = ssz.MarshalUint64(dst, uint64(version))
+
+	// Offset (1) 'Value'
+	dst = ssz.WriteOffset(dst, versionedOffset)
+
+	val, err := valFunc(version)
+	if err != nil {
+		return nil, errors.Wrap(err, "sszValFromVersion from version")
+	}
+
+	// Field (1) 'Value'
+	if dst, err = val.MarshalSSZTo(dst); err != nil {
+		return nil, errors.Wrap(err, "marshal sszValFromVersion")
+	}
+
+	return dst, nil
+}
+
+func unmarshalSSZVersioned(buf []byte, valFunc func(eth2spec.DataVersion) (sszType, error)) (eth2spec.DataVersion, error) {
+	if len(buf) < versionedOffset {
+		return 0, errors.Wrap(ssz.ErrSize, "versioned object too short")
+	}
+
+	// Field (0) 'Version'
+	version := eth2spec.DataVersion(ssz.UnmarshallUint64(buf[0:8]))
+
+	// Offset (1) 'Value'
+	o1 := ssz.ReadOffset(buf[8:12])
+	if versionedOffset > o1 {
+		return 0, errors.Wrap(ssz.ErrOffset, "sszValFromVersion offset", z.Any("version", version))
+	}
+
+	val, err := valFunc(version)
+	if err != nil {
+		return 0, errors.Wrap(err, "sszValFromVersion from version", z.Any("version", version))
+	}
+
+	if err = val.UnmarshalSSZ(buf[o1:]); err != nil {
+		return 0, errors.Wrap(err, "unmarshal sszValFromVersion", z.Any("version", version))
+	}
+
+	return version, nil
+}
+
+func sizeSSZVersioned(value sszType) int {
+	return versionedOffset + value.SizeSSZ()
+}
+
+// VersionedSSZValueForT exposes the sszValFromVersion method of a type for testing purposes.
+func VersionedSSZValueForT(t *testing.T, value any, version eth2spec.DataVersion) sszType {
+	t.Helper()
+
+	resp, err := value.(interface {
+		sszValFromVersion(eth2spec.DataVersion) (sszType, error)
+	}).sszValFromVersion(version)
+	require.NoError(t, err)
+
+	return resp
+}

--- a/core/ssz_test.go
+++ b/core/ssz_test.go
@@ -1,0 +1,185 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package core_test
+
+import (
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	ssz "github.com/ferranbt/fastssz"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+// TestSSZ tests SSZ marshalling and unmarshalling.
+func TestSSZ(t *testing.T) {
+	tests := []struct {
+		zero func() any
+	}{
+		{zero: func() any { return new(core.VersionedSignedBeaconBlock) }},
+		{zero: func() any { return new(core.Attestation) }},
+		{zero: func() any { return new(core.VersionedSignedBlindedBeaconBlock) }},
+		{zero: func() any { return new(core.SignedAggregateAndProof) }},
+		{zero: func() any { return new(core.SignedSyncMessage) }},
+		{zero: func() any { return new(core.SyncContributionAndProof) }},
+		{zero: func() any { return new(core.SignedSyncContributionAndProof) }},
+		{zero: func() any { return new(core.AggregatedAttestation) }},
+		{zero: func() any { return new(core.VersionedBeaconBlock) }},
+		{zero: func() any { return new(core.VersionedBlindedBeaconBlock) }},
+		{zero: func() any { return new(core.SyncContribution) }},
+	}
+
+	f := testutil.NewEth2Fuzzer(t)
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%T", test.zero()), func(t *testing.T) {
+			val1, val2 := test.zero(), test.zero()
+
+			f.Fuzz(val1)
+
+			marshaller, ok := val1.(ssz.Marshaler)
+			require.True(t, ok)
+
+			b, err := marshaller.MarshalSSZ()
+			testutil.RequireNoError(t, err)
+
+			unmarshaller, ok := val2.(ssz.Unmarshaler)
+			require.True(t, ok)
+
+			err = unmarshaller.UnmarshalSSZ(b)
+			testutil.RequireNoError(t, err)
+
+			require.Equal(t, val1, val2)
+		})
+	}
+}
+
+func TestMarshalUnsignedProto(t *testing.T) {
+	tests := []struct {
+		unsignedPtr func() any // Need any pointer to avoid wrapping in interface which doesnt' support fuzzing.
+		dutyType    core.DutyType
+	}{
+		{
+			dutyType:    core.DutyAttester,
+			unsignedPtr: func() any { return new(core.AttestationData) },
+		},
+		{
+			dutyType:    core.DutyAggregator,
+			unsignedPtr: func() any { return new(core.AggregatedAttestation) },
+		},
+		{
+			dutyType:    core.DutyProposer,
+			unsignedPtr: func() any { return new(core.VersionedBeaconBlock) },
+		},
+		{
+			dutyType:    core.DutyBuilderProposer,
+			unsignedPtr: func() any { return new(core.VersionedBlindedBeaconBlock) },
+		},
+		{
+			dutyType:    core.DutySyncContribution,
+			unsignedPtr: func() any { return new(core.SyncContribution) },
+		},
+	}
+
+	f := testutil.NewEth2Fuzzer(t)
+	for _, enabledSSZ := range []bool{true, false} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%T_%v", test.unsignedPtr(), enabledSSZ), func(t *testing.T) {
+				if enabledSSZ {
+					core.EnabledSSZMarshallingForT(t)
+				}
+
+				unsignedPtr := test.unsignedPtr()
+				f.Fuzz(unsignedPtr)
+
+				// Dereference the pointer to get the unsigned data.
+				unsigned := reflect.ValueOf(unsignedPtr).Elem().Interface().(core.UnsignedData)
+
+				set := core.UnsignedDataSet{
+					testutil.RandomCorePubKey(t): unsigned,
+				}
+
+				pb, err := core.UnsignedDataSetToProto(set)
+				require.NoError(t, err)
+
+				b, err := proto.Marshal(pb)
+				require.NoError(t, err)
+				t.Log(len(b))
+
+				set2, err := core.UnsignedDataSetFromProto(test.dutyType, pb)
+				require.NoError(t, err)
+
+				require.Equal(t, set, set2)
+			})
+		}
+	}
+}
+
+func TestMarshalParSignedProto(t *testing.T) {
+	tests := []struct {
+		signedPtr func() any // Need any pointer to avoid wrapping in interface which doesnt' support fuzzing.
+		dutyType  core.DutyType
+	}{
+		{
+			dutyType:  core.DutyAttester,
+			signedPtr: func() any { return new(core.Attestation) },
+		},
+		{
+			dutyType:  core.DutyAggregator,
+			signedPtr: func() any { return new(core.SignedAggregateAndProof) },
+		},
+		{
+			dutyType:  core.DutyProposer,
+			signedPtr: func() any { return new(core.VersionedSignedBeaconBlock) },
+		},
+		{
+			dutyType:  core.DutyBuilderProposer,
+			signedPtr: func() any { return new(core.VersionedSignedBlindedBeaconBlock) },
+		},
+		{
+			dutyType:  core.DutySyncContribution,
+			signedPtr: func() any { return new(core.SignedSyncContributionAndProof) },
+		},
+	}
+
+	f := testutil.NewEth2Fuzzer(t)
+	for _, enabledSSZ := range []bool{true, false} {
+		for _, test := range tests {
+			t.Run(fmt.Sprintf("%T_%v", test.signedPtr(), enabledSSZ), func(t *testing.T) {
+				if enabledSSZ {
+					core.EnabledSSZMarshallingForT(t)
+				}
+
+				signedPtr := test.signedPtr()
+				f.Fuzz(signedPtr)
+
+				// Dereference the pointer to get the signed data.
+				signed := reflect.ValueOf(signedPtr).Elem().Interface().(core.SignedData)
+
+				set := core.ParSignedDataSet{
+					testutil.RandomCorePubKey(t): core.ParSignedData{
+						SignedData: signed,
+						ShareIdx:   rand.Intn(10),
+					},
+				}
+
+				pb, err := core.ParSignedDataSetToProto(set)
+				require.NoError(t, err)
+
+				b, err := proto.Marshal(pb)
+				require.NoError(t, err)
+				t.Log(len(b))
+
+				set2, err := core.ParSignedDataSetFromProto(test.dutyType, pb)
+				require.NoError(t, err)
+
+				require.Equal(t, set, set2)
+			})
+		}
+	}
+}

--- a/testutil/fuzz.go
+++ b/testutil/fuzz.go
@@ -1,0 +1,114 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package testutil
+
+import (
+	"testing"
+
+	v1deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	fuzz "github.com/google/gofuzz"
+	"github.com/prysmaticlabs/go-bitfield"
+
+	"github.com/obolnetwork/charon/core"
+)
+
+// NewEth2Fuzzer returns a fuzzer for valid eth2 types.
+//
+// Note go-eth2-client Versioned*Blocks are not support, instead use core.Versioned*Blocks.
+func NewEth2Fuzzer(t *testing.T) *fuzz.Fuzzer {
+	t.Helper()
+
+	blindedVersions := []eth2spec.DataVersion{
+		eth2spec.DataVersionBellatrix,
+		eth2spec.DataVersionCapella,
+		// eth2spec.DataVersionDeneb,
+	}
+
+	allVersions := []eth2spec.DataVersion{
+		eth2spec.DataVersionPhase0,
+		eth2spec.DataVersionAltair,
+		eth2spec.DataVersionBellatrix,
+		eth2spec.DataVersionCapella,
+		eth2spec.DataVersionDeneb,
+	}
+
+	return fuzz.New().
+		NilChance(0).
+		Funcs(
+			// bitfield.Bitlist trailing byte must not be zero
+			func(e *bitfield.Bitlist, c fuzz.Continue) {
+				c.FuzzNoCustom(e)
+				l := len(*e)
+				(*e)[l-1] = 1
+			},
+			// eth2p0.AttesterSlashings may not be more than 2
+			func(e *[]*eth2p0.AttesterSlashing, c fuzz.Continue) {
+				c.FuzzNoCustom(e)
+				if len(*e) > 2 {
+					*e = (*e)[:2]
+				}
+			},
+			// Eth1Data.BlockHash must be 32 bytes
+			func(e *eth2p0.ETH1Data, c fuzz.Continue) {
+				c.FuzzNoCustom(e)
+				e.BlockHash = RandomBytes32()
+			},
+			// Just zero BeaconBlockBody.Deposits to pass validation.
+			func(e *[]*eth2p0.Deposit, c fuzz.Continue) {
+				*e = []*eth2p0.Deposit{}
+			},
+			// SyncAggregate.SyncCommitteeBits must have 64 bits
+			func(e *altair.SyncAggregate, c fuzz.Continue) {
+				c.FuzzNoCustom(e)
+				bits := bitfield.NewBitvector512()
+				for i := 0; i < 64; i++ {
+					bits.SetBitAt(uint64(i), true)
+				}
+				e.SyncCommitteeBits = bits
+			}, // SyncCommitteeContribution.AggregationBits must have 16 bits
+			func(e *altair.SyncCommitteeContribution, c fuzz.Continue) {
+				c.FuzzNoCustom(e)
+				bits := bitfield.NewBitvector128()
+				for i := 0; i < 16; i++ {
+					bits.SetBitAt(uint64(i), true)
+				}
+				e.AggregationBits = bits
+			},
+			// VersionBlingedBeaconBlock.Deneb SSZ not supported by goeth2client yet, so nil it.
+			func(e **v1deneb.BlindedBeaconBlock, c fuzz.Continue) {
+				*e = nil
+			},
+			// []deneb.KzgCommitment has max size 4.
+			func(e *[]deneb.KzgCommitment, c fuzz.Continue) {
+				c.FuzzNoCustom(e)
+				if len(*e) > 4 {
+					*e = (*e)[:4]
+				}
+			},
+			// Populate one of the versions of these Versioned*Block types.
+			func(e *core.VersionedSignedBlindedBeaconBlock, c fuzz.Continue) {
+				e.Version = blindedVersions[(c.Intn(len(blindedVersions)))]
+				val := core.VersionedSSZValueForT(t, e, e.Version)
+				c.Fuzz(val)
+			},
+			func(e *core.VersionedBlindedBeaconBlock, c fuzz.Continue) {
+				e.Version = blindedVersions[(c.Intn(len(blindedVersions)))]
+				val := core.VersionedSSZValueForT(t, e, e.Version)
+				c.Fuzz(val)
+			},
+			func(e *core.VersionedSignedBeaconBlock, c fuzz.Continue) {
+				e.Version = allVersions[(c.Intn(len(allVersions)))]
+				val := core.VersionedSSZValueForT(t, e, e.Version)
+				c.Fuzz(val)
+			},
+			func(e *core.VersionedBeaconBlock, c fuzz.Continue) {
+				e.Version = allVersions[(c.Intn(len(allVersions)))]
+				val := core.VersionedSSZValueForT(t, e, e.Version)
+				c.Fuzz(val)
+			},
+		)
+}


### PR DESCRIPTION
First step in migrating to SSZ encoding of eth2 objects in protobufs. Support unmarshalling of SSZ. This will reduce bandwidth usage by 2x.

category: feature
ticket: #2203 