### PR TITLE
p2p: enable delimited protocol negotiation

### DIFF
--- a/p2p/receive_test.go
+++ b/p2p/receive_test.go
@@ -110,7 +110,11 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("server error", func(t *testing.T) {
 		_, err := sendReceive(-1)
-		require.ErrorContains(t, err, "no or zero response received")
+		if delimitedClient && delimitedServer {
+			require.ErrorContains(t, err, "read response: EOF")
+		} else {
+			require.ErrorContains(t, err, "no or zero response received")
+		}
 	})
 
 	t.Run("ok", func(t *testing.T) {
@@ -122,6 +126,10 @@ func testSendReceive(t *testing.T, delimitedClient, delimitedServer bool) {
 
 	t.Run("empty response", func(t *testing.T) {
 		_, err := sendReceive(101)
-		require.ErrorContains(t, err, "no or zero response received")
+		if delimitedClient && delimitedServer {
+			require.ErrorContains(t, err, "read response: EOF")
+		} else {
+			require.ErrorContains(t, err, "no or zero response received")
+		}
 	})
 }


### PR DESCRIPTION
Enables length delimited protocol negotiation in upcoming v0.16. 

This was delayed in v0.15, so enabling now, see https://github.com/ObolNetwork/charon/pull/1954.

category: feature
ticket: https://github.com/ObolNetwork/charon/issues/1884
