### PR TITLE
core/consensus: change round AB test timers

### DIFF
--- a/core/consensus/roundtimer_internal_test.go
+++ b/core/consensus/roundtimer_internal_test.go
@@ -38,7 +38,7 @@ func TestIncreasingRoundTimer(t *testing.T) {
 
 	for _, tt := range tests {
 		fakeClock := clockwork.NewFakeClock()
-		timer := newIncreasingRoundTimer()
+		timer := newIncreasingRoundTimer().(*increasingRoundTimer)
 		timer.clock = fakeClock
 
 		t.Run(tt.name, func(t *testing.T) {
@@ -61,10 +61,12 @@ func TestIncreasingRoundTimer(t *testing.T) {
 	}
 }
 
-func TestDoubleLeadRoundTimer(t *testing.T) {
+func TestDoubleEagerLinearRoundTimer(t *testing.T) {
 	fakeClock := clockwork.NewFakeClock()
-	timer := newDoubleLeadRoundTimer()
+	timer := newDoubleEagerLinearRoundTimer().(*doubleEagerLinearRoundTimer)
 	timer.clock = fakeClock
+
+	require.True(t, timer.Type().Eager())
 
 	assert := func(t *testing.T, ch <-chan time.Time, d time.Duration, expect bool) {
 		t.Helper()
@@ -99,80 +101,22 @@ func TestDoubleLeadRoundTimer(t *testing.T) {
 
 	// Get round 2 timerType.
 	timerC, stop = timer.Timer(2)
-	// Advance time by 250ms (1s remains).
-	assert(t, timerC, 250*time.Millisecond, false)
+	// Advance time by 1.5s (0.5s remains).
+	assert(t, timerC, 1500*time.Millisecond, false)
 	stop()
 
 	// Get round 2 timerType again.
 	timerC, stop = timer.Timer(2)
-	// Assert it times out after 1s+1250ms
-	assert(t, timerC, time.Second+1250*time.Millisecond, true)
+	// Assert it times out after 0.5ms+2s
+	assert(t, timerC, 2500*time.Millisecond, true)
 	stop()
-}
-
-func TestExponentialRoundTimer(t *testing.T) {
-	tests := []struct {
-		name  string
-		round int64
-		want  time.Duration
-	}{
-		{
-			name:  "round 1",
-			round: 1,
-			want:  750 * time.Millisecond,
-		},
-		{
-			name:  "round 2",
-			round: 2,
-			want:  1500 * time.Millisecond,
-		},
-		{
-			name:  "round 3",
-			round: 3,
-			want:  3000 * time.Millisecond,
-		},
-		{
-			name:  "round 4",
-			round: 4,
-			want:  6000 * time.Millisecond,
-		},
-		{
-			name:  "round 5",
-			round: 5,
-			want:  12000 * time.Millisecond,
-		},
-	}
-
-	for _, tt := range tests {
-		fakeClock := clockwork.NewFakeClock()
-		timer := newExponentialRoundTimer()
-		timer.clock = fakeClock
-
-		t.Run(tt.name, func(t *testing.T) {
-			// Start the timerType
-			timerC, stop := timer.Timer(tt.round)
-
-			// Advance the fake clock
-			fakeClock.Advance(tt.want)
-
-			// Check if the timerType fires
-			select {
-			case <-timerC:
-			default:
-				require.Fail(t, "Fail", "Timer(round %d) did not fire, want %v", tt.round, tt.want)
-			}
-
-			// Stop the timerType
-			stop()
-		})
-	}
 }
 
 func TestGetTimerFunc(t *testing.T) {
 	featureset.EnableForT(t, featureset.QBFTTimersABTest)
 
 	timerFunc := getTimerFunc()
-	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(4)).Type())
-	require.Equal(t, timerDoubleLead, timerFunc(core.NewAttesterDuty(5)).Type())
-	require.Equal(t, timerExponential, timerFunc(core.NewAttesterDuty(6)).Type())
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(0)).Type())
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(1)).Type())
+	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(2)).Type())
 }


### PR DESCRIPTION
Refactors the roundtimer AB testing candidates: Just the legacy `inc` and the new `eager_dlinear`. This is after simulation benchmarking showed that the following timer would work best:
 - `eager`, so start times are aligned between all nodes.
 - `double`, doubles round times if pre-prepare is detected (extended round with valid leaders).
 - `linear`, 1s, 2s, 3s, which means 4 round in 10s, which should be enough for almost all clusters.
 
category: refactor
ticket: #2117 
