### PR TITLE
app: add constant node_version metric label

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -198,6 +198,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		"cluster_name":    cState.Name,
 		"cluster_peer":    p2p.PeerName(tcpNode.ID()),
 		"cluster_network": network,
+		"node_version":    version.Version,
 	}
 	log.SetLokiLabels(labels)
 	promRegistry, err := promauto.NewRegistry(labels)


### PR DESCRIPTION
Appends additional label `node_version` to all prometheus metrics. This allows grouping metrics by charon version which aids in regression and performance detection. 

category: misc
ticket: none