### PR TITLE
core/consensus: add 2 of 3 test

### DIFF
--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -639,10 +639,15 @@ func TestFormulas(t *testing.T) {
 	assert(t, 11, 8, 3)
 	assert(t, 12, 8, 3)
 	assert(t, 13, 9, 4)
+	assert(t, 14, 10, 4)
 	assert(t, 15, 10, 4)
+	assert(t, 16, 11, 5)
 	assert(t, 17, 12, 5)
+	assert(t, 18, 12, 5)
 	assert(t, 19, 13, 6)
+	assert(t, 20, 14, 6)
 	assert(t, 21, 14, 6)
+	assert(t, 22, 15, 7)
 }
 
 // makeIsLeader returns a leader election function.


### PR DESCRIPTION
Add a qbft component test for different cluster sizes and count of offline nodes, including 2 of 3. This shows that a 2of3 cluster works, even though it isnt' BFT.

category: test
ticket: none