### PR TITLE
p2p: force direct connections

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -299,7 +299,6 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	p2p.RegisterConnectionLogger(ctx, tcpNode, peerIDs)
-	p2p.ForceDirectConnections(ctx, tcpNode, peerIDs)
 
 	life.RegisterStop(lifecycle.StopP2PTCPNode, lifecycle.HookFuncErr(tcpNode.Close))
 
@@ -310,6 +309,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PPing, p2p.NewPingService(tcpNode, peerIDs, conf.TestConfig.TestPingConfig))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PEventCollector, p2p.NewEventCollector(tcpNode))
 	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartP2PRouters, p2p.NewRelayRouter(tcpNode, peerIDs, relays))
+	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartForceDirectConns, p2p.ForceDirectConnections(tcpNode, peerIDs))
 
 	return tcpNode, nil
 }

--- a/app/app.go
+++ b/app/app.go
@@ -299,6 +299,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	p2p.RegisterConnectionLogger(ctx, tcpNode, peerIDs)
+	p2p.ForceDirectConnections(ctx, tcpNode, peerIDs)
 
 	life.RegisterStop(lifecycle.StopP2PTCPNode, lifecycle.HookFuncErr(tcpNode.Close))
 

--- a/app/lifecycle/order.go
+++ b/app/lifecycle/order.go
@@ -21,6 +21,7 @@ const (
 	StartValidatorAPI
 	StartP2PPing
 	StartP2PRouters
+	StartForceDirectConns
 	StartP2PConsensus
 	StartSimulator
 	StartScheduler

--- a/app/lifecycle/orderstart_string.go
+++ b/app/lifecycle/orderstart_string.go
@@ -18,17 +18,18 @@ func _() {
 	_ = x[StartValidatorAPI-5]
 	_ = x[StartP2PPing-6]
 	_ = x[StartP2PRouters-7]
-	_ = x[StartP2PConsensus-8]
-	_ = x[StartSimulator-9]
-	_ = x[StartScheduler-10]
-	_ = x[StartP2PEventCollector-11]
-	_ = x[StartPeerInfo-12]
-	_ = x[StartParSigDB-13]
+	_ = x[StartForceDirectConns-8]
+	_ = x[StartP2PConsensus-9]
+	_ = x[StartSimulator-10]
+	_ = x[StartScheduler-11]
+	_ = x[StartP2PEventCollector-12]
+	_ = x[StartPeerInfo-13]
+	_ = x[StartParSigDB-14]
 }
 
-const _OrderStart_name = "TrackerPrivkeyLockAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersP2PConsensusSimulatorSchedulerP2PEventCollectorPeerInfoParSigDB"
+const _OrderStart_name = "TrackerPrivkeyLockAggSigDBRelayMonitoringAPIValidatorAPIP2PPingP2PRoutersForceDirectConnsP2PConsensusSimulatorSchedulerP2PEventCollectorPeerInfoParSigDB"
 
-var _OrderStart_index = [...]uint8{0, 7, 18, 26, 31, 44, 56, 63, 73, 85, 94, 103, 120, 128, 136}
+var _OrderStart_index = [...]uint8{0, 7, 18, 26, 31, 44, 56, 63, 73, 89, 101, 110, 119, 136, 144, 152}
 
 func (i OrderStart) String() string {
 	if i < 0 || i >= OrderStart(len(_OrderStart_index)-1) {

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -206,7 +206,7 @@ type connEvent struct {
 	Peer      peer.ID
 }
 
-// connLogger implements network.Notifee and only sends logEvents on a channel since
+// connLogger implements network.Notifiee and only sends logEvents on a channel since
 // it is used as a map key internally in libp2p, it cannot contain complex types.
 type connLogger struct {
 	events chan connEvent

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -328,10 +328,6 @@ func RegisterConnectionLogger(ctx context.Context, tcpNode host.Host, peerIDs []
 				if e.Connected && peers[e.Peer] { // Do not instrument relays.
 					peerConnCounter.WithLabelValues(name).Inc()
 				}
-
-				// Attempt direct connections if host is connected to relay.
-				// if e.Connected && typ == addrTypeRelay {
-				// }
 			}
 		}
 	}()

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -250,6 +250,7 @@ func ForceDirectConnections(tcpNode host.Host, peerIDs []peer.ID) lifecycle.Hook
 
 	return func(ctx context.Context) {
 		ticker := time.NewTicker(1 * time.Minute)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-ctx.Done():

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -243,7 +243,7 @@ func ForceDirectConnections(tcpNode host.Host, peerIDs []peer.ID) lifecycle.Hook
 			// All existing connections are through relays, so we can try force dialing a direct connection.
 			err := tcpNode.Connect(network.WithForceDirectDial(ctx, "relay_to_direct"), peer.AddrInfo{ID: p})
 			if err == nil {
-				log.Debug(ctx, "Direct connection to peer successful", z.Str("peer", PeerName(p)))
+				log.Debug(ctx, "Forced direct connection to peer successful", z.Str("peer", PeerName(p)))
 			}
 		}
 	}


### PR DESCRIPTION
Force direct connection when there is an existing relay connection to the peer.

category: feature 
ticket: #2114 
