### PR TITLE
p2p: use direct connection for ping

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -220,23 +220,13 @@ func ForceDirectConnections(tcpNode host.Host, peerIDs []peer.ID) lifecycle.Hook
 			}
 
 			conns := tcpNode.Network().ConnsToPeer(p)
-			directConn := false
 			if len(conns) == 0 {
 				// Skip if there isn't any existing connection to peer. Note that we only force direct connection
 				// if there is already an existing relay connection between the host and peer.
 				continue
 			}
 
-			for _, conn := range conns {
-				if IsRelayAddr(conn.RemoteMultiaddr()) {
-					continue
-				}
-				directConn = true
-
-				break
-			}
-
-			if directConn {
+			if isDirectConnAvailable(conns) {
 				continue
 			}
 

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -86,6 +86,8 @@ func pingPeerOnce(ctx context.Context, svc *ping.PingService, p peer.ID,
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	isDirectConn := isDirectConnAvailable(svc.Host.Network().ConnsToPeer(p))
+
 	for result := range svc.Ping(ctx, p) {
 		if IsRelayError(result.Error) || errors.Is(result.Error, context.Canceled) {
 			// Just exit if relay error or context cancelled.
@@ -103,7 +105,25 @@ func pingPeerOnce(ctx context.Context, svc *ping.PingService, p peer.ID,
 
 		observePing(p, result.RTT)
 		callback(p, svc.Host)
+
+		// Try to reconnect again via direct connection if it was connected via relay but direct connection is now available.
+		if !isDirectConn && isDirectConnAvailable(svc.Host.Network().ConnsToPeer(p)) {
+			return
+		}
 	}
+}
+
+// isDirectConnAvailable returns true if direct connection is available in the given set of connections.
+func isDirectConnAvailable(conns []network.Conn) bool {
+	for _, conn := range conns {
+		if IsRelayAddr(conn.RemoteMultiaddr()) {
+			continue
+		}
+
+		return true
+	}
+
+	return false
 }
 
 // IsRelayError returns true if the error is due to temporary relay circuit recycling.

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -90,7 +90,7 @@ func pingPeerOnce(ctx context.Context, svc *ping.PingService, p peer.ID,
 		select {
 		case <-ctx.Done():
 			return
-		case result := <-svc.Ping(ctx, p):
+		case result := <-svc.Ping(ctx, p): // Only ping once to always use "best" connection.
 			if IsRelayError(result.Error) || errors.Is(result.Error, context.Canceled) {
 				// Just exit if relay error or context cancelled.
 				return


### PR DESCRIPTION
The Ping service was reporting wrong latencies. This is because the ping service creates a long lived stream to the peer using the relay connection. It uses relay connection to report metrics even if direct connection is now available. This is resolved by using new stream/connection for each ping.

category: bug
ticket: none