### PR TITLE
github: overwrite version with tagged releases

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: docker/setup-buildx-action@v1
     - name: Define docker image meta data tags
       id: meta
-      uses: docker/metadata-action@v3
+      uses: docker/metadata-action@v4
       with:
         images: |
           obolnetwork/charon
@@ -44,12 +44,16 @@ jobs:
         username: obolnetwork
         password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+    - name: Maybe overwrite app/version.Version with git tag
+      if: github.ref_type == 'tag'
+      run: echo 'GO_BUILD_FLAGS=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
+
     - uses: docker/build-push-action@v4
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        build-args: GITHUB_SHA=${{ github.sha }}
+        build-args: GITHUB_SHA=${{ github.sha }} GO_BUILD_FLAGS=${{ env.GO_BUILD_FLAGS }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Set short git commit SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ARG GO_BUILD_FLAGS
 RUN \
    --mount=type=cache,target=/go/pkg \
    --mount=type=cache,target=/root/.cache/go-build \
-   go build "${GO_BUILD_FLAGS}" -o charon .
+   go build -o charon "${GO_BUILD_FLAGS}" .
 
 # Copy final binary into light stage.
 FROM debian:bullseye-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,13 @@ RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source
 WORKDIR /app/charon
 COPY . .
+# Populate GO_BUILD_FLAGS build args to override build flags.
+ARG GO_BUILD_FLAGS
 # Build with Go module and Go build caches.
 RUN \
    --mount=type=cache,target=/go/pkg \
    --mount=type=cache,target=/root/.cache/go-build \
-   go build -o charon .
+   go build "${GO_BUILD_FLAGS}" -o charon .
 
 # Copy final binary into light stage.
 FROM debian:bullseye-slim

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -12,13 +12,12 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 )
 
-const (
-	// Version is the branch version of the codebase.
-	//  - Main branch: v0.X-dev
-	//  - Release branch: v0.X-rc
-	// It is overridden by git tags when building official releases.
-	Version = "v0.16-dev"
-)
+// Version is the branch version of the codebase.
+//   - Main branch: v0.X-dev
+//   - Release branch: v0.X-rc
+//
+// It is overwritten at build-time with the git tag for official releases.
+var Version = "v0.16-dev"
 
 // Supported returns the supported minor versions in order of precedence.
 func Supported() []string {


### PR DESCRIPTION
Sets the app/version.Version variable to the git tag when building tagged docker images. 

category: misc
ticket: #2097 
