### PR TITLE
cmd: reduce minimum nodes to 3

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -46,7 +46,7 @@ const (
 	// See https://etherscan.io/address/0x0000000000000000000000000000000000000000.
 	zeroAddress    = "0x0000000000000000000000000000000000000000"
 	defaultNetwork = "mainnet"
-	minNodes       = 4
+	minNodes       = 3
 )
 
 type clusterConfig struct {
@@ -755,7 +755,7 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 	}
 
 	if len(def.Operators) < minNodes {
-		return errors.New("insufficient number of nodes (min = 4)", z.Int("num_nodes", len(def.Operators)))
+		return errors.New("insufficient number of nodes", z.Int("num_nodes", len(def.Operators)), z.Int("min", minNodes))
 	}
 
 	if len(keymanagerAddrs) > 0 && (len(keymanagerAddrs) != len(def.Operators)) {

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -183,7 +183,7 @@ func validateConfig(threshold, numOperators int, network string) error {
 
 	// Don't allow cluster size to be less than 4.
 	if numOperators < minNodes {
-		return errors.New("insufficient operator ENRs (min = 4)")
+		return errors.New("insufficient operator ENRs", z.Int("count", numOperators), z.Int("min", minNodes))
 	}
 
 	if !eth2util.ValidNetwork(network) {

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -89,11 +89,11 @@ func TestCreateDkgInvalid(t *testing.T) {
 		},
 		{
 			conf:   createDKGConfig{OperatorENRs: []string{""}},
-			errMsg: "insufficient operator ENRs (min = 4)",
+			errMsg: "insufficient operator ENRs",
 		},
 		{
 			conf:   createDKGConfig{},
-			errMsg: "insufficient operator ENRs (min = 4)",
+			errMsg: "insufficient operator ENRs",
 		},
 	}
 
@@ -119,7 +119,7 @@ func TestRequireOperatorENRFlag(t *testing.T) {
 		{
 			name: "operator ENRs less than threshold",
 			args: []string{"dkg", "--operator-enrs=enr:-JG4QG472ZVvl8ySSnUK9uNVDrP_hjkUrUqIxUC75aayzmDVQedXkjbqc7QKyOOS71VmlqnYzri_taV8ZesFYaoQSIOGAYHtv1WsgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKwwq_CAld6oVKOrixE-JzMtvvNgb9yyI-_rwq4NFtajIN0Y3CCDhqDdWRwgg4u", "--fee-recipient-addresses=0xa6430105220d0b29688b734b8ea0f3ca9936e846", "--withdrawal-addresses=0xa6430105220d0b29688b734b8ea0f3ca9936e846"},
-			err:  "insufficient operator ENRs (min = 4)",
+			err:  "insufficient operator ENRs",
 		},
 	}
 
@@ -190,9 +190,9 @@ func TestValidateConfig(t *testing.T) {
 
 	t.Run("insufficient ENRs", func(t *testing.T) {
 		threshold := 1
-		numOperators := 3
+		numOperators := 2
 		err := validateConfig(threshold, numOperators, "")
-		require.ErrorContains(t, err, "insufficient operator ENRs (min = 4)")
+		require.ErrorContains(t, err, "insufficient operator ENRs")
 	})
 
 	t.Run("invalid network", func(t *testing.T) {

--- a/cmd/testdata/TestCreateCluster_goerli_files.golden
+++ b/cmd/testdata/TestCreateCluster_goerli_files.golden
@@ -2,7 +2,6 @@
  "node0",
  "node1",
  "node2",
- "node3",
  "node0/charon-enr-private-key",
  "node0/cluster-lock.json",
  "node0/deposit-data.json",
@@ -14,9 +13,5 @@
  "node2/charon-enr-private-key",
  "node2/cluster-lock.json",
  "node2/deposit-data.json",
- "node2/validator_keys",
- "node3/charon-enr-private-key",
- "node3/cluster-lock.json",
- "node3/deposit-data.json",
- "node3/validator_keys"
+ "node2/validator_keys"
 ]

--- a/cmd/testdata/TestCreateCluster_goerli_output.golden
+++ b/cmd/testdata/TestCreateCluster_goerli_output.golden
@@ -2,7 +2,7 @@ Created charon cluster:
  --split-existing-keys=false
 
 charon/
-├─ node[0-3]/			Directory for each node
+├─ node[0-2]/			Directory for each node
 │  ├─ charon-enr-private-key	Charon networking private key for node authentication
 │  ├─ cluster-lock.json		Cluster lock defines the cluster lock file which is signed by all nodes
 │  ├─ deposit-data.json		Deposit data file is used to activate a Distributed Validator on DV Launchpad


### PR DESCRIPTION
Decreases the minimum number of nodes to 3 so we can test this scenario. 

Also fix matrix smoke test.

category: misc
ticket: none