### PR TITLE
eth2util: remove ropsten from supported networks

### DIFF
--- a/eth2util/network.go
+++ b/eth2util/network.go
@@ -50,16 +50,10 @@ var (
 		ForkVersionHex:   "0x90000069",
 		GenesisTimestamp: 1655733600,
 	}
-	// TODO(dhruv): drop support of ropsten as it is deprecated by ethereum foundation.
-	Ropsten = Network{
-		ChainID:        3,
-		Name:           "ropsten",
-		ForkVersionHex: "0x80000069",
-	}
 )
 
 var supportedNetworks = []Network{
-	Mainnet, Goerli, Gnosis, Sepolia, Ropsten,
+	Mainnet, Goerli, Gnosis, Sepolia,
 }
 
 // ForkVersionToChainID returns the chainID corresponding to the provided fork version.

--- a/eth2util/network_test.go
+++ b/eth2util/network_test.go
@@ -68,3 +68,13 @@ func TestNetworkToForkVersionBytes(t *testing.T) {
 	require.Error(t, err)
 	require.ErrorContains(t, err, "invalid network name")
 }
+
+func TestSupportedNetwork(t *testing.T) {
+	t.Run("supported network", func(t *testing.T) {
+		require.True(t, eth2util.ValidNetwork("sepolia"))
+	})
+
+	t.Run("unsupported network", func(t *testing.T) {
+		require.False(t, eth2util.ValidNetwork("ropsten"))
+	})
+}


### PR DESCRIPTION
Removes ropsten from supported networks as it is already [deprecated](https://blog.ethereum.org/2022/06/21/testnet-deprecation) by the EF in Q4'22.

category: misc
ticket: none 
