### PR TITLE
cluster: move v1.7.0 to draft

### DIFF
--- a/cluster/version.go
+++ b/cluster/version.go
@@ -5,11 +5,11 @@ package cluster
 import "testing"
 
 const (
-	currentVersion = v1_7
+	currentVersion = v1_6
 	dkgAlgo        = "default"
 
-	v1_7 = "v1.7.0" // Default
-	v1_6 = "v1.6.0"
+	v1_7 = "v1.7.0" // Draft
+	v1_6 = "v1.6.0" // Default
 	v1_5 = "v1.5.0"
 	v1_4 = "v1.4.0"
 	v1_3 = "v1.3.0"

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -187,8 +187,19 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition)
 			}
 		}
 
+		previousVersions := []string{"v1.0.0", "v1.1.0", "v1.2.0", "v1.3.0", "v1.4.0", "v1.5.0"}
 		for _, val := range lock.Validators {
-			require.NotEmpty(t, val.BuilderRegistration)
+			if isAnyVersion(lock.Version, previousVersions...) {
+				break
+			}
+
+			if isAnyVersion(lock.Version, "v1.6.0", "v1.7.0") {
+				require.NotEmpty(t, val.DepositData)
+			}
+
+			if isAnyVersion(lock.Version, "v1.7.0") {
+				require.NotEmpty(t, val.BuilderRegistration)
+			}
 		}
 	})
 }
@@ -634,4 +645,14 @@ func newObolAPIHandler(ctx context.Context, t *testing.T, result chan<- struct{}
 		case result <- struct{}{}:
 		}
 	})
+}
+
+func isAnyVersion(version string, versions ...string) bool {
+	for _, v := range versions {
+		if version == v {
+			return true
+		}
+	}
+
+	return false
 }

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -77,7 +77,8 @@ func TestDKG(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 1, withAlgo(test.dkgAlgo), cluster.WithVersion("v1.7.0"))
+			lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 1, withAlgo(test.dkgAlgo),
+				cluster.WithVersion("v1.7.0")) // TODO(dhruv): remove WithVersion option once v1.7.0 is released.
 			dir := t.TempDir()
 
 			testDKG(t, lock.Definition, dir, keys, test.keymanager, test.publish)


### PR DESCRIPTION
Moves v1.7.0 of cluster version to draft and makes v1.6.0 current version.

category: misc
ticket: #2246 
