### PR TITLE
cmd: add NodeSignatures to create cluster

### DIFF
--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -201,6 +201,13 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition)
 				require.NotEmpty(t, val.BuilderRegistration)
 			}
 		}
+
+		if isAnyVersion(lock.Version, "v1.7.0") {
+			require.NotEmpty(t, lock.NodeSignatures)
+			for _, ns := range lock.NodeSignatures {
+				require.NotEmpty(t, ns)
+			}
+		}
 	})
 }
 


### PR DESCRIPTION
Makes `charon create cluster` command feature-complete with regards to `charon dkg` execution output.

category: feature
ticket: #2204 
