### PR TITLE
core/scheduler: fix race

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -125,6 +125,7 @@ func (s *Scheduler) Run() error {
 // emitCoreSlot calls all slot subscriptions asynchronously with the provided slot.
 func (s *Scheduler) emitCoreSlot(ctx context.Context, slot core.Slot) {
 	for _, sub := range s.slotSubs {
+		sub := sub
 		go func(sub func(context.Context, core.Slot) error) {
 			err := sub(ctx, slot)
 			if err != nil {


### PR DESCRIPTION
Fixes data race in `scheduler`.

The data race was identified in one of our integration test runs - https://github.com/ObolNetwork/charon/actions/runs/5112385783/jobs/9190355166?pr=2240#step:5:4209.

category: bug 
ticket: none 

