### PR TITLE
dkg: sync privkeylock before exiting

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -138,7 +138,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 			return err
 		}
 
-		life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartPrivkeyLock, lifecycle.HookFunc(lockSvc.Run))
+		life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartPrivkeyLock, lifecycle.HookFuncErr(lockSvc.Run))
+		life.RegisterStop(lifecycle.StopPrivkeyLock, lifecycle.HookFuncMin(lockSvc.Close))
 	}
 
 	if err := wireTracing(life, conf); err != nil {

--- a/app/privkeylock/privkeylock.go
+++ b/app/privkeylock/privkeylock.go
@@ -67,23 +67,23 @@ type Service struct {
 }
 
 // Run runs the service, updating the lock file every second and deleting it on context cancellation.
-func (h *Service) Run(ctx context.Context) error {
-	tick := time.NewTicker(h.updatePeriod)
+func (s *Service) Run(ctx context.Context) error {
+	tick := time.NewTicker(s.updatePeriod)
 	defer tick.Stop()
 
-	defer h.wg.Done()
+	defer s.wg.Done()
 
 	for {
 		select {
 		case <-ctx.Done():
-			if err := os.Remove(h.path); err != nil {
+			if err := os.Remove(s.path); err != nil {
 				return errors.Wrap(err, "deleting private key lock file failed")
 			}
 
 			return nil
 		case <-tick.C:
 			// Overwrite lockfile with new metadata
-			if err := writeFile(h.path, h.command, time.Now()); err != nil {
+			if err := writeFile(s.path, s.command, time.Now()); err != nil {
 				return err
 			}
 		}
@@ -91,8 +91,8 @@ func (h *Service) Run(ctx context.Context) error {
 }
 
 // Done waits until Service has finished deleting the private key lock file.
-func (h *Service) Done() {
-	h.wg.Wait()
+func (s *Service) Done() {
+	s.wg.Wait()
 }
 
 // metadata is the metadata stored in the lock file.

--- a/app/privkeylock/privkeylock_internal_test.go
+++ b/app/privkeylock/privkeylock_internal_test.go
@@ -3,7 +3,6 @@
 package privkeylock
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -36,16 +35,12 @@ func TestService(t *testing.T) {
 	// Delete the file so Run will create it again.
 	require.NoError(t, os.Remove(path))
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	var eg errgroup.Group
-	eg.Go(func() error {
-		return svc.Run(ctx) // Run will create the file.
-	})
+	eg.Go(svc.Run) // Run will create the file.
 
 	eg.Go(func() error {
 		assertFileExists(t, path)
-		cancel()
+		svc.Close()
 
 		return nil
 	})

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -87,7 +87,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 
-	// make sure to always wait for lockSvc to be done.
+	// Make sure to always wait for lockSvc to be done.
 	defer func() {
 		// explicitly cancel the context and wait until the privkey lock is deleted
 		cancel()

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -82,7 +82,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	lockSvc, err := privkeylock.New(p2p.KeyPath(conf.DataDir)+".lock", "charon dkg")
 	if err != nil {
-		// cancel manually here because we'll defer cancel() and lockSvc.Done() later
+		// Cancel manually here because we'll defer cancel() and lockSvc.Done() later.
 		cancel()
 		return err
 	}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -89,7 +89,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	// Make sure to always wait for lockSvc to be done.
 	defer func() {
-		// explicitly cancel the context and wait until the privkey lock is deleted
+		// Explicitly cancel the context and wait until the privkey lock is deleted.
 		cancel()
 		lockSvc.Done()
 	}()

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -313,6 +313,10 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	log.Info(ctx, "Successfully completed DKG ceremony 🎉")
 
+	// explicitly cancel the context and wait until the privkey lock is deleted
+	cancel()
+	lockSvc.Done()
+
 	return nil
 }
 

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -186,6 +186,14 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 	testutil.SkipIfBindErr(t, err)
 	require.NoError(t, err)
 
+	// check that the privkey lock file has been deleted in all nodes at the end of dkg
+	for i := 0; i < len(def.Operators); i++ {
+		lockPath := path.Join(dir, fmt.Sprintf("node%d", i), "charon-enr-private-key.lock")
+
+		_, openErr := os.Open(lockPath)
+		require.ErrorIs(t, openErr, os.ErrNotExist)
+	}
+
 	if keymanager {
 		// Wait until all keystores are received by the keymanager server
 		expectedReceives := len(def.Operators)


### PR DESCRIPTION
Block `dkg` exit until `privkeylock.Run()` enclosing goroutine exits, ensuring that the private key lock file is always deleted.

`Run()` is supposed to be executed in a goroutine, and since we can't control the scheduler it might be scheduled *after* the `main` one exits, leading to the `ctx.Done()` code path to sometimes never be executed.

category: bug
ticket: #2258 