### PR TITLE
cluster: release config version v1.7.0

### DIFF
--- a/cluster/version.go
+++ b/cluster/version.go
@@ -5,11 +5,11 @@ package cluster
 import "testing"
 
 const (
-	currentVersion = v1_6
+	currentVersion = v1_7
 	dkgAlgo        = "default"
 
-	v1_7 = "v1.7.0" // Draft
-	v1_6 = "v1.6.0" // Default
+	v1_7 = "v1.7.0" // Default
+	v1_6 = "v1.6.0"
 	v1_5 = "v1.5.0"
 	v1_4 = "v1.4.0"
 	v1_3 = "v1.3.0"

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -77,8 +77,7 @@ func TestDKG(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 1, withAlgo(test.dkgAlgo),
-				cluster.WithVersion("v1.7.0")) // TODO(dhruv): remove WithVersion option once v1.7.0 is released.
+			lock, keys, _ := cluster.NewForT(t, vals, nodes, nodes, 1, withAlgo(test.dkgAlgo))
 			dir := t.TempDir()
 
 			testDKG(t, lock.Definition, dir, keys, test.keymanager, test.publish)


### PR DESCRIPTION
Make v1.7.0 cluster config version default.

category: misc
ticket: none
