### PR TITLE
eth2util/keystore: fix bug

### DIFF
--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -188,7 +188,7 @@ func loadFiles(dir string, sortKeyfiles func([]string) ([]string, error)) ([]tbl
 
 	for result := range join() {
 		if result.Err != nil {
-			return nil, errors.Wrap(err, "write keys")
+			return nil, errors.Wrap(result.Err, "write keys")
 		}
 
 		// PSA: this is a concurrent array write, and it works because we're not


### PR DESCRIPTION
Fixes a bug in `keystore` that returns an invalid error message.

category: bug 
ticket: none 
