### PR TITLE
testutil/integration: 700 validators in nightly

### DIFF
--- a/testutil/integration/nightly_dkg_test.go
+++ b/testutil/integration/nightly_dkg_test.go
@@ -269,7 +269,7 @@ func TestDKGWithHighValidatorsAmt(t *testing.T) {
 	const (
 		threshold = 3
 		numNodes  = 4
-		numVals   = 1000
+		numVals   = 700
 		relayURL  = "https://0.relay.obol.tech"
 	)
 


### PR DESCRIPTION
Nightly tests are sometimes not able to be executed in 1h30m, so we're dropping them to 700.

category: test
ticket: #2239 
