### PR TITLE
testutil/integration: drop down to 200 validators

### DIFF
--- a/testutil/integration/nightly_dkg_test.go
+++ b/testutil/integration/nightly_dkg_test.go
@@ -269,7 +269,7 @@ func TestDKGWithHighValidatorsAmt(t *testing.T) {
 	const (
 		threshold = 3
 		numNodes  = 4
-		numVals   = 700
+		numVals   = 200
 		relayURL  = "https://0.relay.obol.tech"
 	)
 


### PR DESCRIPTION
Nightly tests are still timing out, try with 200 validators now.

category: test
ticket: #2239 
