### PR TITLE
github: set -a when building with flags

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -54,14 +54,16 @@ jobs:
 
     - name: Maybe overwrite app/version.Version with git tag
       if: github.ref_type == 'tag'
-      run: echo 'GO_BUILD_FLAGS=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
+      run: |
+        echo 'GO_BUILD_FLAGS_1=-a' >> $GITHUB_ENV
+        echo 'GO_BUILD_FLAGS_2=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
 
     - uses: docker/build-push-action@v4
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        build-args: GITHUB_SHA=${{ github.sha }} GO_BUILD_FLAGS=${{ env.GO_BUILD_FLAGS }}
+        build-args: GITHUB_SHA=${{ github.sha }} GO_BUILD_FLAGS_1=${{ env.GO_BUILD_FLAGS_1 }} GO_BUILD_FLAGS_2=${{ env.GO_BUILD_FLAGS_2 }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Set short git commit SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,15 @@ RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source
 WORKDIR /app/charon
 COPY . .
-# Populate GO_BUILD_FLAGS build args to override build flags.
-ARG GO_BUILD_FLAGS
+# Populate GO_BUILD_FLAGS_1 or _2 with build args to override build flags.
+ARG GO_BUILD_FLAGS_1
+ARG GO_BUILD_FLAGS_2
+RUN echo "Building with GO_BUILD_FLAGS_1=${GO_BUILD_FLAGS_1} GO_BUILD_FLAGS_2=${GO_BUILD_FLAGS_2}"
 # Build with Go module and Go build caches.
 RUN \
    --mount=type=cache,target=/go/pkg \
    --mount=type=cache,target=/root/.cache/go-build \
-   go build -o charon "${GO_BUILD_FLAGS}" .
+   go build -o charon "${GO_BUILD_FLAGS_1}" "${GO_BUILD_FLAGS_2}" .
 RUN echo "Built charon version=$(./charon version)"
 
 # Copy final binary into light stage.


### PR DESCRIPTION
Also use `-a` flag to force rebuild when setting `-ldflags` when overriding tagged versions. 

Since `-ldflags=-X path/to/package.Var=foo` contains a space inside the value, the only way I could get this to work is to provide it via an additional `GO_BUILD_FLAG_2` variable. The other option would be wrangling arrays and splitting using something like `IFS=' ' read -ra BUILD_ARGS <<< "$OPTIONAL_BUILD_ARGS"` but I feel this is more verbose but simpler to understand.

category: misc
ticket: #2270