### PR TITLE
github: fix build push build arg format

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -54,16 +54,16 @@ jobs:
 
     - name: Maybe overwrite app/version.Version with git tag
       if: github.ref_type == 'tag'
-      run: |
-        echo 'GO_BUILD_FLAGS_1=-a' >> $GITHUB_ENV
-        echo 'GO_BUILD_FLAGS_2=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
+      run: echo 'GO_BUILD_FLAG=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
 
     - uses: docker/build-push-action@v4
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        build-args: GITHUB_SHA=${{ github.sha }} GO_BUILD_FLAGS_1=${{ env.GO_BUILD_FLAGS_1 }} GO_BUILD_FLAGS_2=${{ env.GO_BUILD_FLAGS_2 }}
+        build-args: |
+          GITHUB_SHA=${{ github.sha }}
+          GO_BUILD_FLAG=${{ env.GO_BUILD_FLAG }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Set short git commit SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,17 +5,15 @@ RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source
 WORKDIR /app/charon
 COPY . .
-# Populate GO_BUILD_FLAGS_1 or _2 with build args to override build flags.
-ARG GO_BUILD_FLAGS_1
-ARG GO_BUILD_FLAGS_2
-ENV GO_BUILD_FLAGS_1=${GO_BUILD_FLAGS_1}
-ENV GO_BUILD_FLAGS_2=${GO_BUILD_FLAGS_2}
-RUN echo "Building with GO_BUILD_FLAGS_1=${GO_BUILD_FLAGS_1} GO_BUILD_FLAGS_2=${GO_BUILD_FLAGS_2}"
+# Populate GO_BUILD_FLAG with a build arg to provide a optional go build flag.
+ARG GO_BUILD_FLAG
+ENV GO_BUILD_FLAG=${GO_BUILD_FLAG}
+RUN echo "Building with GO_BUILD_FLAG='${GO_BUILD_FLAG}'"
 # Build with Go module and Go build caches.
 RUN \
    --mount=type=cache,target=/go/pkg \
    --mount=type=cache,target=/root/.cache/go-build \
-   go build -o charon "${GO_BUILD_FLAGS_1}" "${GO_BUILD_FLAGS_2}" .
+   go build -o charon "${GO_BUILD_FLAG}" .
 RUN echo "Built charon version=$(./charon version)"
 
 # Copy final binary into light stage.


### PR DESCRIPTION
Fixes the github action "build-push-deploys" `build-args` parameter. It is a [list parameter that is new line delimited](https://github.com/docker/build-push-action#inputs).

Also remove `-a` build arg since it isn't required. Make it explicit that `GO_BUILD_FLAG` only supports a single flag.

category: misc
ticket: #2270 