### PR TITLE
cmd: add charon alpha add-validators-solo command

### DIFF
--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -44,6 +44,7 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 }
 
 func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err error) {
+	// TODO(xenowits): Implement this in next PR, see issue https://github.com/ObolNetwork/charon/issues/1887.
 	return validateConf(conf)
 }
 

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -1,0 +1,79 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+type addValidatorsConfig struct {
+	Lockfile          string
+	NumVals           int
+	WithdrawalAddrs   []string
+	FeeRecipientAddrs []string
+}
+
+func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) error) *cobra.Command {
+	var config addValidatorsConfig
+
+	cmd := &cobra.Command{
+		Use:   "add-validators-solo",
+		Short: "Creates and adds new validators to a solo distributed validator cluster",
+		Long:  `Creates and adds new validators to a distributed validator cluster. It generates keys for the new validators and also generates a new cluster state file with the legacy_lock and add_validators mutations. It is executed by a solo operator cluster.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runFunc(cmd.Context(), config)
+		},
+	}
+
+	bindAddValidatorsFlags(cmd, &config)
+
+	return cmd
+}
+
+func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
+	cmd.Flags().IntVar(&config.NumVals, "num-validators", 1, "The count of new distributed validators to add in the cluster.")
+	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster.")
+	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each new validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
+	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each new validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
+}
+
+func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err error) {
+	return validateConf(conf)
+}
+
+// validateConf returns an error if the provided validators config fails validation checks.
+func validateConf(conf addValidatorsConfig) error {
+	if conf.NumVals <= 0 {
+		return errors.New("insufficient validator count", z.Int("validators", conf.NumVals))
+	}
+
+	if len(conf.FeeRecipientAddrs) == 0 {
+		return errors.New("empty fee recipient addresses")
+	}
+
+	if len(conf.WithdrawalAddrs) == 0 {
+		return errors.New("empty withdrawal addresses")
+	}
+
+	if len(conf.FeeRecipientAddrs) != len(conf.WithdrawalAddrs) {
+		return errors.New("fee recipient and withdrawal addresses lengths mismatch",
+			z.Int("fee_recipients", len(conf.FeeRecipientAddrs)),
+			z.Int("withdrawal_addresses", len(conf.WithdrawalAddrs)),
+		)
+	}
+
+	if len(conf.FeeRecipientAddrs) != conf.NumVals {
+		return errors.New("count of validators and addresses mismatch",
+			z.Int("num_addresses", len(conf.FeeRecipientAddrs)),
+			z.Int("num_validators", conf.NumVals),
+		)
+	}
+
+	return nil
+}

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -68,11 +68,23 @@ func validateConf(conf addValidatorsConfig) error {
 		)
 	}
 
-	if len(conf.FeeRecipientAddrs) != conf.NumVals {
-		return errors.New("count of validators and addresses mismatch",
-			z.Int("num_addresses", len(conf.FeeRecipientAddrs)),
-			z.Int("num_validators", conf.NumVals),
-		)
+	if conf.NumVals > 1 {
+		// There can be a single address for n validators.
+		if len(conf.FeeRecipientAddrs) == 1 {
+			return nil
+		}
+
+		// Or, there can be n addresses for n validators.
+		if conf.NumVals != len(conf.FeeRecipientAddrs) {
+			return errors.New("count of validators and addresses mismatch", z.Int("num_addresses", len(conf.FeeRecipientAddrs)), z.Int("num_validators", conf.NumVals))
+		}
+
+		return nil
+	}
+
+	// There can only be a single address for a single validator.
+	if len(conf.FeeRecipientAddrs) != 1 {
+		return errors.New("count of validators and addresses mismatch", z.Int("num_addresses", len(conf.FeeRecipientAddrs)), z.Int("num_validators", conf.NumVals))
 	}
 
 	return nil

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateConfigAddValidators(t *testing.T) {
+	const feeRecipientAddr = "0x0000000000000000000000000000000000000000"
+
+	tests := []struct {
+		name   string
+		conf   addValidatorsConfig
+		errMsg string
+	}{
+		{
+			name: "insufficient validators",
+			conf: addValidatorsConfig{
+				NumVals: 0,
+			},
+			errMsg: "insufficient validator count",
+		},
+		{
+			name: "empty fee recipient addrs",
+			conf: addValidatorsConfig{
+				NumVals:           1,
+				FeeRecipientAddrs: nil,
+			},
+			errMsg: "empty fee recipient addresses",
+		},
+		{
+			name: "empty withdrawal addrs",
+			conf: addValidatorsConfig{
+				NumVals:           1,
+				WithdrawalAddrs:   nil,
+				FeeRecipientAddrs: []string{feeRecipientAddr},
+			},
+			errMsg: "empty withdrawal addresses",
+		},
+		{
+			name: "addrs length mismatch",
+			conf: addValidatorsConfig{
+				NumVals:           1,
+				WithdrawalAddrs:   []string{feeRecipientAddr, feeRecipientAddr},
+				FeeRecipientAddrs: []string{feeRecipientAddr},
+			},
+			errMsg: "fee recipient and withdrawal addresses lengths mismatch",
+		},
+		{
+			name: "count and addrs mismatch",
+			conf: addValidatorsConfig{
+				NumVals:           2,
+				WithdrawalAddrs:   []string{feeRecipientAddr},
+				FeeRecipientAddrs: []string{feeRecipientAddr},
+			},
+			errMsg: "count of validators and addresses mismatch",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConf(tt.conf)
+			require.Equal(t, tt.errMsg, err.Error())
+		})
+	}
+}

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -50,20 +50,40 @@ func TestValidateConfigAddValidators(t *testing.T) {
 			errMsg: "fee recipient and withdrawal addresses lengths mismatch",
 		},
 		{
-			name: "count and addrs mismatch",
+			name: "single addr for all validators",
 			conf: addValidatorsConfig{
 				NumVals:           2,
 				WithdrawalAddrs:   []string{feeRecipientAddr},
 				FeeRecipientAddrs: []string{feeRecipientAddr},
 			},
+		},
+		{
+			name: "count and addrs mismatch",
+			conf: addValidatorsConfig{
+				NumVals:           2,
+				WithdrawalAddrs:   []string{feeRecipientAddr, feeRecipientAddr, feeRecipientAddr},
+				FeeRecipientAddrs: []string{feeRecipientAddr, feeRecipientAddr, feeRecipientAddr},
+			},
 			errMsg: "count of validators and addresses mismatch",
+		},
+		{
+			name: "multiple addrs for multiple validators",
+			conf: addValidatorsConfig{
+				NumVals:           2,
+				WithdrawalAddrs:   []string{feeRecipientAddr, feeRecipientAddr},
+				FeeRecipientAddrs: []string{feeRecipientAddr, feeRecipientAddr},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := validateConf(tt.conf)
-			require.Equal(t, tt.errMsg, err.Error())
+			if tt.errMsg != "" {
+				require.Equal(t, tt.errMsg, err.Error())
+			} else {
+				require.NoError(t, err)
+			}
 		})
 	}
 }

--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -1,0 +1,19 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newAlphaCmd(cmds ...*cobra.Command) *cobra.Command {
+	root := &cobra.Command{
+		Use:   "alpha",
+		Short: "Alpha charon subcommands are work-in-progress features that are not released to the users.",
+		Long:  "Alpha charon subcommands are work-in-progress features that are not released to the users. They are future functionalities for a charon distributed cluster.",
+	}
+
+	root.AddCommand(cmds...)
+
+	return root
+}

--- a/cmd/alpha.go
+++ b/cmd/alpha.go
@@ -9,8 +9,8 @@ import (
 func newAlphaCmd(cmds ...*cobra.Command) *cobra.Command {
 	root := &cobra.Command{
 		Use:   "alpha",
-		Short: "Alpha charon subcommands are work-in-progress features that are not released to the users.",
-		Long:  "Alpha charon subcommands are work-in-progress features that are not released to the users. They are future functionalities for a charon distributed cluster.",
+		Short: "Alpha subcommands provide early access to in-development features",
+		Long:  `Alpha subcommands represent features that are currently under development. They're not yet released for general use, but offer a glimpse into future functionalities planned for the distributed cluster system.`,
 	}
 
 	root.AddCommand(cmds...)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,6 +44,9 @@ func New() *cobra.Command {
 			newCreateClusterCmd(runCreateCluster),
 		),
 		newCombineCmd(newCombineFunc),
+		newAlphaCmd(
+			newAddValidatorsCmd(runAddValidatorsSolo),
+		),
 	)
 }
 


### PR DESCRIPTION
Adds `charon alpha add-validators-solo` command to `cmd` package. It doesn't contain the actual functionality for adding validators.

category: feature 
ticket: #1887 
