### PR TITLE
core: enable ssz encoding in protos

### DIFF
--- a/core/consensus/msg_internal_test.go
+++ b/core/consensus/msg_internal_test.go
@@ -32,7 +32,7 @@ func TestHashProto(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t,
-		"281aa1a75b2bd09f00f2d69bdf1256b83350dac475108cde608fc3f11428e54d",
+		"d8f9bc3de8b0cb0e3eb1f773c14a96d58f7acaf0f09192ce6562d84ea315e67b",
 		hex.EncodeToString(hash[:]),
 	)
 }

--- a/core/proto.go
+++ b/core/proto.go
@@ -13,15 +13,15 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-// sszMarshallingEnabled will be enabled in v0.17.
-var sszMarshallingEnabled = false
+// sszMarshallingEnabled is enabled from v0.17.
+var sszMarshallingEnabled = true
 
-// EnabledSSZMarshallingForT enables SSZ marshalling for the duration of the test.
-func EnabledSSZMarshallingForT(t *testing.T) {
+// DisableSSZMarshallingForT disables SSZ marshalling for the duration of the test.
+func DisableSSZMarshallingForT(t *testing.T) {
 	t.Helper()
-	sszMarshallingEnabled = true
+	sszMarshallingEnabled = false
 	t.Cleanup(func() {
-		sszMarshallingEnabled = false
+		sszMarshallingEnabled = true
 	})
 }
 

--- a/core/ssz_test.go
+++ b/core/ssz_test.go
@@ -92,13 +92,13 @@ func TestMarshalUnsignedProto(t *testing.T) {
 
 	seed := time.Now().Unix()
 
-	for _, enabledSSZ := range []bool{true, false} {
+	for _, disableSSZ := range []bool{true, false} {
 		for i, test := range tests {
 			f := testutil.NewEth2Fuzzer(t, seed+int64(i)) // Use the same seed for ssz vs json for each type.
 
-			t.Run(fmt.Sprintf("%T_%v", test.unsignedPtr(), enabledSSZ), func(t *testing.T) {
-				if enabledSSZ {
-					core.EnabledSSZMarshallingForT(t)
+			t.Run(fmt.Sprintf("%T_%v", test.unsignedPtr(), disableSSZ), func(t *testing.T) {
+				if disableSSZ {
+					core.DisableSSZMarshallingForT(t)
 				}
 
 				unsignedPtr := test.unsignedPtr()
@@ -121,7 +121,7 @@ func TestMarshalUnsignedProto(t *testing.T) {
 
 				b, err := proto.Marshal(pb)
 				require.NoError(t, err)
-				if enabledSSZ {
+				if disableSSZ {
 					sszSizes[fmt.Sprintf("%T", unsignedPtr)] = len(b)
 				} else {
 					jsonSizes[fmt.Sprintf("%T", unsignedPtr)] = len(b)
@@ -170,13 +170,13 @@ func TestMarshalParSignedProto(t *testing.T) {
 
 	seed := time.Now().Unix()
 
-	for _, enabledSSZ := range []bool{true, false} {
+	for _, disabledSSZ := range []bool{true, false} {
 		for i, test := range tests {
 			f := testutil.NewEth2Fuzzer(t, seed+int64(i)) // Use the same seed for ssz vs json for each type.
 
-			t.Run(fmt.Sprintf("%T_%v", test.signedPtr(), enabledSSZ), func(t *testing.T) {
-				if enabledSSZ {
-					core.EnabledSSZMarshallingForT(t)
+			t.Run(fmt.Sprintf("%T_%v", test.signedPtr(), disabledSSZ), func(t *testing.T) {
+				if disabledSSZ {
+					core.DisableSSZMarshallingForT(t)
 				}
 
 				signedPtr := test.signedPtr()
@@ -202,7 +202,7 @@ func TestMarshalParSignedProto(t *testing.T) {
 
 				b, err := proto.Marshal(pb)
 				require.NoError(t, err)
-				if enabledSSZ {
+				if disabledSSZ {
 					sszSizes[fmt.Sprintf("%T", signedPtr)] = len(b)
 				} else {
 					jsonSizes[fmt.Sprintf("%T", signedPtr)] = len(b)


### PR DESCRIPTION
Enables SSZ encoding in protos by default. This decreases wire bandwitdh requirements. 

> Note this breaks compatibility with v0.15 and earlier. So v0.17 will only be compatible with v0.16.

category: feature 
ticket: #2203 
