### PR TITLE
app: disable resource manager

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -21,6 +21,7 @@ import (
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 	"go.uber.org/automaxprocs/maxprocs"
@@ -286,7 +287,10 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	// Start libp2p TCP node.
-	opts := []libp2p.Option{p2p.WithBandwidthReporter(peerIDs)}
+	opts := []libp2p.Option{
+		p2p.WithBandwidthReporter(peerIDs),
+		libp2p.ResourceManager(&network.NullResourceManager{}),
+	}
 	opts = append(opts, conf.TestConfig.LibP2POpts...)
 
 	tcpNode, err := p2p.NewTCPNode(ctx, conf.P2P, p2pKey, connGater,

--- a/app/app.go
+++ b/app/app.go
@@ -289,7 +289,7 @@ func wireP2P(ctx context.Context, life *lifecycle.Manager, conf Config,
 	// Start libp2p TCP node.
 	opts := []libp2p.Option{
 		p2p.WithBandwidthReporter(peerIDs),
-		libp2p.ResourceManager(&network.NullResourceManager{}),
+		libp2p.ResourceManager(new(network.NullResourceManager)),
 	}
 	opts = append(opts, conf.TestConfig.LibP2POpts...)
 

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -40,7 +40,7 @@ func startP2P(ctx context.Context, config Config, key *k1.PrivateKey, reporter m
 	}
 
 	tcpNode, err := p2p.NewTCPNode(ctx, config.P2PConfig, key, p2p.NewOpenGater(), config.FilterPrivAddrs,
-		libp2p.ResourceManager(&network.NullResourceManager{}), libp2p.BandwidthReporter(reporter))
+		libp2p.ResourceManager(new(network.NullResourceManager)), libp2p.BandwidthReporter(reporter))
 	if err != nil {
 		return nil, errors.Wrap(err, "new tcp node")
 	}


### PR DESCRIPTION
Disable resource manager in charon to avoid `resource limit exceeded` error from libp2p.

category: misc
ticket: #2277
