### PR TITLE
app: refine "wrong fork version" error 

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -784,20 +784,20 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		}
 	}
 	if !ok {
-		lockForkVersion, err := eth2util.ForkVersionToNetwork(forkVersion)
+		lockNetwork, err := eth2util.ForkVersionToNetwork(forkVersion)
 		if err != nil {
 			return nil, errors.New("cannot parse lock file fork version")
 		}
 
-		networkForkVersion, err := eth2util.ForkVersionToNetwork(schedule[0].CurrentVersion[:])
+		bnNetwork, err := eth2util.ForkVersionToNetwork(schedule[0].CurrentVersion[:])
 		if err != nil {
 			return nil, errors.New("cannot parse network current fork version")
 		}
 
 		return nil, errors.New(
 			"mismatch between lock file fork version and beacon node fork schedule. Ensure the beacon node is on the correct network",
-			z.Str("expected", networkForkVersion),
-			z.Str("actual", lockForkVersion),
+			z.Str("beacon_node", bnNetwork),
+			z.Str("lock_file", lockNetwork),
 		)
 	}
 

--- a/app/app.go
+++ b/app/app.go
@@ -784,7 +784,21 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 		}
 	}
 	if !ok {
-		return nil, errors.New("lock file fork version not in beacon node fork schedule (probably wrong chain/network)")
+		lockForkVersion, err := eth2util.ForkVersionToNetwork(forkVersion)
+		if err != nil {
+			return nil, errors.New("cannot parse lock file fork version")
+		}
+
+		networkForkVersion, err := eth2util.ForkVersionToNetwork(schedule[0].CurrentVersion[:])
+		if err != nil {
+			return nil, errors.New("cannot parse network current fork version")
+		}
+
+		return nil, errors.New(
+			"mismatch between lock file fork version and beacon node fork schedule. Ensure the beacon node is on the correct network",
+			z.Str("expected", networkForkVersion),
+			z.Str("actual", lockForkVersion),
+		)
 	}
 
 	return eth2Cl, nil


### PR DESCRIPTION
Now reports human-readable network names for lock file and network fork version.

category: refactor
ticket: none
