### PR TITLE
app/peerinfo: instrument version compatibility

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Maybe overwrite app/version.Version with git tag
       if: github.ref_type == 'tag'
-      run: echo 'GO_BUILD_FLAGS=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
+      run: echo 'GO_BUILD_FLAGS=-ldflags=-X github.com/obolnetwork/charon/app/version.version=${{ github.ref_name }}' >> $GITHUB_ENV
 
     - uses: docker/build-push-action@v4
       with:

--- a/app/app.go
+++ b/app/app.go
@@ -199,7 +199,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		"cluster_name":    cState.Name,
 		"cluster_peer":    p2p.PeerName(tcpNode.ID()),
 		"cluster_network": network,
-		"charon_version":  version.Version,
+		"charon_version":  version.Version.String(),
 	}
 	log.SetLokiLabels(labels)
 	promRegistry, err := promauto.NewRegistry(labels)

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -113,7 +113,7 @@ func initStartupMetrics(peerName string, threshold, numOperators, numValidators 
 
 	hash, _ := version.GitCommit()
 	gitGauge.WithLabelValues(hash).Set(1)
-	versionGauge.WithLabelValues(version.Version).Set(1)
+	versionGauge.WithLabelValues(version.Version.String()).Set(1)
 	peerNameGauge.WithLabelValues(peerName).Set(1)
 
 	thresholdGauge.Set(float64(threshold))

--- a/app/peerinfo/adhoc_test.go
+++ b/app/peerinfo/adhoc_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
 )
@@ -21,16 +22,16 @@ func TestDoOnce(t *testing.T) {
 
 	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), peerstore.PermanentAddrTTL)
 
-	version := "v0"
+	vers := version.Version
 	lockHash := []byte("123")
 	gitHash := "abc"
 	// Register the server handler that either
-	_ = peerinfo.New(server, []peer.ID{server.ID(), client.ID()}, version, lockHash, gitHash, p2p.SendReceive)
+	_ = peerinfo.New(server, []peer.ID{server.ID(), client.ID()}, vers, lockHash, gitHash, p2p.SendReceive)
 
 	info, _, ok, err := peerinfo.DoOnce(context.Background(), client, server.ID())
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, version, info.CharonVersion)
+	require.Equal(t, vers.String(), info.CharonVersion)
 	require.Equal(t, gitHash, info.GitHash)
 	require.Equal(t, lockHash, info.LockHash)
 }

--- a/app/peerinfo/metrics.go
+++ b/app/peerinfo/metrics.go
@@ -46,4 +46,11 @@ var (
 		Name:      "index",
 		Help:      "Constant gauge set to the peer index in the cluster definition",
 	}, []string{"peer"})
+
+	peerCompatibleGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Subsystem: "peerinfo",
+		Name:      "version_support",
+		Help:      "Set to 1 if the peer's version is supported by (compatible with) the current version, else 0 if unsupported.",
+	}, []string{"peer"})
 )

--- a/app/peerinfo/peerinfo_internal_test.go
+++ b/app/peerinfo/peerinfo_internal_test.go
@@ -1,0 +1,70 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package peerinfo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/version"
+)
+
+func TestSupporterVersion(t *testing.T) {
+	tests := []struct {
+		PeerVersion       string
+		SupportedVersions []version.SemVer
+		ErrContains       string
+	}{
+		{
+			PeerVersion:       "v0.1.0",
+			SupportedVersions: semvers("v0.1"),
+		},
+		{
+			PeerVersion:       "v0.1.1",
+			SupportedVersions: semvers("v0.1"),
+		},
+		{
+			PeerVersion:       "v0.1.2",
+			SupportedVersions: semvers("v0.2", "v0.1"),
+		},
+		{
+			PeerVersion:       "v0.1-rc",
+			SupportedVersions: semvers("v0.1"),
+		},
+		{
+			PeerVersion:       "v0.1.3",
+			SupportedVersions: semvers("v0.2"),
+			ErrContains:       "unsupported peer version",
+		},
+		{
+			PeerVersion:       "v0.2.0",
+			SupportedVersions: semvers("v0.1"),
+		},
+		{
+			PeerVersion:       "",
+			SupportedVersions: semvers("v0.1"),
+			ErrContains:       "invalid version string",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.PeerVersion, func(t *testing.T) {
+			err := supportedPeerVersion(test.PeerVersion, test.SupportedVersions)
+			if test.ErrContains != "" {
+				require.ErrorContains(t, err, test.ErrContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func semvers(s ...string) []version.SemVer {
+	var resp []version.SemVer
+	for _, v := range s {
+		sv, _ := version.Parse(v)
+		resp = append(resp, sv)
+	}
+
+	return resp
+}

--- a/app/peerinfo/peerinfo_test.go
+++ b/app/peerinfo/peerinfo_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/peerinfo"
+	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
 )
@@ -23,26 +24,26 @@ func TestPeerInfo(t *testing.T) {
 	const gitCommit = "1234567"
 
 	nodes := []struct {
-		Version  string
+		Version  version.SemVer
 		LockHash []byte
 		Offset   time.Duration
 		Ignore   bool
 	}{
 		{
-			Version:  "local",
+			Version:  version.Supported()[0],
 			LockHash: []byte("abcdef"),
 		},
 		{
-			Version:  "ok",
+			Version:  version.Supported()[0],
 			LockHash: []byte("abcdef"),
 		},
 		{
-			Version:  "nok",
+			Version:  version.Supported()[1],
 			LockHash: []byte("000000"),
 			Offset:   time.Minute,
 		},
 		{
-			Version: "ignored",
+			Version: semver(t, "v0.0"),
 			Ignore:  true,
 		},
 	}
@@ -106,7 +107,7 @@ func TestPeerInfo(t *testing.T) {
 						continue
 					}
 					node := nodes[i]
-					require.Equal(t, node.Version, version)
+					require.Equal(t, node.Version.String(), version)
 					require.Equal(t, gitCommit, gitHash)
 					require.Equal(t, nowFunc(i)().Unix(), startTime.Unix())
 
@@ -138,4 +139,13 @@ func TestPeerInfo(t *testing.T) {
 
 	<-ctx.Done()
 	cancel()
+}
+
+func semver(t *testing.T, v string) version.SemVer {
+	t.Helper()
+
+	sv, err := version.Parse(v)
+	require.NoError(t, err)
+
+	return sv
 }

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -25,7 +25,7 @@ var Version, _ = Parse(version) // Error is caught in tests.
 // Supported returns the supported minor versions in order of precedence.
 func Supported() []SemVer {
 	return []SemVer{
-		// Current typeMinor version always goes first.
+		// Current minor version always goes first.
 		{major: 0, minor: 17},
 		{major: 0, minor: 16},
 	}
@@ -73,7 +73,7 @@ const (
 	typePreRelease
 )
 
-// SemVer represents a semantic version. A valid SemVer contains a major and typeMinor version
+// SemVer represents a semantic version. A valid SemVer contains a major and minor version
 // and optionally either a typePatch version or a pre-release label, i.e., v1.2 or v1.2.3 or v1.2-rc.
 type SemVer struct {
 	semVerType semVerType
@@ -94,7 +94,7 @@ func (v SemVer) String() string {
 	return fmt.Sprintf("v%d.%d-%s", v.major, v.minor, v.preRelease)
 }
 
-// Minor returns the typeMinor version of the semantic version.
+// Minor returns the minor version of the semantic version.
 // It strips the typePatch version and pre-release label if present.
 func (v SemVer) Minor() SemVer {
 	return SemVer{
@@ -142,6 +142,7 @@ func Compare(a, b SemVer) int {
 
 var semverRegex = regexp.MustCompile(`^v(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?$`)
 
+// Parse parses a semantic version string into a SemVer.
 func Parse(version string) (SemVer, error) {
 	matches := semverRegex.FindStringSubmatch(version)
 	if len(matches) == 0 || len(matches) != 5 {

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -4,28 +4,30 @@ package version
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 	"runtime/debug"
-	"strings"
+	"strconv"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 )
 
+// version a string since it is overwritten at build-time with the git tag for official releases.
+var version = "v0.17-dev"
+
 // Version is the branch version of the codebase.
 //   - Main branch: v0.X-dev
 //   - Release branch: v0.X-rc
-//
-// It is overwritten at build-time with the git tag for official releases.
-var Version = "v0.17-dev"
+var Version, _ = Parse(version) // Error is caught in tests.
 
 // Supported returns the supported minor versions in order of precedence.
-func Supported() []string {
-	return []string{
-		"v0.17",
-		"v0.16", // Current minor version always goes first.
-		"v0.15",
-		"v0.14",
+func Supported() []SemVer {
+	return []SemVer{
+		// Current typeMinor version always goes first.
+		{major: 0, minor: 17},
+		{major: 0, minor: 16},
 	}
 }
 
@@ -57,25 +59,121 @@ func GitCommit() (hash string, timestamp string) {
 func LogInfo(ctx context.Context, msg string) {
 	gitHash, gitTimestamp := GitCommit()
 	log.Info(ctx, msg,
-		z.Str("version", Version),
+		z.Str("version", Version.String()),
 		z.Str("git_commit_hash", gitHash),
 		z.Str("git_commit_time", gitTimestamp),
 	)
 }
 
-// Minor returns the minor version of the provided version string.
-func Minor(version string) (string, error) {
-	split := strings.Split(version, ".")
-	if len(split) < 2 {
-		return "", errors.New("invalid version string")
+type semVerType int
+
+const (
+	typeMinor semVerType = iota
+	typePatch
+	typePreRelease
+)
+
+// SemVer represents a semantic version. A valid SemVer contains a major and typeMinor version
+// and optionally either a typePatch version or a pre-release label, i.e., v1.2 or v1.2.3 or v1.2-rc.
+type SemVer struct {
+	semVerType semVerType
+	major      int
+	minor      int
+	patch      int
+	preRelease string
+}
+
+// String returns the string representation of the semantic version.
+func (v SemVer) String() string {
+	if v.semVerType == typeMinor {
+		return fmt.Sprintf("v%d.%d", v.major, v.minor)
+	} else if v.semVerType == typePatch {
+		return fmt.Sprintf("v%d.%d.%d", v.major, v.minor, v.patch)
 	}
 
-	major := split[0]
+	return fmt.Sprintf("v%d.%d-%s", v.major, v.minor, v.preRelease)
+}
 
-	minor := split[1]
-	if split := strings.Split(minor, "-"); len(split) > 1 {
-		minor = split[0]
+// Minor returns the typeMinor version of the semantic version.
+// It strips the typePatch version and pre-release label if present.
+func (v SemVer) Minor() SemVer {
+	return SemVer{
+		semVerType: typeMinor,
+		major:      v.major,
+		minor:      v.minor,
+	}
+}
+
+// Compare returns an integer comparing two semantic versions.
+// Only major and minor versions are used for comparison, unless both a and b
+// have patch versions, in which case the patch version is also used.
+// Pre-release labels are ignored.
+//
+// The result will be 0 if a == b, -1 if a < b, and +1 if a > b.
+func Compare(a, b SemVer) int {
+	if a.major != b.major {
+		if a.major < b.major {
+			return -1
+		}
+
+		return 1
 	}
 
-	return major + "." + minor, nil
+	if a.minor != b.minor {
+		if a.minor < b.minor {
+			return -1
+		}
+
+		return 1
+	}
+
+	if a.semVerType != typePatch || b.semVerType != typePatch {
+		return 0
+	}
+
+	if a.patch == b.patch {
+		return 0
+	} else if a.patch < b.patch {
+		return -1
+	} else {
+		return 1
+	}
+}
+
+var semverRegex = regexp.MustCompile(`^v(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?$`)
+
+func Parse(version string) (SemVer, error) {
+	matches := semverRegex.FindStringSubmatch(version)
+	if len(matches) == 0 || len(matches) != 5 {
+		return SemVer{}, errors.New("invalid version string", z.Str("version", version))
+	}
+
+	major, _ := strconv.Atoi(matches[1])
+	minor, _ := strconv.Atoi(matches[2])
+
+	var (
+		patch      int
+		preRelease string
+		typ        = typeMinor
+	)
+
+	// If there is a patch version
+	if matches[3] != "" {
+		patch, _ = strconv.Atoi(matches[3])
+		typ = typePatch
+	}
+
+	// If there is a pre-release label
+	if matches[4] != "" {
+		preRelease = matches[4]
+		typ = typePreRelease
+	}
+
+	return SemVer{
+		major:      major,
+		minor:      minor,
+		patch:      patch,
+		preRelease: preRelease,
+		semVerType: typ,
+	}, nil
 }

--- a/app/version/version_internal_test.go
+++ b/app/version/version_internal_test.go
@@ -1,0 +1,74 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package version
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidVersion(t *testing.T) {
+	v, err := Parse(version)
+	require.NoError(t, err)
+	require.Equal(t, v, Version)
+}
+
+func TestParseSemVer(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    SemVer
+		wantErr bool
+	}{
+		{
+			name:    "Patch",
+			version: "v1.2.3",
+			want:    SemVer{major: 1, minor: 2, patch: 3, semVerType: typePatch},
+			wantErr: false,
+		},
+		{
+			name:    "PreRelease",
+			version: "v0.17-dev",
+			want:    SemVer{major: 0, minor: 17, preRelease: "dev", semVerType: typePreRelease},
+		},
+		{
+			name:    "Minor",
+			version: "v0.1",
+			want:    SemVer{major: 0, minor: 1, semVerType: typeMinor},
+		},
+		{
+			name:    "Empty",
+			version: "",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid 1",
+			version: "invalid",
+			wantErr: true,
+		},
+		{
+			name:    "No v prefix",
+			version: "1.2.3",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid 2",
+			version: "12-dev",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.version)
+
+			if (err != nil) != tt.wantErr {
+				require.Fail(t, "Unexpected error", "ParseSemVer() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -41,7 +41,7 @@ func bindVersionFlags(flags *pflag.FlagSet, config *versionConfig) {
 
 func runVersionCmd(out io.Writer, config versionConfig) {
 	hash, timestamp := version.GitCommit()
-	_, _ = fmt.Fprintf(out, "%s [git_commit_hash=%s,git_commit_time=%s]\n", version.Version, hash, timestamp)
+	_, _ = fmt.Fprintf(out, "%v [git_commit_hash=%s,git_commit_time=%s]\n", version.Version, hash, timestamp)
 
 	if !config.Verbose {
 		return

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -235,7 +235,7 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot int64, defSet core
 		// TODO(dhruv): replace hardcoded graffiti with the one from cluster-lock.json
 		var graffiti [32]byte
 		commitSHA, _ := version.GitCommit()
-		copy(graffiti[:], fmt.Sprintf("charon/%s-%s", version.Version, commitSHA))
+		copy(graffiti[:], fmt.Sprintf("charon/%v-%s", version.Version, commitSHA))
 		block, err := f.eth2Cl.BeaconBlockProposal(ctx, eth2p0.Slot(uint64(slot)), randao, graffiti[:])
 		if err != nil {
 			return nil, err
@@ -273,7 +273,7 @@ func (f *Fetcher) fetchBuilderProposerData(ctx context.Context, slot int64, defS
 		// TODO(dhruv): replace hardcoded graffiti with the one from cluster-lock.json
 		var graffiti [32]byte
 		commitSHA, _ := version.GitCommit()
-		copy(graffiti[:], fmt.Sprintf("charon/%s-%s", version.Version, commitSHA))
+		copy(graffiti[:], fmt.Sprintf("charon/%v-%s", version.Version, commitSHA))
 		block, err := f.eth2Cl.BlindedBeaconBlockProposal(ctx, eth2p0.Slot(uint64(slot)), randao, graffiti[:])
 		if err != nil {
 			return nil, err

--- a/core/infosync/infosync.go
+++ b/core/infosync/infosync.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/priority"
@@ -27,7 +28,7 @@ const (
 )
 
 // New returns a new infosync component.
-func New(prioritiser *priority.Component, versions []string, protocols []protocol.ID,
+func New(prioritiser *priority.Component, versions []version.SemVer, protocols []protocol.ID,
 	proposals []core.ProposalType,
 ) *Component {
 	// Add a mock alpha protocol if alpha features enabled in order to test infosync in prod.
@@ -75,7 +76,7 @@ func New(prioritiser *priority.Component, versions []string, protocols []protoco
 
 type Component struct {
 	prioritiser *priority.Component
-	versions    []string
+	versions    []version.SemVer
 	protocols   []protocol.ID
 	proposals   []core.ProposalType
 
@@ -143,7 +144,7 @@ func (c *Component) Trigger(ctx context.Context, slot int64) error {
 	return c.prioritiser.Prioritise(ctx, core.NewInfoSyncDuty(slot),
 		priority.TopicProposal{
 			Topic:      topicVersion,
-			Priorities: c.versions,
+			Priorities: versionsToStrings(c.versions),
 		},
 		priority.TopicProposal{
 			Topic:      topicProtocol,
@@ -153,6 +154,16 @@ func (c *Component) Trigger(ctx context.Context, slot int64) error {
 			Topic:      topicProposal,
 			Priorities: proposalsToStrings(c.proposals),
 		})
+}
+
+// versionsToStrings returns the versions as strings.
+func versionsToStrings(versions []version.SemVer) []string {
+	var resp []string
+	for _, version := range versions {
+		resp = append(resp, version.String())
+	}
+
+	return resp
 }
 
 // protocolsToStrings returns the protocols as strings.

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -991,7 +991,7 @@ func (c Component) ValidatorsByPubKey(ctx context.Context, stateID string, pubsh
 func (Component) NodeVersion(context.Context) (string, error) {
 	commitSHA, _ := version.GitCommit()
 
-	return fmt.Sprintf("obolnetwork/charon/%s-%s/%s-%s", version.Version, commitSHA, runtime.GOARCH, runtime.GOOS), nil
+	return fmt.Sprintf("obolnetwork/charon/%v-%s/%s-%s", version.Version, commitSHA, runtime.GOARCH, runtime.GOOS), nil
 }
 
 // convertValidators returns the validator map with root public keys replaced by public shares for all validators that are part of the cluster.

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -385,10 +385,7 @@ func startSyncProtocol(ctx context.Context, tcpNode host.Host, key *k1.PrivateKe
 	}
 
 	// DKG compatibility is minor version dependent.
-	minorVersion, err := version.Minor(version.Version)
-	if err != nil {
-		return nil, errors.Wrap(err, "get version")
-	}
+	minorVersion := version.Version.Minor()
 
 	server := sync.NewServer(tcpNode, len(peerIDs)-1, defHash, minorVersion)
 	server.Start(ctx)

--- a/dkg/sync/client.go
+++ b/dkg/sync/client.go
@@ -15,13 +15,14 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/expbackoff"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
 	pb "github.com/obolnetwork/charon/dkg/dkgpb/v1"
 	"github.com/obolnetwork/charon/p2p"
 )
 
 // NewClient returns a new Client instance.
-func NewClient(tcpNode host.Host, peer peer.ID, hashSig []byte, version string) *Client {
+func NewClient(tcpNode host.Host, peer peer.ID, hashSig []byte, version version.SemVer) *Client {
 	return &Client{
 		tcpNode:   tcpNode,
 		peer:      peer,
@@ -46,7 +47,7 @@ type Client struct {
 
 	// Immutable state
 	hashSig []byte
-	version string
+	version version.SemVer
 	tcpNode host.Host
 	peer    peer.ID
 }
@@ -165,7 +166,7 @@ func (c *Client) sendMsg(stream network.Stream, shutdown bool) (*pb.MsgSyncRespo
 		Timestamp:     timestamppb.Now(),
 		HashSignature: c.hashSig,
 		Shutdown:      shutdown,
-		Version:       c.version,
+		Version:       c.version.String(),
 	}
 
 	if err := writeSizedProto(stream, msg); err != nil {

--- a/dkg/sync/sync_test.go
+++ b/dkg/sync/sync_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestSyncProtocol(t *testing.T) {
-	versions := make(map[int]string)
+	versions := make(map[int]version.SemVer)
 	for i := 0; i < 5; i++ {
 		versions[i] = version.Version
 	}
@@ -41,12 +41,26 @@ func TestSyncProtocol(t *testing.T) {
 
 	t.Run("invalid version", func(t *testing.T) {
 		testCluster(t, 2,
-			map[int]string{0: "v0", 1: "v1", 2: "v2", 3: "v3"},
+			map[int]version.SemVer{
+				0: semver(t, "v0.1"),
+				1: semver(t, "v0.2"),
+				2: semver(t, "v0.3"),
+				3: semver(t, "v0.4"),
+			},
 			"mismatching charon version; expect=")
 	})
 }
 
-func testCluster(t *testing.T, n int, versions map[int]string, expectErr string) {
+func semver(t *testing.T, v string) version.SemVer {
+	t.Helper()
+
+	sv, err := version.Parse(v)
+	require.NoError(t, err)
+
+	return sv
+}
+
+func testCluster(t *testing.T, n int, versions map[int]version.SemVer, expectErr string) {
 	t.Helper()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -27,6 +27,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_peerinfo_index` | Gauge | Constant gauge set to the peer index in the cluster definition | `peer` |
 | `app_peerinfo_start_time_secs` | Gauge | Constant gauge set to the peer start time of the binary in unix seconds | `peer` |
 | `app_peerinfo_version` | Gauge | Constant gauge with version label set to peer`s charon version. | `peer, version` |
+| `app_peerinfo_version_support` | Gauge | Set to 1 if the peer`s version is supported by (compatible with) the current version, else 0 if unsupported. | `peer` |
 | `app_start_time_secs` | Gauge | Gauge set to the app start time of the binary in unix seconds |  |
 | `app_version` | Gauge | Constant gauge with label set to current app version | `version` |
 | `cluster_network` | Gauge | Constant gauge with label set to the current network (chain) | `network` |

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -67,7 +67,7 @@ func NewTCPNode(ctx context.Context, cfg Config, key *k1.PrivateKey, connGater C
 		// Set TCP listen addresses.
 		libp2p.ListenAddrs(addrs...),
 		// Set up user-agent.
-		libp2p.UserAgent("obolnetwork-charon/" + version.Version),
+		libp2p.UserAgent("obolnetwork-charon/" + version.Version.String()),
 		// Limit connections to DV peers.
 		libp2p.ConnectionGater(connGater),
 		// Enable Autonat (required for hole punching)

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -94,13 +94,13 @@ func TestSmoke(t *testing.T) {
 			},
 			DefineTmplFunc: func(data *compose.TmplData) {
 				// Use oldest supported version for cluster lock
-				pegImageTag(data.Nodes, 0, last(version.Supported()[1:])+".0")
+				pegImageTag(data.Nodes, 0, last(version.Supported()[1:])+"-rc")
 			},
 			RunTmplFunc: func(data *compose.TmplData) {
 				// Node 0 is local build
 				pegImageTag(data.Nodes, 1, version.Version.String()) // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
-				pegImageTag(data.Nodes, 2, nth(version.Supported()[1:], 1)+".0")
-				pegImageTag(data.Nodes, 3, nth(version.Supported()[1:], 2)+".0")
+				pegImageTag(data.Nodes, 2, nth(version.Supported()[1:], 1)+"-rc")
+				pegImageTag(data.Nodes, 3, nth(version.Supported()[1:], 2)+"-rc")
 			},
 		},
 		{

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -98,7 +98,7 @@ func TestSmoke(t *testing.T) {
 			},
 			RunTmplFunc: func(data *compose.TmplData) {
 				// Node 0 is local build
-				pegImageTag(data.Nodes, 1, version.Version) // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
+				pegImageTag(data.Nodes, 1, version.Version.String()) // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
 				pegImageTag(data.Nodes, 2, nth(version.Supported()[1:], 1)+".0")
 				pegImageTag(data.Nodes, 3, nth(version.Supported()[1:], 2)+".0")
 			},
@@ -204,11 +204,11 @@ func pegImageTag(nodes []compose.TmplNode, index int, imageTag string) {
 }
 
 // last returns the last element of a slice.
-func last(s []string) string {
-	return s[len(s)-1]
+func last(s []version.SemVer) string {
+	return s[len(s)-1].String()
 }
 
 // nth returns the nth element of a slice, wrapping if n > len(s).
-func nth(s []string, n int) string {
-	return s[n%len(s)]
+func nth(s []version.SemVer, n int) string {
+	return s[n%len(s)].String()
 }


### PR DESCRIPTION
Instrument whether peer versions are supported or not.

Introduces a `version.SemVer` type to avoid string wrangling.

category: feature
ticket: #2293 