### PR TITLE
core/tracker: track inclusion events

### DIFF
--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -198,6 +198,9 @@ type Tracker interface {
 
 	// BroadcasterBroadcast sends Broadcaster component's broadcast events to tracker.
 	BroadcasterBroadcast(Duty, PubKey, SignedData, error)
+
+	// InclusionChecked sends InclusionChecker component's check events to tracker.
+	InclusionChecked(Duty, PubKey, SignedData, error)
 }
 
 // wireFuncs defines the core workflow components as a list of input and output functions

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -37,7 +37,9 @@ func TestDuplicateAttData(t *testing.T) {
 		}, nil
 	}
 
-	incl, err := NewInclusion(ctx, bmock)
+	noopTrackerInclFunc := func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {}
+
+	incl, err := NewInclusion(ctx, bmock, noopTrackerInclFunc)
 	require.NoError(t, err)
 
 	done := make(chan struct{})
@@ -81,6 +83,7 @@ func TestInclusion(t *testing.T) {
 		attIncludedFunc: func(ctx context.Context, sub submission, block block) {
 			included = append(included, sub.Duty)
 		},
+		trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
 	}
 
 	// Create some duties

--- a/core/tracker/reason.go
+++ b/core/tracker/reason.go
@@ -186,4 +186,10 @@ var (
 		Short: "failed to broadcast duty to beacon node",
 		Long:  "Reason `bcast` indicates that beacon node returned an error while submitting aggregated duty signature to beacon node.",
 	}
+
+	reasonChainIncl = reason{
+		Code:  "chain_inclusion",
+		Short: "duty not included on-chain",
+		Long:  "Reason `chain_inclusion` indicates that even though charon broadcasted the duty successfully, it wasn't included in the beacon chain. This is expected for up to 20% of attestations. It may however indicate problematic charon broadcast delays or beacon node network problems.",
+	}
 )

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -29,7 +29,7 @@ const (
 	sigAgg                // Partial signed data aggregated; emitted from sigagg
 	aggSigDB              // Aggregated signed data stored in aggsigdb
 	bcast                 // Aggregated data submitted to beacon node
-	chainInclusion        // Aggregated data submitted to beacon node
+	chainInclusion        // Aggregated data included in canonical chain
 	sentinel
 )
 

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -29,6 +29,7 @@ const (
 	sigAgg                // Partial signed data aggregated; emitted from sigagg
 	aggSigDB              // Aggregated signed data stored in aggsigdb
 	bcast                 // Aggregated data submitted to beacon node
+	chainInclusion        // Aggregated data submitted to beacon node
 	sentinel
 )
 
@@ -44,6 +45,7 @@ var stepLabels = map[step]string{
 	sigAgg:           "sig_aggregation",
 	aggSigDB:         "aggsig_db",
 	bcast:            "bcast",
+	chainInclusion:   "chain_inclusion",
 	sentinel:         "sentinel",
 }
 
@@ -194,11 +196,20 @@ func dutyFailedStep(es []event) (bool, step, error) {
 	}
 
 	// Final step was successful.
-	if lastEvent.step == bcast && lastEvent.stepErr == nil {
+	if lastEvent.step == lastStep(es[0].duty.Type) && lastEvent.stepErr == nil {
 		return false, zero, nil
 	}
 
 	return true, lastEvent.step, lastEvent.stepErr
+}
+
+// lastStep returns the last step of the duty which is either bcast or chainInclusion.
+func lastStep(dutyType core.DutyType) step {
+	if inclSupported[dutyType] {
+		return chainInclusion
+	}
+
+	return bcast
 }
 
 // analyseDutyFailed detects if the given duty failed.
@@ -257,7 +268,17 @@ func analyseDutyFailed(duty core.Duty, allEvents map[core.Duty][]event, msgRootC
 	case aggSigDB:
 		reason = reasonAggSigDB
 	case bcast:
-		reason = reasonBcast
+		if failedErr == nil {
+			failedErr = errors.New("bug: missing chain inclusion event")
+		} else {
+			reason = reasonBcast
+		}
+	case chainInclusion:
+		if failedErr == nil {
+			failedErr = errors.New("bug: missing chain inclusion error")
+		} else {
+			reason = reasonChainIncl
+		}
 	case zero:
 		failedErr = errors.New("no events for duty") // This should never happen.
 	default:
@@ -469,7 +490,7 @@ func newFailedDutyReporter() func(ctx context.Context, duty core.Duty, failed bo
 	}
 }
 
-// newUnsupportedIgnorer returns a filter that ignores duties that are not supported by the node.
+// newUnsupportedIgnorer returns a filter that ignores duties that are not inclSupported by the node.
 func newUnsupportedIgnorer() func(ctx context.Context, duty core.Duty, failed bool, step step, reason reason) bool {
 	var (
 		loggedNoAggregator    bool
@@ -783,6 +804,19 @@ func (t *Tracker) BroadcasterBroadcast(duty core.Duty, pubkey core.PubKey, _ cor
 		step:    bcast,
 		pubkey:  pubkey,
 		stepErr: stepErr,
+	}:
+	}
+}
+
+func (t *Tracker) InclusionChecked(duty core.Duty, key core.PubKey, _ core.SignedData, err error) {
+	select {
+	case <-t.quit:
+		return
+	case t.input <- event{
+		duty:    duty,
+		step:    chainInclusion,
+		pubkey:  key,
+		stepErr: err,
 	}:
 	}
 }

--- a/docs/reasons.md
+++ b/docs/reasons.md
@@ -17,6 +17,10 @@ maintain system performance.
   - *Summary*: failed to broadcast duty to beacon node
   - *Details*: Reason `bcast` indicates that beacon node returned an error while submitting aggregated duty signature to beacon node.
 
+### Failure Reason: `chain_inclusion`
+  - *Summary*: duty not included on-chain
+  - *Details*: Reason `chain_inclusion` indicates that even though charon broadcasted the duty successfully, it wasn`t included in the beacon chain. This is expected for up to 20% of attestations. It may however indicate problematic charon broadcast delays or beacon node network problems.
+
 ### Failure Reason: `consensus`
   - *Summary*: consensus algorithm didn`t complete
   - *Details*: Reason `consensus` indicates a duty failed in consensus step. This could indicate that insufficient honest peers participated in consensus or p2p network connection problems.


### PR DESCRIPTION
Extends tracker duty failure reasons to include "chain inclusion" results. Duties will subsequently only be marked as success if included onchain, and accordinlgy marked as failed if not included onchain.

Note that chain inclusion is only checked if the duty was broadcasted, so this doesn't actually "make duty failures objective", since if the local node failed to broadcast, it will not check inclusion and will mark the duty as failed regardless of actual results.

category: feature
ticket: #2200 
