### PR TITLE
compose: disable visualisation in smoke tests

### DIFF
--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -114,6 +114,9 @@ type Config struct {
 
 	// SyntheticBlockProposals configures use of synthetic block proposals in simnet cluster.
 	SyntheticBlockProposals bool `json:"synthetic_block_proposals"`
+
+	// Monitoring enables monitoring stack for the compose cluster. It includes grafana, loki and jaeger services.
+	Monitoring bool `json:"monitoring"`
 }
 
 // VCStrings returns the VCs field as a slice of strings.
@@ -141,5 +144,6 @@ func NewDefaultConfig() Config {
 		FeatureSet:              defaultFeatureSet,
 		SlotDuration:            time.Second,
 		SyntheticBlockProposals: true,
+		Monitoring:              true,
 	}
 }

--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -68,7 +68,7 @@ services:
   {{end -}}
   {{end -}}
 
-  {{if .Monitoring}}
+  {{if .Alerting}}
   curl:
     # Can be used to curl services; e.g. docker-compose exec curl curl http://prometheus:9090/api/v1/rules\?type\=alert
     image: curlimages/curl:latest
@@ -84,7 +84,9 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./prometheus/rules.yml:/etc/prometheus/rules.yml
+  {{end}}
 
+  {{if .Monitoring}}
   grafana:
     image: grafana/grafana:latest
     {{if .MonitoringPorts}}ports:

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -47,7 +47,8 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 		CharonCommand:   cmdRun,
 		Nodes:           nodes,
 		Relay:           true,
-		Monitoring:      true,
+		Monitoring:      conf.Monitoring,
+		Alerting:        true,
 		MonitoringPorts: !conf.DisableMonitoringPorts,
 		VCs:             vcs,
 	}

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -162,6 +162,7 @@ func TestSmoke(t *testing.T) {
 			require.NoError(t, err)
 
 			conf := compose.NewDefaultConfig()
+			conf.Monitoring = false
 			conf.DisableMonitoringPorts = true
 			conf.BuildLocal = true
 			conf.ImageTag = "local"

--- a/testutil/compose/template.go
+++ b/testutil/compose/template.go
@@ -32,6 +32,7 @@ type TmplData struct {
 
 	Relay           bool
 	Monitoring      bool
+	Alerting        bool
 	MonitoringPorts bool
 }
 

--- a/testutil/compose/testdata/TestDockerCompose_define_create_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_create_template.golden
@@ -15,5 +15,6 @@
  "VCs": null,
  "Relay": false,
  "Monitoring": false,
+ "Alerting": false,
  "MonitoringPorts": false
 }

--- a/testutil/compose/testdata/TestDockerCompose_define_create_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_create_yml.golden
@@ -13,5 +13,7 @@ services:
     <<: *node-base
     
 
+  
+
 networks:
   compose:

--- a/testutil/compose/testdata/TestDockerCompose_define_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_dkg_template.golden
@@ -52,5 +52,6 @@
  "VCs": null,
  "Relay": false,
  "Monitoring": false,
+ "Alerting": false,
  "MonitoringPorts": false
 }

--- a/testutil/compose/testdata/TestDockerCompose_define_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_dkg_yml.golden
@@ -23,5 +23,7 @@ services:
       CHARON_NETWORK: goerli
     
 
+  
+
 networks:
   compose:

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_template.golden
@@ -60,5 +60,6 @@
  "VCs": null,
  "Relay": false,
  "Monitoring": false,
+ "Alerting": false,
  "MonitoringPorts": false
 }

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
@@ -25,5 +25,7 @@ services:
       CHARON_NETWORK: goerli
     
 
+  
+
 networks:
   compose:

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_template.golden
@@ -216,5 +216,6 @@
  "VCs": null,
  "Relay": true,
  "Monitoring": false,
+ "Alerting": false,
  "MonitoringPorts": false
 }

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -96,5 +96,7 @@ services:
       CHARON_LOKI_ADDRESS: http://loki:3100/loki/api/v1/push
   
 
+  
+
 networks:
   compose:

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -473,5 +473,6 @@
  ],
  "Relay": true,
  "Monitoring": true,
+ "Alerting": true,
  "MonitoringPorts": true
 }

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -218,7 +218,9 @@ services:
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./prometheus/rules.yml:/etc/prometheus/rules.yml
+  
 
+  
   grafana:
     image: grafana/grafana:latest
     ports:

--- a/testutil/compose/testdata/TestNewDefaultConfig.golden
+++ b/testutil/compose/testdata/TestNewDefaultConfig.golden
@@ -20,5 +20,6 @@
  "insecure_keys": false,
  "slot_duration": 1000000000,
  "fuzz": false,
- "synthetic_block_proposals": true
+ "synthetic_block_proposals": true,
+ "monitoring": true
 }


### PR DESCRIPTION
Disable visualisation services in smoke tests. It includes grafana, loki and jaegar.

category: fixbuild
ticket: none
