### PR TITLE
eth2util/keystore: handle single keystore case

### DIFF
--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -395,7 +395,7 @@ func randomHex32() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// validateKeystoreFilename validates keystore filename and returns index of the keystore file.
+// validateKeystoreFilename checks if the given keystore filename is valid and returns index of the keystore file.
 func validateKeystoreFilename(file string) (int, error) {
 	prefix := filepath.Dir(file)
 	extractor := regexp.MustCompile(`keystore-(?:insecure-)?([0-9]+).json`)

--- a/eth2util/keystore/keystore_internal_test.go
+++ b/eth2util/keystore/keystore_internal_test.go
@@ -83,3 +83,51 @@ func Test_orderByKeystoreNum(t *testing.T) {
 		})
 	}
 }
+
+func Test_validateKeystoreFilename(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		want    int
+		wantErr string
+	}{
+		{
+			name:    "filename with expected pattern",
+			file:    "keystore-25.json",
+			want:    25,
+			wantErr: "",
+		},
+		{
+			name:    "filename with expected pattern insecure",
+			file:    "keystore-insecure-25.json",
+			want:    25,
+			wantErr: "",
+		},
+		{
+			name:    "filename with unexpected pattern",
+			file:    "keystore-foo.json",
+			wantErr: "keystore filenames do not match expected pattern 'keystore-%d.json' or 'keystore-insecure-%d.json'",
+		},
+		{
+			name:    "filename with unexpected pattern",
+			file:    "keystore-foo.json",
+			wantErr: "keystore filenames do not match expected pattern 'keystore-%d.json' or 'keystore-insecure-%d.json'",
+		},
+		{
+			name:    "filename with unexpected pattern insecure",
+			file:    "keystore-insecure-foo.json",
+			wantErr: "keystore filenames do not match expected pattern 'keystore-%d.json' or 'keystore-insecure-%d.json'",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateKeystoreFilename(tt.file)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/eth2util/keystore/keystore_internal_test.go
+++ b/eth2util/keystore/keystore_internal_test.go
@@ -13,6 +13,7 @@ func Test_orderByKeystoreNum(t *testing.T) {
 		name     string
 		files    []string
 		want     []string
+		wantIdxs []int
 		errCheck require.ErrorAssertionFunc
 	}{
 		{
@@ -29,6 +30,7 @@ func Test_orderByKeystoreNum(t *testing.T) {
 				"/keystore-3.json",
 				"/keystore-10.json",
 			},
+			[]int{1, 2, 3, 10},
 			require.NoError,
 		},
 		{
@@ -45,6 +47,7 @@ func Test_orderByKeystoreNum(t *testing.T) {
 				"/keystore-insecure-3.json",
 				"/keystore-insecure-10.json",
 			},
+			[]int{1, 2, 3, 10},
 			require.NoError,
 		},
 		{
@@ -54,26 +57,29 @@ func Test_orderByKeystoreNum(t *testing.T) {
 				"/keystore-insecure-failtoo.json",
 			},
 			nil,
+			nil,
 			require.Error,
 		},
 		{
 			"single file path yields the exact same thing",
 			[]string{
-				"/keystore-0.json",
+				"/keystore-1.json",
 			},
 			[]string{
-				"/keystore-0.json",
+				"/keystore-1.json",
 			},
+			[]int{1},
 			require.NoError,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _, err := orderByKeystoreNum(tt.files)
+			got, indices, err := orderByKeystoreNum(tt.files)
 
 			tt.errCheck(t, err)
 			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantIdxs, indices)
 		})
 	}
 }


### PR DESCRIPTION
Handle single keystore case in `orderByKeystoreNum` function. Prior to this, it was returning nil as indices slice for single keystore file. This is because comparator function of sort is not called for a single element slice and this comparator function is responsible for populating indices slice.

category: bug
ticket: none
