### PR TITLE
cmd: write cluster manifest to disk

### DIFF
--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Load loads a cluster manifest from disk. It supports both legacy lock files and raw DAG files.
-// TODO(xenowits): Refactor, pass in two file names, try loading manifest.pb first, then legacy lock.
+// TODO(xenowits): Refactor, load either from manifest or lock file, see https://github.com/ObolNetwork/charon/issues/2334.
 func Load(file string, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, error) {
 	b, err := os.ReadFile(file)
 	if err != nil {

--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Load loads a cluster manifest from disk. It supports both legacy lock files and raw DAG files.
-// TODO(corver): Refactor, pass in two file names, try loading manifest.pb first, then legacy lock.
+// TODO(xenowits): Refactor, pass in two file names, try loading manifest.pb first, then legacy lock.
 func Load(file string, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, error) {
 	b, err := os.ReadFile(file)
 	if err != nil {

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -89,11 +89,8 @@ func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err erro
 		return err
 	}
 
-	// Write backup of the current cluster manifest to disk
-	err = writeClusterBackup(conf.ClusterBackupDir, cluster)
-	if err != nil {
-		return err
-	}
+	// Will be used to create cluster backup
+	oldCluster := proto.Clone(cluster).(*manifestpb.Cluster)
 
 	if err = validateConf(conf, len(cluster.Operators)); err != nil {
 		return errors.Wrap(err, "validate config")
@@ -157,6 +154,12 @@ func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err erro
 	cluster, err = manifest.Transform(cluster, addVals)
 	if err != nil {
 		return errors.Wrap(err, "transform cluster manifest")
+	}
+
+	// Save cluster backup to disk
+	err = writeClusterBackup(conf.ClusterBackupDir, oldCluster)
+	if err != nil {
+		return err
 	}
 
 	// Save cluster manifest to disk

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -6,11 +6,13 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"os"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/spf13/cobra"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/k1util"
@@ -27,11 +29,13 @@ import (
 
 // addValidatorsConfig is config for the `add-validators` command.
 type addValidatorsConfig struct {
-	Lockfile          string
-	EnrPrivKeyfiles   []string
 	NumVals           int
 	WithdrawalAddrs   []string
 	FeeRecipientAddrs []string
+
+	Lockfile            string
+	ClusterManifestFile string
+	EnrPrivKeyfiles     []string
 
 	TestConfig TestConfig
 }
@@ -65,15 +69,16 @@ func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) erro
 // bindAddValidatorsFlags binds command line flags for the `add-validators` command.
 func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 	cmd.Flags().IntVar(&config.NumVals, "num-validators", 1, "The count of new distributed validators to add in the cluster.")
-	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster.")
-	cmd.Flags().StringSliceVar(&config.EnrPrivKeyfiles, "private-key-files", nil, "Comma separated list of paths to charon enr private key files. This should be in the same order as the operators, ie, first private key file should correspond to the first operator and so on.")
 	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each new validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each new validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
+	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster.")
+	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file.")
+	cmd.Flags().StringSliceVar(&config.EnrPrivKeyfiles, "private-key-files", nil, "Comma separated list of paths to charon enr private key files. This should be in the same order as the operators, ie, first private key file should correspond to the first operator and so on.")
 }
 
 func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err error) {
 	// Read lock file to load mutable cluster manifest.
-	cluster, err := loadClusterState(conf)
+	cluster, err := loadClusterManifest(conf)
 	if err != nil {
 		return err
 	}
@@ -137,12 +142,16 @@ func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err erro
 	}
 
 	// Finally, perform a cluster transformation.
-	_, err = manifest.Transform(cluster, addVals)
+	cluster, err = manifest.Transform(cluster, addVals)
 	if err != nil {
 		return errors.Wrap(err, "transform cluster manifest")
 	}
 
-	// TODO(xenowits): Write new cluster manifest to disk, see issue https://github.com/ObolNetwork/charon/issues/1887.
+	// Save cluster manifest to disk
+	err = writeClusterManifest(conf.ClusterManifestFile, cluster)
+	if err != nil {
+		return errors.Wrap(err, "write cluster manifest")
+	}
 
 	return nil
 }
@@ -180,8 +189,8 @@ func builderRegistration(secret tbls.PrivateKey, pubkey tbls.PublicKey, feeRecip
 	}, nil
 }
 
-// loadClusterState returns the cluster manifest from the given file path.
-func loadClusterState(conf addValidatorsConfig) (*manifestpb.Cluster, error) {
+// loadClusterManifest returns the cluster manifest from the given file path.
+func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, error) {
 	if conf.TestConfig.Lock != nil {
 		return manifest.NewClusterFromLock(*conf.TestConfig.Lock)
 	}
@@ -204,6 +213,22 @@ func loadClusterState(conf addValidatorsConfig) (*manifestpb.Cluster, error) {
 	}
 
 	return cluster, nil
+}
+
+// writeClusterManifest writes the provided cluster manifest to disk.
+func writeClusterManifest(filename string, cluster *manifestpb.Cluster) error {
+	b, err := proto.Marshal(cluster)
+	if err != nil {
+		return errors.Wrap(err, "marshal proto")
+	}
+
+	//nolint:gosec // File needs to be read-write since the cluster manifest is modified by mutations.
+	err = os.WriteFile(filename, b, 0o644) // Read-write
+	if err != nil {
+		return errors.Wrap(err, "write cluster manifest")
+	}
+
+	return nil
 }
 
 // validateConf returns an error if the provided validators config fails validation checks.

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -71,8 +71,8 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 	cmd.Flags().IntVar(&config.NumVals, "num-validators", 1, "The count of new distributed validators to add in the cluster.")
 	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each new validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each new validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
-	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster.")
-	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file.")
+	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
+	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringSliceVar(&config.EnrPrivKeyfiles, "private-key-files", nil, "Comma separated list of paths to charon enr private key files. This should be in the same order as the operators, ie, first private key file should correspond to the first operator and so on.")
 }
 

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -78,7 +78,7 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each new validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
 	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster.")
 	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file.")
-	cmd.Flags().StringVar(&config.ClusterBackupDir, "cluster-backup-dir", ".charon/cluster-backups", "The directory containing cluster manifest backup files.")
+	cmd.Flags().StringVar(&config.ClusterBackupDir, "cluster-backup-dir", ".charon/cluster-manifest-backups", "The directory containing cluster manifest backup files.")
 	cmd.Flags().StringSliceVar(&config.EnrPrivKeyfiles, "private-key-files", nil, "Comma separated list of paths to charon enr private key files. This should be in the same order as the operators, ie, first private key file should correspond to the first operator and so on.")
 }
 

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -35,7 +35,6 @@ type addValidatorsConfig struct {
 
 	Lockfile            string   // Path to the legacy cluster lock file
 	ClusterManifestFile string   // Path to the cluster manifest file
-	ClusterBackupDir    string   // Directory containing cluster manifest backup files
 	EnrPrivKeyfiles     []string // Paths to node enr private keys
 
 	TestConfig TestConfig
@@ -78,7 +77,7 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 }
 
 func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err error) {
-	// Read lock file to load mutable cluster manifest
+	// Read lock file to load cluster manifest
 	cluster, err := loadClusterManifest(conf)
 	if err != nil {
 		return err
@@ -148,6 +147,8 @@ func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err erro
 		return errors.Wrap(err, "transform cluster manifest")
 	}
 
+	// TODO(xenowits): Write cluster backup, see https://github.com/ObolNetwork/charon/issues/2345.
+
 	// Save cluster manifest to disk
 	err = writeClusterManifest(conf.ClusterManifestFile, cluster)
 	if err != nil {
@@ -190,7 +191,7 @@ func builderRegistration(secret tbls.PrivateKey, pubkey tbls.PublicKey, feeRecip
 	}, nil
 }
 
-// loadClusterManifest returns the cluster manifest from the given file path.
+// loadClusterManifest returns the cluster manifest from the provided config.
 func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, error) {
 	if conf.TestConfig.Lock != nil {
 		return manifest.NewClusterFromLock(*conf.TestConfig.Lock)

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -119,6 +119,9 @@ func TestRunAddValidators(t *testing.T) {
 
 	tmp := t.TempDir()
 	manifestFile := path.Join(tmp, "cluster-manifest.pb")
+	backupDir := path.Join(tmp, "cluster-backups")
+	require.NoError(t, os.Mkdir(backupDir, 0o777))
+
 	conf := addValidatorsConfig{
 		NumVals:           1,
 		WithdrawalAddrs:   []string{feeRecipientAddr},
@@ -128,6 +131,7 @@ func TestRunAddValidators(t *testing.T) {
 			P2PKeys: p2pKeys,
 		},
 		ClusterManifestFile: manifestFile,
+		ClusterBackupDir:    backupDir,
 	}
 
 	err := runAddValidatorsSolo(context.Background(), conf)

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -123,7 +123,7 @@ func TestRunAddValidators(t *testing.T) {
 
 	tmp := t.TempDir()
 	manifestFile := path.Join(tmp, "cluster-manifest.pb")
-	backupDir := path.Join(tmp, "cluster-backups")
+	backupDir := path.Join(tmp, "cluster-manifest-backups")
 
 	conf := addValidatorsConfig{
 		NumVals:           1,
@@ -159,7 +159,7 @@ func TestRunAddValidators(t *testing.T) {
 	b, err = os.ReadFile(backupFile)
 	require.NoError(t, err)
 
-	// Verify if new validator is included in updated cluster manifest
+	// Verify if backup manifest still contains a single validator, ie, it is unchanged
 	var msgBackup manifestpb.Cluster
 	require.NoError(t, proto.Unmarshal(b, &msgBackup))
 	require.Equal(t, len(msgBackup.Validators), valCount)

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -4,10 +4,13 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path"
 	"testing"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/obolnetwork/charon/cluster"
 	manifestpb "github.com/obolnetwork/charon/cluster/manifestpb/v1"
@@ -114,6 +117,8 @@ func TestRunAddValidators(t *testing.T) {
 	const n = 3
 	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, 0)
 
+	tmp := t.TempDir()
+	manifestFile := path.Join(tmp, "cluster-manifest.pb")
 	conf := addValidatorsConfig{
 		NumVals:           1,
 		WithdrawalAddrs:   []string{feeRecipientAddr},
@@ -122,10 +127,21 @@ func TestRunAddValidators(t *testing.T) {
 			Lock:    &lock,
 			P2PKeys: p2pKeys,
 		},
+		ClusterManifestFile: manifestFile,
 	}
 
 	err := runAddValidatorsSolo(context.Background(), conf)
 	require.NoError(t, err)
+
+	// Verify if the cluster manifest file is saved to disk
+	b, err := os.ReadFile(manifestFile)
+	require.NoError(t, err)
+
+	var msg manifestpb.Cluster
+	require.NoError(t, proto.Unmarshal(b, &msg))
+
+	// Verify if new validator is included in updated cluster manifest
+	require.Equal(t, msg.Validators[len(msg.Validators)-1].FeeRecipientAddress, feeRecipientAddr)
 }
 
 func TestValidateP2PKeysOrder(t *testing.T) {

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -120,7 +120,6 @@ func TestRunAddValidators(t *testing.T) {
 	tmp := t.TempDir()
 	manifestFile := path.Join(tmp, "cluster-manifest.pb")
 	backupDir := path.Join(tmp, "cluster-backups")
-	require.NoError(t, os.Mkdir(backupDir, 0o777))
 
 	conf := addValidatorsConfig{
 		NumVals:           1,


### PR DESCRIPTION
Writes cluster updated by `charon alpha add-validators-solo` command to disk. The new file is named `cluster-manifest.pb`.

category: feature 
ticket: #1887 
