### PR TITLE
core: add remaining nil checks

### DIFF
--- a/core/consensus/msg.go
+++ b/core/consensus/msg.go
@@ -17,6 +17,10 @@ import (
 
 // newMsg returns a new msg.
 func newMsg(pbMsg *pbv1.QBFTMsg, justification []*pbv1.QBFTMsg, values map[[32]byte]*anypb.Any) (msg, error) {
+	if pbMsg == nil {
+		return msg{}, errors.New("qbft msg proto cannot be nil")
+	}
+
 	// Do all possible error conversions first.
 	var (
 		valueHash         [32]byte

--- a/core/consensus/msg.go
+++ b/core/consensus/msg.go
@@ -18,7 +18,7 @@ import (
 // newMsg returns a new msg.
 func newMsg(pbMsg *pbv1.QBFTMsg, justification []*pbv1.QBFTMsg, values map[[32]byte]*anypb.Any) (msg, error) {
 	if pbMsg == nil {
-		return msg{}, errors.New("qbft msg proto cannot be nil")
+		return msg{}, errors.New("nil qbft message")
 	}
 
 	// Do all possible error conversions first.

--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -122,7 +122,7 @@ func newInternal(tcpNode host.Host, peers []peer.ID, minRequired int,
 		func() proto.Message { return new(pbv1.PriorityMsg) },
 		func(ctx context.Context, pID peer.ID, msg proto.Message) (proto.Message, bool, error) {
 			prioMsg, ok := msg.(*pbv1.PriorityMsg)
-			if !ok {
+			if !ok || prioMsg == nil {
 				return nil, false, errors.New("invalid priority message")
 			}
 
@@ -200,6 +200,10 @@ func (p *Prioritiser) Prioritise(ctx context.Context, msg *pbv1.PriorityMsg) err
 
 // handleRequest handles a priority message exchange initiated by a peer.
 func (p *Prioritiser) handleRequest(ctx context.Context, pID peer.ID, msg *pbv1.PriorityMsg) (*pbv1.PriorityMsg, error) {
+	if msg == nil {
+		return nil, errors.New("priority msg proto cannot be nil")
+	}
+
 	if pID.String() != msg.PeerId {
 		return nil, errors.New("invalid priority message peer id", z.Str("expect", pID.String()), z.Str("actual", msg.PeerId))
 	} else if err := p.msgValidator(msg); err != nil {

--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -201,7 +201,7 @@ func (p *Prioritiser) Prioritise(ctx context.Context, msg *pbv1.PriorityMsg) err
 // handleRequest handles a priority message exchange initiated by a peer.
 func (p *Prioritiser) handleRequest(ctx context.Context, pID peer.ID, msg *pbv1.PriorityMsg) (*pbv1.PriorityMsg, error) {
 	if msg == nil {
-		return nil, errors.New("priority msg proto cannot be nil")
+		return nil, errors.New("nil priority message")
 	}
 
 	if pID.String() != msg.PeerId {


### PR DESCRIPTION
Add remaining nil checks that were missing as part of OBOL-03.

category: misc
ticket: #1997
