### PR TITLE
cmd: backup cluster manifests

### DIFF
--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -250,6 +250,7 @@ func writeClusterManifest(filename string, cluster *manifestpb.Cluster) error {
 }
 
 // writeManifestBackup writes the provided cluster in a cluster manifest backup file inside the backup directory.
+// The backup files are stored as "cluster-manifest-backup-<unix_timestamp>.pb".
 func writeManifestBackup(backupDir string, cluster *manifestpb.Cluster) error {
 	// Check if the backup directory exists, creating a new one if it doesn't exist.
 	info, err := os.Stat(backupDir)
@@ -264,11 +265,11 @@ func writeManifestBackup(backupDir string, cluster *manifestpb.Cluster) error {
 		return errors.New("backup dir already exists and is a file", z.Str("backup-dir", backupDir))
 	}
 
-	filename := fmt.Sprintf("cluster-manifest-backup-%d.pb", time.Now().Unix()) // "cluster-manifest-backup-1687250009.pb"
-	backupFile := path.Join(backupDir, filename)
+	filename := fmt.Sprintf("cluster-manifest-backup-%d.pb", time.Now().Unix()) // Ex: "cluster-manifest-backup-1687250009.pb"
+	backupPath := path.Join(backupDir, filename)
 
-	// Write the backup to disk
-	err = writeClusterManifest(backupFile, cluster)
+	// Write backup to disk
+	err = writeClusterManifest(backupPath, cluster)
 	if err != nil {
 		return errors.Wrap(err, "write cluster manifest backup")
 	}

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -38,7 +39,6 @@ type addValidatorsConfig struct {
 
 	Lockfile        string   // Path to the legacy cluster lock file
 	ManifestFile    string   // Path to the cluster manifest file
-	DataDir         string   // Data directory to store cluster manifest backups
 	EnrPrivKeyfiles []string // Paths to node enr private keys
 
 	TestConfig TestConfig
@@ -77,7 +77,6 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each new validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
 	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringVar(&config.ManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
-	cmd.Flags().StringVar(&config.DataDir, "data-dir", ".charon", "The directory where cluster manifest backups are stored.")
 	cmd.Flags().StringSliceVar(&config.EnrPrivKeyfiles, "private-key-files", nil, "Comma separated list of paths to charon enr private key files. This should be in the same order as the operators, ie, first private key file should correspond to the first operator and so on.")
 }
 
@@ -156,7 +155,8 @@ func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err erro
 
 	// Save manifest backup to disk before overriding manifest file
 	if !isLegacyLock {
-		err = writeManifestBackup(conf.DataDir, manifestBackup)
+		dataDir := filepath.Dir(conf.ManifestFile)
+		err = writeManifestBackup(dataDir, manifestBackup)
 		if err != nil {
 			return err
 		}

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -132,7 +132,6 @@ func TestRunAddValidators(t *testing.T) {
 			P2PKeys: p2pKeys,
 		},
 		ManifestFile: manifestFile,
-		DataDir:      tmp,
 	}
 
 	err := runAddValidatorsSolo(context.Background(), conf)
@@ -146,6 +145,13 @@ func TestRunAddValidators(t *testing.T) {
 	require.NoError(t, proto.Unmarshal(b, msg))
 	require.Equal(t, len(msg.Validators), 2) // valCount+1
 	require.Equal(t, msg.Validators[1].FeeRecipientAddress, feeRecipientAddr)
+
+	entries, err := os.ReadDir(tmp)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(entries))
+
+	require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest-backup"))
+	require.True(t, strings.Contains(entries[1].Name(), "cluster-manifest"))
 }
 
 func TestValidateP2PKeysOrder(t *testing.T) {

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -122,7 +123,7 @@ func TestRunAddValidators(t *testing.T) {
 
 	tmp := t.TempDir()
 	manifestFile := path.Join(tmp, "cluster-manifest.pb")
-
+	backupDir := path.Join(tmp, "cluster-manifest-backups")
 	conf := addValidatorsConfig{
 		NumVals:           1,
 		WithdrawalAddrs:   []string{feeRecipientAddr},
@@ -131,7 +132,8 @@ func TestRunAddValidators(t *testing.T) {
 			Lock:    &lock,
 			P2PKeys: p2pKeys,
 		},
-		ManifestFile: manifestFile,
+		ManifestFile:      manifestFile,
+		ManifestBackupDir: backupDir,
 	}
 
 	err := runAddValidatorsSolo(context.Background(), conf)
@@ -141,10 +143,25 @@ func TestRunAddValidators(t *testing.T) {
 	b, err := os.ReadFile(manifestFile)
 	require.NoError(t, err)
 
-	var msg manifestpb.Cluster
-	require.NoError(t, proto.Unmarshal(b, &msg))
+	msg := new(manifestpb.Cluster)
+	require.NoError(t, proto.Unmarshal(b, msg))
 	require.Equal(t, len(msg.Validators), 2) // valCount+1
 	require.Equal(t, msg.Validators[1].FeeRecipientAddress, feeRecipientAddr)
+
+	// Verify if backup directory is created
+	entries, err := os.ReadDir(backupDir)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(entries))
+	require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest-backup"))
+
+	backupFile := path.Join(backupDir, entries[0].Name())
+	b, err = os.ReadFile(backupFile)
+	require.NoError(t, err)
+
+	// Verify if backup manifest still contains a single validator, ie, it is unchanged
+	msgBackup := new(manifestpb.Cluster)
+	require.NoError(t, proto.Unmarshal(b, msgBackup))
+	require.Equal(t, len(msgBackup.Validators), valCount)
 }
 
 func TestValidateP2PKeysOrder(t *testing.T) {
@@ -195,5 +212,40 @@ func TestValidateP2PKeysOrder(t *testing.T) {
 
 		err := validateP2PKeysOrder(p2pKeys, ops)
 		require.ErrorContains(t, err, "invalid p2p key order")
+	})
+}
+
+func TestWriteClusterBackup(t *testing.T) {
+	t.Run("dir is a file", func(t *testing.T) {
+		file := path.Join(t.TempDir(), "clusters")
+		_, err := os.Create(file)
+		require.NoError(t, err)
+
+		err = writeManifestBackup(file, &manifestpb.Cluster{})
+		require.ErrorContains(t, err, "backup dir already exists and is a file")
+	})
+
+	t.Run("dir already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		clusterName := "Test#001"
+		err := writeManifestBackup(dir, &manifestpb.Cluster{Name: clusterName})
+		require.NoError(t, err)
+
+		entries, err := os.ReadDir(dir)
+		require.NoError(t, err)
+		require.Equal(t, 1, len(entries))
+		require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest-backup"))
+
+		b, err := os.ReadFile(path.Join(dir, entries[0].Name()))
+		require.NoError(t, err)
+
+		var msg manifestpb.Cluster
+		require.NoError(t, proto.Unmarshal(b, &msg))
+		require.Equal(t, clusterName, msg.Name)
+	})
+
+	t.Run("create backup dir", func(t *testing.T) {
+		err := writeManifestBackup("", &manifestpb.Cluster{})
+		require.ErrorContains(t, err, "create backup dir")
 	})
 }


### PR DESCRIPTION
Backup `cluster-manifest.pb` files before overriding.

Also adds a new flag `--data-dir` to specify the directory where the backups will be stored, default is `.charon`.

The backup filenames following this pattern: `cluster-manifest-backup-20060102150405.pb`.

category: feature 
ticket: #2345 
