### PR TITLE
combine: add support for `--no-verify`

### DIFF
--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -11,11 +11,12 @@ import (
 	"github.com/obolnetwork/charon/cmd/combine"
 )
 
-func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir string, force bool) error) *cobra.Command {
+func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir string, force, noverify bool) error) *cobra.Command {
 	var (
 		clusterDir string
 		outputDir  string
 		force      bool
+		noverify   bool
 	)
 
 	cmd := &cobra.Command{
@@ -24,7 +25,13 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir strin
 		Long:  "Combines the private key shares from a threshold of operators in a distributed validator cluster into a set of validator private keys that can be imported into a standard Ethereum validator client.\n\nWarning: running the resulting private keys in a validator alongside the original distributed validator cluster *will* result in slashing.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runFunc(cmd.Context(), clusterDir, outputDir, force)
+			return runFunc(
+				cmd.Context(),
+				clusterDir,
+				outputDir,
+				force,
+				noverify,
+			)
 		},
 	}
 
@@ -35,11 +42,13 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir strin
 		&force,
 	)
 
+	bindNoVerifyFlag(cmd.Flags(), &noverify)
+
 	return cmd
 }
 
-func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force bool) error {
-	return combine.Combine(ctx, clusterDir, outputDir, force)
+func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force, noverify bool) error {
+	return combine.Combine(ctx, clusterDir, outputDir, force, noverify)
 }
 
 func bindCombineFlags(flags *pflag.FlagSet, clusterDir, outputDir *string, force *bool) {

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -143,12 +143,12 @@ func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bo
 
 // shareIdxByPubkeys maps private keys to the valIndex validator public shares in the manifest file.
 // It preserves the order as found in the validator public share slice.
-func shareIdxByPubkeys(manifest *manifestpb.Cluster, secrets []tbls.PrivateKey, valIndex int) (map[int]tbls.PrivateKey, error) {
+func shareIdxByPubkeys(cluster *manifestpb.Cluster, secrets []tbls.PrivateKey, valIndex int) (map[int]tbls.PrivateKey, error) {
 	pubkMap := make(map[tbls.PublicKey]int)
 
-	for peerIdx := 0; peerIdx < len(manifest.Validators[valIndex].PubShares); peerIdx++ {
+	for peerIdx := 0; peerIdx < len(cluster.Validators[valIndex].PubShares); peerIdx++ {
 		peerIdx := peerIdx
-		pubShareRaw := manifest.Validators[valIndex].GetPubShares()[peerIdx]
+		pubShareRaw := cluster.Validators[valIndex].GetPubShares()[peerIdx]
 
 		pubShare, err := tblsconv.PubkeyFromBytes(pubShareRaw)
 		if err != nil {
@@ -208,7 +208,7 @@ func loadManifest(ctx context.Context, dir string, noverify bool) (*manifestpb.C
 
 	var (
 		possibleValKeysDir []string
-		lastManifest       *manifestpb.Cluster
+		lastCluster        *manifestpb.Cluster
 	)
 
 	for _, sd := range root {
@@ -235,14 +235,14 @@ func loadManifest(ctx context.Context, dir string, noverify bool) (*manifestpb.C
 
 		possibleValKeysDir = append(possibleValKeysDir, vcdPath)
 
-		lastManifest = cl
+		lastCluster = cl
 	}
 
-	if lastManifest == nil {
+	if lastCluster == nil {
 		return nil, nil, errors.New("no manifest file found")
 	}
 
-	return lastManifest, possibleValKeysDir, nil
+	return lastCluster, possibleValKeysDir, nil
 }
 
 func verifyLock(ctx context.Context, lock cluster.Lock, noverify bool) error {

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -128,7 +128,7 @@ func TestCombineNoVerifyDifferentValidatorData(t *testing.T) {
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
 	combineTest(t, lock, shares, true, true, func(valIndex int, src cluster.Lock) cluster.Lock {
 		if valIndex == 1 {
-			src.Validators[valIndex].PubKey = bytes.Repeat([]byte{42}, 32)
+			src.Validators[valIndex].PubKey = bytes.Repeat([]byte{42}, 48)
 		}
 
 		return src

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -3,6 +3,7 @@
 package combine_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,11 +19,15 @@ import (
 	"github.com/obolnetwork/charon/tbls"
 )
 
+func noLockModif(_ int, l cluster.Lock) cluster.Lock {
+	return l
+}
+
 func TestCombineNoLockfile(t *testing.T) {
 	td := t.TempDir()
 	od := t.TempDir()
-	err := combine.Combine(context.Background(), td, od, false)
-	require.ErrorContains(t, err, "lock file not found")
+	err := combine.Combine(context.Background(), td, od, false, false)
+	require.ErrorContains(t, err, "no manifest file found")
 }
 
 func TestCombineCannotLoadKeystore(t *testing.T) {
@@ -77,22 +82,67 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "node0")))
 
-	err := combine.Combine(context.Background(), dir, od, false, combine.WithInsecureKeysForT(t))
+	err := combine.Combine(context.Background(), dir, od, false, false, combine.WithInsecureKeysForT(t))
 	require.Error(t, err)
 }
 
 // This test exists because of https://github.com/ObolNetwork/charon/issues/2151.
 func TestCombineLotsOfVals(t *testing.T) {
 	lock, _, shares := cluster.NewForT(t, 100, 3, 4, 0)
-	combineTest(t, lock, shares)
+	combineTest(t, lock, shares, false, false, noLockModif)
 }
 
 func TestCombine(t *testing.T) {
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
-	combineTest(t, lock, shares)
+	combineTest(t, lock, shares, false, false, noLockModif)
 }
 
-func combineTest(t *testing.T, lock cluster.Lock, shares [][]tbls.PrivateKey) {
+func TestCombineNoVerifyGoodLock(t *testing.T) {
+	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
+	combineTest(t, lock, shares, true, false, noLockModif)
+}
+
+func TestCombineNoVerifyBadLock(t *testing.T) {
+	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
+	combineTest(t, lock, shares, true, false, func(valIndex int, src cluster.Lock) cluster.Lock {
+		if valIndex == 1 {
+			src.Name = "booohooo"
+		}
+
+		return src
+	})
+}
+
+func TestCombineBadLock(t *testing.T) {
+	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
+	combineTest(t, lock, shares, false, true, func(valIndex int, src cluster.Lock) cluster.Lock {
+		if valIndex == 1 {
+			src.Name = "booohooo"
+		}
+
+		return src
+	})
+}
+
+func TestCombineNoVerifyDifferentValidatorData(t *testing.T) {
+	lock, _, shares := cluster.NewForT(t, 2, 3, 4, 0)
+	combineTest(t, lock, shares, true, true, func(valIndex int, src cluster.Lock) cluster.Lock {
+		if valIndex == 1 {
+			src.Validators[valIndex].PubKey = bytes.Repeat([]byte{42}, 32)
+		}
+
+		return src
+	})
+}
+
+func combineTest(
+	t *testing.T,
+	lock cluster.Lock,
+	shares [][]tbls.PrivateKey,
+	noVerify bool,
+	wantErr bool,
+	modifyLockFile func(valIndex int, src cluster.Lock) cluster.Lock,
+) {
 	t.Helper()
 
 	// calculate expected public keys and secrets
@@ -147,6 +197,7 @@ func combineTest(t *testing.T, lock cluster.Lock, shares [][]tbls.PrivateKey) {
 	}
 
 	for idx, keys := range secrets {
+		idx := idx
 		ep := filepath.Join(dir, fmt.Sprintf("node%d", idx))
 
 		vk := filepath.Join(ep, "validator_keys")
@@ -158,10 +209,15 @@ func combineTest(t *testing.T, lock cluster.Lock, shares [][]tbls.PrivateKey) {
 		lf, err := os.OpenFile(filepath.Join(ep, "cluster-lock.json"), os.O_WRONLY|os.O_CREATE, 0o755)
 		require.NoError(t, err)
 
-		require.NoError(t, json.NewEncoder(lf).Encode(lock))
+		require.NoError(t, json.NewEncoder(lf).Encode(modifyLockFile(idx, lock)))
 	}
 
-	err := combine.Combine(context.Background(), dir, od, true, combine.WithInsecureKeysForT(t))
+	err := combine.Combine(context.Background(), dir, od, true, noVerify, combine.WithInsecureKeysForT(t))
+	if wantErr {
+		require.Error(t, err)
+		return
+	}
+
 	require.NoError(t, err)
 
 	keyFiles, err := keystore.LoadFilesUnordered(od)
@@ -252,10 +308,10 @@ func TestCombineTwiceWithoutForceFails(t *testing.T) {
 		require.NoError(t, json.NewEncoder(lf).Encode(lock))
 	}
 
-	err := combine.Combine(context.Background(), dir, od, false, combine.WithInsecureKeysForT(t))
+	err := combine.Combine(context.Background(), dir, od, false, false, combine.WithInsecureKeysForT(t))
 	require.NoError(t, err)
 
-	err = combine.Combine(context.Background(), dir, od, false, combine.WithInsecureKeysForT(t))
+	err = combine.Combine(context.Background(), dir, od, false, false, combine.WithInsecureKeysForT(t))
 	require.Error(t, err)
 
 	keyFiles, err := keystore.LoadFilesUnordered(od)


### PR DESCRIPTION
This flag warns the user if any of the cluster manifest files fail hash verification.

It behaves like exactly like `charon run --no-verify`.

The code will not stop if a diverging set of validator keys is present in the cluster manifests, but will error if not all public keys yielded by the combined private keys are present in the validator keys set.

category: feature
ticket: #2321 
