### PR TITLE
core: increase inclusion checks

### DIFF
--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -84,6 +84,7 @@ func TestInclusion(t *testing.T) {
 			included = append(included, sub.Duty)
 		},
 		trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
+		submissions:     make(map[subkey]submission),
 	}
 
 	// Create some duties


### PR DESCRIPTION
Submit inclusion check regardless the outcome of broadcasting, since even though we might fail to broadcast, peers may have succeeded. 

This is mostly the case in blinded beacon blocks since only a single peer will have the original builder connected.

Also make `inclTracker.Submitted` idempotent, since it may now be called multiple times on retries.

category: bug
ticket: none
