### PR TITLE
compose/smoke: add blinded block smoke tests

### DIFF
--- a/testutil/compose/compose_internal_test.go
+++ b/testutil/compose/compose_internal_test.go
@@ -100,6 +100,6 @@ func TestParseTemplate(t *testing.T) {
 	_, err := template.New("").Parse(string(tmpl))
 	require.NoError(t, err)
 
-	_, err = getVC(VCTeku, 0, 1, false)
+	_, err = getVC(VCTeku, 0, 1, false, true)
 	require.NoError(t, err)
 }

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -117,6 +117,9 @@ type Config struct {
 
 	// Monitoring enables monitoring stack for the compose cluster. It includes grafana, loki and jaeger services.
 	Monitoring bool `json:"monitoring"`
+
+	// BuilderAPI enables the builder API for the compose cluster.
+	BuilderAPI bool `json:"builder_api"`
 }
 
 // VCStrings returns the VCs field as a slice of strings.

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -142,6 +142,7 @@ func newNodeEnvs(index int, conf Config, vcType VCType) []kv {
 		kv{"loki-addresses", "http://loki:3100/loki/api/v1/push"},
 		kv{"loki-service", fmt.Sprintf("node%d", index)},
 		kv{"synthetic-block-proposals", fmt.Sprintf(`"%v"`, conf.SyntheticBlockProposals)},
+		kv{"builder-api", fmt.Sprintf(`"%v"`, conf.BuilderAPI)},
 	)
 }
 

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -153,6 +153,19 @@ func TestSmoke(t *testing.T) {
 				conf.VCs = []compose.VCType{compose.VCLodestar}
 			},
 		},
+		{
+			Name: "blinded_blocks_vmock",
+			ConfigFunc: func(conf *compose.Config) {
+				conf.BuilderAPI = true
+			},
+		},
+		{
+			Name: "blinded_blocks_teku",
+			ConfigFunc: func(conf *compose.Config) {
+				conf.BuilderAPI = true
+				conf.VCs = []compose.VCType{compose.VCTeku}
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -110,9 +110,9 @@ func TestSmoke(t *testing.T) {
 			},
 			RunTmplFunc: func(data *compose.TmplData) {
 				data.VCs[0].Image = "consensys/teku:latest"
-				data.VCs[1].Image = "consensys/teku:22.5"
-				data.VCs[2].Image = "consensys/teku:22.4"
-				data.VCs[3].Image = "consensys/teku:22.3"
+				data.VCs[1].Image = "consensys/teku:23.6.0"
+				data.VCs[2].Image = "consensys/teku:23.5.0"
+				data.VCs[3].Image = "consensys/teku:23.4.0"
 			},
 		},
 		{

--- a/testutil/compose/testdata/TestDockerCompose_run_template.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_template.golden
@@ -92,6 +92,10 @@
     {
      "Key": "synthetic-block-proposals",
      "Value": "\"true\""
+    },
+    {
+     "Key": "builder-api",
+     "Value": "\"false\""
     }
    ],
    "Ports": [
@@ -201,6 +205,10 @@
     {
      "Key": "synthetic-block-proposals",
      "Value": "\"true\""
+    },
+    {
+     "Key": "builder-api",
+     "Value": "\"false\""
     }
    ],
    "Ports": [
@@ -310,6 +318,10 @@
     {
      "Key": "synthetic-block-proposals",
      "Value": "\"true\""
+    },
+    {
+     "Key": "builder-api",
+     "Value": "\"false\""
     }
    ],
    "Ports": [
@@ -419,6 +431,10 @@
     {
      "Key": "synthetic-block-proposals",
      "Value": "\"true\""
+    },
+    {
+     "Key": "builder-api",
+     "Value": "\"false\""
     }
    ],
    "Ports": [
@@ -446,7 +462,7 @@
    "Label": "teku",
    "Image": "consensys/teku:latest",
    "Build": "",
-   "Command": "|\n      validator-client\n      --network=auto\n      --beacon-node-api-endpoint=\"http://node0:3600\"\n      --validator-keys=\"/compose/node0/validator_keys/keystore-0.json:/compose/node0/validator_keys/keystore-0.txt\"\n      --validator-keys=\"/compose/node0/validator_keys/keystore-1.json:/compose/node0/validator_keys/keystore-1.txt\"\n      --validators-proposer-default-fee-recipient=\"0x0000000000000000000000000000000000000000\"",
+   "Command": "|\n      validator-client\n      --network=auto\n      --beacon-node-api-endpoint=\"http://node0:3600\"\n      --validator-keys=\"/compose/node0/validator_keys/keystore-0.json:/compose/node0/validator_keys/keystore-0.txt\"\n      --validator-keys=\"/compose/node0/validator_keys/keystore-1.json:/compose/node0/validator_keys/keystore-1.txt\"\n      --validators-proposer-default-fee-recipient=\"0x0000000000000000000000000000000000000000\"\n      --validators-proposer-blinded-blocks-enabled=false",
    "Ports": null
   },
   {
@@ -467,7 +483,7 @@
    "Label": "teku",
    "Image": "consensys/teku:latest",
    "Build": "",
-   "Command": "|\n      validator-client\n      --network=auto\n      --beacon-node-api-endpoint=\"http://node3:3600\"\n      --validator-keys=\"/compose/node3/validator_keys/keystore-0.json:/compose/node3/validator_keys/keystore-0.txt\"\n      --validator-keys=\"/compose/node3/validator_keys/keystore-1.json:/compose/node3/validator_keys/keystore-1.txt\"\n      --validators-proposer-default-fee-recipient=\"0x0000000000000000000000000000000000000000\"",
+   "Command": "|\n      validator-client\n      --network=auto\n      --beacon-node-api-endpoint=\"http://node3:3600\"\n      --validator-keys=\"/compose/node3/validator_keys/keystore-0.json:/compose/node3/validator_keys/keystore-0.txt\"\n      --validator-keys=\"/compose/node3/validator_keys/keystore-1.json:/compose/node3/validator_keys/keystore-1.txt\"\n      --validators-proposer-default-fee-recipient=\"0x0000000000000000000000000000000000000000\"\n      --validators-proposer-blinded-blocks-enabled=false",
    "Ports": null
   }
  ],

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -33,6 +33,7 @@ services:
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node0
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
+      CHARON_BUILDER_API: "false"
     
     ports:
       - "3600:3600"
@@ -68,6 +69,7 @@ services:
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node1
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
+      CHARON_BUILDER_API: "false"
     
     ports:
       - "13600:3600"
@@ -103,6 +105,7 @@ services:
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node2
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
+      CHARON_BUILDER_API: "false"
     
     ports:
       - "23600:3600"
@@ -138,6 +141,7 @@ services:
       CHARON_LOKI_ADDRESSES: http://loki:3100/loki/api/v1/push
       CHARON_LOKI_SERVICE: node3
       CHARON_SYNTHETIC_BLOCK_PROPOSALS: "true"
+      CHARON_BUILDER_API: "false"
     
     ports:
       - "33600:3600"
@@ -172,6 +176,7 @@ services:
       --validator-keys="/compose/node0/validator_keys/keystore-0.json:/compose/node0/validator_keys/keystore-0.txt"
       --validator-keys="/compose/node0/validator_keys/keystore-1.json:/compose/node0/validator_keys/keystore-1.txt"
       --validators-proposer-default-fee-recipient="0x0000000000000000000000000000000000000000"
+      --validators-proposer-blinded-blocks-enabled=false
     networks: [compose]
     depends_on: [node0]
     environment:
@@ -197,6 +202,7 @@ services:
       --validator-keys="/compose/node3/validator_keys/keystore-0.json:/compose/node3/validator_keys/keystore-0.txt"
       --validator-keys="/compose/node3/validator_keys/keystore-1.json:/compose/node3/validator_keys/keystore-1.txt"
       --validators-proposer-default-fee-recipient="0x0000000000000000000000000000000000000000"
+      --validators-proposer-blinded-blocks-enabled=false
     networks: [compose]
     depends_on: [node3]
     environment:

--- a/testutil/compose/testdata/TestNewDefaultConfig.golden
+++ b/testutil/compose/testdata/TestNewDefaultConfig.golden
@@ -21,5 +21,6 @@
  "slot_duration": 1000000000,
  "fuzz": false,
  "synthetic_block_proposals": true,
- "monitoring": true
+ "monitoring": true,
+ "builder_api": false
 }


### PR DESCRIPTION
Adds compose smoke tests for blinded blocks, both vmock and teku.

category: test
ticket: #2317
