### PR TITLE
cluster/manifest: load cluster from disk

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -72,7 +72,7 @@ type Config struct {
 	Log                     log.Config
 	Feature                 featureset.Config
 	LockFile                string
-	ClusterManifestFile     string
+	ManifestFile            string
 	NoVerify                bool
 	PrivKeyFile             string
 	PrivKeyLocking          bool

--- a/app/app.go
+++ b/app/app.go
@@ -72,6 +72,7 @@ type Config struct {
 	Log                     log.Config
 	Feature                 featureset.Config
 	LockFile                string
+	ClusterManifestFile     string
 	NoVerify                bool
 	PrivKeyFile             string
 	PrivKeyLocking          bool

--- a/app/disk.go
+++ b/app/disk.go
@@ -34,7 +34,7 @@ func loadClusterManifest(ctx context.Context, conf Config) (*manifestpb.Cluster,
 		return nil
 	}
 
-	cluster, err := manifest.Load(conf.LockFile, verifyLock)
+	cluster, _, err := manifest.Load(conf.ClusterManifestFile, conf.LockFile, verifyLock)
 	if err != nil {
 		return nil, errors.Wrap(err, "load cluster manifest")
 	}

--- a/app/disk.go
+++ b/app/disk.go
@@ -34,7 +34,7 @@ func loadClusterManifest(ctx context.Context, conf Config) (*manifestpb.Cluster,
 		return nil
 	}
 
-	cluster, _, err := manifest.Load(conf.ClusterManifestFile, conf.LockFile, verifyLock)
+	cluster, _, err := manifest.Load(conf.ManifestFile, conf.LockFile, verifyLock)
 	if err != nil {
 		return nil, errors.Wrap(err, "load cluster manifest")
 	}

--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -16,7 +16,6 @@ import (
 // Load loads a cluster from disk and returns true if cluster was loaded from a legacy lock file.
 // It supports reading from both cluster manifest and legacy lock files.
 // If both files are provided, it first reads the manifest file before reading the legacy lock file.
-// TODO(xenowits): Remove loading from legacy lock when we fully adopt mutable cluster manifests.
 func Load(manifestFile, legacyLockFile string, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, bool, error) {
 	b, err := os.ReadFile(manifestFile)
 	if err == nil {

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -75,7 +75,7 @@ func TestLoad(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			loaded, loadMetadata, err := manifest.Load(tt.manifestFile, tt.legacyLockFile, nil)
+			loaded, isLegacyLock, err := manifest.Load(tt.manifestFile, tt.legacyLockFile, nil)
 			if tt.errorMsg != "" {
 				require.ErrorContains(t, err, tt.errorMsg)
 				return
@@ -83,13 +83,7 @@ func TestLoad(t *testing.T) {
 
 			require.True(t, proto.Equal(cluster, loaded))
 
-			if tt.isLegacyLock {
-				require.Equal(t, tt.legacyLockFile, loadMetadata.Filename)
-			} else {
-				require.Equal(t, tt.manifestFile, loadMetadata.Filename)
-			}
-
-			require.Equal(t, tt.isLegacyLock, loadMetadata.IsLegacyLock)
+			require.Equal(t, tt.isLegacyLock, isLegacyLock)
 		})
 	}
 }
@@ -115,7 +109,7 @@ func testLoadLegacy(t *testing.T, version string) {
 	err = os.WriteFile(file, b, 0o644)
 	require.NoError(t, err)
 
-	cluster, loadMetadata, err := manifest.Load("", file, nil)
+	cluster, isLegacyLock, err := manifest.Load("", file, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, lock.LockHash, cluster.Hash)
@@ -125,8 +119,7 @@ func testLoadLegacy(t *testing.T, version string) {
 	require.Equal(t, lock.ForkVersion, cluster.ForkVersion)
 	require.Equal(t, len(lock.Validators), len(cluster.Validators))
 	require.Equal(t, len(lock.Operators), len(cluster.Operators))
-	require.Equal(t, loadMetadata.IsLegacyLock, true)
-	require.Equal(t, loadMetadata.Filename, file)
+	require.Equal(t, isLegacyLock, true)
 
 	for i, validator := range cluster.Validators {
 		require.Equal(t, lock.Validators[i].PubKey, validator.PublicKey)

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -50,6 +50,7 @@ func TestLoad(t *testing.T) {
 		name           string
 		manifestFile   string
 		legacyLockFile string
+		isLegacyLock   bool
 		errorMsg       string
 	}{
 		{
@@ -63,6 +64,7 @@ func TestLoad(t *testing.T) {
 		{
 			name:           "only legacy lock",
 			legacyLockFile: legacyLockFile,
+			isLegacyLock:   true,
 		},
 		{
 			name:           "both files",
@@ -73,13 +75,21 @@ func TestLoad(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			loaded, _, err := manifest.Load(tt.manifestFile, tt.legacyLockFile, nil)
+			loaded, loadMetadata, err := manifest.Load(tt.manifestFile, tt.legacyLockFile, nil)
 			if tt.errorMsg != "" {
 				require.ErrorContains(t, err, tt.errorMsg)
 				return
 			}
 
 			require.True(t, proto.Equal(cluster, loaded))
+
+			if tt.isLegacyLock {
+				require.Equal(t, tt.legacyLockFile, loadMetadata.Filename)
+			} else {
+				require.Equal(t, tt.manifestFile, loadMetadata.Filename)
+			}
+
+			require.Equal(t, tt.isLegacyLock, loadMetadata.IsLegacyLock)
 		})
 	}
 }

--- a/cluster/manifest/mutationlegacylock_test.go
+++ b/cluster/manifest/mutationlegacylock_test.go
@@ -56,10 +56,9 @@ func TestLegacyLock(t *testing.T) {
 	})
 
 	t.Run("cluster loaded from lock", func(t *testing.T) {
-		cluster, loadMetadata, err := manifest.Load("", "testdata/lock.json", nil)
+		cluster, isLegacyLock, err := manifest.Load("", "testdata/lock.json", nil)
 		require.NoError(t, err)
-		require.Equal(t, true, loadMetadata.IsLegacyLock)
-		require.Equal(t, "testdata/lock.json", loadMetadata.Filename)
+		require.Equal(t, true, isLegacyLock)
 
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})
@@ -73,10 +72,9 @@ func TestLegacyLock(t *testing.T) {
 		file := path.Join(t.TempDir(), "manifest.pb")
 		require.NoError(t, os.WriteFile(file, b, 0o644))
 
-		cluster, loadMetadata, err := manifest.Load(file, "", nil)
+		cluster, isLegacyLock, err := manifest.Load(file, "", nil)
 		require.NoError(t, err)
-		require.Equal(t, false, loadMetadata.IsLegacyLock)
-		require.Equal(t, file, loadMetadata.Filename)
+		require.Equal(t, false, isLegacyLock)
 
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})

--- a/cluster/manifest/mutationlegacylock_test.go
+++ b/cluster/manifest/mutationlegacylock_test.go
@@ -25,27 +25,27 @@ func TestZeroCluster(t *testing.T) {
 }
 
 func TestLegacyLock(t *testing.T) {
-	lockJON, err := os.ReadFile("testdata/lock.json")
+	lockJSON, err := os.ReadFile("testdata/lock.json")
 	require.NoError(t, err)
 
 	var lock cluster.Lock
-	testutil.RequireNoError(t, json.Unmarshal(lockJON, &lock))
+	testutil.RequireNoError(t, json.Unmarshal(lockJSON, &lock))
 
-	signed, err := manifest.NewLegacyLock(lock)
+	legacyLock, err := manifest.NewLegacyLock(lock)
 	require.NoError(t, err)
 
 	t.Run("proto", func(t *testing.T) {
-		testutil.RequireGoldenProto(t, signed)
+		testutil.RequireGoldenProto(t, legacyLock)
 	})
 
 	t.Run("cluster", func(t *testing.T) {
-		cluster, err := manifest.Materialise(&manifestpb.SignedMutationList{Mutations: []*manifestpb.SignedMutation{signed}})
+		cluster, err := manifest.Materialise(&manifestpb.SignedMutationList{Mutations: []*manifestpb.SignedMutation{legacyLock}})
 		require.NoError(t, err)
 		require.Equal(t, lock.LockHash, cluster.Hash)
-		testutil.RequireGoldenProto(t, cluster)
+		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})
 
-	b, err := proto.Marshal(signed)
+	b, err := proto.Marshal(legacyLock)
 	require.NoError(t, err)
 
 	signed2 := new(manifestpb.SignedMutation)
@@ -56,19 +56,28 @@ func TestLegacyLock(t *testing.T) {
 	})
 
 	t.Run("cluster loaded from lock", func(t *testing.T) {
-		cluster, err := manifest.Load("testdata/lock.json", nil)
+		cluster, loadMetadata, err := manifest.Load("", "testdata/lock.json", nil)
 		require.NoError(t, err)
+		require.Equal(t, true, loadMetadata.IsLegacyLock)
+		require.Equal(t, "testdata/lock.json", loadMetadata.Filename)
+
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})
 
 	t.Run("cluster loaded from manifest", func(t *testing.T) {
-		b, err := proto.Marshal(&manifestpb.SignedMutationList{Mutations: []*manifestpb.SignedMutation{signed}})
+		cluster, err := manifest.Materialise(&manifestpb.SignedMutationList{Mutations: []*manifestpb.SignedMutation{legacyLock}})
+		require.NoError(t, err)
+
+		b, err := proto.Marshal(cluster)
 		require.NoError(t, err)
 		file := path.Join(t.TempDir(), "manifest.pb")
 		require.NoError(t, os.WriteFile(file, b, 0o644))
 
-		cluster, err := manifest.Load(file, nil)
+		cluster, loadMetadata, err := manifest.Load(file, "", nil)
 		require.NoError(t, err)
+		require.Equal(t, false, loadMetadata.IsLegacyLock)
+		require.Equal(t, file, loadMetadata.Filename)
+
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})
 }

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -33,9 +33,9 @@ type addValidatorsConfig struct {
 	WithdrawalAddrs   []string // Withdrawal address of each validator
 	FeeRecipientAddrs []string // Fee recipient address of each validator
 
-	Lockfile            string   // Path to the legacy cluster lock file
-	ClusterManifestFile string   // Path to the cluster manifest file
-	EnrPrivKeyfiles     []string // Paths to node enr private keys
+	Lockfile        string   // Path to the legacy cluster lock file
+	ManifestFile    string   // Path to the cluster manifest file
+	EnrPrivKeyfiles []string // Paths to node enr private keys
 
 	TestConfig TestConfig
 }
@@ -72,7 +72,7 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each new validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each new validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
 	cmd.Flags().StringVar(&config.Lockfile, "lock-file", ".charon/cluster-lock.json", "The path to the legacy cluster lock file defining distributed validator cluster. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
-	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
+	cmd.Flags().StringVar(&config.ManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringSliceVar(&config.EnrPrivKeyfiles, "private-key-files", nil, "Comma separated list of paths to charon enr private key files. This should be in the same order as the operators, ie, first private key file should correspond to the first operator and so on.")
 }
 
@@ -154,7 +154,7 @@ func runAddValidatorsSolo(_ context.Context, conf addValidatorsConfig) (err erro
 	}
 
 	// Save cluster manifest to disk
-	err = writeClusterManifest(conf.ClusterManifestFile, cluster)
+	err = writeClusterManifest(conf.ManifestFile, cluster)
 	if err != nil {
 		return errors.Wrap(err, "write cluster manifest")
 	}
@@ -214,7 +214,7 @@ func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, manifes
 		return nil
 	}
 
-	cluster, loadMetadata, err := manifest.Load(conf.ClusterManifestFile, conf.Lockfile, verifyLock)
+	cluster, loadMetadata, err := manifest.Load(conf.ManifestFile, conf.Lockfile, verifyLock)
 	if err != nil {
 		return nil, manifest.LoadMetadata{}, errors.Wrap(err, "load cluster manifest")
 	}

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -131,7 +131,7 @@ func TestRunAddValidators(t *testing.T) {
 			Lock:    &lock,
 			P2PKeys: p2pKeys,
 		},
-		ClusterManifestFile: manifestFile,
+		ManifestFile: manifestFile,
 	}
 
 	err := runAddValidatorsSolo(context.Background(), conf)

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -72,6 +72,7 @@ func TestCmdFlags(t *testing.T) {
 					Disabled:  nil,
 				},
 				LockFile:               ".charon/cluster-lock.json",
+				ClusterManifestFile:    ".charon/cluster-manifest.pb",
 				PrivKeyFile:            ".charon/charon-enr-private-key",
 				PrivKeyLocking:         false,
 				SimnetValidatorKeysDir: ".charon/validator_keys",

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -72,7 +72,7 @@ func TestCmdFlags(t *testing.T) {
 					Disabled:  nil,
 				},
 				LockFile:               ".charon/cluster-lock.json",
-				ClusterManifestFile:    ".charon/cluster-manifest.pb",
+				ManifestFile:           ".charon/cluster-manifest.pb",
 				PrivKeyFile:            ".charon/charon-enr-private-key",
 				PrivKeyLocking:         false,
 				SimnetValidatorKeysDir: ".charon/validator_keys",

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -217,9 +217,10 @@ func loadManifest(ctx context.Context, dir string, noverify bool) (*manifestpb.C
 		}
 
 		// try opening the lock file
-		lfPath := filepath.Join(dir, sd.Name(), "cluster-lock.json")
+		lockFile := filepath.Join(dir, sd.Name(), "cluster-lock.json")
+		manifestFile := filepath.Join(dir, sd.Name(), "cluster-manifest.pb")
 
-		cl, err := manifest.Load(lfPath, func(lock cluster.Lock) error {
+		cl, _, err := manifest.Load(manifestFile, lockFile, func(lock cluster.Lock) error {
 			return verifyLock(ctx, lock, noverify)
 		})
 		if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,6 +63,7 @@ func bindNoVerifyFlag(flags *pflag.FlagSet, config *bool) {
 
 func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringVar(&config.LockFile, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster.")
+	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringSliceVar(&config.BeaconNodeAddrs, "beacon-node-endpoints", nil, "Comma separated list of one or more beacon node endpoint URLs.")
 	cmd.Flags().StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API.")
 	cmd.Flags().StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the monitoring API (prometheus, pprof).")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -63,7 +63,7 @@ func bindNoVerifyFlag(flags *pflag.FlagSet, config *bool) {
 
 func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringVar(&config.LockFile, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
-	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
+	cmd.Flags().StringVar(&config.ManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringSliceVar(&config.BeaconNodeAddrs, "beacon-node-endpoints", nil, "Comma separated list of one or more beacon node endpoint URLs.")
 	cmd.Flags().StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API.")
 	cmd.Flags().StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the monitoring API (prometheus, pprof).")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -62,7 +62,7 @@ func bindNoVerifyFlag(flags *pflag.FlagSet, config *bool) {
 }
 
 func bindRunFlags(cmd *cobra.Command, config *app.Config) {
-	cmd.Flags().StringVar(&config.LockFile, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster.")
+	cmd.Flags().StringVar(&config.LockFile, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining distributed validator cluster. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringVar(&config.ClusterManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringSliceVar(&config.BeaconNodeAddrs, "beacon-node-endpoints", nil, "Comma separated list of one or more beacon node endpoint URLs.")
 	cmd.Flags().StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -134,6 +134,7 @@ Flags:
       --log-level string                   Log level; debug, info, warn or error (default "info")
       --loki-addresses strings             Enables sending of logfmt structured logs to these Loki log aggregation server addresses. This is in addition to normal stderr logs.
       --loki-service string                Service label sent with logs to Loki. (default "charon")
+      --manifest-file string               The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence. (default ".charon/cluster-manifest.pb")
       --monitoring-address string          Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
       --no-verify                          Disables cluster definition and lock file verification.
       --p2p-allowlist string               Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -128,7 +128,7 @@ Flags:
   -h, --help                               Help for run
       --jaeger-address string              Listening address for jaeger tracing.
       --jaeger-service string              Service name used for jaeger tracing. (default "charon")
-      --lock-file string                   The path to the cluster lock file defining distributed validator cluster. (default ".charon/cluster-lock.json")
+      --lock-file string                   The path to the cluster lock file defining distributed validator cluster. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence. (default ".charon/cluster-lock.json")
       --log-color string                   Log color; auto, force, disable. (default "auto")
       --log-format string                  Log format; console, logfmt or json (default "console")
       --log-level string                   Log level; debug, info, warn or error (default "info")


### PR DESCRIPTION
Loads cluster either from `cluster manifest` or `legacy lock` file. If both files are provided, `cluster manifest` is read first.

category: feature 
ticket: #2334 
