### PR TITLE
cmd: fix bug in `add-validators-solo` command

### DIFF
--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -48,6 +48,8 @@ type addValidatorsConfig struct {
 type TestConfig struct {
 	// Lock provides the lock explicitly, skips loading from disk.
 	Lock *cluster.Lock
+	// Manifest provides the cluster manifest explicitly, skips loading from disk.
+	Manifest *manifestpb.Cluster
 	// P2PKeys provides the p2p private keys explicitly, skips loading keystores from disk.
 	P2PKeys []*k1.PrivateKey
 }
@@ -207,6 +209,10 @@ func builderRegistration(secret tbls.PrivateKey, pubkey tbls.PublicKey, feeRecip
 // loadClusterManifest returns the cluster manifest from the provided config. It returns true if
 // the cluster was loaded from a legacy lock file.
 func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, bool, error) {
+	if conf.TestConfig.Manifest != nil {
+		return conf.TestConfig.Manifest, false, nil
+	}
+
 	if conf.TestConfig.Lock != nil {
 		m, err := manifest.NewClusterFromLock(*conf.TestConfig.Lock)
 		return m, false, err

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -146,8 +146,9 @@ func TestRunAddValidators(t *testing.T) {
 
 		var msg manifestpb.Cluster
 		require.NoError(t, proto.Unmarshal(b, &msg))
-		require.Equal(t, len(msg.Validators), 2) // valCount+1
+		require.Equal(t, valCount+1, len(msg.Validators))
 		require.Equal(t, msg.Validators[1].FeeRecipientAddress, feeRecipientAddr)
+		require.Equal(t, msg.Validators[1].WithdrawalAddress, feeRecipientAddr)
 	})
 
 	t.Run("add validators twice", func(t *testing.T) {
@@ -179,7 +180,7 @@ func TestRunAddValidators(t *testing.T) {
 		conf.TestConfig.Lock = nil
 		conf.TestConfig.Manifest = cluster
 
-		// Then add another one
+		// Then add the second validator
 		require.NoError(t, runAddValidatorsSolo(context.Background(), conf))
 
 		b, err = os.ReadFile(manifestFile)

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -187,9 +187,10 @@ func TestRunAddValidators(t *testing.T) {
 		cluster = new(manifestpb.Cluster)
 		require.NoError(t, proto.Unmarshal(b, cluster))
 
-		// The cluster manifest should contain three validators since the original cluster
-		// already had one validator, and we added two more.
+		// The cluster manifest should contain three validators now since the
+		// original cluster already had one validator, and we added two more.
 		require.Equal(t, valCount+2, len(cluster.Validators))
+		require.Equal(t, cluster.InitialMutationHash, lock.LockHash)
 
 		entries, err := os.ReadDir(tmp)
 		require.NoError(t, err)


### PR DESCRIPTION
Fixes bug in `add-validators-solo` command identified [here](https://github.com/ObolNetwork/charon/pull/2369/files#r1243873252).

Also adds a unit test which runs the command twice and ensures that the final manifest has two extra validators as expected.

category: bug 
ticket: none 
