### PR TITLE
cmd: fix bug in test config

### DIFF
--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -215,7 +215,7 @@ func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, bool, e
 
 	if conf.TestConfig.Lock != nil {
 		m, err := manifest.NewClusterFromLock(*conf.TestConfig.Lock)
-		return m, false, err
+		return m, true, err
 	}
 
 	verifyLock := func(lock cluster.Lock) error {


### PR DESCRIPTION
Fixes bug in add-validators test config.

This fixes the build failure on main - https://github.com/ObolNetwork/charon/actions/runs/5397078524/jobs/9801399390

category: bug 
ticket: none 
