### PR TITLE
cmd: fix error message

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -933,11 +933,13 @@ func writeLockToAPI(ctx context.Context, publishAddr string, lock cluster.Lock) 
 // validateAddresses checks if we have sufficient addresses. It also fills addresses slices if only one is provided.
 func validateAddresses(numVals int, feeRecipientAddrs []string, withdrawalAddrs []string) ([]string, []string, error) {
 	if len(feeRecipientAddrs) != numVals && len(feeRecipientAddrs) != 1 {
-		return nil, nil, errors.New("insufficient fee recipient addresses")
+		return nil, nil, errors.New("mismatching --num-validators and --fee-recipient-addresses",
+			z.Int("num_validators", numVals), z.Int("addresses", len(feeRecipientAddrs)))
 	}
 
 	if len(withdrawalAddrs) != numVals && len(withdrawalAddrs) != 1 {
-		return nil, nil, errors.New("insufficient withdrawal addresses")
+		return nil, nil, errors.New("mismatching --num-validators and --withdrawal-addresses",
+			z.Int("num_validators", numVals), z.Int("addresses", len(withdrawalAddrs)))
 	}
 
 	if len(feeRecipientAddrs) == 1 {

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -399,13 +399,22 @@ func TestSplitKeys(t *testing.T) {
 }
 
 func TestMultipleAddresses(t *testing.T) {
-	t.Run("insufficient addresses in config", func(t *testing.T) {
+	t.Run("insufficient fee recipient addresses", func(t *testing.T) {
 		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{
 			NumDVs:            4,
 			FeeRecipientAddrs: []string{},
 			WithdrawalAddrs:   []string{},
 		})
-		require.ErrorContains(t, err, "insufficient fee recipient addresses")
+		require.ErrorContains(t, err, "mismatching --num-validators and --fee-recipient-addresses")
+	})
+
+	t.Run("insufficient withdrawal addresses", func(t *testing.T) {
+		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{
+			NumDVs:            1,
+			FeeRecipientAddrs: []string{feeRecipientAddr},
+			WithdrawalAddrs:   []string{},
+		})
+		require.ErrorContains(t, err, "mismatching --num-validators and --withdrawal-addresses")
 	})
 
 	t.Run("insufficient addresses from remote URL", func(t *testing.T) {


### PR DESCRIPTION
Fix non-intuitive error message in `create cluster` command.

category: refactor 
ticket: #2340 
