### PR TITLE
cmd: simplify `create cluster` logic

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -107,7 +107,7 @@ func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
 	flags.StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
 	flags.StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia.")
 	flags.BoolVar(&config.Clean, "clean", false, "Delete the cluster directory before generating it.")
-	flags.IntVar(&config.NumDVs, "num-validators", 1, "The number of distributed validators needed in the cluster.")
+	flags.IntVar(&config.NumDVs, "num-validators", 0, "The number of distributed validators needed in the cluster.")
 	flags.BoolVar(&config.SplitKeys, "split-existing-keys", false, "Split an existing validator's private key into a set of distributed validator private key shares. Does not re-create deposit data for this key.")
 	flags.StringVar(&config.SplitKeysDir, "split-keys-dir", "", "Directory containing keys to split. Expects keys in keystore-*.json and passwords in keystore-*.txt. Requires --split-existing-keys.")
 	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech", "The URL to publish the lock file to.")
@@ -137,6 +137,11 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	// Ensure sufficient auth tokens are provided for the keymanager addresses
 	if len(conf.KeymanagerAddrs) != len(conf.KeymanagerAuthTokens) {
 		return errors.New("number of --keymanager-addresses do not match --keymanager-auth-tokens. Please fix configuration flags")
+	}
+
+	if conf.SplitKeys && conf.NumDVs == 0 {
+		// set conf.NumDVs to 1 if the user didn't specify num-validators
+		conf.NumDVs = 1
 	}
 
 	var def cluster.Definition

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -141,8 +141,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 
 	var secrets []tbls.PrivateKey
 
-	switch conf.SplitKeys {
-	case true:
+	if conf.SplitKeys {
 		if conf.NumDVs != 0 {
 			return errors.New("can't specify --num-validators with --split-existing-keys. Please fix configuration flags")
 		}
@@ -153,7 +152,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		}
 
 		conf.NumDVs = len(secrets)
-	default:
+	} else {
 		if conf.NumDVs == 0 {
 			return errors.New("missing --num-validators flag")
 		}

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -139,9 +139,29 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		return errors.New("number of --keymanager-addresses do not match --keymanager-auth-tokens. Please fix configuration flags")
 	}
 
-	if conf.SplitKeys && conf.NumDVs == 0 {
-		// set conf.NumDVs to 1 if the user didn't specify num-validators
-		conf.NumDVs = 1
+	var secrets []tbls.PrivateKey
+
+	switch conf.SplitKeys {
+	case true:
+		if conf.NumDVs != 0 {
+			return errors.New("can't specify --num-validators with --split-existing-keys. Please fix configuration flags")
+		}
+
+		secrets, err = getKeys(conf.SplitKeysDir)
+		if err != nil {
+			return err
+		}
+
+		conf.NumDVs = len(secrets)
+	default:
+		if conf.NumDVs == 0 {
+			return errors.New("missing --num-validators flag")
+		}
+
+		secrets, err = generateKeys(conf.NumDVs)
+		if err != nil {
+			return err
+		}
 	}
 
 	var def cluster.Definition
@@ -157,52 +177,18 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		}
 	}
 
-	numNodes := len(def.Operators)
+	if def.NumValidators != conf.NumDVs {
+		errTmpl := "provided cluster definition doesn't contain the same amount of validators"
 
-	if !conf.SplitKeys && def.NumValidators == 0 {
-		return errors.New("num-validators cannot be equal to 0")
-	}
+		err := errors.New(errTmpl + " as specified in --num-validators")
+		if conf.SplitKeys {
+			err = errors.New(errTmpl + " contained in --split-keys-dir")
+		}
 
-	// Get root bls secrets
-	secrets, err := getKeys(conf.SplitKeys, conf.SplitKeysDir, def.NumValidators)
-	if err != nil {
 		return err
 	}
 
-	// Check if NumValidators provided in the given definition file mismatches with the number of split-keys provided.
-	if conf.DefFile != "" && conf.SplitKeys && def.NumValidators != len(secrets) {
-		return errors.New("number of keystores provided in split-keys-dir does not matches with NumValidators in the given definition file",
-			z.Int("num-validators", def.NumValidators), z.Int("split-keys-dir", len(secrets)))
-	}
-
-	// Check if provided --num-validators mismatches with the number of secrets obtained from split-keys-dir.
-	if conf.SplitKeys && def.NumValidators != len(secrets) {
-		if def.NumValidators > 1 {
-			return errors.New("num-validators provided is not equal to keystores provided in split-keys-dir",
-				z.Int("num-validators", def.NumValidators), z.Int("split-keys", len(secrets)))
-		}
-
-		// Override definition according to the secrets obtained from split-keys-dir if num-validators are 0 or 1 (default).
-		def.NumValidators = len(secrets)
-		feeRecipientAddrs, withdrawalAddrs, err := validateAddresses(def.NumValidators, conf.FeeRecipientAddrs, conf.WithdrawalAddrs)
-		if err != nil {
-			return err
-		}
-
-		def.ValidatorAddresses = []cluster.ValidatorAddresses{}
-		for i := 0; i < def.NumValidators; i++ {
-			def.ValidatorAddresses = append(def.ValidatorAddresses, cluster.ValidatorAddresses{
-				FeeRecipientAddress: feeRecipientAddrs[i],
-				WithdrawalAddress:   withdrawalAddrs[i],
-			})
-		}
-
-		// Update config and definition hash.
-		def, err = def.SetDefinitionHashes()
-		if err != nil {
-			return err
-		}
-	}
+	numNodes := len(def.Operators)
 
 	// Validate definition
 	err = validateDef(ctx, conf.InsecureKeys, conf.KeymanagerAddrs, def)
@@ -458,21 +444,22 @@ func writeWarning(w io.Writer) {
 	_, _ = w.Write([]byte(sb.String()))
 }
 
-// getKeys fetches secret keys for each distributed validator.
-func getKeys(splitKeys bool, splitKeysDir string, numDVs int) ([]tbls.PrivateKey, error) {
-	if splitKeys {
-		if splitKeysDir == "" {
-			return nil, errors.New("--split-keys-dir required when splitting keys")
-		}
-
-		files, err := keystore.LoadFilesUnordered(splitKeysDir)
-		if err != nil {
-			return nil, err
-		}
-
-		return files.Keys(), nil
+// getKeys fetches secret keys from splitKeysDir.
+func getKeys(splitKeysDir string) ([]tbls.PrivateKey, error) {
+	if splitKeysDir == "" {
+		return nil, errors.New("--split-keys-dir required when splitting keys")
 	}
 
+	files, err := keystore.LoadFilesUnordered(splitKeysDir)
+	if err != nil {
+		return nil, err
+	}
+
+	return files.Keys(), nil
+}
+
+// generateKeys generates numDVs amount of tbls.PrivateKeys.
+func generateKeys(numDVs int) ([]tbls.PrivateKey, error) {
 	var secrets []tbls.PrivateKey
 	for i := 0; i < numDVs; i++ {
 		secret, err := tbls.GenerateSecretKey()

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -35,20 +35,12 @@ func TestCreateCluster(t *testing.T) {
 	def, err := loadDefinition(context.Background(), defPath)
 	require.NoError(t, err)
 
-	// Serve definition over network
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defBytes, err := os.ReadFile(defPath)
-		require.NoError(t, err)
-
-		_, err = w.Write(defBytes)
-		require.NoError(t, err)
-	}))
-	defer srv.Close()
-
 	tests := []struct {
-		Name   string
-		Config clusterConfig
-		Prep   func(*testing.T, clusterConfig) clusterConfig
+		Name            string
+		Config          clusterConfig
+		Prep            func(*testing.T, clusterConfig) clusterConfig
+		defFileProvider func() []byte
+		expectedErr     string
 	}{
 		{
 			Name: "simnet",
@@ -63,7 +55,6 @@ func TestCreateCluster(t *testing.T) {
 			Config: clusterConfig{
 				NumNodes:  4,
 				Threshold: 3,
-				NumDVs:    1, // Default
 				SplitKeys: true,
 			},
 			Prep: func(t *testing.T, config clusterConfig) clusterConfig {
@@ -85,6 +76,25 @@ func TestCreateCluster(t *testing.T) {
 			},
 		},
 		{
+			Name: "missing numdvs with no split keys set",
+			Config: clusterConfig{
+				NumNodes:  4,
+				Threshold: 3,
+				NumDVs:    0,
+			},
+			expectedErr: "missing --num-validators flag",
+		},
+		{
+			Name: "splitkeys with numdvs set",
+			Config: clusterConfig{
+				NumNodes:  4,
+				Threshold: 3,
+				SplitKeys: true,
+				NumDVs:    1,
+			},
+			expectedErr: "can't specify --num-validators with --split-existing-keys. Please fix configuration flags",
+		},
+		{
 			Name: "goerli",
 			Config: clusterConfig{
 				NumNodes:  minNodes,
@@ -97,17 +107,86 @@ func TestCreateCluster(t *testing.T) {
 			Name: "solo flow definition from disk",
 			Config: clusterConfig{
 				DefFile: defPath,
+				NumDVs:  2,
 			},
 		},
 		{
 			Name: "solo flow definition from network",
 			Config: clusterConfig{
-				DefFile: srv.URL,
+				NumDVs: 2,
+			},
+			defFileProvider: func() []byte {
+				data, err := json.Marshal(def)
+				require.NoError(t, err)
+
+				return data
+			},
+		},
+		{
+			Name: "number of validators in def file differs from --num-validators",
+			Config: clusterConfig{
+				NumDVs: 2,
+			},
+			defFileProvider: func() []byte {
+				def := def
+
+				def.NumValidators = 3
+				def.ValidatorAddresses = make([]cluster.ValidatorAddresses, 3)
+				data, err := json.Marshal(def)
+				require.NoError(t, err)
+
+				return data
+			},
+			expectedErr: "provided cluster definition doesn't contain the same amount of validators as specified in --num-validators",
+		},
+		{
+			Name: "number of validators in def file differs from amount of keys in splitkeys",
+			Config: clusterConfig{
+				SplitKeys: true,
+			},
+			defFileProvider: func() []byte {
+				def := def
+
+				def.NumValidators = 3
+				def.ValidatorAddresses = make([]cluster.ValidatorAddresses, 3)
+				data, err := json.Marshal(def)
+				require.NoError(t, err)
+
+				return data
+			},
+			expectedErr: "provided cluster definition doesn't contain the same amount of validators contained in --split-keys-dir",
+			Prep: func(t *testing.T, config clusterConfig) clusterConfig {
+				t.Helper()
+
+				keyDir := t.TempDir()
+
+				secret1, err := tbls.GenerateSecretKey()
+				require.NoError(t, err)
+				secret2, err := tbls.GenerateSecretKey()
+				require.NoError(t, err)
+
+				err = keystore.StoreKeysInsecure([]tbls.PrivateKey{secret1, secret2}, keyDir, keystore.ConfirmInsecureKeys)
+				require.NoError(t, err)
+
+				config.SplitKeysDir = keyDir
+
+				return config
 			},
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			if test.defFileProvider != nil {
+				// Serve definition over network
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					_, err := w.Write(test.defFileProvider())
+					require.NoError(t, err)
+				}))
+
+				defer srv.Close()
+
+				test.Config.DefFile = srv.URL
+			}
 			if test.Prep != nil {
 				test.Config = test.Prep(t, test.Config)
 			}
@@ -120,12 +199,12 @@ func TestCreateCluster(t *testing.T) {
 				test.Config.Network = eth2util.Goerli.Name
 			}
 
-			testCreateCluster(t, test.Config, def)
+			testCreateCluster(t, test.Config, def, test.expectedErr)
 		})
 	}
 }
 
-func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition) {
+func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition, expectedErr string) {
 	t.Helper()
 
 	dir := t.TempDir()
@@ -137,6 +216,11 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition)
 	if err != nil {
 		log.Error(context.Background(), "", err)
 	}
+	if expectedErr != "" {
+		require.ErrorContains(t, err, expectedErr)
+		return
+	}
+
 	require.NoError(t, err)
 
 	t.Run("output", func(t *testing.T) {
@@ -321,7 +405,7 @@ func TestSplitKeys(t *testing.T) {
 			conf: clusterConfig{
 				DefFile: "../cluster/examples/cluster-definition-002.json",
 			},
-			expectedErrMsg: "number of keystores provided in split-keys-dir does not matches with NumValidators in the given definition file",
+			expectedErrMsg: "provided cluster definition doesn't contain the same amount of validators contained in --split-keys-dir",
 		},
 		{
 			name:         "split keys from local definition with same NumValidators",
@@ -336,23 +420,12 @@ func TestSplitKeys(t *testing.T) {
 			numSplitKeys: 3,
 			conf: clusterConfig{
 				Name:              "test split keys",
-				NumDVs:            1,
 				NumNodes:          minNodes,
 				Threshold:         3,
 				FeeRecipientAddrs: []string{zeroAddress},
 				WithdrawalAddrs:   []string{zeroAddress},
 				ClusterDir:        t.TempDir(),
 			},
-		},
-		{
-			name:         "split keys from config with mismatch num-validators",
-			numSplitKeys: 3,
-			conf: clusterConfig{
-				NumDVs:            2,
-				FeeRecipientAddrs: []string{zeroAddress},
-				WithdrawalAddrs:   []string{zeroAddress},
-			},
-			expectedErrMsg: "num-validators provided is not equal to keystores provided in split-keys-dir",
 		},
 	}
 
@@ -425,7 +498,7 @@ func TestMultipleAddresses(t *testing.T) {
 		}))
 		defer srv.Close()
 
-		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{DefFile: srv.URL, NumNodes: minNodes})
+		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{DefFile: srv.URL, NumNodes: minNodes, NumDVs: 2})
 		require.ErrorContains(t, err, "num_validators not matching validators length")
 	})
 }
@@ -472,7 +545,6 @@ func TestKeymanager(t *testing.T) {
 		SplitKeysDir:         keyDir,
 		SplitKeys:            true,
 		NumNodes:             minNodes,
-		NumDVs:               1,
 		KeymanagerAddrs:      addrs,
 		KeymanagerAuthTokens: authTokens,
 		Network:              eth2util.Goerli.Name,


### PR DESCRIPTION
This PR refactors `create cluster` logic to make it slightly simpler.

New behaviors:
 - if `--split-existing-keys` is enabled, `--num-validators` cannot be set
 - `--num-validators` must be present unless `--split-existing-keys` is enabled, otherwise `create cluster` exits with error
 - split key generation and disk read
 - don't fill in with random keys when splitting: during `--split-existing-keys` before this PR, if the user specified a `--num-validators` greater than the amount of keys contained in `--split-keys-dir` Charon would fill in the blanks with random keys
 - if definition file validator amount and `--num-validators` don't match, the creation process stops

category: refactor
ticket: #2341 
