### PR TITLE
p2p: add support for multi protocols to Send

### DIFF
--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -253,7 +253,7 @@ func Send(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID pe
 		opt(&o)
 	}
 	// Circuit relay connections are transient
-	s, err := tcpNode.NewStream(network.WithUseTransient(ctx, ""), peerID, protoID)
+	s, err := tcpNode.NewStream(network.WithUseTransient(ctx, ""), peerID, o.protocols...)
 	if err != nil {
 		return errors.Wrap(err, "tcpNode stream")
 	}

--- a/p2p/sender_test.go
+++ b/p2p/sender_test.go
@@ -20,108 +20,107 @@ import (
 )
 
 func TestSend(t *testing.T) {
+	var (
+		undelimID = protocol.ID("undelimited")
+		delimID   = protocol.ID("delimited")
+	)
+
 	tests := []struct {
-		name                string
-		delimitedClient     bool
-		delimitedServer     bool
-		delimitedOnlyClient bool
-		delimitedOnlyServer bool
+		name               string
+		delimitedClient    bool
+		delimitedServer    bool
+		clientBasicProtoID protocol.ID
+		serverBasicProtoID protocol.ID
 	}{
 		{
-			name:            "non-delimited client and server",
-			delimitedClient: false,
-			delimitedServer: false,
+			name:               "non-delimited client and server",
+			delimitedClient:    false,
+			delimitedServer:    false,
+			clientBasicProtoID: undelimID,
+			serverBasicProtoID: undelimID,
 		},
 		{
-			name:            "delimited client and server",
-			delimitedClient: true,
-			delimitedServer: true,
+			name:               "delimited client and server",
+			delimitedClient:    true,
+			delimitedServer:    true,
+			clientBasicProtoID: undelimID,
+			serverBasicProtoID: undelimID,
 		},
 		{
-			name:            "delimited client and non-delimited server",
-			delimitedClient: true,
-			delimitedServer: false,
+			name:               "delimited client and non-delimited server",
+			delimitedClient:    true,
+			delimitedServer:    false,
+			clientBasicProtoID: undelimID,
+			serverBasicProtoID: undelimID,
 		},
 		{
-			name:            "non-delimited client and delimited server",
-			delimitedClient: false,
-			delimitedServer: true,
+			name:               "non-delimited client and delimited server",
+			delimitedClient:    false,
+			delimitedServer:    true,
+			clientBasicProtoID: undelimID,
+			serverBasicProtoID: undelimID,
 		},
 		{
-			name:                "delimited only client and delimited server",
-			delimitedClient:     true,
-			delimitedServer:     true,
-			delimitedOnlyClient: true,
+			name:               "delimited only client and delimited server",
+			delimitedClient:    true,
+			delimitedServer:    true,
+			clientBasicProtoID: delimID,
+			serverBasicProtoID: undelimID,
 		},
 		{
-			name:                "delimited client and delimited only server",
-			delimitedClient:     true,
-			delimitedServer:     true,
-			delimitedOnlyServer: true,
+			name:               "delimited client and delimited only server",
+			delimitedClient:    true,
+			delimitedServer:    true,
+			clientBasicProtoID: undelimID,
+			serverBasicProtoID: delimID,
 		},
 		{
-			name:                "delimited only client and delimited only server",
-			delimitedClient:     true,
-			delimitedServer:     true,
-			delimitedOnlyServer: true,
-			delimitedOnlyClient: true,
+			name:               "delimited only client and delimited only server",
+			delimitedClient:    true,
+			delimitedServer:    true,
+			clientBasicProtoID: delimID,
+			serverBasicProtoID: delimID,
 		},
 		{
-			name:                "delimited only client and non-delimited server, protocols not supported",
-			delimitedClient:     true,
-			delimitedServer:     false,
-			delimitedOnlyClient: true,
+			name:               "delimited only client and non-delimited server, protocols not supported",
+			delimitedClient:    true,
+			delimitedServer:    false,
+			clientBasicProtoID: delimID,
+			serverBasicProtoID: undelimID,
 		},
 		{
-			name:                "non-delimited client and delimited only server, protocols not supported",
-			delimitedClient:     false,
-			delimitedServer:     true,
-			delimitedOnlyServer: true,
+			name:               "non-delimited client and delimited only server, protocols not supported",
+			delimitedClient:    false,
+			delimitedServer:    true,
+			clientBasicProtoID: undelimID,
+			serverBasicProtoID: delimID,
 		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			testSend(t, test.delimitedClient, test.delimitedServer, test.delimitedOnlyClient, test.delimitedOnlyServer)
+			testSend(t, test.clientBasicProtoID, test.serverBasicProtoID, delimID, test.delimitedClient, test.delimitedServer)
 		})
 	}
 }
 
-func testSend(t *testing.T, delimitedClient, delimitedServer, delimitedOnlyClient, delimitedOnlyServer bool) {
+func testSend(t *testing.T, clientBasicProtoID, serverBasicProtoID, delimitedID protocol.ID, delimitedClient, delimitedServer bool) {
 	t.Helper()
 
 	var (
-		pID1        = protocol.ID("undelimited")
-		pID2        = protocol.ID("delimited")
 		errNegative = errors.New("negative slot")
 		ctx         = context.Background()
 		server      = testutil.CreateHost(t, testutil.AvailableAddr(t))
 		client      = testutil.CreateHost(t, testutil.AvailableAddr(t))
 	)
 
-	getBasicProtoIDClient := func() protocol.ID {
-		if delimitedClient && delimitedOnlyClient {
-			return pID2
-		}
-
-		return pID1
-	}
-
-	getBasicProtoIDServer := func() protocol.ID {
-		if delimitedServer && delimitedOnlyServer {
-			return pID2
-		}
-
-		return pID1
-	}
-
 	var serverOpt []p2p.SendRecvOption
 	if delimitedServer {
-		serverOpt = append(serverOpt, p2p.WithDelimitedProtocol(pID2))
+		serverOpt = append(serverOpt, p2p.WithDelimitedProtocol(delimitedID))
 	}
 
 	var clientOpt []p2p.SendRecvOption
 	if delimitedClient {
-		clientOpt = append(clientOpt, p2p.WithDelimitedProtocol(pID2))
+		clientOpt = append(clientOpt, p2p.WithDelimitedProtocol(delimitedID))
 	}
 
 	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), peerstore.PermanentAddrTTL)
@@ -132,7 +131,7 @@ func testSend(t *testing.T, delimitedClient, delimitedServer, delimitedOnlyClien
 	// Register the server handler that either:
 	//  - Errors if slot is negative
 	//  - Returns nothing otherwise
-	p2p.RegisterHandler("server", server, getBasicProtoIDServer(),
+	p2p.RegisterHandler("server", server, serverBasicProtoID,
 		func() proto.Message { return new(pbv1.Duty) },
 		func(ctx context.Context, peerID peer.ID, req proto.Message) (proto.Message, bool, error) {
 			log.Info(ctx, "See protocol logging field")
@@ -157,12 +156,12 @@ func testSend(t *testing.T, delimitedClient, delimitedServer, delimitedOnlyClien
 
 	protocolNotSupported := func() bool {
 		// Client supports ONLY delimited protocol while Server supports ONLY non-delimited protocol.
-		if getBasicProtoIDClient() == pID2 && !delimitedServer {
+		if clientBasicProtoID == delimitedID && !delimitedServer {
 			return true
 		}
 
 		// Server supports ONLY delimited protocol while Client supports ONLY non-delimited protocol.
-		if getBasicProtoIDServer() == pID2 && !delimitedClient {
+		if serverBasicProtoID == delimitedID && !delimitedClient {
 			return true
 		}
 
@@ -170,20 +169,20 @@ func testSend(t *testing.T, delimitedClient, delimitedServer, delimitedOnlyClien
 	}
 
 	if protocolNotSupported() {
-		err := p2p.Send(ctx, client, getBasicProtoIDClient(), server.ID(), &pbv1.Duty{Slot: 100}, clientOpt...)
+		err := p2p.Send(ctx, client, clientBasicProtoID, server.ID(), &pbv1.Duty{Slot: 100}, clientOpt...)
 		require.ErrorContains(t, err, "protocols not supported")
 
 		return
 	}
 
 	t.Run("server error", func(t *testing.T) {
-		err := p2p.Send(ctx, client, getBasicProtoIDClient(), server.ID(), &pbv1.Duty{Slot: -1}, clientOpt...)
+		err := p2p.Send(ctx, client, clientBasicProtoID, server.ID(), &pbv1.Duty{Slot: -1}, clientOpt...)
 		require.NoError(t, err)
 		require.ErrorContains(t, <-serverErrChan, "negative slot")
 	})
 
 	t.Run("ok", func(t *testing.T) {
-		err := p2p.Send(ctx, client, getBasicProtoIDClient(), server.ID(), &pbv1.Duty{Slot: 100}, clientOpt...)
+		err := p2p.Send(ctx, client, clientBasicProtoID, server.ID(), &pbv1.Duty{Slot: 100}, clientOpt...)
 		require.NoError(t, err)
 		require.NoError(t, <-serverErrChan)
 	})


### PR DESCRIPTION
Add support for multi protocols to `p2p.Send(...)`.

category: bug
ticket: #2386