### PR TITLE
cmd: `create cluster` outputs in working dir

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -310,7 +310,7 @@ func cleanNodeDirs(clusterDir string, nodeAmount int) error {
 	for idx := 0; idx < nodeAmount; idx++ {
 		nodeDirPath := path.Join(nodeDir(clusterDir, idx))
 		if err := os.RemoveAll(nodeDirPath); err != nil {
-			return errors.Wrap(err, "remove cluster dir")
+			return errors.Wrap(err, "remove node dir")
 		}
 	}
 


### PR DESCRIPTION
Creates `nodeX` directories in the current working directory rather than `.charon/cluster`.

Closes #2302.

category: refactor
ticket: #2302
