### PR TITLE
cmd: `create cluster` cleanup

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -276,7 +276,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	return writeOutput(w, conf.SplitKeys, conf.ClusterDir, numNodes, keysToDisk)
 }
 
-// validateCreateConfig  eturns an error if any of the provided config parameter is invalid.
+// validateCreateConfig returns an error if any of the provided config parameters are invalid.
 func validateCreateConfig(conf clusterConfig) error {
 	if conf.NumNodes == 0 {
 		return errors.New("missing --nodes parameter")

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -97,16 +98,15 @@ func newCreateClusterCmd(runFunc func(context.Context, io.Writer, clusterConfig)
 
 func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
 	flags.StringVar(&config.Name, "name", "", "The cluster name")
-	flags.StringVar(&config.ClusterDir, "cluster-dir", ".charon/cluster", "The target folder to create the cluster in.")
+	flags.StringVar(&config.ClusterDir, "cluster-dir", "./", "The target folder to create the cluster in.")
 	flags.StringVar(&config.DefFile, "definition-file", "", "Optional path to a cluster definition file or an HTTP URL. This overrides all other configuration flags.")
 	flags.StringSliceVar(&config.KeymanagerAddrs, "keymanager-addresses", nil, "Comma separated list of keymanager URLs to import validator key shares to. Note that multiple addresses are required, one for each node in the cluster, with node0's keyshares being imported to the first address, node1's keyshares to the second, and so on.")
 	flags.StringSliceVar(&config.KeymanagerAuthTokens, "keymanager-auth-tokens", nil, "Authentication bearer tokens to interact with the keymanager URLs. Don't include the \"Bearer\" symbol, only include the api-token.")
-	flags.IntVarP(&config.NumNodes, "nodes", "", 4, "The number of charon nodes in the cluster. Minimum is 3.")
+	flags.IntVarP(&config.NumNodes, "nodes", "", 0, "The number of charon nodes in the cluster. Minimum is 3.")
 	flags.IntVarP(&config.Threshold, "threshold", "", 0, "Optional override of threshold required for signature reconstruction. Defaults to ceil(n*2/3) if zero. Warning, non-default values decrease security.")
 	flags.StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	flags.StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
-	flags.StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia.")
-	flags.BoolVar(&config.Clean, "clean", false, "Delete the cluster directory before generating it.")
+	flags.StringVar(&config.Network, "network", "", "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia.")
 	flags.IntVar(&config.NumDVs, "num-validators", 0, "The number of distributed validators needed in the cluster.")
 	flags.BoolVar(&config.SplitKeys, "split-existing-keys", false, "Split an existing validator's private key into a set of distributed validator private key shares. Does not re-create deposit data for this key.")
 	flags.StringVar(&config.SplitKeysDir, "split-keys-dir", "", "Directory containing keys to split. Expects keys in keystore-*.json and passwords in keystore-*.txt. Requires --split-existing-keys.")
@@ -120,13 +120,17 @@ func bindInsecureFlags(flags *pflag.FlagSet, insecureKeys *bool) {
 
 func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) error {
 	var err error
-	if conf.Clean {
-		// Remove previous directories
-		if err = os.RemoveAll(conf.ClusterDir); err != nil {
-			return errors.Wrap(err, "remove cluster dir")
-		}
-	} else if _, err = os.Stat(path.Join(nodeDir(conf.ClusterDir, 0), "cluster-lock.json")); err == nil {
-		return errors.New("existing cluster found. Try again with --clean")
+
+	if conf.NumNodes == 0 {
+		return errors.New("missing --nodes parameter")
+	}
+
+	if len(strings.TrimSpace(conf.Network)) == 0 {
+		return errors.New("missing --network parameter")
+	}
+
+	if err = detectNodeDirs(conf.ClusterDir, conf.NumNodes); err != nil {
+		return err
 	}
 
 	// Map prater to goerli to ensure backwards compatibility with older cluster definitions and cluster locks.
@@ -290,7 +294,21 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		writeWarning(w)
 	}
 
-	writeOutput(w, conf.SplitKeys, conf.ClusterDir, numNodes, keysToDisk)
+	return writeOutput(w, conf.SplitKeys, conf.ClusterDir, numNodes, keysToDisk)
+}
+
+// detectNodeDirs returns error if there's a `nodeX`-style directory in clusterDir.
+func detectNodeDirs(clusterDir string, nodeAmount int) error {
+	for idx := 0; idx < nodeAmount; idx++ {
+		absPath, err := filepath.Abs(nodeDir(clusterDir, idx))
+		if err != nil {
+			return errors.Wrap(err, "absolute path retrieval")
+		}
+
+		if _, err := os.Stat(filepath.Join(absPath, "cluster-lock.json")); err == nil {
+			return errors.New("found existing node directory, please ensure it is deleted before running this command", z.Str("node_path", absPath))
+		}
+	}
 
 	return nil
 }
@@ -744,12 +762,17 @@ func newPeer(clusterDir string, peerIdx int) (enr.Record, *k1.PrivateKey, error)
 }
 
 // writeOutput writes the cluster generation output.
-func writeOutput(out io.Writer, splitKeys bool, clusterDir string, numNodes int, keysToDisk bool) {
+func writeOutput(out io.Writer, splitKeys bool, clusterDir string, numNodes int, keysToDisk bool) error {
+	absClusterDir, err := filepath.Abs(clusterDir)
+	if err != nil {
+		return errors.Wrap(err, "absolute path retrieval")
+	}
+
 	var sb strings.Builder
 	_, _ = sb.WriteString("Created charon cluster:\n")
 	_, _ = sb.WriteString(fmt.Sprintf(" --split-existing-keys=%v\n", splitKeys))
 	_, _ = sb.WriteString("\n")
-	_, _ = sb.WriteString(strings.TrimSuffix(clusterDir, "/") + "/\n")
+	_, _ = sb.WriteString(strings.TrimSuffix(absClusterDir, "/") + "/\n")
 	_, _ = sb.WriteString(fmt.Sprintf("├─ node[0-%d]/\t\t\tDirectory for each node\n", numNodes-1))
 	_, _ = sb.WriteString("│  ├─ charon-enr-private-key\tCharon networking private key for node authentication\n")
 	_, _ = sb.WriteString("│  ├─ cluster-lock.json\t\tCluster lock defines the cluster lock file which is signed by all nodes\n")
@@ -761,6 +784,8 @@ func writeOutput(out io.Writer, splitKeys bool, clusterDir string, numNodes int,
 	}
 
 	_, _ = fmt.Fprint(out, sb.String())
+
+	return nil
 }
 
 // nodeDir returns a node directory.

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -279,11 +279,11 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 // validateCreateConfig returns an error if any of the provided config parameters are invalid.
 func validateCreateConfig(conf clusterConfig) error {
 	if conf.NumNodes == 0 {
-		return errors.New("missing --nodes parameter")
+		return errors.New("missing --nodes flag")
 	}
 
 	if len(strings.TrimSpace(conf.Network)) == 0 {
-		return errors.New("missing --network parameter")
+		return errors.New("missing --network flag")
 	}
 
 	if err := detectNodeDirs(conf.ClusterDir, conf.NumNodes); err != nil {

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -78,14 +78,14 @@ func TestCreateCluster(t *testing.T) {
 		{
 			Name:        "missing nodes amount flag",
 			Config:      clusterConfig{},
-			expectedErr: "missing --nodes parameter",
+			expectedErr: "missing --nodes flag",
 		},
 		{
 			Name: "missing network flag",
 			Config: clusterConfig{
 				NumNodes: 4,
 			},
-			expectedErr: "missing --network parameter",
+			expectedErr: "missing --network flag",
 		},
 		{
 			Name: "missing numdvs with no split keys set",

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -79,7 +79,7 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 		conf.Network = eth2util.Goerli.Name
 	}
 
-	if err = validateConfig(conf.Threshold, len(conf.OperatorENRs), conf.Network); err != nil {
+	if err = validateDKGConfig(conf.Threshold, len(conf.OperatorENRs), conf.Network); err != nil {
 		return err
 	}
 
@@ -174,8 +174,8 @@ func validateWithdrawalAddrs(addrs []string, network string) error {
 	return nil
 }
 
-// validateConfig returns an error if any of the provided config parameter is invalid.
-func validateConfig(threshold, numOperators int, network string) error {
+// validateDKGConfig returns an error if any of the provided config parameter is invalid.
+func validateDKGConfig(threshold, numOperators int, network string) error {
 	if threshold > numOperators {
 		return errors.New("threshold cannot be greater than length of operators",
 			z.Int("threshold", threshold), z.Int("operators", numOperators))

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -180,25 +180,25 @@ func TestValidateWithdrawalAddr(t *testing.T) {
 	})
 }
 
-func TestValidateConfig(t *testing.T) {
+func TestValidateDKGConfig(t *testing.T) {
 	t.Run("invalid threshold", func(t *testing.T) {
 		threshold := 5
 		numOperators := 4
-		err := validateConfig(threshold, numOperators, "")
+		err := validateDKGConfig(threshold, numOperators, "")
 		require.ErrorContains(t, err, "threshold cannot be greater than length of operators")
 	})
 
 	t.Run("insufficient ENRs", func(t *testing.T) {
 		threshold := 1
 		numOperators := 2
-		err := validateConfig(threshold, numOperators, "")
+		err := validateDKGConfig(threshold, numOperators, "")
 		require.ErrorContains(t, err, "insufficient operator ENRs")
 	})
 
 	t.Run("invalid network", func(t *testing.T) {
 		threshold := 3
 		numOperators := 4
-		err := validateConfig(threshold, numOperators, "cosmos")
+		err := validateDKGConfig(threshold, numOperators, "cosmos")
 		require.ErrorContains(t, err, "unsupported network")
 	})
 }


### PR DESCRIPTION
- removed `--clean` subcommand in favor of explicit error messages
- removed default for `--nodes`
- removed default for `--network`
- the default cluster dir is now the current working directory

Closes https://github.com/ObolNetwork/charon/issues/2302.

category: refactor
ticket: #2302
