### PR TITLE
cmd: write deposit datas to disk

### DIFF
--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -16,6 +16,7 @@ import (
 // Load loads a cluster from disk and returns true if cluster was loaded from a legacy lock file.
 // It supports reading from both cluster manifest and legacy lock files.
 // If both files are provided, it first reads the manifest file before reading the legacy lock file.
+// TODO(xenowits): Refactor to return only (cluster, error).
 func Load(manifestFile, legacyLockFile string, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, bool, error) {
 	b, err := os.ReadFile(manifestFile)
 	if err == nil {

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -167,11 +167,10 @@ func runAddValidatorsSolo(ctx context.Context, conf addValidatorsConfig) (err er
 		return errors.Wrap(err, "transform cluster manifest")
 	}
 
-	err = saveDepositDatas(conf.ClusterDir, len(cluster.Operators), secrets, vals, cluster.ForkVersion)
+	err = saveDepositDatas(ctx, conf.ClusterDir, len(cluster.Operators), secrets, vals, cluster.ForkVersion)
 	if err != nil {
 		return err
 	}
-	log.Debug(ctx, "Saved deposit data file to disk")
 
 	// Save cluster manifests to disk
 	err = writeClusterManifests(conf.ClusterDir, len(cluster.Operators), cluster)
@@ -274,7 +273,7 @@ func writeClusterManifests(clusterDir string, numOps int, cluster *manifestpb.Cl
 }
 
 // saveDepositDatas creates deposit data for each validator and writes the deposit data to disk for each node.
-func saveDepositDatas(clusterDir string, numOps int, secrets []tbls.PrivateKey, vals []*manifestpb.Validator, forkVersion []byte) error {
+func saveDepositDatas(ctx context.Context, clusterDir string, numOps int, secrets []tbls.PrivateKey, vals []*manifestpb.Validator, forkVersion []byte) error {
 	network, err := eth2util.ForkVersionToNetwork(forkVersion)
 	if err != nil {
 		return errors.Wrap(err, "fork version to network")
@@ -321,6 +320,8 @@ func saveDepositDatas(clusterDir string, numOps int, secrets []tbls.PrivateKey, 
 			return errors.Wrap(err, "write deposit data")
 		}
 	}
+
+	log.Debug(ctx, "Saved deposit data file to disk", z.Str("deposit_data", filename))
 
 	return nil
 }

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"path"
 	"strings"
 	"testing"
-	"time"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
@@ -210,10 +209,10 @@ func TestRunAddValidators(t *testing.T) {
 
 		entries, err := os.ReadDir(path.Join(tmp, "node0"))
 		require.NoError(t, err)
-		require.Equal(t, 3, len(entries))
+		require.Equal(t, 2, len(entries))
 
-		require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest-backup"))
-		require.True(t, strings.Contains(entries[1].Name(), "cluster-manifest"))
+		require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest"))
+		require.True(t, strings.Contains(entries[1].Name(), "deposit-data"))
 	})
 }
 
@@ -266,32 +265,4 @@ func TestValidateP2PKeysOrder(t *testing.T) {
 		err := validateP2PKeysOrder(p2pKeys, ops)
 		require.ErrorContains(t, err, "invalid p2p key order")
 	})
-}
-
-func TestWriteClusterBackup(t *testing.T) {
-	tmp := t.TempDir()
-	clusterName := "test"
-	numOperators := 3
-	for i := 0; i < numOperators; i++ {
-		dir := path.Join(tmp, fmt.Sprintf("node%d", i))
-		require.NoError(t, os.Mkdir(dir, 0o777))
-	}
-
-	c := manifestpb.Cluster{Name: clusterName}
-	currTime := time.Now().Format("20060102150405")
-	require.NoError(t, writeManifestBackups(tmp, numOperators, &c, currTime))
-
-	// Verify if backup file is created
-	entries, err := os.ReadDir(path.Join(tmp, "node0"))
-	require.NoError(t, err)
-	require.Equal(t, 1, len(entries))
-	require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest-backup"))
-
-	backupFile := path.Join(tmp, "node0", entries[0].Name())
-	b, err := os.ReadFile(backupFile)
-	require.NoError(t, err)
-
-	backup := new(manifestpb.Cluster)
-	require.NoError(t, proto.Unmarshal(b, backup))
-	require.Equal(t, clusterName, backup.Name)
 }


### PR DESCRIPTION
Write deposit data file for new validators created in `add-validators-solo` command to each node directory. The new deposit files are named as `deposit-data-20230704173152.json`.

Also deletes logic for backing up cluster manifests. 

category: feature 
ticket: #2379 
