### PR TITLE
cluster: remove deprecated return value

### DIFF
--- a/app/disk.go
+++ b/app/disk.go
@@ -34,7 +34,7 @@ func loadClusterManifest(ctx context.Context, conf Config) (*manifestpb.Cluster,
 		return nil
 	}
 
-	cluster, _, err := manifest.Load(conf.ManifestFile, conf.LockFile, verifyLock)
+	cluster, err := manifest.Load(conf.ManifestFile, conf.LockFile, verifyLock)
 	if err != nil {
 		return nil, errors.Wrap(err, "load cluster manifest")
 	}

--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -16,29 +16,28 @@ import (
 // Load loads a cluster from disk and returns true if cluster was loaded from a legacy lock file.
 // It supports reading from both cluster manifest and legacy lock files.
 // If both files are provided, it first reads the manifest file before reading the legacy lock file.
-// TODO(xenowits): Refactor to return only (cluster, error).
-func Load(manifestFile, legacyLockFile string, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, bool, error) {
+func Load(manifestFile, legacyLockFile string, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, error) {
 	b, err := os.ReadFile(manifestFile)
 	if err == nil {
 		manifest := new(manifestpb.Cluster)
 		if err := proto.Unmarshal(b, manifest); err != nil {
-			return nil, false, errors.Wrap(err, "unmarshal cluster manifest")
+			return nil, errors.Wrap(err, "unmarshal cluster manifest")
 		}
 
-		return manifest, false, nil
+		return manifest, nil
 	}
 
 	b, err = os.ReadFile(legacyLockFile)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "read legacy lock file")
+		return nil, errors.Wrap(err, "read legacy lock file")
 	}
 
 	m, err := loadLegacyLock(b, lockCallback)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "load legacy lock")
+		return nil, errors.Wrap(err, "load legacy lock")
 	}
 
-	return m, true, nil
+	return m, nil
 }
 
 func loadLegacyLock(input []byte, lockCallback func(cluster.Lock) error) (*manifestpb.Cluster, error) {

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -50,7 +50,6 @@ func TestLoad(t *testing.T) {
 		name           string
 		manifestFile   string
 		legacyLockFile string
-		isLegacyLock   bool
 		errorMsg       string
 	}{
 		{
@@ -64,7 +63,6 @@ func TestLoad(t *testing.T) {
 		{
 			name:           "only legacy lock",
 			legacyLockFile: legacyLockFile,
-			isLegacyLock:   true,
 		},
 		{
 			name:           "both files",
@@ -75,15 +73,13 @@ func TestLoad(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			loaded, isLegacyLock, err := manifest.Load(tt.manifestFile, tt.legacyLockFile, nil)
+			loaded, err := manifest.Load(tt.manifestFile, tt.legacyLockFile, nil)
 			if tt.errorMsg != "" {
 				require.ErrorContains(t, err, tt.errorMsg)
 				return
 			}
 
 			require.True(t, proto.Equal(cluster, loaded))
-
-			require.Equal(t, tt.isLegacyLock, isLegacyLock)
 		})
 	}
 }
@@ -109,7 +105,7 @@ func testLoadLegacy(t *testing.T, version string) {
 	err = os.WriteFile(file, b, 0o644)
 	require.NoError(t, err)
 
-	cluster, isLegacyLock, err := manifest.Load("", file, nil)
+	cluster, err := manifest.Load("", file, nil)
 	require.NoError(t, err)
 
 	require.Equal(t, lock.LockHash, cluster.InitialMutationHash)
@@ -120,7 +116,6 @@ func testLoadLegacy(t *testing.T, version string) {
 	require.Equal(t, lock.ForkVersion, cluster.ForkVersion)
 	require.Equal(t, len(lock.Validators), len(cluster.Validators))
 	require.Equal(t, len(lock.Operators), len(cluster.Operators))
-	require.Equal(t, isLegacyLock, true)
 
 	for i, validator := range cluster.Validators {
 		require.Equal(t, lock.Validators[i].PubKey, validator.PublicKey)

--- a/cluster/manifest/mutationlegacylock_test.go
+++ b/cluster/manifest/mutationlegacylock_test.go
@@ -57,9 +57,8 @@ func TestLegacyLock(t *testing.T) {
 	})
 
 	t.Run("cluster loaded from lock", func(t *testing.T) {
-		cluster, isLegacyLock, err := manifest.Load("", "testdata/lock.json", nil)
+		cluster, err := manifest.Load("", "testdata/lock.json", nil)
 		require.NoError(t, err)
-		require.Equal(t, true, isLegacyLock)
 
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})
@@ -73,9 +72,8 @@ func TestLegacyLock(t *testing.T) {
 		file := path.Join(t.TempDir(), "manifest.pb")
 		require.NoError(t, os.WriteFile(file, b, 0o644))
 
-		cluster, isLegacyLock, err := manifest.Load(file, "", nil)
+		cluster, err = manifest.Load(file, "", nil)
 		require.NoError(t, err)
-		require.Equal(t, false, isLegacyLock)
 
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -94,7 +94,7 @@ func bindAddValidatorsFlags(cmd *cobra.Command, config *addValidatorsConfig) {
 
 func runAddValidatorsSolo(ctx context.Context, conf addValidatorsConfig) (err error) {
 	// Read lock file to load cluster manifest
-	cluster, _, err := loadClusterManifest(conf)
+	cluster, err := loadClusterManifest(conf)
 	if err != nil {
 		return err
 	}
@@ -220,15 +220,13 @@ func builderRegistration(secret tbls.PrivateKey, pubkey tbls.PublicKey, feeRecip
 
 // loadClusterManifest returns the cluster manifest from the provided config. It returns true if
 // the cluster was loaded from a legacy lock file.
-// TODO(xenowits): Refactor to remove boolean in return values, ie, return only (cluster, error).
-func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, bool, error) {
+func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, error) {
 	if conf.TestConfig.Manifest != nil {
-		return conf.TestConfig.Manifest, false, nil
+		return conf.TestConfig.Manifest, nil
 	}
 
 	if conf.TestConfig.Lock != nil {
-		m, err := manifest.NewClusterFromLock(*conf.TestConfig.Lock)
-		return m, true, err
+		return manifest.NewClusterFromLock(*conf.TestConfig.Lock)
 	}
 
 	verifyLock := func(lock cluster.Lock) error {
@@ -243,12 +241,12 @@ func loadClusterManifest(conf addValidatorsConfig) (*manifestpb.Cluster, bool, e
 		return nil
 	}
 
-	cluster, isLegacyLock, err := manifest.Load(conf.ManifestFile, conf.Lockfile, verifyLock)
+	cluster, err := manifest.Load(conf.ManifestFile, conf.Lockfile, verifyLock)
 	if err != nil {
-		return nil, false, errors.Wrap(err, "load cluster manifest")
+		return nil, errors.Wrap(err, "load cluster manifest")
 	}
 
-	return cluster, isLegacyLock, nil
+	return cluster, nil
 }
 
 // writeClusterManifests writes the provided cluster manifest to node directories on disk.

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -222,7 +222,7 @@ func loadManifest(ctx context.Context, dir string, noverify bool) (*manifestpb.C
 		lockFile := filepath.Join(dir, sd.Name(), "cluster-lock.json")
 		manifestFile := filepath.Join(dir, sd.Name(), "cluster-manifest.pb")
 
-		cl, _, err := manifest.Load(manifestFile, lockFile, func(lock cluster.Lock) error {
+		cl, err := manifest.Load(manifestFile, lockFile, func(lock cluster.Lock) error {
 			return verifyLock(ctx, lock, noverify)
 		})
 		if err != nil {


### PR DESCRIPTION
Remove `isLegacyLock` bool return value when loading cluster from either manifest or lock file.

category: refactor 
ticket: none 
