### PR TITLE
*: bump go version to `1.20.6`

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@master

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -12,8 +12,8 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -show=stacks -test ./...

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,9 +14,9 @@ jobs:
         with:
           fetch-depth: 0 # Disable shallow checkout
       - uses: actions/setup-python@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0 # Disable shallow checkout
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.5'
+        go-version: '1.20.6'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - uses: actions/cache@v3
         with:
           path: |
@@ -31,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - uses: actions/cache@v3
         with:
           path: |
@@ -49,9 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2 # For compose to build images
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/track-pr.yml
+++ b/.github/workflows/track-pr.yml
@@ -12,9 +12,9 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_ORG_ADMIN_SECRET }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
 
       - name: "Track PR"
         run: go run github.com/obolnetwork/charon/testutil/trackpr

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -10,9 +10,9 @@ jobs:
       GITHUB_PR: ${{ toJSON(github.event.pull_request) }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.5'
+          go-version: '1.20.6'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.20.5"
+  go: "1.20.6"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -87,7 +87,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.20.5"
+    go: "1.20.6"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.20.5-bullseye AS builder
+FROM golang:1.20.6-bullseye AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source

--- a/testutil/promrated/Dockerfile
+++ b/testutil/promrated/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine AS builder
+FROM golang:1.20.6-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache build-base git


### PR DESCRIPTION
Bump go version to `1.20.6`. Also update `actions/setup-go` to `v4`.

This fixes failing govulnchecks - https://github.com/ObolNetwork/charon/actions/runs/5527733444/jobs/10083789376

category: misc
ticket: none 
