### PR TITLE
app: fix tracker delay to capture inclusion

### DIFF
--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -19,7 +19,7 @@ import (
 
 const (
 	// InclCheckLag is the number of slots to lag before checking inclusion.
-	// We wait for 4 slots to mitigate against reorgs as it should cover almost 100% of the cases of reorgs.
+	// We wait for 4 slots to mitigate against reorgs as it should cover almost all reorg scenarios.
 	// Reorgs of more than 4 slots are very rare in ethereum PoS.
 	InclCheckLag = 4
 	// InclMissedLag is the number of slots after which we assume the duty was not included and we

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -19,8 +19,9 @@ import (
 
 const (
 	// InclCheckLag is the number of slots to lag before checking inclusion.
-	// Half an epoch is good compromise between finality and responsiveness.
-	InclCheckLag = 16
+	// We wait for 4 slots to mitigate against reorgs as it should cover almost 100% of the cases of reorgs.
+	// Reorgs of more than 4 slots are very rare in ethereum PoS.
+	InclCheckLag = 4
 	// InclMissedLag is the number of slots after which we assume the duty was not included and we
 	// delete cached submissions.
 	InclMissedLag = 32


### PR DESCRIPTION
Adds inclusion checker delay to tracker analyser to capture inclusion errors. Also decreases inclusion checker delay to 4 slots from 16 slots.

category: bug
ticket: #2415 
