### PR TITLE
core/consensus: refactor duration metric

### DIFF
--- a/core/consensus/component_internal_test.go
+++ b/core/consensus/component_internal_test.go
@@ -371,7 +371,7 @@ func TestComponent_handle(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var tc Component
 			tc.deadliner = testDeadliner{}
-			tc.mutable.recvBuffers = make(map[core.Duty]chan msg)
+			tc.mutable.instances = make(map[core.Duty]instanceIO)
 
 			msg := &pbv1.ConsensusMsg{
 				Msg: randomMsg(t),

--- a/core/consensus/metrics.go
+++ b/core/consensus/metrics.go
@@ -3,12 +3,9 @@
 package consensus
 
 import (
-	"time"
-
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/obolnetwork/charon/app/promauto"
-	"github.com/obolnetwork/charon/core"
 )
 
 var (
@@ -41,8 +38,3 @@ var (
 		Help:      "Total count of consensus errors",
 	})
 )
-
-func instrumentConsensus(duty core.Duty, round int64, startTime time.Time, typ timerType) {
-	decidedRoundsGauge.WithLabelValues(duty.Type.String(), string(typ)).Set(float64(round))
-	consensusDuration.WithLabelValues(duty.Type.String(), string(typ)).Observe(time.Since(startTime).Seconds())
-}


### PR DESCRIPTION
Refactors the consensus duration metric to `duration=consensus_decided_at-consensus_proposed_at` so that eager timer durations are reflected correctly since they start much earlier than normal timing strategies. 

category: refactor
ticket: #2337
