### PR TITLE
vmock: query attester duties for 2 epochs

### DIFF
--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -430,7 +430,7 @@ func TestComponent_SubmitBeaconBlock(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
-	// PrepareEpoch unsigned beacon block
+	// Prepare unsigned beacon block
 	msg := []byte("randao reveal")
 	sig, err := tbls.Sign(secret, msg)
 	require.NoError(t, err)
@@ -511,7 +511,7 @@ func TestComponent_SubmitBeaconBlockInvalidSignature(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
-	// PrepareEpoch unsigned beacon block
+	// Prepare unsigned beacon block
 	msg := []byte("randao reveal")
 	sig, err := tbls.Sign(secret, msg)
 	require.NoError(t, err)
@@ -741,7 +741,7 @@ func TestComponent_SubmitBlindedBeaconBlock(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
-	// PrepareEpoch unsigned beacon block
+	// Prepare unsigned beacon block
 	msg := []byte("randao reveal")
 	sig, err := tbls.Sign(secret, msg)
 	require.NoError(t, err)
@@ -818,7 +818,7 @@ func TestComponent_SubmitBlindedBeaconBlockInvalidSignature(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderTrue, nil)
 	require.NoError(t, err)
 
-	// PrepareEpoch unsigned beacon block
+	// Prepare unsigned beacon block
 	msg := []byte("randao reveal")
 	sig, err := tbls.Sign(secret, msg)
 	require.NoError(t, err)
@@ -969,7 +969,7 @@ func TestComponent_SubmitVoluntaryExit(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, testutil.BuilderFalse, nil)
 	require.NoError(t, err)
 
-	// PrepareEpoch unsigned voluntary exit
+	// Prepare unsigned voluntary exit
 	exit := &eth2p0.VoluntaryExit{
 		Epoch:          epoch,
 		ValidatorIndex: vIdx,

--- a/eth2util/eth2exp/attagg.go
+++ b/eth2util/eth2exp/attagg.go
@@ -25,7 +25,7 @@ type BeaconCommitteeSelectionAggregator interface {
 
 // BeaconCommitteeSelection is the data required for a beacon committee subscription.
 type BeaconCommitteeSelection struct {
-	// ValidatorIdex is the index of the validator making the aggregate request.
+	// ValidatorIndex is the index of the validator making the aggregate request.
 	ValidatorIndex eth2p0.ValidatorIndex
 	// Slot is the slot for which the validator is possibly aggregating.
 	Slot eth2p0.Slot

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -191,7 +191,7 @@ func wait(ctx context.Context, chs ...chan struct{}) {
 	}
 }
 
-// prepareAttesters returns the attester duties for the provided validators and epoch.
+// prepareAttesters returns the attester duties for the provided validators in the given epoch.
 func prepareAttesters(ctx context.Context, eth2Cl eth2wrap.Client, vals eth2wrap.ActiveValidators, epoch eth2p0.Epoch) (attDuties, error) {
 	if len(vals) == 0 {
 		return nil, nil
@@ -205,7 +205,7 @@ func prepareAttesters(ctx context.Context, eth2Cl eth2wrap.Client, vals eth2wrap
 	return duties, nil
 }
 
-// prepareAggregators does beacon committee subscription selections for the provided attesters and returns the selected aggregators.
+// prepareAggregators does beacon committee selections for the provided attesters and returns the selected aggregators.
 func prepareAggregators(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, vals eth2wrap.ActiveValidators, duties attDuties) (attSelections, error) {
 	if len(duties) == 0 {
 		return nil, nil

--- a/testutil/validatormock/validatormock_test.go
+++ b/testutil/validatormock/validatormock_test.go
@@ -98,7 +98,7 @@ func TestAttest(t *testing.T) {
 			// Assert length and expected attestations
 			require.Len(t, atts, test.ExpectAttestations)
 			require.Len(t, aggs, test.ExpectAggregations)
-			require.NotNil(t, subs)
+			require.Equal(t, 2*len(valSet), len(subs))
 
 			// Sort the outputs to make it deterministic to compare with json.
 			sort.Slice(atts, func(i, j int) bool {


### PR DESCRIPTION
Update validatormock to query attestations at the start of the current epoch for the current and next epochs .

This enables testing of selections endpoints by simulating behaviour of real validator clients which query attester duties for two epochs, current and next. They do this to calculate all subnets to subscribe for attester and aggregator duties.

category: feature 
ticket: #2400 
