### PR TITLE
app: add mutex to `onStartup`

### DIFF
--- a/app/vmock.go
+++ b/app/vmock.go
@@ -43,7 +43,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 
 		return startingUp
 	}
-	setOnStartup := func() {
+	clearOnStartup := func() {
 		mu.Lock()
 		defer mu.Unlock()
 
@@ -83,7 +83,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 			})
 		}
 
-		setOnStartup()
+		clearOnStartup()
 
 		// Prepare sync committee selections when slots tick.
 		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -33,7 +33,10 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 		return err
 	}
 
-	onStartup := true
+	var (
+		mu        sync.Mutex
+		onStartup = true
+	)
 	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
 		// Prepare attestations when slots tick.
 		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {
@@ -67,7 +70,9 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 			})
 		}
 
+		mu.Lock()
 		onStartup = false
+		mu.Unlock()
 
 		// Prepare sync committee selections when slots tick.
 		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -34,9 +34,22 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 	}
 
 	var (
-		mu        sync.Mutex
-		onStartup = true
+		mu         sync.Mutex
+		startingUp = true
 	)
+	onStartup := func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+
+		return startingUp
+	}
+	setOnStartup := func() {
+		mu.Lock()
+		defer mu.Unlock()
+
+		startingUp = false
+	}
+
 	sched.SubscribeSlots(func(ctx context.Context, slot core.Slot) error {
 		// Prepare attestations when slots tick.
 		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {
@@ -44,7 +57,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 		})
 
 		// Prepare sync committee message when epoch tick.
-		if onStartup || slot.FirstInEpoch() {
+		if onStartup() || slot.FirstInEpoch() {
 			vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {
 				// Either call if it is first slot in epoch or on charon startup.
 				return state.SyncCommMember.PrepareEpoch(ctx)
@@ -52,7 +65,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 		}
 
 		// Submit validator registrations when epoch tick.
-		if onStartup || slot.FirstInEpoch() {
+		if onStartup() || slot.FirstInEpoch() {
 			vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {
 				regs, err := validatormock.RegistrationsFromProposerConfig(ctx, state.Eth2Cl)
 				if err != nil {
@@ -70,9 +83,7 @@ func wireValidatorMock(conf Config, pubshares []eth2p0.BLSPubKey, sched core.Sch
 			})
 		}
 
-		mu.Lock()
-		onStartup = false
-		mu.Unlock()
+		setOnStartup()
 
 		// Prepare sync committee selections when slots tick.
 		vMockWrap(ctx, slot.Slot, func(ctx context.Context, state vMockState) error {


### PR DESCRIPTION
Add mutex to `onStartup` variable in `wireValidatorMock()`. This fixes data race identified in this build - https://github.com/ObolNetwork/charon/actions/runs/5551674526/jobs/10138073971?pr=2431#logs. 

The data race arises from two goroutines trying to modify the value of `onStartup`:
1. First goroutine which handles slot X tries to read the value of `onStartup`
2. Second goroutine which handles slot Y tries to update the value to `false`

category: bug 
ticket: none 