### PR TITLE
parsigex: unmarshal data that is about to be broadcasted

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -105,11 +105,8 @@ func (m *ParSigEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSi
 	}
 
 	// TODO: remove this from prod once we know what's going on
-	for _, data := range pb.Set {
-		_, err = core.ParSignedDataFromProto(duty.Type, data)
-		if err != nil {
-			log.Warn(ctx, "ParSignedDataSet which was just marshaled can't be unmarshaled back", err)
-		}
+	if _, err = core.ParSignedDataSetFromProto(duty.Type, pb); err != nil {
+		log.Warn(ctx, "ParSignedDataSet which was just marshaled can't be unmarshaled back", err)
 	}
 
 	msg := pbv1.ParSigExMsg{

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -104,6 +104,14 @@ func (m *ParSigEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSi
 		return err
 	}
 
+	// TODO: remove this from prod once we know what's going on
+	for _, data := range pb.Set {
+		_, err = core.ParSignedDataFromProto(duty.Type, data)
+		if err != nil {
+			log.Warn(ctx, "ParSignedDataSet which was just marshaled can't be unmarshaled back", err)
+		}
+	}
+
 	msg := pbv1.ParSigExMsg{
 		Duty:    core.DutyToProto(duty),
 		DataSet: pb,

--- a/core/proto.go
+++ b/core/proto.go
@@ -251,12 +251,14 @@ func unmarshal(data []byte, v any) error {
 			return nil
 		} else if !bytes.HasPrefix(bytes.TrimSpace(data), []byte("{")) {
 			// No json prefix, so no point attempting json unmarshalling.
+			// TODO: remove "data" log before v0.17.0
 			return errors.Wrap(err, "unmarshal ssz", z.Hex("data", data))
 		}
 	}
 
 	// Else try json
 	if err := json.Unmarshal(data, v); err != nil {
+		// TODO: remove "data" log before v0.17.0
 		return errors.Wrap(err, "unmarshal json", z.Hex("data", data))
 	}
 

--- a/core/proto.go
+++ b/core/proto.go
@@ -251,13 +251,13 @@ func unmarshal(data []byte, v any) error {
 			return nil
 		} else if !bytes.HasPrefix(bytes.TrimSpace(data), []byte("{")) {
 			// No json prefix, so no point attempting json unmarshalling.
-			return errors.Wrap(err, "unmarshal ssz")
+			return errors.Wrap(err, "unmarshal ssz", z.Hex("data", data))
 		}
 	}
 
 	// Else try json
 	if err := json.Unmarshal(data, v); err != nil {
-		return errors.Wrap(err, "unmarshal json")
+		return errors.Wrap(err, "unmarshal json", z.Hex("data", data))
 	}
 
 	return nil


### PR DESCRIPTION
Also log full hex encoded byte arrays that fail to get unmarshaled in their original type.

Needed to troubleshoot https://github.com/ObolNetwork/charon/issues/2433.

category: misc
ticket: #2433
