### PR TITLE
app/health: zero discarded metric

### DIFF
--- a/app/health/checker.go
+++ b/app/health/checker.go
@@ -94,6 +94,7 @@ func (c *Checker) scrape() error {
 	c.metrics = append(c.metrics, metrics)
 
 	if len(c.metrics) > c.maxScrapes {
+		c.metrics[0] = nil
 		c.metrics = c.metrics[1:]
 	}
 


### PR DESCRIPTION
Zero out the last metric of c.metrics before reslicing it, marking it as ready to be garbage collected.

category: bug
ticket: #2438 
