### PR TITLE
cmd: fix `create cluster` regression

### DIFF
--- a/cmd/testdata/TestCreateCluster_splitkeys_with_cluster_definition_files.golden
+++ b/cmd/testdata/TestCreateCluster_splitkeys_with_cluster_definition_files.golden
@@ -1,0 +1,22 @@
+[
+ "node0",
+ "node1",
+ "node2",
+ "node3",
+ "node0/charon-enr-private-key",
+ "node0/cluster-lock.json",
+ "node0/deposit-data.json",
+ "node0/validator_keys",
+ "node1/charon-enr-private-key",
+ "node1/cluster-lock.json",
+ "node1/deposit-data.json",
+ "node1/validator_keys",
+ "node2/charon-enr-private-key",
+ "node2/cluster-lock.json",
+ "node2/deposit-data.json",
+ "node2/validator_keys",
+ "node3/charon-enr-private-key",
+ "node3/cluster-lock.json",
+ "node3/deposit-data.json",
+ "node3/validator_keys"
+]

--- a/cmd/testdata/TestCreateCluster_splitkeys_with_cluster_definition_output.golden
+++ b/cmd/testdata/TestCreateCluster_splitkeys_with_cluster_definition_output.golden
@@ -1,0 +1,18 @@
+
+***************** WARNING: Splitting keys **********************
+ Please make sure any existing validator has been shut down for
+ at least 2 finalised epochs before starting the charon cluster,
+ otherwise slashing could occur.                               
+****************************************************************
+
+Created charon cluster:
+ --split-existing-keys=true
+
+charon/
+├─ node[0-3]/			Directory for each node
+│  ├─ charon-enr-private-key	Charon networking private key for node authentication
+│  ├─ cluster-lock.json		Cluster lock defines the cluster lock file which is signed by all nodes
+│  ├─ deposit-data.json		Deposit data file is used to activate a Distributed Validator on DV Launchpad
+│  ├─ validator_keys		Validator keystores and password
+│  │  ├─ keystore-*.json	Validator private share key for duty signing
+│  │  ├─ keystore-*.txt		Keystore password files for keystore-*.json


### PR DESCRIPTION
After the `create cluster` refactor a couple PR's back, definition file was essentially ignored.

This PR restores that functionality back.

category: bug
ticket: #2444

Closes #2444 