### PR TITLE
core/priority: don't start consensus twice

### DIFF
--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -303,6 +303,10 @@ func runInstance(ctx context.Context, duty core.Duty, own *pbv1.PriorityMsg,
 		case msg := <-responses:
 			addMsg(msg)
 		case <-exTimeout:
+			if consStarted {
+				continue
+			}
+
 			log.Debug(ctx, "Priority protocol instance exchange timeout, starting consensus")
 			consStarted = true
 			err := startConsensus(ctx, duty, msgs, minRequired, consensus)


### PR DESCRIPTION
If consensus has been started because enough messages have been received, don't also start it if exchangeTimeout is reached.

category: bug
ticket: #2439 