### PR TITLE
gomod: downgrade go-eth2-client

### DIFF
--- a/core/testdata/TestJSONSerialisation_VersionedBeaconBlock.json.golden
+++ b/core/testdata/TestJSONSerialisation_VersionedBeaconBlock.json.golden
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 1,
   "block": {
     "slot": "17349330445822630798",
     "proposer_index": "8074401586156473090",

--- a/core/testdata/TestJSONSerialisation_VersionedBlindedBeaconBlock.json.golden
+++ b/core/testdata/TestJSONSerialisation_VersionedBlindedBeaconBlock.json.golden
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 4,
   "block": {
     "slot": "17349330445822630798",
     "proposer_index": "8074401586156473090",

--- a/core/testdata/TestJSONSerialisation_VersionedSignedBeaconBlock.json.golden
+++ b/core/testdata/TestJSONSerialisation_VersionedSignedBeaconBlock.json.golden
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 1,
   "block": {
     "message": {
       "slot": "12258969221770119542",

--- a/core/testdata/TestJSONSerialisation_VersionedSignedBlindedBeaconBlock.json.golden
+++ b/core/testdata/TestJSONSerialisation_VersionedSignedBlindedBeaconBlock.json.golden
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 4,
   "block": {
     "message": {
       "slot": "12258969221770119542",

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
 const (
@@ -613,23 +614,16 @@ func TestRouter(t *testing.T) {
 	})
 
 	t.Run("get validators with no validator ids provided", func(t *testing.T) {
-		idx := eth2p0.ValidatorIndex(99)
 		handler := testHandler{
 			ValidatorsFunc: func(_ context.Context, stateID string, indices []eth2p0.ValidatorIndex) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
-				val := testutil.RandomValidator(t)
-				val.Index = idx
-
-				return map[eth2p0.ValidatorIndex]*eth2v1.Validator{
-					idx: val,
-				}, nil
+				return beaconmock.ValidatorSetA, nil
 			},
 		}
 
 		callback := func(ctx context.Context, cl *eth2http.Service) {
 			res, err := cl.Validators(ctx, "head", nil)
 			require.NoError(t, err)
-			require.Len(t, res, 1)
-			require.NotNil(t, res[idx])
+			require.EqualValues(t, beaconmock.ValidatorSetA, res)
 		}
 
 		testRouter(t, handler, callback)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/obolnetwork/charon
 go 1.20
 
 require (
-	github.com/attestantio/go-eth2-client v0.18.0
+	github.com/attestantio/go-eth2-client v0.17.0
 	github.com/bufbuild/buf v1.25.0
 	github.com/coinbase/kryptology v1.5.6-0.20220316191335-269410e1b06b
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
-github.com/attestantio/go-eth2-client v0.18.0 h1:W8/d6Fa0SvgwO6ybcEwBiRZP1yaUCq7JlvMHHAx3O6Q=
-github.com/attestantio/go-eth2-client v0.18.0/go.mod h1:KSVlZSW1A3jUg5H8O89DLtqxgJprRfTtI7k89fLdhu0=
+github.com/attestantio/go-eth2-client v0.17.0 h1:Rvn/tmLHRRztoS2c/6AmsslGucyytWMvnQlAUz4EvYY=
+github.com/attestantio/go-eth2-client v0.17.0/go.mod h1:N+BNIxaHmul44d0tTjwFrUJU/g6MIblFP67oagm1Lwo=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
@@ -518,7 +518,7 @@ github.com/r3labs/sse/v2 v2.10.0/go.mod h1:Igau6Whc+F17QUgML1fYe1VPZzTV6EMCnYktE
 github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtBsk=
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rs/cors v1.9.0 h1:l9HGsTsHJcvW14Nk7J9KFz8bzeAWXn3CG6bgt7LsrAE=
 github.com/rs/cors v1.9.0/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=


### PR DESCRIPTION
Downgrades `go-eth2-client` version to v0.17.0. We need to do this in order to be compatible with beacon nodes until all the clients implement latest updates of beacon API specs like returning `Eth-Consensus-Version` as response header in some endpoints.

category: bug
ticket: none
