### PR TITLE
core: fix wrong UnmarshalSSZ error message

### DIFF
--- a/core/ssz.go
+++ b/core/ssz.go
@@ -205,7 +205,7 @@ func (b VersionedSignedBlindedBeaconBlock) MarshalSSZTo(buf []byte) ([]byte, err
 func (b *VersionedSignedBlindedBeaconBlock) UnmarshalSSZ(buf []byte) error {
 	version, err := unmarshalSSZVersioned(buf, b.sszValFromVersion)
 	if err != nil {
-		return errors.Wrap(err, "unmarshal VersionedSignedBeaconBlock")
+		return errors.Wrap(err, "unmarshal VersionedSignedBlindedBeaconBlock")
 	}
 
 	b.Version = version


### PR DESCRIPTION
Was returning a "VersionedSignedBeaconBlock" error message, while the object being unmarshaled is a VersionedSignedBlindedBeaconBlock.

category: bug 
ticket: none