### PR TITLE
parsigex: remove unmarshal logs

### DIFF
--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -104,11 +104,6 @@ func (m *ParSigEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSi
 		return err
 	}
 
-	// TODO: remove this from prod once we know what's going on
-	if _, err = core.ParSignedDataSetFromProto(duty.Type, pb); err != nil {
-		log.Warn(ctx, "ParSignedDataSet which was just marshaled can't be unmarshaled back", err)
-	}
-
 	msg := pbv1.ParSigExMsg{
 		Duty:    core.DutyToProto(duty),
 		DataSet: pb,

--- a/core/proto.go
+++ b/core/proto.go
@@ -251,15 +251,13 @@ func unmarshal(data []byte, v any) error {
 			return nil
 		} else if !bytes.HasPrefix(bytes.TrimSpace(data), []byte("{")) {
 			// No json prefix, so no point attempting json unmarshalling.
-			// TODO: remove "data" log before v0.17.0
-			return errors.Wrap(err, "unmarshal ssz", z.Hex("data", data))
+			return errors.Wrap(err, "unmarshal ssz")
 		}
 	}
 
 	// Else try json
 	if err := json.Unmarshal(data, v); err != nil {
-		// TODO: remove "data" log before v0.17.0
-		return errors.Wrap(err, "unmarshal json", z.Hex("data", data))
+		return errors.Wrap(err, "unmarshal json")
 	}
 
 	return nil


### PR DESCRIPTION
This reverts commit 6075930ef2bcb64200cd2b8b762048540f0ca718, since we [identified](https://obollabs.slack.com/archives/C05GZ3U44F9/p1689937965228159) the cause for the unmarshaling error.

category: misc
ticket: #2433 