### PR TITLE
app/log: decrease default log filter from 1h to 12s

### DIFF
--- a/app/log/filter.go
+++ b/app/log/filter.go
@@ -26,9 +26,9 @@ type filter struct {
 	limit rate.Limit
 }
 
-// defaultFilter returns the default filter with a period of 1 minute.
+// defaultFilter returns the default filter with a period of 1 slot.
 func defaultFilter() filter {
-	return filter{limit: rate.Every(time.Minute)}
+	return filter{limit: rate.Every(time.Second * 12)}
 }
 
 // Filter returns a stateful structure logging field that results in
@@ -39,7 +39,7 @@ func defaultFilter() filter {
 //	for event := range eventPipe() {
 //	  err := process(event)
 //	  if err != nil {
-//	    log.Error(ctx, "This error should only be logged max once an minute", err, filter)
+//	    log.Error(ctx, "This error should only be logged max once a slot (12s)", err, filter)
 //	  }
 //	}
 func Filter(opts ...FilterOption) z.Field {

--- a/app/log/filter.go
+++ b/app/log/filter.go
@@ -26,9 +26,9 @@ type filter struct {
 	limit rate.Limit
 }
 
-// defaultFilter returns the default filter with a period of 1 hour.
+// defaultFilter returns the default filter with a period of 1 minute.
 func defaultFilter() filter {
-	return filter{limit: rate.Every(time.Hour)}
+	return filter{limit: rate.Every(time.Minute)}
 }
 
 // Filter returns a stateful structure logging field that results in
@@ -39,7 +39,7 @@ func defaultFilter() filter {
 //	for event := range eventPipe() {
 //	  err := process(event)
 //	  if err != nil {
-//	    log.Error(ctx, "This error should only be logged max once an hour", err, filter)
+//	    log.Error(ctx, "This error should only be logged max once an minute", err, filter)
 //	  }
 //	}
 func Filter(opts ...FilterOption) z.Field {


### PR DESCRIPTION
I think an hour is maybe too much, it is hiding information. Once a slot (every 12 secs) feels better. VC triggered logs are often roughly once a slot per type. So this would have same visibility level. 

category: refactor 
ticket: none