### PR TITLE
app/version: bump to `v0.17-rc`

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 // version a string since it is overwritten at build-time with the git tag for official releases.
-var version = "v0.17-dev"
+var version = "v0.17-rc"
 
 // Version is the branch version of the codebase.
 //   - Main branch: v0.X-dev


### PR DESCRIPTION
Bump version of `main-v0.17` release branch to `v0.17-rc` to prepare a release candidate for the `v0.17` release.

category: feature 
ticket: none 
