### PR TITLE
github: fix build push build arg format

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -54,7 +54,7 @@ jobs:
 
     - name: Maybe overwrite app/version.Version with git tag
       if: github.ref_type == 'tag'
-      run: echo 'GO_BUILD_FLAG=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
+      run: echo 'GO_BUILD_FLAG=-ldflags=-X github.com/obolnetwork/charon/app/version.version=${{ github.ref_name }}' >> $GITHUB_ENV
 
     - uses: docker/build-push-action@v4
       with:

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -54,14 +54,16 @@ jobs:
 
     - name: Maybe overwrite app/version.Version with git tag
       if: github.ref_type == 'tag'
-      run: echo 'GO_BUILD_FLAGS=-ldflags=-X github.com/obolnetwork/charon/app/version.version=${{ github.ref_name }}' >> $GITHUB_ENV
+      run: echo 'GO_BUILD_FLAG=-ldflags=-X github.com/obolnetwork/charon/app/version.Version=${{ github.ref_name }}' >> $GITHUB_ENV
 
     - uses: docker/build-push-action@v4
       with:
         context: .
         platforms: linux/amd64,linux/arm64
         push: true
-        build-args: GITHUB_SHA=${{ github.sha }} GO_BUILD_FLAGS=${{ env.GO_BUILD_FLAGS }}
+        build-args: |
+          GITHUB_SHA=${{ github.sha }}
+          GO_BUILD_FLAG=${{ env.GO_BUILD_FLAG }}
         tags: ${{ steps.meta.outputs.tags }}
 
     - name: Set short git commit SHA

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,16 @@ RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source
 WORKDIR /app/charon
 COPY . .
-# Populate GO_BUILD_FLAGS build args to override build flags.
-ARG GO_BUILD_FLAGS
+# Populate GO_BUILD_FLAG with a build arg to provide a optional go build flag.
+ARG GO_BUILD_FLAG
+ENV GO_BUILD_FLAG=${GO_BUILD_FLAG}
+RUN echo "Building with GO_BUILD_FLAG='${GO_BUILD_FLAG}'"
 # Build with Go module and Go build caches.
 RUN \
    --mount=type=cache,target=/go/pkg \
    --mount=type=cache,target=/root/.cache/go-build \
-   go build -o charon "${GO_BUILD_FLAGS}" .
+   go build -o charon "${GO_BUILD_FLAG}" . \
+RUN echo "Built charon version=$(./charon version)" \
 
 # Copy final binary into light stage.
 FROM debian:bullseye-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source
 WORKDIR /app/charon
 COPY . .
-# Populate GO_BUILD_FLAG with a build arg to provide a optional go build flag.
+# Populate GO_BUILD_FLAG with a build arg to provide an optional go build flag.
 ARG GO_BUILD_FLAG
 ENV GO_BUILD_FLAG=${GO_BUILD_FLAG}
 RUN echo "Building with GO_BUILD_FLAG='${GO_BUILD_FLAG}'"


### PR DESCRIPTION
Fixes the github action "build-push-deploys" `build-args` parameter. It is a [list parameter that is new line delimited](https://github.com/docker/build-push-action#inputs).

Also remove `-a` build arg since it isn't required. Make it explicit that `GO_BUILD_FLAG` only supports a single flag.

This ports the fix from `main-v0.16` release branch to main.

category: misc
ticket: #2270 
