### PR TITLE
dkg: increase bcast receive timeout

### DIFF
--- a/dkg/bcast/helpers.go
+++ b/dkg/bcast/helpers.go
@@ -4,6 +4,7 @@ package bcast
 
 import (
 	"context"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
 	"google.golang.org/protobuf/proto"
@@ -14,6 +15,7 @@ const (
 	protocolIDPrefix = "/charon/dkg/bcast/1.0.0"
 	protocolIDSig    = protocolIDPrefix + "/sig"
 	protocolIDMsg    = protocolIDPrefix + "/msg"
+	receiveTimeout   = time.Minute // Allow for peers to be out of sync, with some sending messages much earlier and having to wait.
 )
 
 // hashFunc is a function that hashes a any-wrapped protobuf message.

--- a/dkg/bcast/server.go
+++ b/dkg/bcast/server.go
@@ -30,12 +30,14 @@ func newServer(tcpNode host.Host, signFunc signFunc, verifyFunc verifyFunc) *ser
 		func() proto.Message { return new(pb.BCastSigRequest) },
 		s.handleSigRequest,
 		p2p.WithDelimitedProtocol(protocolIDSig),
+		p2p.WithReceiveTimeout(receiveTimeout),
 	)
 
 	p2p.RegisterHandler("bcast", tcpNode, protocolIDMsg,
 		func() proto.Message { return new(pb.BCastMessage) },
 		s.handleMessage,
 		p2p.WithDelimitedProtocol(protocolIDMsg),
+		p2p.WithReceiveTimeout(receiveTimeout),
 	)
 
 	return s

--- a/p2p/receive.go
+++ b/p2p/receive.go
@@ -53,9 +53,8 @@ func RegisterHandler(logTopic string, tcpNode host.Host, pID protocol.ID,
 		t0 := time.Now()
 		name := PeerName(s.Conn().RemotePeer())
 
-		timeout := time.Second * 5
-		_ = s.SetReadDeadline(time.Now().Add(timeout))
-		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		_ = s.SetReadDeadline(time.Now().Add(o.receiveTimeout))
+		ctx, cancel := context.WithTimeout(context.Background(), o.receiveTimeout)
 		ctx = log.WithTopic(ctx, logTopic)
 		ctx = log.WithCtx(ctx,
 			z.Str("peer", name),

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -21,9 +21,10 @@ import (
 )
 
 const (
-	senderHysteresis = 3
-	senderBuffer     = senderHysteresis + 1
-	maxMsgSize       = 128 << 20 // 128MB
+	senderHysteresis  = 3
+	senderBuffer      = senderHysteresis + 1
+	maxMsgSize        = 128 << 20 // 128MB
+	defaultRcvTimeout = time.Second * 5
 )
 
 // SendFunc is an abstract function responsible for sending libp2p messages.
@@ -147,6 +148,14 @@ type sendRecvOpts struct {
 	writersByProtocol map[protocol.ID]func(network.Stream) pbio.Writer
 	readersByProtocol map[protocol.ID]func(network.Stream) pbio.Reader
 	rttCallback       func(time.Duration)
+	receiveTimeout    time.Duration
+}
+
+// WithReceiveTimeout returns an option for SendReceive that sets a timeout for handling incoming messages.
+func WithReceiveTimeout(timeout time.Duration) func(*sendRecvOpts) {
+	return func(opts *sendRecvOpts) {
+		opts.receiveTimeout = timeout
+	}
 }
 
 // WithSendReceiveRTT returns an option for SendReceive that sets a callback for the RTT.
@@ -175,7 +184,8 @@ func defaultSendRecvOpts(pID protocol.ID) sendRecvOpts {
 		readersByProtocol: map[protocol.ID]func(s network.Stream) pbio.Reader{
 			pID: func(s network.Stream) pbio.Reader { return legacyReadWriter{s} },
 		},
-		rttCallback: func(time.Duration) {},
+		rttCallback:    func(time.Duration) {},
+		receiveTimeout: defaultRcvTimeout,
 	}
 }
 


### PR DESCRIPTION
Makes DKG P2P receive timeout configurable and increases it from the default 5s to 1min allowing peers to broadcast messages much earlier and having them wait longer for the receiver to handle to properly.

This was encountered in large DKG where some peers are much slower than others, still doing key generation even though others are already sharing node sigs and erroring after 5s since the slow peer doensn't have a lock hash yet to verify the received node sigs.

category: refactor
ticket: none
