### PR TITLE
p2p: set default send timeout

### DIFF
--- a/dkg/bcast/client.go
+++ b/dkg/bcast/client.go
@@ -133,7 +133,8 @@ func (c *client) Broadcast(ctx context.Context, msgID string, msg proto.Message)
 			continue // Skip self.
 		}
 
-		err := c.sendFunc(ctx, c.tcpNode, protocolIDMsg, pID, bcastMsg, p2p.WithDelimitedProtocol(protocolIDMsg))
+		err := c.sendFunc(ctx, c.tcpNode, protocolIDMsg, pID, bcastMsg,
+			p2p.WithDelimitedProtocol(protocolIDMsg), p2p.WithSendTimeout(sendTimeout))
 		if err != nil {
 			return errors.Wrap(err, "send message")
 		}

--- a/dkg/bcast/helpers.go
+++ b/dkg/bcast/helpers.go
@@ -15,7 +15,8 @@ const (
 	protocolIDPrefix = "/charon/dkg/bcast/1.0.0"
 	protocolIDSig    = protocolIDPrefix + "/sig"
 	protocolIDMsg    = protocolIDPrefix + "/msg"
-	receiveTimeout   = time.Minute // Allow for peers to be out of sync, with some sending messages much earlier and having to wait.
+	receiveTimeout   = time.Minute                 // Allow for peers to be out of sync, with some sending messages much earlier and having to wait.
+	sendTimeout      = time.Minute + 2*time.Second // Allow for server to timeout first.
 )
 
 // hashFunc is a function that hashes a any-wrapped protobuf message.

--- a/dkg/bcast/helpers.go
+++ b/dkg/bcast/helpers.go
@@ -15,8 +15,8 @@ const (
 	protocolIDPrefix = "/charon/dkg/bcast/1.0.0"
 	protocolIDSig    = protocolIDPrefix + "/sig"
 	protocolIDMsg    = protocolIDPrefix + "/msg"
-	receiveTimeout   = time.Minute                 // Allow for peers to be out of sync, with some sending messages much earlier and having to wait.
-	sendTimeout      = time.Minute + 2*time.Second // Allow for server to timeout first.
+	receiveTimeout   = time.Minute                    // Allow for peers to be out of sync, with some sending messages much earlier and having to wait.
+	sendTimeout      = receiveTimeout + 2*time.Second // Allow for server to timeout first.
 )
 
 // hashFunc is a function that hashes a any-wrapped protobuf message.

--- a/p2p/sender_test.go
+++ b/p2p/sender_test.go
@@ -38,6 +38,25 @@ func TestWithReceiveTimeout(t *testing.T) {
 	require.ErrorContains(t, err, "no or zero response received")
 }
 
+func TestWithSendTimeout(t *testing.T) {
+	server := testutil.CreateHost(t, testutil.AvailableAddr(t))
+	client := testutil.CreateHost(t, testutil.AvailableAddr(t))
+
+	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), time.Hour)
+
+	protocolID := protocol.ID("testprotocol")
+	p2p.RegisterHandler("test", server, protocolID, func() proto.Message { return new(pbv1.Duty) },
+		func(ctx context.Context, peerID peer.ID, req proto.Message) (proto.Message, bool, error) {
+			require.Fail(t, "this should not be called")
+			return nil, false, nil
+		})
+
+	err := p2p.SendReceive(context.Background(), client, server.ID(),
+		new(pbv1.Duty), new(pbv1.Duty), protocolID, p2p.WithSendTimeout(0))
+	require.Error(t, err)
+	require.ErrorContains(t, err, "deadline")
+}
+
 func TestSend(t *testing.T) {
 	var (
 		undelimID = protocol.ID("undelimited")

--- a/p2p/sender_test.go
+++ b/p2p/sender_test.go
@@ -47,7 +47,6 @@ func TestWithSendTimeout(t *testing.T) {
 	protocolID := protocol.ID("testprotocol")
 	p2p.RegisterHandler("test", server, protocolID, func() proto.Message { return new(pbv1.Duty) },
 		func(ctx context.Context, peerID peer.ID, req proto.Message) (proto.Message, bool, error) {
-			require.Fail(t, "this should not be called")
 			return nil, false, nil
 		})
 


### PR DESCRIPTION
We didn't actually set timeouts when sending libp2p messages, only when receiving message. Not setting timeouts is bad practice. See more info on this [here](https://dev.to/bearer/the-importance-of-request-timeouts-l3n) and [here](https://medium.com/booking-com-development/io-socket-timeout-socket-timeout-made-easy-4dfd43e777f7).

This sets the send timeout equivalent to the read timeout, allowing up to 1s latency between nodes, so read timeout+2s.

category: misc
ticket: none