### PR TITLE
dkg: exchange sigTypes concurrently

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -183,7 +183,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.Wrap(err, "get peer IDs")
 	}
 
-	ex := newExchanger(ctx, tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators, []sigType{
+	ex := newExchanger(tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators, []sigType{
 		sigLock,
 		sigDepositData,
 		sigValidatorRegistration,

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -183,7 +183,11 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.Wrap(err, "get peer IDs")
 	}
 
-	ex := newExchanger(tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators)
+	ex := newExchanger(ctx, tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators, []sigType{
+		sigLock,
+		sigDepositData,
+		sigValidatorRegistration,
+	})
 
 	// Register Frost libp2p handlers
 	peerMap := make(map[peer.ID]cluster.NodeIdx)

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -4,10 +4,15 @@ package dkg
 
 import (
 	"context"
+	"sync"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/parsigdb"
 	"github.com/obolnetwork/charon/core/parsigex"
@@ -29,6 +34,46 @@ const (
 	sigValidatorRegistration sigType = 103
 )
 
+// sigTypeStore is a shorthand for a map of sigType to map of core.PubKey to slice of core.ParSignedData.
+type sigTypeStore map[sigType]map[core.PubKey][]core.ParSignedData
+
+// dataByPubkey maps a sigType to its map of public key to slice of core.ParSignedData..
+type dataByPubkey struct {
+	store sigTypeStore
+	lock  sync.Mutex
+}
+
+// set sets data for the given sigType and core.PubKey.
+func (stb *dataByPubkey) set(pubKey core.PubKey, sigType sigType, data []core.ParSignedData) {
+	stb.lock.Lock()
+	defer stb.lock.Unlock()
+
+	_, ok := stb.store[sigType]
+	if !ok {
+		stb.store[sigType] = map[core.PubKey][]core.ParSignedData{}
+	}
+
+	stb.store[sigType][pubKey] = data
+}
+
+// get gets all the core.ParSignedData for a given core.PubKey.
+func (stb *dataByPubkey) get(sigType sigType) map[core.PubKey][]core.ParSignedData {
+	stb.lock.Lock()
+	defer stb.lock.Unlock()
+
+	if len(stb.store[sigType]) == 0 {
+		return nil
+	}
+
+	ret := make(map[core.PubKey][]core.ParSignedData)
+
+	for k, v := range stb.store[sigType] {
+		ret[k] = v
+	}
+
+	return ret
+}
+
 // sigData includes the fields obtained from sigdb when threshold is reached.
 type sigData struct {
 	sigType sigType
@@ -38,24 +83,37 @@ type sigData struct {
 
 // exchanger is responsible for exchanging partial signatures between peers on libp2p.
 type exchanger struct {
-	sigChan chan sigData
-	sigex   *parsigex.ParSigEx
-	sigdb   *parsigdb.MemDB
-	numVals int
+	sigChan  chan sigData
+	sigex    *parsigex.ParSigEx
+	sigdb    *parsigdb.MemDB
+	numVals  int
+	sigTypes map[sigType]bool
+	sigData  dataByPubkey
 }
 
-func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *exchanger {
+func newExchanger(ctx context.Context, tcpNode host.Host, peerIdx int, peers []peer.ID, vals int, sigTypes []sigType) *exchanger {
 	// Partial signature roots not known yet, so skip verification in parsigex, rather verify before we aggregate.
 	noopVerifier := func(ctx context.Context, duty core.Duty, key core.PubKey, data core.ParSignedData) error {
 		return nil
 	}
 
+	st := make(map[sigType]bool)
+
+	for _, sigType := range sigTypes {
+		st[sigType] = true
+	}
+
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
-		sigdb:   parsigdb.NewMemDB(len(peers), noopDeadliner{}),
-		sigex:   parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers, noopVerifier),
-		sigChan: make(chan sigData, vals), // Allow buffering all signature sets
-		numVals: vals,
+		sigdb:    parsigdb.NewMemDB(len(peers), noopDeadliner{}),
+		sigex:    parsigex.NewParSigEx(tcpNode, p2p.Send, peerIdx, peers, noopVerifier),
+		sigChan:  make(chan sigData, vals), // Allow buffering all signature sets
+		numVals:  vals,
+		sigTypes: st,
+		sigData: dataByPubkey{
+			store: sigTypeStore{},
+			lock:  sync.Mutex{},
+		},
 	}
 
 	// Wiring core workflow components
@@ -63,7 +121,36 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int) *ex
 	ex.sigdb.SubscribeThreshold(ex.pushPsigs)
 	ex.sigex.Subscribe(ex.sigdb.StoreExternal)
 
+	go func() {
+		if err := ex.readSigs(ctx); err != nil {
+			log.Warn(ctx, "Exchanger readSigs ctx error", err)
+		}
+	}()
+
 	return ex
+}
+
+func (e *exchanger) readSigs(ctx context.Context) error {
+	ctx = log.WithTopic(ctx, "exchanger")
+
+	for {
+		select {
+		case <-ctx.Done():
+			err := ctx.Err()
+			if !errors.Is(err, context.Canceled) {
+				return err
+			}
+
+			return nil
+		case peerSet := <-e.sigChan:
+			if !e.sigTypes[peerSet.sigType] {
+				log.Warn(ctx, "Unrecognized sigType", nil, z.Int("sigType", int(peerSet.sigType)))
+				continue
+			}
+
+			e.sigData.set(peerSet.pubkey, peerSet.sigType, peerSet.psigs)
+		}
+	}
 }
 
 // exchange exhanges partial signatures of lockhash/deposit-data among dkg participants and returns all the partial
@@ -76,26 +163,18 @@ func (e *exchanger) exchange(ctx context.Context, sigType sigType, set core.ParS
 		return nil, err
 	}
 
-	sets := make(map[core.PubKey][]core.ParSignedData)
-	for {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case peerSet := <-e.sigChan:
-			if sigType != peerSet.sigType {
-				// Do nothing if duty doesn't match
-				continue
-			}
-			sets[peerSet.pubkey] = peerSet.psigs
-		}
+	tick := time.NewTicker(50 * time.Millisecond)
+	defer tick.Stop()
 
+	for range tick.C {
 		// We are done when we have ParSignedData of all the DVs from all each peer
-		if len(sets) == e.numVals {
-			break
+		if data := e.sigData.get(sigType); data != nil {
+			return data, nil
 		}
 	}
 
-	return sets, nil
+	// should never happen
+	return nil, errors.New("no data for sigType", z.Int("sigType", int(sigType)))
 }
 
 // pushPsigs is responsible for writing partial signature data to sigChan obtained from other peers.

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -166,15 +166,17 @@ func (e *exchanger) exchange(ctx context.Context, sigType sigType, set core.ParS
 	tick := time.NewTicker(50 * time.Millisecond)
 	defer tick.Stop()
 
-	for range tick.C {
-		// We are done when we have ParSignedData of all the DVs from all each peer
-		if data := e.sigData.get(sigType); data != nil {
-			return data, nil
+	for {
+		select {
+		case <-tick.C:
+			// We are done when we have ParSignedData of all the DVs from all each peer
+			if data := e.sigData.get(sigType); data != nil {
+				return data, nil
+			}
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		}
 	}
-
-	// should never happen
-	return nil, errors.New("no data for sigType", z.Int("sigType", int(sigType)))
 }
 
 // pushPsigs is responsible for writing partial signature data to sigChan obtained from other peers.

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -83,7 +83,7 @@ func TestExchanger(t *testing.T) {
 	}
 
 	for i := 0; i < nodes; i++ {
-		ex := newExchanger(ctx, hosts[i], i, peers, dvs, []sigType{
+		ex := newExchanger(hosts[i], i, peers, dvs, []sigType{
 			sigLock,
 			sigDepositData,
 			sigValidatorRegistration,

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -83,12 +83,39 @@ func TestExchanger(t *testing.T) {
 	}
 
 	for i := 0; i < nodes; i++ {
-		ex := newExchanger(hosts[i], i, peers, dvs)
+		ex := newExchanger(ctx, hosts[i], i, peers, dvs, []sigType{
+			sigLock,
+			sigDepositData,
+			sigValidatorRegistration,
+		})
 		exchangers = append(exchangers, ex)
 	}
 
 	respChan := make(chan map[core.PubKey][]core.ParSignedData)
 	var wg sync.WaitGroup
+
+	// send multiple (supported) messages at the same time, showing that exchanger can exchange messages of various
+	// sigTypes concurrently
+	for i := 0; i < nodes; i++ {
+		wg.Add(2)
+		go func(node int) {
+			defer wg.Done()
+
+			data, err := exchangers[node].exchange(ctx, sigDepositData, dataToBeSent[node])
+			require.NoError(t, err)
+
+			respChan <- data
+		}(i)
+		go func(node int) {
+			defer wg.Done()
+
+			data, err := exchangers[node].exchange(ctx, sigValidatorRegistration, dataToBeSent[node])
+			require.NoError(t, err)
+
+			respChan <- data
+		}(i)
+	}
+
 	for i := 0; i < nodes; i++ {
 		wg.Add(1)
 		go func(node int) {


### PR DESCRIPTION
Before this commit, calling `exchange()` would listen for new incoming messages and discard everything that didn't carry the expected `sigType`.

In a DKG one node might fall behind the others (for example, while DKG'ing 3000 validator keys) and send `sigTypes` that the other peers have already received threshold for.

This PR makes sure a given instance of `exchanger` will hold onto all messages whose `sigTypes` are specified during its initialization phase.

Calling `exchange()` will return as soon as there are enough messages for the specified `sigType`, but different `sigType`s messages will still be stored and will be returned when requested by means of another `exchange()` call, with a different `sigType` argument.

category: bug
ticket: #2491

Closes #2491.
