### PR TITLE
dkg: lockstep success message

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -345,12 +345,6 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Saved deposit data file to disk")
 
-	if conf.TestConfig.ShutdownCallback != nil {
-		conf.TestConfig.ShutdownCallback()
-	}
-	log.Debug(ctx, "Graceful shutdown delay", z.Int("seconds", int(conf.ShutdownDelay.Seconds())))
-	time.Sleep(conf.ShutdownDelay)
-
 	// Signature verification and disk key write was step 6, advance to step 7
 	if err := nextStepSync(ctx); err != nil {
 		return err
@@ -361,6 +355,12 @@ func Run(ctx context.Context, conf Config) (err error) {
 	if err = stopSync(ctx); err != nil {
 		return errors.Wrap(err, "sync shutdown") // Consider increasing --shutdown-delay if this occurs often.
 	}
+
+	if conf.TestConfig.ShutdownCallback != nil {
+		conf.TestConfig.ShutdownCallback()
+	}
+	log.Debug(ctx, "Graceful shutdown delay", z.Int("seconds", int(conf.ShutdownDelay.Seconds())))
+	time.Sleep(conf.ShutdownDelay)
 
 	return nil
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -350,8 +350,6 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return err
 	}
 
-	log.Info(ctx, "Successfully completed DKG ceremony 🎉")
-
 	if err = stopSync(ctx); err != nil {
 		return errors.Wrap(err, "sync shutdown") // Consider increasing --shutdown-delay if this occurs often.
 	}
@@ -361,6 +359,8 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 	log.Debug(ctx, "Graceful shutdown delay", z.Int("seconds", int(conf.ShutdownDelay.Seconds())))
 	time.Sleep(conf.ShutdownDelay)
+
+	log.Info(ctx, "Successfully completed DKG ceremony 🎉")
 
 	return nil
 }

--- a/dkg/sync/client.go
+++ b/dkg/sync/client.go
@@ -38,7 +38,7 @@ func NewClient(tcpNode host.Host, peer peer.ID, hashSig []byte, version version.
 		done:      make(chan struct{}),
 		reconnect: true,
 		version:   version,
-		period:    time.Second,
+		period:    250 * time.Millisecond,
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
Make every peer participating in the DKG wait for the "slow" one, and synchronize the `Successfully completed DKG ceremony 🎉` message output.


category: misc
ticket: none