### PR TITLE
core/validatorapi: close proxy requests on shutdown

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -434,7 +434,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	if err := wireVAPIRouter(life, conf.ValidatorAPIAddr, eth2Cl, vapi, vapiCalls); err != nil {
+	if err := wireVAPIRouter(ctx, life, conf.ValidatorAPIAddr, eth2Cl, vapi, vapiCalls); err != nil {
 		return err
 	}
 
@@ -896,10 +896,10 @@ func createMockValidators(pubkeys []eth2p0.BLSPubKey) beaconmock.ValidatorSet {
 }
 
 // wireVAPIRouter constructs the validator API router and registers it with the life cycle manager.
-func wireVAPIRouter(life *lifecycle.Manager, vapiAddr string, eth2Cl eth2wrap.Client,
+func wireVAPIRouter(ctx context.Context, life *lifecycle.Manager, vapiAddr string, eth2Cl eth2wrap.Client,
 	handler validatorapi.Handler, vapiCalls func(),
 ) error {
-	vrouter, err := validatorapi.NewRouter(handler, eth2Cl)
+	vrouter, err := validatorapi.NewRouter(ctx, handler, eth2Cl)
 	if err != nil {
 		return errors.Wrap(err, "new monitoring server")
 	}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -887,10 +887,10 @@ type addressProvider interface {
 
 // proxyHandler returns a reverse proxy handler.
 // Proxied requests use the provided context, so are cancelled when the context is cancelled.
-func proxyHandler(ctx context.Context, eth2Cl addressProvider) http.HandlerFunc {
+func proxyHandler(ctx context.Context, addrProvider addressProvider) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Get active beacon node address.
-		targetURL, err := getBeaconNodeAddress(eth2Cl)
+		targetURL, err := getBeaconNodeAddress(addrProvider)
 		if err != nil {
 			ctx := log.WithTopic(r.Context(), "vapi")
 			log.Error(ctx, "Proxy target beacon node address", err)
@@ -922,8 +922,8 @@ func proxyHandler(ctx context.Context, eth2Cl addressProvider) http.HandlerFunc 
 }
 
 // getBeaconNodeAddress returns an active beacon node proxy target address.
-func getBeaconNodeAddress(eth2Cl addressProvider) (*url.URL, error) {
-	addr := eth2Cl.Address()
+func getBeaconNodeAddress(addrProvider addressProvider) (*url.URL, error) {
+	addr := addrProvider.Address()
 	targetURL, err := url.Parse(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid beacon node address", z.Str("address", addr))

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -912,8 +912,12 @@ func proxyHandler(ctx context.Context, eth2Cl addressProvider) http.HandlerFunc 
 		}
 		proxy.ErrorLog = stdlog.New(io.Discard, "", 0)
 
+		// Use provided context for proxied requests, so long running
+		// requests are cancelled when this context is cancelled (soft shutdown).
+		clonedReq := r.Clone(ctx)
+
 		defer observeAPILatency("proxy")()
-		proxy.ServeHTTP(proxyResponseWriter{w.(writeFlusher)}, r.Clone(ctx))
+		proxy.ServeHTTP(proxyResponseWriter{w.(writeFlusher)}, clonedReq)
 	}
 }
 


### PR DESCRIPTION
Fixes soft shutdown by cancelling long running proxied requests.

This is because long lived connections are not interrupted by `http.Server.Shutdown`:
```
// Shutdown gracefully shuts down the server without interrupting any
// active connections. Shutdown works by first closing all open
// listeners, then closing all idle connections, and then waiting
// indefinitely for connections to return to idle and then shut down...
```

category: bug
ticket: #2435
