### PR TITLE
core: batch signed data set

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -635,8 +635,7 @@ func wireRecaster(ctx context.Context, eth2Cl eth2wrap.Client, sched core.Schedu
 			return errors.Wrap(err, "calculate slot from timestamp")
 		}
 
-		set := map[core.PubKey]core.SignedData{pubkey: signedData}
-		if err = recaster.Store(ctx, core.NewBuilderRegistrationDuty(slot), set); err != nil {
+		if err = recaster.Store(ctx, core.NewBuilderRegistrationDuty(slot), core.SignedDataSet{pubkey: signedData}); err != nil {
 			return errors.Wrap(err, "recaster store registration")
 		}
 	}

--- a/core/aggsigdb/memory.go
+++ b/core/aggsigdb/memory.go
@@ -41,7 +41,17 @@ type MemDB struct {
 }
 
 // Store implements core.AggSigDB, see its godoc.
-func (db *MemDB) Store(ctx context.Context, duty core.Duty, pubKey core.PubKey, data core.SignedData) error {
+func (db *MemDB) Store(ctx context.Context, duty core.Duty, set core.SignedDataSet) error {
+	for pubKey, data := range set {
+		if err := db.store(ctx, duty, pubKey, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (db *MemDB) store(ctx context.Context, duty core.Duty, pubKey core.PubKey, data core.SignedData) error {
 	clone, err := data.Clone() // Clone before storing.
 	if err != nil {
 		return err

--- a/core/aggsigdb/memory_internal_test.go
+++ b/core/aggsigdb/memory_internal_test.go
@@ -27,7 +27,7 @@ func TestDutyExpiration(t *testing.T) {
 	pubkey := testutil.RandomCorePubKey(t)
 	sig := testutil.RandomCoreSignature()
 
-	err := db.Store(ctx, duty, pubkey, sig)
+	err := db.Store(ctx, duty, core.SignedDataSet{pubkey: sig})
 	require.NoError(t, err)
 
 	resp, err := db.Await(ctx, duty, pubkey)
@@ -94,7 +94,7 @@ func TestCancelledQuery(t *testing.T) {
 	wg.Wait()
 
 	// Store something and ensure no blocked queries
-	err := db.Store(ctx, duty, pubkey, sig)
+	err := db.Store(ctx, duty, core.SignedDataSet{pubkey: sig})
 	require.NoError(t, err)
 	require.Equal(t, 0, <-queryCount)
 }

--- a/core/aggsigdb/memory_test.go
+++ b/core/aggsigdb/memory_test.go
@@ -25,7 +25,7 @@ func TestCoreAggsigdb_MemDB_WriteRead(t *testing.T) {
 	testPubKey := core.PubKey("pubkey")
 	testSignedData := testutil.RandomCoreSignature()
 
-	err := db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err := db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.NoError(t, err)
 
 	result, err := db.Await(context.Background(), testDuty, testPubKey)
@@ -57,7 +57,7 @@ func TestCoreAggsigdb_MemDB_WriteUnblocks(t *testing.T) {
 
 	runtime.Gosched()
 
-	err := db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err := db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.NoError(t, err)
 
 	wg.Wait()
@@ -137,10 +137,10 @@ func TestCoreAggsigdb_MemDB_CancelAwaitDoesnotblock(t *testing.T) {
 	cancel()
 	wg.Wait()
 
-	err := db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err := db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.Error(t, err)
 
-	err = db.Store(context.Background(), testDuty, testPubKey2, testSignedData)
+	err = db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey2: testSignedData})
 	require.Error(t, err)
 }
 
@@ -155,10 +155,10 @@ func TestCoreAggsigdb_MemDB_CannotOverwrite(t *testing.T) {
 	testSignedData := testutil.RandomCoreSignature()
 	testSignedData2 := testutil.RandomCoreSignature()
 
-	err := db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err := db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.NoError(t, err)
 
-	err = db.Store(context.Background(), testDuty, testPubKey, testSignedData2)
+	err = db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData2})
 	require.Error(t, err)
 }
 
@@ -172,10 +172,10 @@ func TestCoreAggsigdb_MemDB_WriteIdempotent(t *testing.T) {
 	testPubKey := core.PubKey("pubkey")
 	testSignedData := testutil.RandomCoreSignature()
 
-	err := db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err := db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.NoError(t, err)
 
-	err = db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err = db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.NoError(t, err)
 
 	result, err := db.Await(context.Background(), testDuty, testPubKey)
@@ -192,7 +192,7 @@ func TestCoreAggsigdb_MemDB_WriteReadAftersStopped(t *testing.T) {
 	testPubKey := core.PubKey("pubkey")
 	testSignedData := testutil.RandomCoreSignature()
 
-	err := db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err := db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.NoError(t, err)
 
 	result, err := db.Await(context.Background(), testDuty, testPubKey)
@@ -201,7 +201,7 @@ func TestCoreAggsigdb_MemDB_WriteReadAftersStopped(t *testing.T) {
 
 	cancel()
 
-	err = db.Store(context.Background(), testDuty, testPubKey, testSignedData)
+	err = db.Store(context.Background(), testDuty, core.SignedDataSet{testPubKey: testSignedData})
 	require.Equal(t, err.Error(), aggsigdb.ErrStopped.Error())
 
 	_, err = db.Await(context.Background(), testDuty, testPubKey)

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -185,7 +185,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 
 		err = b.eth2Cl.SubmitSyncCommitteeContributions(ctx, contributions)
 		if err == nil {
-			log.Info(ctx, "Successfully submitted sync committee contribution to beacon node",
+			log.Info(ctx, "Successfully submitted sync committee contributions to beacon node",
 				z.Any("delay", b.delayFunc(duty.Slot)))
 		}
 

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -169,7 +169,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 
 		err = b.eth2Cl.SubmitSyncCommitteeMessages(ctx, msgs)
 		if err == nil {
-			log.Info(ctx, "Successfully submitted sync committee message to beacon node",
+			log.Info(ctx, "Successfully submitted sync committee messages to beacon node",
 				z.Any("delay", b.delayFunc(duty.Slot)))
 		}
 

--- a/core/bcast/bcast_test.go
+++ b/core/bcast/bcast_test.go
@@ -55,9 +55,9 @@ func TestBroadcast(t *testing.T) {
 
 			for i := 0; i < test.bcastCnt; i++ {
 				err := bcaster.Broadcast(ctx,
-					core.Duty{Type: test.duty},
-					testutil.RandomCorePubKey(t),
-					test.aggData,
+					core.Duty{Type: test.duty}, core.SignedDataSet{
+						testutil.RandomCorePubKey(t): test.aggData,
+					},
 				)
 				require.NoError(t, err)
 			}

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -29,7 +29,7 @@ func NewMemDB(threshold int, deadliner core.Deadliner) *MemDB {
 type MemDB struct {
 	mu           sync.Mutex
 	internalSubs []func(context.Context, core.Duty, core.ParSignedDataSet) error
-	threshSubs   []func(context.Context, core.Duty, core.PubKey, []core.ParSignedData) error
+	threshSubs   []func(context.Context, core.Duty, map[core.PubKey][]core.ParSignedData) error
 
 	entries    map[key][]core.ParSignedData
 	keysByDuty map[core.Duty][]key
@@ -47,7 +47,7 @@ func (db *MemDB) SubscribeInternal(fn func(context.Context, core.Duty, core.ParS
 
 // SubscribeThreshold registers a callback when *threshold*
 // partially signed duty is reached for a DV.
-func (db *MemDB) SubscribeThreshold(fn func(context.Context, core.Duty, core.PubKey, []core.ParSignedData) error) {
+func (db *MemDB) SubscribeThreshold(fn func(context.Context, core.Duty, map[core.PubKey][]core.ParSignedData) error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 	db.threshSubs = append(db.threshSubs, fn)
@@ -80,6 +80,8 @@ func (db *MemDB) StoreInternal(ctx context.Context, duty core.Duty, signedSet co
 func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet core.ParSignedDataSet) error {
 	_ = db.deadliner.Add(duty) // TODO(corver): Distinguish between no deadline supported vs already expired.
 
+	output := make(map[core.PubKey][]core.ParSignedData)
+
 	for pubkey, sig := range signedSet {
 		sigs, ok, err := db.store(key{Duty: duty, PubKey: pubkey}, sig)
 		if err != nil {
@@ -102,21 +104,18 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 			continue
 		}
 
-		// Call the threshSubs (which includes SigAgg component)
-		for _, sub := range db.threshSubs {
-			// Clone before calling each subscriber.
-			var clones []core.ParSignedData
-			for _, psig := range psigs {
-				clone, err := psig.Clone()
-				if err != nil {
-					return err
-				}
-				clones = append(clones, clone)
-			}
+		output[pubkey] = psigs
+	}
 
-			if err := sub(ctx, duty, pubkey, clones); err != nil {
-				return err
-			}
+	if len(output) == 0 {
+		return nil
+	}
+
+	// Call the threshSubs (which includes SigAgg component)
+	for _, sub := range db.threshSubs {
+		// Clone before calling each subscriber.
+		if err := sub(ctx, duty, clone(output)); err != nil {
+			return err
 		}
 	}
 
@@ -175,6 +174,24 @@ func (db *MemDB) store(k key, value core.ParSignedData) ([]core.ParSignedData, b
 	}
 
 	return append([]core.ParSignedData(nil), db.entries[k]...), true, nil
+}
+
+// clone returns a deep copy of the provided map.
+func clone(output map[core.PubKey][]core.ParSignedData) map[core.PubKey][]core.ParSignedData {
+	clone := make(map[core.PubKey][]core.ParSignedData)
+	for pubkey, sigs := range output {
+		var clones []core.ParSignedData
+		for _, sig := range sigs {
+			clone, err := sig.Clone()
+			if err != nil {
+				panic(err)
+			}
+			clones = append(clones, clone)
+		}
+		clone[pubkey] = clones
+	}
+
+	return clone
 }
 
 // getThresholdMatching returns true and threshold number of partial signed data with identical data or false.

--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -122,7 +122,7 @@ func TestMemDBThreshold(t *testing.T) {
 	go db.Trim(ctx)
 
 	timesCalled := 0
-	db.SubscribeThreshold(func(_ context.Context, _ core.Duty, _ core.PubKey, _ []core.ParSignedData) error {
+	db.SubscribeThreshold(func(_ context.Context, _ core.Duty, _ map[core.PubKey][]core.ParSignedData) error {
 		timesCalled++
 
 		return nil

--- a/core/retry.go
+++ b/core/retry.go
@@ -41,9 +41,9 @@ func WithAsyncRetry(retryer *retry.Retryer[Duty]) WireOption {
 
 			return nil
 		}
-		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, key PubKey, data SignedData) error {
+		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, set SignedDataSet) error {
 			go retryer.DoAsync(ctx, duty, "bcast", "broadcast", func(ctx context.Context) error {
-				return clone.BroadcasterBroadcast(ctx, duty, key, data)
+				return clone.BroadcasterBroadcast(ctx, duty, set)
 			})
 
 			return nil

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -107,17 +107,17 @@ func WithTracing() WireOption {
 
 			return clone.ParSigExBroadcast(ctx, duty, set)
 		}
-		w.SigAggAggregate = func(parent context.Context, duty Duty, key PubKey, data []ParSignedData) error {
+		w.SigAggAggregate = func(parent context.Context, duty Duty, set map[PubKey][]ParSignedData) error {
 			ctx, span := tracer.Start(parent, "core/sigagg.Aggregate")
 			defer span.End()
 
-			return clone.SigAggAggregate(ctx, duty, key, data)
+			return clone.SigAggAggregate(ctx, duty, set)
 		}
-		w.AggSigDBStore = func(parent context.Context, duty Duty, key PubKey, data SignedData) error {
+		w.AggSigDBStore = func(parent context.Context, duty Duty, set SignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/aggsigdb.Store")
 			defer span.End()
 
-			return clone.AggSigDBStore(ctx, duty, key, data)
+			return clone.AggSigDBStore(ctx, duty, set)
 		}
 		w.AggSigDBAwait = func(parent context.Context, duty Duty, key PubKey) (SignedData, error) {
 			ctx, span := tracer.Start(parent, "core/aggsigdb.Await")
@@ -125,11 +125,11 @@ func WithTracing() WireOption {
 
 			return clone.AggSigDBAwait(ctx, duty, key)
 		}
-		w.BroadcasterBroadcast = func(parent context.Context, duty Duty, key PubKey, data SignedData) error {
+		w.BroadcasterBroadcast = func(parent context.Context, duty Duty, set SignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/broadcaster.Broadcast")
 			defer span.End()
 
-			return clone.BroadcasterBroadcast(ctx, duty, key, data)
+			return clone.BroadcasterBroadcast(ctx, duty, set)
 		}
 	}
 }

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -337,9 +337,16 @@ type InclusionChecker struct {
 }
 
 // Submitted is called when a duty has been submitted.
-func (a *InclusionChecker) Submitted(duty core.Duty, pubkey core.PubKey, data core.SignedData) error {
+func (a *InclusionChecker) Submitted(duty core.Duty, set core.SignedDataSet) error {
 	slotStart := a.genesis.Add(a.slotDuration * time.Duration(duty.Slot))
-	return a.core.Submitted(duty, pubkey, data, time.Since(slotStart))
+
+	for key, data := range set {
+		if err := a.core.Submitted(duty, key, data, time.Since(slotStart)); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (a *InclusionChecker) Run(ctx context.Context) {

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -767,44 +767,50 @@ func (t *Tracker) ParSigDBStoredExternal(duty core.Duty, set core.ParSignedDataS
 }
 
 // SigAggAggregated implements core.Tracker interface.
-func (t *Tracker) SigAggAggregated(duty core.Duty, pubkey core.PubKey, _ []core.ParSignedData, stepErr error) {
-	select {
-	case <-t.quit:
-		return
-	case t.input <- event{
-		duty:    duty,
-		step:    sigAgg,
-		pubkey:  pubkey,
-		stepErr: stepErr,
-	}:
+func (t *Tracker) SigAggAggregated(duty core.Duty, set map[core.PubKey][]core.ParSignedData, stepErr error) {
+	for pubkey := range set {
+		select {
+		case <-t.quit:
+			return
+		case t.input <- event{
+			duty:    duty,
+			step:    sigAgg,
+			pubkey:  pubkey,
+			stepErr: stepErr,
+		}:
+		}
 	}
 }
 
 // AggSigDBStored implements core.Tracker interface.
-func (t *Tracker) AggSigDBStored(duty core.Duty, pubkey core.PubKey, _ core.SignedData, stepErr error) {
-	select {
-	case <-t.quit:
-		return
-	case t.input <- event{
-		duty:    duty,
-		step:    aggSigDB,
-		pubkey:  pubkey,
-		stepErr: stepErr,
-	}:
+func (t *Tracker) AggSigDBStored(duty core.Duty, set core.SignedDataSet, stepErr error) {
+	for pubkey := range set {
+		select {
+		case <-t.quit:
+			return
+		case t.input <- event{
+			duty:    duty,
+			step:    aggSigDB,
+			pubkey:  pubkey,
+			stepErr: stepErr,
+		}:
+		}
 	}
 }
 
 // BroadcasterBroadcast implements core.Tracker interface.
-func (t *Tracker) BroadcasterBroadcast(duty core.Duty, pubkey core.PubKey, _ core.SignedData, stepErr error) {
-	select {
-	case <-t.quit:
-		return
-	case t.input <- event{
-		duty:    duty,
-		step:    bcast,
-		pubkey:  pubkey,
-		stepErr: stepErr,
-	}:
+func (t *Tracker) BroadcasterBroadcast(duty core.Duty, set core.SignedDataSet, stepErr error) {
+	for pubkey := range set {
+		select {
+		case <-t.quit:
+			return
+		case t.input <- event{
+			duty:    duty,
+			step:    bcast,
+			pubkey:  pubkey,
+			stepErr: stepErr,
+		}:
+		}
 	}
 }
 

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -104,8 +104,8 @@ func TestTrackerFailedDuty(t *testing.T) {
 				tr.ParSigDBStoredInternal(td.duty, td.parSignedDataSet, nil)
 				tr.ParSigDBStoredExternal(td.duty, td.parSignedDataSet, nil)
 				for _, pubkey := range pubkeys {
-					tr.SigAggAggregated(td.duty, pubkey, nil, nil)
-					tr.BroadcasterBroadcast(td.duty, pubkey, nil, nil)
+					tr.SigAggAggregated(td.duty, map[core.PubKey][]core.ParSignedData{pubkey: nil}, nil)
+					tr.BroadcasterBroadcast(td.duty, core.SignedDataSet{pubkey: nil}, nil)
 					if lastStep(td.duty.Type) == chainInclusion {
 						tr.InclusionChecked(td.duty, pubkey, nil, nil)
 					}
@@ -487,8 +487,8 @@ func TestTrackerParticipation(t *testing.T) {
 				tr.ParSigDBStoredExternal(td.duty, data, nil)
 			}
 			for _, pk := range pubkeys {
-				tr.SigAggAggregated(td.duty, pk, nil, nil)
-				tr.BroadcasterBroadcast(td.duty, pk, nil, nil)
+				tr.SigAggAggregated(td.duty, map[core.PubKey][]core.ParSignedData{pk: nil}, nil)
+				tr.BroadcasterBroadcast(td.duty, core.SignedDataSet{pk: nil}, nil)
 				if lastStep(td.duty.Type) == chainInclusion {
 					tr.InclusionChecked(td.duty, pk, nil, nil)
 				}
@@ -726,7 +726,7 @@ func TestFromSlot(t *testing.T) {
 		close(done)
 	}()
 
-	tr.SigAggAggregated(core.NewAggregatorDuty(thisSlot), "", nil, nil)
+	tr.SigAggAggregated(core.NewAggregatorDuty(thisSlot), map[core.PubKey][]core.ParSignedData{"": nil}, nil)
 	tr.ParSigDBStoredInternal(core.NewProposerDuty(thisSlot), nil, nil)
 	tr.FetcherFetched(core.NewAggregatorDuty(thisSlot), nil, nil)
 

--- a/core/tracking.go
+++ b/core/tracking.go
@@ -50,26 +50,26 @@ func WithTracking(tracker Tracker, inclusion InclusionChecker) WireOption {
 
 			return err
 		}
-		w.SigAggAggregate = func(ctx context.Context, duty Duty, key PubKey, data []ParSignedData) error {
-			err := clone.SigAggAggregate(ctx, duty, key, data)
-			tracker.SigAggAggregated(duty, key, data, err)
+		w.SigAggAggregate = func(ctx context.Context, duty Duty, set map[PubKey][]ParSignedData) error {
+			err := clone.SigAggAggregate(ctx, duty, set)
+			tracker.SigAggAggregated(duty, set, err)
 
 			return err
 		}
-		w.AggSigDBStore = func(ctx context.Context, duty Duty, key PubKey, data SignedData) error {
-			err := clone.AggSigDBStore(ctx, duty, key, data)
-			tracker.AggSigDBStored(duty, key, data, err)
+		w.AggSigDBStore = func(ctx context.Context, duty Duty, set SignedDataSet) error {
+			err := clone.AggSigDBStore(ctx, duty, set)
+			tracker.AggSigDBStored(duty, set, err)
 
 			return err
 		}
-		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, pubkey PubKey, data SignedData) error {
+		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, set SignedDataSet) error {
 			// Check inclusion even if we fail to broadcast, since peers may succeed.
-			if err := inclusion.Submitted(duty, pubkey, data); err != nil {
+			if err := inclusion.Submitted(duty, set); err != nil {
 				log.Error(ctx, "Bug: failed to submit duty to inclusion checker", err)
 			}
 
-			err := clone.BroadcasterBroadcast(ctx, duty, pubkey, data)
-			tracker.BroadcasterBroadcast(duty, pubkey, data, err)
+			err := clone.BroadcasterBroadcast(ctx, duty, set)
+			tracker.BroadcasterBroadcast(duty, set, err)
 			if err != nil {
 				return err
 			}

--- a/core/types.go
+++ b/core/types.go
@@ -447,6 +447,24 @@ func (s ParSignedDataSet) Clone() (ParSignedDataSet, error) {
 	return resp, nil
 }
 
+// SignedDataSet is a set of signed duty data objects, one per validator.
+type SignedDataSet map[PubKey]SignedData
+
+// Clone returns a cloned copy of the SignedDataSet. For an immutable core workflow architecture,
+// remember to clone data when it leaves the current scope (sharing, storing, returning, etc).
+func (s SignedDataSet) Clone() (SignedDataSet, error) {
+	resp := make(SignedDataSet, len(s))
+	for key, data := range s {
+		var err error
+		resp[key], err = data.Clone()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return resp, nil
+}
+
 // Slot is a beacon chain slot including chain metadata to infer epoch and next slot.
 type Slot struct {
 	Slot          int64

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -146,14 +146,16 @@ func (e *exchanger) exchange(ctx context.Context, sigType sigType, set core.ParS
 }
 
 // pushPsigs is responsible for writing partial signature data to sigChan obtained from other peers.
-func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, pk core.PubKey, psigs []core.ParSignedData) error {
+func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, set map[core.PubKey][]core.ParSignedData) error {
 	sigType := sigType(duty.Slot)
 
 	if !e.sigTypes[sigType] {
 		return errors.New("unrecognized sigType", z.Int("sigType", int(sigType)))
 	}
 
-	e.sigData.set(pk, sigType, psigs)
+	for pk, psigs := range set {
+		e.sigData.set(pk, sigType, psigs)
+	}
 
 	return nil
 }


### PR DESCRIPTION
Introduce the `core.SignedDataSet` type and refactor `sigagg`, `aggSigDB` and `bcast` interfaces to use it. This supports batching when broadcasting signed data to beacon API which should improve latency and decrease BN load for large clusters.

category: feature
ticket: #2373
