### PR TITLE
app/obolapi: create cluster launchpad URL (#2518)

### DIFF
--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -5,6 +5,7 @@ package obolapi
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,11 +16,21 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 )
 
+const (
+	// launchpadReturnPathFmt is the URL path format string at which one can find details for a given cluster lock hash.
+	launchpadReturnPathFmt = "/lock/0x%X/launchpad"
+)
+
 // New returns a new Client.
-func New(url string) Client {
-	return Client{
-		baseURL: url,
+func New(urlStr string) (Client, error) {
+	_, err := url.ParseRequestURI(urlStr) // check that urlStr is valid
+	if err != nil {
+		return Client{}, errors.Wrap(err, "could not parse Obol API URL")
 	}
+
+	return Client{
+		baseURL: urlStr,
+	}, nil
 }
 
 // Client is the REST client for obol-api requests.
@@ -27,32 +38,50 @@ type Client struct {
 	baseURL string // Base obol-api URL
 }
 
+// url returns a *url.URL from the baseURL stored in c.
+// Will panic if somehow c.baseURL got corrupted, and it's not a valid URL anymore.
+func (c Client) url() *url.URL {
+	baseURL, err := url.ParseRequestURI(c.baseURL)
+	if err != nil {
+		panic(errors.Wrap(err, "could not parse Obol API URL, this should never happen"))
+	}
+
+	return baseURL
+}
+
 // PublishLock posts the lockfile to obol-api.
 func (c Client) PublishLock(ctx context.Context, lock cluster.Lock) error {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	addr, err := url.JoinPath(c.baseURL, "lock")
-	if err != nil {
-		return errors.Wrap(err, "invalid address")
-	}
-
-	url, err := url.Parse(addr)
-	if err != nil {
-		return errors.Wrap(err, "invalid endpoint")
-	}
+	addr := c.url()
+	addr.Path = "lock"
 
 	b, err := lock.MarshalJSON()
 	if err != nil {
 		return errors.Wrap(err, "marshal lock")
 	}
 
-	err = httpPost(ctx, url, b)
+	err = httpPost(ctx, addr, b)
 	if err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// LaunchpadURLForLock returns the Launchpad cluster dashboard page for a given lock, on the given
+// Obol API client.
+func (c Client) LaunchpadURLForLock(lock cluster.Lock) string {
+	lURL := c.url()
+
+	lURL.Path = launchpadURLPath(lock)
+
+	return lURL.String()
+}
+
+func launchpadURLPath(lock cluster.Lock) string {
+	return fmt.Sprintf(launchpadReturnPathFmt, lock.LockHash)
 }
 
 func httpPost(ctx context.Context, url *url.URL, b []byte) error {


### PR DESCRIPTION
Add the `LaunchpadURLForLock` method, which generates a Launchpad cluster dashboard URL for a given cluster lock.

Reference this method in `dkg` and `create cluster` commands so that at the end of those processes, if the user has specified `--publish`, the Launchpad dashboard URL will be printed on the console.

category: feature
ticket: none
cherry-picks: https://github.com/ObolNetwork/charon/pull/2518