### PR TITLE
core: implement duty gater

### DIFF
--- a/core/gater.go
+++ b/core/gater.go
@@ -14,7 +14,8 @@ const defaultAllowedFutureEpochs = 2
 
 // DutyGaterFunc is a function that returns true if the duty is allowed to be processed.
 // It checks whether or not duties received from peers over the wire are too far in the future.
-type DutyGaterFunc func(duty Duty) bool
+// It doesn't check whether or not the duty is in the past, that is done by Deadliner.
+type DutyGaterFunc func(Duty) bool
 
 // WithDutyGaterForT returns a function that sets the nowFunc and allowedFutureEpochs in
 // order to create a DutyGaterFunc for use in tests.

--- a/core/gater.go
+++ b/core/gater.go
@@ -1,0 +1,66 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package core
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/obolnetwork/charon/app/eth2wrap"
+)
+
+const defaultAllowedFutureEpochs = 2
+
+// DutyGaterFunc is a function that returns true if the duty is allowed to be processed.
+// It checks whether or not duties received from peers over the wire are too far in the future.
+type DutyGaterFunc func(duty Duty) bool
+
+// WithDutyGaterForT returns a function that sets the nowFunc and allowedFutureEpochs in
+// order to create a DutyGaterFunc for use in tests.
+func WithDutyGaterForT(_ *testing.T, nowFunc func() time.Time, allowedFutureEpochs int) func(*dutyGaterOptions) {
+	return func(o *dutyGaterOptions) {
+		o.nowFunc = nowFunc
+		o.allowedFutureEpochs = allowedFutureEpochs
+	}
+}
+
+type dutyGaterOptions struct {
+	allowedFutureEpochs int
+	nowFunc             func() time.Time
+}
+
+// NewDutyGater returns a new instance of DutyGaterFunc.
+func NewDutyGater(ctx context.Context, eth2Cl eth2wrap.Client, opts ...func(*dutyGaterOptions)) (DutyGaterFunc, error) {
+	o := dutyGaterOptions{
+		allowedFutureEpochs: defaultAllowedFutureEpochs,
+		nowFunc:             time.Now,
+	}
+	for _, opt := range opts {
+		opt(&o)
+	}
+
+	genesisTime, err := eth2Cl.GenesisTime(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	slotDuration, err := eth2Cl.SlotDuration(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(duty Duty) bool {
+		currentSlot := o.nowFunc().Sub(genesisTime) / slotDuration
+		currentEpoch := uint64(currentSlot) / slotsPerEpoch
+
+		dutyEpoch := uint64(duty.Slot) / slotsPerEpoch
+
+		return dutyEpoch <= currentEpoch+uint64(o.allowedFutureEpochs)
+	}, nil
+}

--- a/core/gater_test.go
+++ b/core/gater_test.go
@@ -1,0 +1,47 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package core_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+func TestDutyGater(t *testing.T) {
+	now := time.Now()
+	allowedFutureEpochs := 2
+
+	// Allow slots 0-3.
+	slotDuration := time.Second
+	bmock, err := beaconmock.New(
+		beaconmock.WithGenesisTime(now),
+		beaconmock.WithSlotDuration(slotDuration),
+		beaconmock.WithSlotsPerEpoch(2),
+	)
+	require.NoError(t, err)
+
+	gater, err := core.NewDutyGater(context.Background(), bmock, core.WithDutyGaterForT(t,
+		func() time.Time { return now },
+		allowedFutureEpochs,
+	))
+	require.NoError(t, err)
+
+	// Allow slots 0-5.
+	require.True(t, gater(core.Duty{Slot: 0})) // Current epoch
+	require.True(t, gater(core.Duty{Slot: 1}))
+	require.True(t, gater(core.Duty{Slot: 2})) // N+1 epoch
+	require.True(t, gater(core.Duty{Slot: 3}))
+	require.True(t, gater(core.Duty{Slot: 4})) // N+2 epoch
+	require.True(t, gater(core.Duty{Slot: 5}))
+
+	// Disallow slots 6 and after.
+	require.False(t, gater(core.Duty{Slot: 6})) // N+3 epoch
+	require.False(t, gater(core.Duty{Slot: 7}))
+	require.False(t, gater(core.Duty{Slot: 1000}))
+}


### PR DESCRIPTION
Implement duty gater that checks whether duties are too far in the future. Next step is to wire it when duties are received over the wire.

category: feature
ticket: #2506 
