### PR TITLE
docs: update v2 release process

### DIFF
--- a/docs/branching.md
+++ b/docs/branching.md
@@ -29,9 +29,39 @@ We follow [Trunk Based Development](https://trunkbaseddevelopment.com/) as a bra
 
 Charon is set up to create a release with Github Actions triggered by a tag. To create a new release:
 
-1. Ensure the build is green and that all tests are passing
-2. Identify the version of the release, e.g. `v0.1.2` (note the `v`).
-3. Push a PR that bumps charon version global variable, see example https://github.com/ObolNetwork/charon/pull/312
-4. Merge above PR, checkout latest main, and tag it: `git tag <version> && git push --tags`
-5. Double-check the generated release and changelog: `https://github.com/ObolNetwork/charon/releases/tag/<version>`
-6. Maybe generate a changelog manually and/or update the release: `go run testutil/genchangelog/main.go`
+The important aspects of the release process are:
+- Releases are cut from release branches, not the main branch. Release branches are named `main-v0.X`.
+- Release candidates, `v0.X.Y-rc[1-99]`, are created for each patch release from commits in the release branch. They are thoroughly tested both internally and externally before a release is created.
+- Critical patches and fixes to releases are cherry-picked from main to the release branch.
+- The Charon binary version, `charon version`, are inferred from git tags at build time using `ldflags`, not hardcoded app/version versions.
+- Hardcoded Charon app/version is only used to indicate branch type and major version, `v0.X-rc` for release branches or `v0.Y-dev` for main branch.
+
+The process to follow for the next v0.16.0 release is the following:
+1. Note the previous release was v0.15.X.
+2. When approaching the release, the dev team identifies a “release captain” who is responsible for driving the release process.
+3. The dev team then focuses on tickets required to be included in the release.
+4. The dev team also avoids adding risky or large changes during this “pre-release” period.
+5. When all relevant changes have been included in main, a new “release branch”. It must be called `main-v0.16`.
+   - Release branches are called `main-v0.X`
+   - Release branches are high risk branches, and must be treated with the same security mindset as the `main` branch.
+   - Note that github branch matching doesn’t support OR logic, so we chose a common `main*` prefix to identify all protected branches.
+6. After the release branch has been created, the `main` branch app/version is manually updated to `v0.17-dev` and add `v0.17` to `version.Supported()` versions.
+   - `v0.X-dev` indicates that the code is in the main branch.
+   - It also indicates this is development only code not an official release.
+   - It also indicates all code with this version would be included in the `v0.17.0` release. It indicates "pre-v0.17.0" but "post-v0.16.X".
+7. The first commit on the `main-v0.16` release branch must manually update the app/version to `v0.16-rc`.
+   - `v0.X-rc` indicates that the code is in a release branch.
+   - It also indicates this is cherry-picked commits and fixes included in an official release.
+   - It does not indicate which `v0.X.Y` release the commit will be included in.
+8. To create a release (`v0.16.X[-rcY]`), someone with git tag privileges creates and pushes such a git tag to the latest commit on the release branch.
+   - Note that the `build-push-release` action should dynamically update the app/version to the value of the git tag when building the docker image.
+9. Before a `v0.16.X` release is created, a `v0.16.X-rc[1-99]` release candidate needs to be created and thoroughly tested both internally and externally.
+10. After a `v0.16.X` release was created, the release notes need to be created.
+   - The release github action does auto generate release notes.
+   - If they are incorrect, manual release notes can be created via: `go run testutil/genchangelog/main.go --range=v0.15.0..v0.16.0`.
+
+Note that images are built and tagged for each commit on the main and release branch using the app/version tag, e.g. `v0.X-dev` for `main`, and `v0.X-rc` for release branches. Main branch commits are also tagged with `latest`.
+
+Note that any commit on main that affects the backwards compatibility must update `app/version.Supported` versions.
+
+Note that commits on release branches MUST NOT affect the backwards compatibility nor modify the `app/version.Supported` versions.


### PR DESCRIPTION
Aligns the release process docs with the v2 [doc](https://docs.google.com/document/d/1A_TtUB54rhxz_Nxw3HHLfR6bVvJpUNe2S8AaIlP0rL0/edit).

category: docs
ticket: none
