### PR TITLE
eth2util/keymanager: dynamically set request timeout

### DIFF
--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -88,7 +88,7 @@ type keymanagerReq struct {
 
 // postKeys pushes the secrets to the provided keymanager address. The HTTP request times out after 10s.
 func postKeys(ctx context.Context, addr, authToken string, reqBody keymanagerReq) error {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, time.Duration(2*len(reqBody.Keystores))*time.Second)
 	defer cancel()
 
 	reqBytes, err := json.Marshal(reqBody)

--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -86,7 +86,7 @@ type keymanagerReq struct {
 	Passwords []string `json:"passwords"`
 }
 
-// postKeys pushes the secrets to the provided keymanager address. The HTTP request times out after 10s.
+// postKeys pushes the secrets to the provided keymanager address. The HTTP request timeout is calculated based on the amount of keystores being pushed. For each keystore, the timeout is incremented by 2 seconds.
 func postKeys(ctx context.Context, addr, authToken string, reqBody keymanagerReq) error {
 	ctx, cancel := context.WithTimeout(ctx, time.Duration(2*len(reqBody.Keystores))*time.Second)
 	defer cancel()


### PR DESCRIPTION
Using the `--keymanager-addresses` flag to automatically import keystores fails when creating a cluster with more than a handful of keystores due to the request timing out while the remote signer is importing the keystores.

This PR adjusts the behavior by making the timeout value dependent on the amount of keystores to be imported, setting a timeout of 2 seconds per keystore. This value was chosen rather arbitrarily as a "safe", high enough value based on my experience with importing keystores, this taking around 0.25 - 0.5 seconds per keystore.

Feel free to lower the value as you deem fit. However, the request timing out can be rather annoying to resolve, since the entire `create cluster` process needs to be started over and keystores need to manually be removed from keymanagers where they were already imported. This is why I propose to use a safe, albeit little high, timeout value.

category: bug
ticket: none
