### PR TITLE
cmd/combine: ensure output dir exists

### DIFF
--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -129,6 +129,10 @@ func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bo
 		combinedKeys = append(combinedKeys, secret)
 	}
 
+	if err := os.MkdirAll(outputDir, 0o755); err != nil {
+		return errors.Wrap(err, "ensure output directory exists", z.Str("output_dir", outputDir))
+	}
+
 	ksPath := filepath.Join(outputDir, "keystore-0.json")
 	_, err = os.Stat(ksPath)
 	if err == nil && !force {

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -249,7 +250,7 @@ func combineTest(
 	}
 
 	dir := t.TempDir()
-	od := t.TempDir()
+	od := path.Join(dir, "validator_keys")
 
 	// flatten secrets, each validator slice is unpacked in a flat structure
 	var rawSecrets []tbls.PrivateKey

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -296,3 +296,11 @@ func storeNewKeyForT(t *testing.T, target string) tbls.PrivateKey {
 
 	return secret
 }
+
+func TestCheckDir(t *testing.T) {
+	err := keystore.StoreKeys(nil, "foo")
+	require.ErrorContains(t, err, "not exist")
+
+	err = keystore.StoreKeys(nil, "testdata/keystore-scrypt.json")
+	require.ErrorContains(t, err, "not a directory")
+}


### PR DESCRIPTION
Ensures the output folder exists before writing combined keys to it.

Cherry-pick: #2537 

category: bug
ticket: #2536
