### PR TITLE
eth2util: fix fork version

### DIFF
--- a/eth2util/network.go
+++ b/eth2util/network.go
@@ -54,7 +54,7 @@ var (
 	Holesky = Network{
 		ChainID:               17000,
 		Name:                  "holesky",
-		GenesisForkVersionHex: "0x00017000",
+		GenesisForkVersionHex: "0x01017000",
 		GenesisTimestamp:      1696000704,
 	}
 )


### PR DESCRIPTION
Fix holesky genesis fork version.

Cherry-pick: #2600

category: bug
ticket: none