### PR TITLE
*: bump go version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.52.2
+          version: v1.54.2
       - name: notify failure
         if: failure() && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -show=stacks -test ./...

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -show=stacks -test ./...

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.20.7'
+        go-version: '1.21.2'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21.2'
+        go-version: '1.21.3'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: actions/cache@v3
         with:
           path: |
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: actions/cache@v3
         with:
           path: |
@@ -51,7 +51,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: actions/cache@v3
         with:
           path: |
@@ -78,7 +78,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: actions/cache@v3
         with:
           path: |
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: actions/cache@v3
         with:
           path: |
@@ -51,7 +51,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: actions/cache@v3
         with:
           path: |
@@ -78,7 +78,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.2'
+          go-version: '1.21.3'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.20.7'
+          go-version: '1.21.2'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.21.2"
+  go: "1.21.3"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -89,7 +89,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.21.2"
+    go: "1.21.3"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.20.7"
+  go: "1.21.2"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -89,7 +89,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.20.7"
+    go: "1.21.2"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,7 +12,14 @@ linters-settings:
     rules:
       main:
         allow:
-          - *
+          - $gostd
+        deny:
+          - pkg: "github.com/pkg/errors"
+            desc: Prefer ./app/errors
+          - pkg: "github.com/golang/protobuf"
+            desc: Prefer google.golang.org/protobuf
+          - pkg: "github.com/gogo/protobuf/proto"
+            desc: Prefer google.golang.org/protobuf
   exhaustive:
     default-signifies-exhaustive: true
   forbidigo:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,8 +11,6 @@ linters-settings:
   depguard:
     rules:
       main:
-        allow:
-          - $gostd
         deny:
           - pkg: "github.com/pkg/errors"
             desc: Prefer ./app/errors

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,6 +8,11 @@ linters-settings:
   dupl:
     # tokens count to trigger issue, 150 by default
     threshold: 400
+  depguard:
+    rules:
+      main:
+        allow:
+          - *
   exhaustive:
     default-signifies-exhaustive: true
   forbidigo:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     rev: v0.0.2
     hooks:
       - id: check-go-version
-        args: [ -v=go1.20 ] # Only check minor version locally
+        args: [ -v=go1.21 ] # Only check minor version locally
         pass_filenames: false
         additional_dependencies: [ packaging ]
       - id: check-licence-header

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.21.2-bullseye AS builder
+FROM golang:1.21.3-bullseye AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.20.7-bullseye AS builder
+FROM golang:1.21.2-bullseye AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source

--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -183,7 +183,7 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			name := p2p.PeerName(peerID)
 
 			// Validator git hash with regex.
-			if !gitHashMatch.Match([]byte(resp.GitHash)) {
+			if !gitHashMatch.MatchString(resp.GitHash) {
 				log.Warn(ctx, "Invalid peer git hash", nil, z.Str("peer", name))
 				return
 			}

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -105,38 +105,38 @@ func NewDefinition(name string, numVals int, threshold int, feeRecipientAddresse
 //   - definition_hash: field ordering when calculating definition hash. Some fields are excluded indicated by `-`.
 type Definition struct {
 	// UUID is a human-readable random unique identifier. Max 64 chars.
-	UUID string `json:"uuid" ssz:"ByteList[64]" config_hash:"0" definition_hash:"0"`
+	UUID string `config_hash:"0" definition_hash:"0" json:"uuid" ssz:"ByteList[64]"`
 
 	// Name is a human-readable cosmetic identifier. Max 256 chars.
-	Name string `json:"name" ssz:"ByteList[256]" config_hash:"1" definition_hash:"1"`
+	Name string `config_hash:"1" definition_hash:"1" json:"name" ssz:"ByteList[256]"`
 
 	// Version is the schema version of this definition. Max 16 chars.
-	Version string `json:"version" ssz:"ByteList[16]" config_hash:"2" definition_hash:"2"`
+	Version string `config_hash:"2" definition_hash:"2" json:"version" ssz:"ByteList[16]"`
 
 	// Timestamp is the human-readable timestamp of this definition. Max 32 chars.
 	// Note that this was added in v1.1.0, so may be empty for older versions.
-	Timestamp string `json:"timestamp" ssz:"ByteList[32]" config_hash:"3" definition_hash:"3"`
+	Timestamp string `config_hash:"3" definition_hash:"3" json:"timestamp" ssz:"ByteList[32]"`
 
 	// NumValidators is the number of DVs (n*32ETH) to be created in the cluster lock file.
-	NumValidators int `json:"num_validators" ssz:"uint64" config_hash:"4" definition_hash:"4"`
+	NumValidators int `config_hash:"4" definition_hash:"4" json:"num_validators" ssz:"uint64"`
 
 	// Threshold required for signature reconstruction. Defaults to safe value for number of nodes/peers.
-	Threshold int `json:"threshold" ssz:"uint64" config_hash:"5" definition_hash:"5"`
+	Threshold int `config_hash:"5" definition_hash:"5" json:"threshold" ssz:"uint64"`
 
 	// DKGAlgorithm to use for key generation. Max 32 chars.
-	DKGAlgorithm string `json:"dkg_algorithm" ssz:"ByteList[32]" config_hash:"6" definition_hash:"6"`
+	DKGAlgorithm string `config_hash:"6" definition_hash:"6" json:"dkg_algorithm" ssz:"ByteList[32]"`
 
 	// ForkVersion defines the cluster's 4 byte beacon chain fork version (network/chain identifier).
 	ForkVersion []byte `json:"fork_version,0xhex" ssz:"Bytes4" config_hash:"7" definition_hash:"7"`
 
 	// Operators define the charon nodes in the cluster and their operators. Max 256 operators.
-	Operators []Operator `json:"operators" ssz:"CompositeList[256]" config_hash:"8" definition_hash:"8"`
+	Operators []Operator `config_hash:"8" definition_hash:"8" json:"operators" ssz:"CompositeList[256]"`
 
 	// Creator identifies the creator of a cluster definition. They may also be an operator.
-	Creator Creator `json:"creator" ssz:"Composite" config_hash:"9" definition_hash:"9"`
+	Creator Creator `config_hash:"9" definition_hash:"9" json:"creator" ssz:"Composite"`
 
 	// ValidatorAddresses define addresses of each validator.
-	ValidatorAddresses []ValidatorAddresses `json:"validators" ssz:"CompositeList[65536]" config_hash:"10" definition_hash:"10"`
+	ValidatorAddresses []ValidatorAddresses `config_hash:"10" definition_hash:"10" json:"validators" ssz:"CompositeList[65536]"`
 
 	// ConfigHash uniquely identifies a cluster definition excluding operator ENRs and signatures.
 	ConfigHash []byte `json:"config_hash,0xhex" ssz:"Bytes32" config_hash:"-" definition_hash:"11"`

--- a/cluster/deposit.go
+++ b/cluster/deposit.go
@@ -6,16 +6,16 @@ package cluster
 // https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/beacon-chain.md#depositdata
 type DepositData struct {
 	// PubKey is the validator public key.
-	PubKey []byte `json:"pubkey"  ssz:"Bytes48" lock_hash:"0"`
+	PubKey []byte `json:"pubkey" lock_hash:"0" ssz:"Bytes48"`
 
 	// WithdrawalCredentials included in the deposit.
-	WithdrawalCredentials []byte `json:"withdrawal_credentials"  ssz:"Bytes32" lock_hash:"1"`
+	WithdrawalCredentials []byte `json:"withdrawal_credentials" lock_hash:"1" ssz:"Bytes32"`
 
 	// Amount is the amount in Gwei to be deposited.
-	Amount int `json:"amount"  ssz:"uint64" lock_hash:"2"`
+	Amount int `json:"amount" lock_hash:"2" ssz:"uint64"`
 
 	// Signature is the BLS signature of the deposit message (above three fields).
-	Signature []byte `json:"signature"  ssz:"Bytes96" lock_hash:"3"`
+	Signature []byte `json:"signature" lock_hash:"3" ssz:"Bytes96"`
 }
 
 // depositDataJSON is the json formatter of DepositData.

--- a/cluster/distvalidator.go
+++ b/cluster/distvalidator.go
@@ -17,17 +17,17 @@ import (
 // DistValidator is a distributed validator (1x32ETH) managed by the cluster.
 type DistValidator struct {
 	// PubKey is the distributed validator group public key.
-	PubKey []byte `json:"distributed_public_key"  ssz:"Bytes48" lock_hash:"0"`
+	PubKey []byte `json:"distributed_public_key" lock_hash:"0" ssz:"Bytes48"`
 
 	// PubShares are the public keys corresponding to each node's secret key share.
 	// It can be used to verify a partial signature created by any node in the cluster.
-	PubShares [][]byte `json:"public_shares,omitempty" ssz:"CompositeList[256],Bytes48" lock_hash:"1"`
+	PubShares [][]byte `json:"public_shares,omitempty" lock_hash:"1" ssz:"CompositeList[256],Bytes48"`
 
 	// DepositData is the validator deposit data.
-	DepositData DepositData `json:"deposit_data,omitempty" ssz:"Composite" lock_hash:"2"`
+	DepositData DepositData `json:"deposit_data,omitempty" lock_hash:"2" ssz:"Composite"`
 
 	// BuilderRegistration is the pre-generated signed validator builder registration.
-	BuilderRegistration BuilderRegistration `json:"builder_registration,omitempty" ssz:"Composite" lock_hash:"3"`
+	BuilderRegistration BuilderRegistration `json:"builder_registration,omitempty" lock_hash:"3" ssz:"Composite"`
 }
 
 // PublicKey returns the validator BLS group public key.

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -20,22 +20,22 @@ import (
 // Lock extends the cluster config Definition with bls threshold public keys and checksums.
 type Lock struct {
 	// Definition is embedded and extended by Lock.
-	Definition `json:"cluster_definition" ssz:"Composite" lock_hash:"0"`
+	Definition `json:"cluster_definition" lock_hash:"0" ssz:"Composite"`
 
 	// Validators are the distributed validators (n*32ETH) managed by the cluster.
-	Validators []DistValidator `json:"distributed_validators" ssz:"Composite[65536]" lock_hash:"1"`
+	Validators []DistValidator `json:"distributed_validators" lock_hash:"1" ssz:"Composite[65536]"`
 
 	// LockHash uniquely identifies a cluster lock.
-	LockHash []byte `json:"lock_hash" ssz:"Bytes32" lock_hash:"-"`
+	LockHash []byte `json:"lock_hash" lock_hash:"-" ssz:"Bytes32"`
 
 	// SignatureAggregate is the bls aggregate signature of the lock hash signed by
 	// all the private key shares of all the distributed validators.
 	// It acts as an attestation by all the distributed validators
 	// of the charon cluster they are part of.
-	SignatureAggregate []byte `json:"signature_aggregate" ssz:"Bytes96" lock_hash:"-"`
+	SignatureAggregate []byte `json:"signature_aggregate" lock_hash:"-" ssz:"Bytes96"`
 
 	// NodeSignatures contains a signature of the lock hash for each operator defined in the Definition.
-	NodeSignatures [][]byte `json:"node_signatures" ssz:"Composite" lock_hash:"-"`
+	NodeSignatures [][]byte `json:"node_signatures" lock_hash:"-" ssz:"Composite"`
 }
 
 func (l Lock) MarshalJSON() ([]byte, error) {

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -18,7 +18,7 @@ type Operator struct {
 	Address string `json:"address,0xhex" ssz:"Bytes20" config_hash:"0" definition_hash:"0"`
 
 	// ENR identifies the charon node. Max 1024 chars.
-	ENR string `json:"enr" ssz:"ByteList[1024]" config_hash:"-" definition_hash:"1"`
+	ENR string `config_hash:"-" definition_hash:"1" json:"enr" ssz:"ByteList[1024]"`
 
 	// ConfigSignature is an EIP712 signature of the config_hash using privkey corresponding to operator Ethereum Address.
 	ConfigSignature []byte `json:"config_signature,0xhex" ssz:"Bytes65" config_hash:"-" definition_hash:"2"`

--- a/cluster/registration.go
+++ b/cluster/registration.go
@@ -8,16 +8,16 @@ import (
 
 // BuilderRegistration defines pre-generated signed validator builder registration to be sent to builder network.
 type BuilderRegistration struct {
-	Message   Registration `json:"message" ssz:"Composite" lock_hash:"0"`
-	Signature []byte       `json:"signature" ssz:"Bytes96" lock_hash:"1"`
+	Message   Registration `json:"message"   lock_hash:"0" ssz:"Composite"`
+	Signature []byte       `json:"signature" lock_hash:"1" ssz:"Bytes96"`
 }
 
 // Registration defines unsigned validator registration message.
 type Registration struct {
-	FeeRecipient []byte    `json:"fee_recipient"  ssz:"Bytes20" lock_hash:"0"`
-	GasLimit     int       `json:"gas_limit"  ssz:"uint64" lock_hash:"1"`
-	Timestamp    time.Time `json:"timestamp"  ssz:"uint64" lock_hash:"2"`
-	PubKey       []byte    `json:"pubkey"  ssz:"Bytes48" lock_hash:"3"`
+	FeeRecipient []byte    `json:"fee_recipient" lock_hash:"0" ssz:"Bytes20"`
+	GasLimit     int       `json:"gas_limit"     lock_hash:"1" ssz:"uint64"`
+	Timestamp    time.Time `json:"timestamp"     lock_hash:"2" ssz:"uint64"`
+	PubKey       []byte    `json:"pubkey"        lock_hash:"3" ssz:"Bytes48"`
 }
 
 // builderRegistrationJSON is the json formatter of BuilderRegistration.

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -97,7 +97,7 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 				return nil, errors.Wrap(err, "store password", z.Str("filename", filename))
 			}
 
-			return nil, nil
+			return nil, nil 
 		},
 		forkjoin.WithWorkers(loadStoreWorkers),
 	)

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -97,7 +97,7 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 				return nil, errors.Wrap(err, "store password", z.Str("filename", filename))
 			}
 
-			return nil, nil 
+			return nil, nil //nolint:nilnil
 		},
 		forkjoin.WithWorkers(loadStoreWorkers),
 	)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/obolnetwork/charon
 
-go 1.20
+go 1.21
 
 require (
 	github.com/attestantio/go-eth2-client v0.18.3

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/bradfitz/go-smtpd v0.0.0-20170404230938-deb6d6237625/go.mod h1:HYsPBT
 github.com/btcsuite/btcd v0.22.1 h1:CnwP9LM/M9xuRrGSCGeMVs9iv09uMqwsVX7EeIpgV2c=
 github.com/btcsuite/btcd v0.22.1/go.mod h1:wqgTSL29+50LRkmOVknEdmt8ZojIzhuWvgu/iptuN7Y=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1 h1:q0rUy8C/TYNBQS1+CGKw68tLOFYSNEs0TFnxxnS9+4U=
+github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1/go.mod h1:7SFka0XMvUgj3hfZtydOrQY2mwhPclbT2snogU7SQQc=
 github.com/bufbuild/buf v1.27.0 h1:0Lg3EaY//KjQDazAkl5pCh3ton24+/dCEUQ3qLPrTc0=
 github.com/bufbuild/buf v1.27.0/go.mod h1:+ccCrjSZNY3w1LNtRWixBVw4A7X5M2O27RjyO3d4RAg=
 github.com/bufbuild/protocompile v0.6.0 h1:Uu7WiSQ6Yj9DbkdnOe7U4mNKp58y9WDMKDn28/ZlunY=
@@ -106,6 +107,7 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -113,6 +115,7 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c h1:pFUpOrbxDR6AkioZ1ySsx5yxlDQZ8stG2b88gTPxgJU=
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
 github.com/decred/dcrd/crypto/blake256 v1.0.1 h1:7PltbUIQB7u/FfZ39+DGa/ShuMyJ5ilcvdfma9wOH6Y=
+github.com/decred/dcrd/crypto/blake256 v1.0.1/go.mod h1:2OfgNZ5wDpcsFmHmCK5gZTPcCXqlm2ArzUIkw9czNJo=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 h1:8UrgZ3GkP4i/CLijOJx79Yu+etlyjdBU4sfcs2WYQMs=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0/go.mod h1:v57UDF4pDQJcEfFUCRop3lJL149eHGSe9Jvczhzjo/0=
 github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
@@ -155,6 +158,7 @@ github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwU
 github.com/francoispqt/gojay v1.2.13 h1:d2m3sFjloqoIUQU3TsHBgj6qg/BVGlTBeHDUmyJnXKk=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
 github.com/fsnotify/fsnotify v1.6.0/go.mod h1:sl3t1tCWJFWoRz9R8WJCbQihKKwmorjAbSClcnxKAGw=
@@ -187,6 +191,7 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.1.0 h1:4KLkAxT3aOY8Li4FRJe/KvhoNFFxo0m6fNuFUO8QJUk=
 github.com/godbus/dbus/v5 v5.1.0/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
+github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid/v5 v5.0.0 h1:p544++a97kEL+svbcFbCQVM9KFu0Yo25UoISXGNNH9M=
 github.com/gofrs/uuid/v5 v5.0.0/go.mod h1:CDOjlDMVAtN56jqyRUZh58JT31Tiw7/oQyEXZV+9bD8=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -239,6 +244,7 @@ github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-containerregistry v0.16.1 h1:rUEt426sR6nyrL3gt+18ibRcvYpKYdpsa5ZW7MA08dQ=
 github.com/google/go-containerregistry v0.16.1/go.mod h1:u0qB2l7mvtWVR5kNcbFIhFY1hLbf8eeGapA+vbFDCtQ=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
@@ -266,6 +272,7 @@ github.com/google/pprof v0.0.0-20230926050212-f7f687d19a98/go.mod h1:czg5+yv1E0Z
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go v2.0.0+incompatible/go.mod h1:SFVmujtThgffbyetf+mdk2eWhX2bMyUtNHzFKcPA9HY=
 github.com/googleapis/gax-go/v2 v2.0.3/go.mod h1:LLvjysVCY1JZeum8Z6l8qUty8fiNwE08qbEPm1M08qg=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -287,7 +294,9 @@ github.com/herumi/bls-eth-go-binary v1.32.0/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwa
 github.com/holiman/uint256 v1.2.2 h1:TXKcSGc2WaxPD2+bmzAsVthL4+pEN0YwXcL5qED83vk=
 github.com/holiman/uint256 v1.2.2/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/huandu/go-clone v1.6.0 h1:HMo5uvg4wgfiy5FoGOqlFLQED/VGRm2D9Pi8g1FXPGc=
+github.com/huandu/go-clone v1.6.0/go.mod h1:ReGivhG6op3GYr+UY3lS6mxjKp7MIGTknuU5TbTVaXE=
 github.com/huandu/go-clone/generic v1.6.0 h1:Wgmt/fUZ28r16F2Y3APotFD59sHk1p78K0XLdbUYN5U=
+github.com/huandu/go-clone/generic v1.6.0/go.mod h1:xgd9ZebcMsBWWcBx5mVMCoqMX24gLWr5lQicr+nVXNs=
 github.com/huin/goupnp v1.2.0 h1:uOKW26NG1hsSSbXIZ1IR7XP9Gjd1U8pnLaCMgntmkmY=
 github.com/huin/goupnp v1.2.0/go.mod h1:gnGPsThkYa7bFi/KWmEysQRf48l2dvR5bxr2OFckNX8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -309,6 +318,7 @@ github.com/jdx/go-netrc v1.0.0 h1:QbLMLyCZGj0NA8glAhxUpf1zDg6cxnWgMBbjq40W0gQ=
 github.com/jdx/go-netrc v1.0.0/go.mod h1:Gh9eFQJnoTNIRHXl2j5bJXA1u84hQWJWgGh569zF3v8=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
 github.com/jhump/protoreflect v1.15.3 h1:6SFRuqU45u9hIZPJAoZ8c28T3nK64BNdp9w6jFonzls=
+github.com/jhump/protoreflect v1.15.3/go.mod h1:4ORHmSBmlCW8fh3xHmJMGyul1zNqZK4Elxc8qKP+p1k=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -331,10 +341,12 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.3/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
@@ -350,6 +362,7 @@ github.com/libp2p/go-libp2p v0.30.0/go.mod h1:nr2g5V7lfftwgiJ78/HrID+pwvayLyqKCE
 github.com/libp2p/go-libp2p-asn-util v0.3.0 h1:gMDcMyYiZKkocGXDQ5nsUQyquC9+H+iLEQHwOCZ7s8s=
 github.com/libp2p/go-libp2p-asn-util v0.3.0/go.mod h1:B1mcOrKUE35Xq/ASTmQ4tN3LNzVVaMNmq2NACuqyB9w=
 github.com/libp2p/go-libp2p-testing v0.12.0 h1:EPvBb4kKMWO29qP4mZGyhVzUyR25dvfUIK5WDu6iPUA=
+github.com/libp2p/go-libp2p-testing v0.12.0/go.mod h1:KcGDRXyN7sQCllucn1cOOS+Dmm7ujhfEyXQL5lvkcPg=
 github.com/libp2p/go-msgio v0.3.0 h1:mf3Z8B1xcFN314sWX+2vOTShIE0Mmn2TXn3YCUQGNj0=
 github.com/libp2p/go-msgio v0.3.0/go.mod h1:nyRM819GmVaF9LX3l03RMh10QdOroF++NBbxAb0mmDM=
 github.com/libp2p/go-nat v0.2.0 h1:Tyz+bUFAYqGyJ/ppPPymMGbIgNRH+WqC5QrT5fKrrGk=
@@ -434,6 +447,7 @@ github.com/neelance/sourcemap v0.0.0-20151028013722-8c68805598ab/go.mod h1:Qr6/a
 github.com/onsi/ginkgo/v2 v2.11.0 h1:WgqUCUt/lT6yXoQ8Wef0fsNn5cAuMK7+KT9UFRz2tcU=
 github.com/onsi/ginkgo/v2 v2.11.0/go.mod h1:ZhrRA5XmEE3x3rhlzamx/JJvujdZoJ2uvgI7kR0iZvM=
 github.com/onsi/gomega v1.27.8 h1:gegWiwZjBsf2DgiSbf5hpokZ98JVDMcWkUiigk6/KXc=
+github.com/onsi/gomega v1.27.8/go.mod h1:2J8vzI/s+2shY9XHRApDkdgPo1TKT7P2u6fXeJKFnNQ=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc5 h1:Ygwkfw9bpDvs+c9E34SdgGOj41dX/cbdlwvlWt0pnFI=
@@ -458,6 +472,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prashantv/gostub v1.1.0 h1:BTyx3RfQjRHnUWaGF9oQos79AlQ5k8WNktv7VGvVH4g=
+github.com/prashantv/gostub v1.1.0/go.mod h1:A5zLQHz7ieHGG7is6LLXLz7I8+3LZzsrV0P1IAHhP5U=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v1.17.0 h1:rl2sfwZMtSthVU752MqfjQozy7blglC+1SOtjMAMh+Q=
 github.com/prometheus/client_golang v1.17.0/go.mod h1:VeL+gMmOAxkS2IqfCq0ZmHSL+LjWfWDUmp1mBz9JgUY=
@@ -489,6 +504,7 @@ github.com/raulk/go-watchdog v1.3.0 h1:oUmdlHxdkXRJlwfG0O9omj8ukerm8MEQavSiDTEtB
 github.com/raulk/go-watchdog v1.3.0/go.mod h1:fIvOnLbF0b0ZwkB9YU4mOW9Did//4vPZtDqv66NfsMU=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
+github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
@@ -565,15 +581,18 @@ github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cb
 github.com/tetratelabs/wazero v1.5.0 h1:Yz3fZHivfDiZFUXnWMPUoiW7s8tC1sjdBtlJn08qYa0=
 github.com/tetratelabs/wazero v1.5.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/umbracle/gohashtree v0.0.2-alpha.0.20230207094856-5b775a815c10 h1:CQh33pStIp/E30b7TxDlXfM0145bn2e8boI30IxAhTg=
+github.com/umbracle/gohashtree v0.0.2-alpha.0.20230207094856-5b775a815c10/go.mod h1:x/Pa0FF5Te9kdrlZKJK82YmAkvL8+f989USgz6Jiw7M=
 github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vbatts/tar-split v0.11.5 h1:3bHCTIheBm1qFTcgh9oPu+nNBtX+XJIupG/vacinCts=
 github.com/vbatts/tar-split v0.11.5/go.mod h1:yZbwRsSeGjusneWgA781EKej9HF8vme8okylkAeNKLk=
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/wealdtech/go-eth2-types/v2 v2.8.2 h1:b5aXlNBLKgjAg/Fft9VvGlqAUCQMP5LzYhlHRrr4yPg=
+github.com/wealdtech/go-eth2-types/v2 v2.8.2/go.mod h1:IAz9Lz1NVTaHabQa+4zjk2QDKMv8LVYo0n46M9o/TXw=
 github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1 h1:9j7bpwjT9wmwBb54ZkBhTm1uNIlFFcCJXefd/YskZPw=
 github.com/wealdtech/go-eth2-wallet-encryptor-keystorev4 v1.4.1/go.mod h1:+tI1VD76E1WINI+Nstg7RVGpUolL5ql10nu2YztMO/4=
 github.com/wealdtech/go-eth2-wallet-types/v2 v2.11.0 h1:yX9+FfUXvPDvZ8Q5bhF+64AWrQwh4a3/HpfTx99DnZc=
+github.com/wealdtech/go-eth2-wallet-types/v2 v2.11.0/go.mod h1:UVP9YFcnPiIzHqbmCMW3qrQ3TK5FOqr1fmKqNT9JGr8=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -599,6 +618,7 @@ go.opentelemetry.io/otel/metric v1.19.0/go.mod h1:L5rUsV9kM1IxCj1MmSdS+JQAcVm319
 go.opentelemetry.io/otel/sdk v1.19.0 h1:6USY6zH+L8uMH8L3t1enZPR3WFEmSTADlqldyHtJi3o=
 go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/sdk/metric v0.39.0 h1:Kun8i1eYf48kHH83RucG93ffz0zGV1sh46FAScOTuDI=
+go.opentelemetry.io/otel/sdk/metric v0.39.0/go.mod h1:piDIRgjcK7u0HCL5pCA4e74qpK/jk3NiUoAHATVAmiI=
 go.opentelemetry.io/otel/trace v1.19.0 h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1Dzxpg=
 go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -1004,6 +1024,7 @@ gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools/v3 v3.0.3 h1:4AuOwCGf4lLR9u3YOe2awrHygurzhO/HeQ6laiA6Sx0=
+gotest.tools/v3 v3.0.3/go.mod h1:Z7Lb0S5l+klDB31fvDQX8ss/FlKDxtlFlw3Oa8Ymbl8=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/testutil/promrated/Dockerfile
+++ b/testutil/promrated/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7-alpine AS builder
+FROM golang:1.21.2-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache build-base git

--- a/testutil/promrated/Dockerfile
+++ b/testutil/promrated/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.2-alpine AS builder
+FROM golang:1.21.3-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache build-base git

--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -93,7 +93,7 @@ func verifyTitle(title string) error {
 		return errors.New("title isn't prefixed with 'package[/subpackage]:'")
 	}
 
-	if !titlePrefix.Match([]byte(split[0])) {
+	if !titlePrefix.MatchString(split[0]) {
 		return errors.New("title prefix doesn't match regex")
 	}
 


### PR DESCRIPTION
Bump charon to `go1.21.3`.

This fixes failing govulnchecks https://github.com/ObolNetwork/charon/actions/runs/6504583723.

category: feature 
ticket: none 
