### PR TITLE
testutil/genchangelog: force fetch tags

### DIFF
--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -424,7 +424,7 @@ func getFirstMatch(r *regexp.Regexp, s string) (string, bool) {
 
 // getLatestTags returns the latest N git tags.
 func getLatestTags(n int) ([]string, error) {
-	out, err := exec.Command("git", "fetch", "--tags").CombinedOutput()
+	out, err := exec.Command("git", "fetch", "--tags", "-f").CombinedOutput()
 	if err != nil {
 		return nil, errors.Wrap(err, "git fetch", z.Str("out", string(out)))
 	}


### PR DESCRIPTION
Always overwrite tags with whatever is available on remote when generating a changelog.

This has no consequence on tags *pushed* on the repo, but only on the working copy of the Github action that is executed.

category: bug
ticket: none