### PR TITLE
testutil/validatormock: fix simnet tests

### DIFF
--- a/testutil/validatormock/component.go
+++ b/testutil/validatormock/component.go
@@ -20,6 +20,10 @@ import (
 // epochWindow is the window size of the lookahead.
 const epochWindow = 2
 
+// delayStartSlots is the number slots to wait before starting validatormock.
+// This is needed to avoid inconsistencies between peers on startup in simnet tests .
+const delayStartSlots = 2
+
 // scheduleTuple is a tuple of a duty and the time it should be performed.
 type scheduleTuple struct {
 	duty      core.Duty
@@ -70,6 +74,7 @@ type Component struct {
 
 	// Mutable state.
 	mu               sync.Mutex
+	delaySlots       int
 	started          bool                       // Whether SlotTicked has been called.
 	attestersBySlot  map[uint64]*SlotAttester   // Slot attesters indexed by slot number.
 	syncCommsByEpoch map[uint64]*SyncCommMember // SyncCommMember indexed by epoch number.
@@ -140,7 +145,26 @@ func (m *Component) Run(ctx context.Context) {
 // SlotTicked is called when a slot ticks/starts. This is called by the scheduler component.
 // This is only called once per slot.
 func (m *Component) SlotTicked(ctx context.Context, slot core.Slot) error {
+	// Check if we need to wait for sometime to start scheduling duties.
+	if m.delayOnStartup() {
+		return nil
+	}
+
 	return m.scheduleSlot(ctx, metaSlot{Slot: uint64(slot.Slot), meta: m.meta})
+}
+
+// delayOnStartup returns true if we need to omit performing duties in the upcoming slot.
+func (m *Component) delayOnStartup() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.delaySlots == delayStartSlots {
+		return false
+	}
+
+	m.delaySlots++
+
+	return true
 }
 
 // scheduleSlot is called when the slot ticks and schedules duties for the provided slot.
@@ -181,8 +205,6 @@ func (m *Component) manageEpochState(ctx context.Context, epoch metaEpoch) error
 
 		// Delete sync committee members.
 		m.deleteSyncCommMembers(e)
-
-		log.Debug(ctx, "Deleted attesters and sync committee members", z.U64("epoch", e.Epoch))
 
 		e = e.Prev()
 	}

--- a/testutil/validatormock/component.go
+++ b/testutil/validatormock/component.go
@@ -17,12 +17,14 @@ import (
 	"github.com/obolnetwork/charon/core"
 )
 
-// epochWindow is the window size of the lookahead.
-const epochWindow = 2
+const (
+	// epochWindow is the window size of the lookahead.
+	epochWindow = 2
 
-// delayStartSlots is the number slots to wait before starting validatormock.
-// This is needed to avoid inconsistencies between peers on startup in simnet tests .
-const delayStartSlots = 2
+	// delayStartSlots is the number slots to wait before starting validatormock.
+	// This is needed to avoid inconsistencies between peers on startup in simnet tests .
+	delayStartSlots = 2
+)
 
 // scheduleTuple is a tuple of a duty and the time it should be performed.
 type scheduleTuple struct {

--- a/testutil/validatormock/component.go
+++ b/testutil/validatormock/component.go
@@ -22,7 +22,7 @@ const (
 	epochWindow = 2
 
 	// delayStartSlots is the number slots to wait before starting validatormock.
-	// This is needed to avoid inconsistencies between peers on startup in simnet tests .
+	// This is needed to avoid inconsistencies between peers on startup in simnet tests.
 	delayStartSlots = 2
 )
 


### PR DESCRIPTION
Fixes panics in simnet tests by introducing a delay in validatormock of 2 slots. The panics were caused by the race condition between scheduling duties of two slots. Note: In simnet tests we have 1s slot duration and 1 slot per epoch. This is happening when scheduler sends slot tick event in between the slot. 

For example, in above scenario on startup first peer got slot tick of 1st slot at 900th Millisecond but it took 200ms to schedule duties for that slot which results in slot tick of 2nd slot. And since we set attester duties once at the start of each epoch, this results in panic as it sets duties twice just because first two slots were out of sync.

category: fixbuild
ticket: none
