### PR TITLE
vmock: change start time of sync selections to start of slot

### DIFF
--- a/testutil/validatormock/component.go
+++ b/testutil/validatormock/component.go
@@ -452,7 +452,7 @@ var dutyStartTimeFuncsByDuty = map[core.DutyType][]dutyStartTimeFunc{
 	core.DutyProposer:                {slotStartTime},
 	core.DutyBuilderProposer:         {slotStartTime},
 	core.DutyBuilderRegistration:     {startOfCurrentEpoch},
-	core.DutyPrepareSyncContribution: {startOfPrevEpoch, startOfCurrentEpoch},
+	core.DutyPrepareSyncContribution: {slotStartTime},
 	core.DutySyncMessage:             {fraction(1, 3)},
 	core.DutySyncContribution:        {fraction(2, 3)},
 }


### PR DESCRIPTION
Changes start time of sync selections in vmock to start of slot as proposed.

category: refactor
ticket: none
