### PR TITLE
testutil/genchangelog: ignore rc's, template changes

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -95,6 +95,11 @@ func (v SemVer) String() string {
 	return fmt.Sprintf("v%d.%d-%s", v.major, v.minor, v.preRelease)
 }
 
+// PreRelease returns true if v represents a tag for a pre-release.
+func (v SemVer) PreRelease() bool {
+	return v.semVerType == typePreRelease
+}
+
 // Minor returns the minor version of the semantic version.
 // It strips the typePatch version and pre-release label if present.
 func (v SemVer) Minor() SemVer {

--- a/app/version/version_test.go
+++ b/app/version/version_test.go
@@ -64,6 +64,16 @@ func TestSemVerCompare(t *testing.T) {
 	}
 }
 
+func TestIsPrerelease(t *testing.T) {
+	preRelease, err := version.Parse("v0.17.1-rc1")
+	require.NoError(t, err)
+	require.True(t, preRelease.PreRelease())
+
+	release, err := version.Parse("v0.17.1")
+	require.NoError(t, err)
+	require.False(t, release.PreRelease())
+}
+
 func TestCurrentInSupported(t *testing.T) {
 	require.Equal(t, 0, version.Compare(version.Version, version.Supported()[0]))
 }

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -4,11 +4,10 @@
 // It requires the following:
 //   - Each commit is a squash merged GitHub PR.
 //   - The commit subject contains the PR number '(#123)'.
-//   - Each commit contains a 'category: foo' line in the body.
-//   - Each commit is linked to a Github Issue via a 'ticket: #321' line in the body.
-//   - Only PRs with supported categories linked to Issues will be included in the changelog.
 //
-//nolint:forbidigo,gosec
+// PRs that don't have a linked ticket or category will be placed in the "What's changed" section of the changelog.
+//
+//nolint:forbidigo
 package main
 
 import (

--- a/testutil/genchangelog/main_internal_test.go
+++ b/testutil/genchangelog/main_internal_test.go
@@ -60,6 +60,11 @@ func TestPRFromLog(t *testing.T) {
 				Body:    "Body\n\ncategory: feature\nticket: none",
 				Subject: "(#266)",
 			},
+			out: pullRequest{
+				Title:    "(#266)",
+				Number:   266,
+				Category: "feature",
+			},
 		},
 		{
 			in: log{

--- a/testutil/genchangelog/template.md
+++ b/testutil/genchangelog/template.md
@@ -1,5 +1,7 @@
 # {{.Tag}} - {{.Date}}
 
+![Obol Logo](https://obol.tech/obolnetwork.png)
+
 This release introduces general fixes and improvements including progress on great new features.
 
 **Full Changelog**: [{{.RangeText}}]({{.RangeLink}})
@@ -8,4 +10,9 @@ This release introduces general fixes and improvements including progress on gre
   {{- range .Issues}}
 - {{.Title}} {{.Label}} ({{range $i, $v := .PRs}}{{if $i}},{{end}}{{$v.Label}}{{end}})
   {{- end}}
+{{end}}
+
+## What's Changed
+{{range .ExtraPRs}}
+- [{{.Title}}](https://github.com/ObolNetwork/charon/pull/{{.Number}})
 {{end}}

--- a/testutil/genchangelog/testdata/TestParsePRs_parsed_prs.golden
+++ b/testutil/genchangelog/testdata/TestParsePRs_parsed_prs.golden
@@ -1,5 +1,23 @@
 [
  {
+  "Title": "app/version: bump to v0.13 (#1641)",
+  "Number": 1641,
+  "Category": "misc",
+  "Issue": 0
+ },
+ {
+  "Title": "cmd: re-add previous relay address for backwards compatibility (#1639)",
+  "Number": 1639,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
+  "Title": "cmd: update default relay address (#1636)",
+  "Number": 1636,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
   "Title": "cmd: add `keymanager-address` flag to create cluster command (#1622)",
   "Number": 1622,
   "Category": "feature",
@@ -18,10 +36,34 @@
   "Issue": 1608
  },
  {
+  "Title": "dkg: fix error handling in TestSyncFlow (#1618)",
+  "Number": 1618,
+  "Category": "test",
+  "Issue": 0
+ },
+ {
   "Title": "cmd: add `--definition-file` flag to create cluster command (#1615)",
   "Number": 1615,
   "Category": "feature",
   "Issue": 1490
+ },
+ {
+  "Title": "core/scheduler: fix flapping test (#1619)",
+  "Number": 1619,
+  "Category": "test",
+  "Issue": 0
+ },
+ {
+  "Title": "core/scheduler: trim duties after 3 epochs (#1616)",
+  "Number": 1616,
+  "Category": "bug",
+  "Issue": 0
+ },
+ {
+  "Title": "app/eth2wrap: instrument custom endpoint latency (#1614)",
+  "Number": 1614,
+  "Category": "misc",
+  "Issue": 0
  },
  {
   "Title": "cmd: rebrand bootnode to relay (#1610)",
@@ -46,6 +88,12 @@
   "Number": 1604,
   "Category": "feature",
   "Issue": 1590
+ },
+ {
+  "Title": "core/aggsigdb: fix flapping test (#1605)",
+  "Number": 1605,
+  "Category": "test",
+  "Issue": 0
  },
  {
   "Title": "core/aggsigdb: delete expired duties and queries (#1598)",
@@ -108,6 +156,12 @@
   "Issue": 1494
  },
  {
+  "Title": "testutil/validatormock: fix getSubcommittees bug (#1579)",
+  "Number": 1579,
+  "Category": "bug",
+  "Issue": 0
+ },
+ {
   "Title": "core: add support for capella blocks (#1570)",
   "Number": 1570,
   "Category": "feature",
@@ -126,10 +180,22 @@
   "Issue": 1540
  },
  {
+  "Title": "app: revert VC health statuses (#1571)",
+  "Number": 1571,
+  "Category": "bug",
+  "Issue": 0
+ },
+ {
   "Title": "testutil/promrated: implement rated fetching and reporting (#1569)",
   "Number": 1569,
   "Category": "misc",
   "Issue": 1540
+ },
+ {
+  "Title": "app/bootnode: fix missing cluster hash in metrics (#1568)",
+  "Number": 1568,
+  "Category": "bug",
+  "Issue": 0
  },
  {
   "Title": "app/monitoringapi: detect all validators queried by VC (#1566)",
@@ -144,10 +210,46 @@
   "Issue": 1540
  },
  {
+  "Title": "cmd/bootnode: refactor metrics (#1564)",
+  "Number": 1564,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
+  "Title": "app/log: increase loki batch send timeout to 10s (#1563)",
+  "Number": 1563,
+  "Category": "misc",
+  "Issue": 0
+ },
+ {
   "Title": "testutil/promrated: add health listener and monitoring endpoint (#1553)",
   "Number": 1553,
   "Category": "misc",
   "Issue": 1540
+ },
+ {
+  "Title": "p2p: add duration labels to receive errors (#1560)",
+  "Number": 1560,
+  "Category": "misc",
+  "Issue": 0
+ },
+ {
+  "Title": "cmd: require name in create cluster (#1559)",
+  "Number": 1559,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
+  "Title": "core/consensus: improve logging (#1557)",
+  "Number": 1557,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
+  "Title": "dkg/sync: add disconnect log to server (#1551)",
+  "Number": 1551,
+  "Category": "misc",
+  "Issue": 0
  },
  {
   "Title": "core/consensus: fix wire compatibility (#1556)",
@@ -162,10 +264,40 @@
   "Issue": 1555
  },
  {
+  "Title": "app/eth2wrap: decrease synth block sizes (#1550)",
+  "Number": 1550,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
   "Title": "testutil/promrated: add initial basic looping and read in config (#1548)",
   "Number": 1548,
   "Category": "misc",
   "Issue": 1540
+ },
+ {
+  "Title": "app: increase sniffed buffer even more (#1549)",
+  "Number": 1549,
+  "Category": "test",
+  "Issue": 0
+ },
+ {
+  "Title": "workflows: upload artefacts always (#1547)",
+  "Number": 1547,
+  "Category": "test",
+  "Issue": 0
+ },
+ {
+  "Title": "app: increase sniffed message buffer (#1546)",
+  "Number": 1546,
+  "Category": "refactor",
+  "Issue": 0
+ },
+ {
+  "Title": "p2p: instrument network throughput (#1545)",
+  "Number": 1545,
+  "Category": "feature",
+  "Issue": 0
  },
  {
   "Title": "app/eth2wrap: use correct fee recipient in synthetic blocks (#1544)",
@@ -180,6 +312,12 @@
   "Issue": 1247
  },
  {
+  "Title": "cmd: redact address flag passwords (#1541)",
+  "Number": 1541,
+  "Category": "bug",
+  "Issue": 0
+ },
+ {
   "Title": "app/eth2wrap: use validators at head for synthetic blocks (#1539)",
   "Number": 1539,
   "Category": "refactor",
@@ -190,6 +328,12 @@
   "Number": 1536,
   "Category": "feature",
   "Issue": 1521
+ },
+ {
+  "Title": "core/priority: fix flapping test (#1535)",
+  "Number": 1535,
+  "Category": "test",
+  "Issue": 0
  },
  {
   "Title": "app/eth2wrap: query previous block for synthetic proposals (#1533)",
@@ -222,10 +366,28 @@
   "Issue": 1527
  },
  {
+  "Title": "p2p: add option to disable port reuse (#1529)",
+  "Number": 1529,
+  "Category": "feature",
+  "Issue": 0
+ },
+ {
+  "Title": "app: fix failing teku exits (#1530)",
+  "Number": 1530,
+  "Category": "test",
+  "Issue": 0
+ },
+ {
   "Title": "cluster: add partial definition verification (#1520)",
   "Number": 1520,
   "Category": "feature",
   "Issue": 1488
+ },
+ {
+  "Title": "core/consensus: add QBFT decided round gauge (#1514)",
+  "Number": 1514,
+  "Category": "misc",
+  "Issue": 0
  },
  {
   "Title": "cmd/bootnode: move bootnode to own package (#1512)",
@@ -234,16 +396,40 @@
   "Issue": 1506
  },
  {
+  "Title": "docs: add declartions section to go guidelines (#1513)",
+  "Number": 1513,
+  "Category": "docs",
+  "Issue": 0
+ },
+ {
   "Title": "app: wire synthetic block proposals (#1499)",
   "Number": 1499,
   "Category": "feature",
   "Issue": 1486
  },
  {
+  "Title": "testutil/trackpr: automate assigning pr to author (#1507)",
+  "Number": 1507,
+  "Category": "misc",
+  "Issue": 0
+ },
+ {
   "Title": "core/qbft: include round when deduping (#1505)",
   "Number": 1505,
   "Category": "bug",
   "Issue": 1493
+ },
+ {
+  "Title": "core/validatorapi: improve query param handling and errors (#1498)",
+  "Number": 1498,
+  "Category": "misc",
+  "Issue": 0
+ },
+ {
+  "Title": "app: fix flapping InfoSync test (#1508)",
+  "Number": 1508,
+  "Category": "test",
+  "Issue": 0
  },
  {
   "Title": "log/loki: lazy loading of cluster labels (#1511)",
@@ -282,10 +468,28 @@
   "Issue": 1421
  },
  {
+  "Title": "app/errors: add sentinel error without stacktrace (#1483)",
+  "Number": 1483,
+  "Category": "misc",
+  "Issue": 0
+ },
+ {
   "Title": "github: update workflows to go1.19.3 (#1481)",
   "Number": 1481,
   "Category": "misc",
   "Issue": 1366
+ },
+ {
+  "Title": "app/eth2wrap: handle block attestations 404 (#1482)",
+  "Number": 1482,
+  "Category": "bug",
+  "Issue": 0
+ },
+ {
+  "Title": "app/eth2wrap: fix block attestation request (#1480)",
+  "Number": 1480,
+  "Category": "bug",
+  "Issue": 0
  },
  {
   "Title": "app/peerinfo: fix clock offset calculation (#1474)",
@@ -300,6 +504,12 @@
   "Issue": 1446
  },
  {
+  "Title": "readme: mark attestation duty as completed for vouch (#1476)",
+  "Number": 1476,
+  "Category": "docs",
+  "Issue": 0
+ },
+ {
   "Title": "core/tracker: implement inclusion delay tracker (#1468)",
   "Number": 1468,
   "Category": "feature",
@@ -310,5 +520,11 @@
   "Number": 1466,
   "Category": "test",
   "Issue": 992
+ },
+ {
+  "Title": "core/consensus: fix nil map panic (#1469)",
+  "Number": 1469,
+  "Category": "bug",
+  "Issue": 0
  }
 ]

--- a/testutil/genchangelog/testdata/TestParsePRs_template.golden
+++ b/testutil/genchangelog/testdata/TestParsePRs_template.golden
@@ -1,46 +1,48 @@
 # v0.13.0 - 1970-01-01
 
+![Obol Logo](https://obol.tech/obolnetwork.png)
+
 This release introduces general fixes and improvements including progress on great new features.
 
 **Full Changelog**: [v0.12.0..v0.13.0](https://github.com/obolnetwork/charon/compare/v0.12.0..v0.13.0)
 
 ## Feature
-- Issue#1464 #1464 (#1570)
-- Issue#1254 #1254 (#1468)
+- Issue#1582 #1582 (#1598)
+- Issue#1490 #1490 (#1615,#1532)
+- Issue#1506 #1506 (#1534,#1512)
+- Issue#1509 #1509 (#1511)
+- Issue#1421 #1421 (#1485)
+- Issue#1446 #1446 (#1473)
 - Issue#1501 #1501 (#1609,#1599,#1597,#1566)
 - Issue#1247 #1247 (#1526)
-- Issue#1509 #1509 (#1511)
-- Issue#1490 #1490 (#1615,#1532)
-- Issue#1486 #1486 (#1544,#1539,#1533,#1499,#1497,#1487)
-- Issue#1506 #1506 (#1534,#1512)
-- Issue#1421 #1421 (#1485)
 - Issue#1503 #1503 (#1622)
-- Issue#1590 #1590 (#1604)
-- Issue#1582 #1582 (#1598)
-- Issue#947 #947 (#1601,#1586)
 - Issue#1584 #1584 (#1596)
-- Issue#1446 #1446 (#1473)
-- Issue#1608 #1608 (#1627,#1624)
-- Issue#1521 #1521 (#1536)
 - Issue#1488 #1488 (#1520)
+- Issue#1590 #1590 (#1604)
+- Issue#1521 #1521 (#1536)
+- Issue#947 #947 (#1601,#1586)
+- Issue#1486 #1486 (#1544,#1539,#1533,#1499,#1497,#1487)
 - Issue#712 #712 (#1496)
+- Issue#1608 #1608 (#1627,#1624)
+- Issue#1464 #1464 (#1570)
+- Issue#1254 #1254 (#1468)
 
 ## Bug
-- Issue#1527 #1527 (#1528)
-- Issue#1555 #1555 (#1556,#1554)
 - Issue#1493 #1493 (#1505)
-- Issue#1540 #1540 (#1575,#1574,#1569,#1562,#1553,#1548)
+- Issue#1527 #1527 (#1528)
 - Issue#1445 #1445 (#1474)
+- Issue#1555 #1555 (#1556,#1554)
 - Issue#978 #978 (#1595)
+- Issue#1540 #1540 (#1575,#1574,#1569,#1562,#1553,#1548)
 
 ## Refactor
 - Issue#1524 #1524 (#1610)
-- Issue#1587 #1587 (#1600)
-- Issue#1475 #1475 (#1495)
-- Issue#1606 #1606 (#1607)
 - Issue#139 #139 (#1489)
-- Issue#1494 #1494 (#1592)
 - Issue#1591 #1591 (#1602)
+- Issue#1494 #1494 (#1592)
+- Issue#1475 #1475 (#1495)
+- Issue#1587 #1587 (#1600)
+- Issue#1606 #1606 (#1607)
 
 ## Test
 - Issue#992 #992 (#1466)
@@ -48,3 +50,77 @@ This release introduces general fixes and improvements including progress on gre
 ## Misc
 - Issue#1366 #1366 (#1481)
 
+
+## What's Changed
+
+- [core/consensus: fix nil map panic (#1469)](https://github.com/ObolNetwork/charon/pull/1469)
+
+- [readme: mark attestation duty as completed for vouch (#1476)](https://github.com/ObolNetwork/charon/pull/1476)
+
+- [app/eth2wrap: fix block attestation request (#1480)](https://github.com/ObolNetwork/charon/pull/1480)
+
+- [app/eth2wrap: handle block attestations 404 (#1482)](https://github.com/ObolNetwork/charon/pull/1482)
+
+- [app/errors: add sentinel error without stacktrace (#1483)](https://github.com/ObolNetwork/charon/pull/1483)
+
+- [core/validatorapi: improve query param handling and errors (#1498)](https://github.com/ObolNetwork/charon/pull/1498)
+
+- [testutil/trackpr: automate assigning pr to author (#1507)](https://github.com/ObolNetwork/charon/pull/1507)
+
+- [app: fix flapping InfoSync test (#1508)](https://github.com/ObolNetwork/charon/pull/1508)
+
+- [docs: add declartions section to go guidelines (#1513)](https://github.com/ObolNetwork/charon/pull/1513)
+
+- [core/consensus: add QBFT decided round gauge (#1514)](https://github.com/ObolNetwork/charon/pull/1514)
+
+- [p2p: add option to disable port reuse (#1529)](https://github.com/ObolNetwork/charon/pull/1529)
+
+- [app: fix failing teku exits (#1530)](https://github.com/ObolNetwork/charon/pull/1530)
+
+- [core/priority: fix flapping test (#1535)](https://github.com/ObolNetwork/charon/pull/1535)
+
+- [cmd: redact address flag passwords (#1541)](https://github.com/ObolNetwork/charon/pull/1541)
+
+- [p2p: instrument network throughput (#1545)](https://github.com/ObolNetwork/charon/pull/1545)
+
+- [app: increase sniffed message buffer (#1546)](https://github.com/ObolNetwork/charon/pull/1546)
+
+- [workflows: upload artefacts always (#1547)](https://github.com/ObolNetwork/charon/pull/1547)
+
+- [app: increase sniffed buffer even more (#1549)](https://github.com/ObolNetwork/charon/pull/1549)
+
+- [app/eth2wrap: decrease synth block sizes (#1550)](https://github.com/ObolNetwork/charon/pull/1550)
+
+- [dkg/sync: add disconnect log to server (#1551)](https://github.com/ObolNetwork/charon/pull/1551)
+
+- [core/consensus: improve logging (#1557)](https://github.com/ObolNetwork/charon/pull/1557)
+
+- [cmd: require name in create cluster (#1559)](https://github.com/ObolNetwork/charon/pull/1559)
+
+- [p2p: add duration labels to receive errors (#1560)](https://github.com/ObolNetwork/charon/pull/1560)
+
+- [app/log: increase loki batch send timeout to 10s (#1563)](https://github.com/ObolNetwork/charon/pull/1563)
+
+- [cmd/bootnode: refactor metrics (#1564)](https://github.com/ObolNetwork/charon/pull/1564)
+
+- [app/bootnode: fix missing cluster hash in metrics (#1568)](https://github.com/ObolNetwork/charon/pull/1568)
+
+- [app: revert VC health statuses (#1571)](https://github.com/ObolNetwork/charon/pull/1571)
+
+- [testutil/validatormock: fix getSubcommittees bug (#1579)](https://github.com/ObolNetwork/charon/pull/1579)
+
+- [core/aggsigdb: fix flapping test (#1605)](https://github.com/ObolNetwork/charon/pull/1605)
+
+- [app/eth2wrap: instrument custom endpoint latency (#1614)](https://github.com/ObolNetwork/charon/pull/1614)
+
+- [core/scheduler: trim duties after 3 epochs (#1616)](https://github.com/ObolNetwork/charon/pull/1616)
+
+- [dkg: fix error handling in TestSyncFlow (#1618)](https://github.com/ObolNetwork/charon/pull/1618)
+
+- [core/scheduler: fix flapping test (#1619)](https://github.com/ObolNetwork/charon/pull/1619)
+
+- [cmd: update default relay address (#1636)](https://github.com/ObolNetwork/charon/pull/1636)
+
+- [cmd: re-add previous relay address for backwards compatibility (#1639)](https://github.com/ObolNetwork/charon/pull/1639)
+
+- [app/version: bump to v0.13 (#1641)](https://github.com/ObolNetwork/charon/pull/1641)

--- a/testutil/genchangelog/testdata/TestParsePRs_template_data.golden
+++ b/testutil/genchangelog/testdata/TestParsePRs_template_data.golden
@@ -10,23 +10,73 @@
    "Issues": [
     {
      "Category": "feature",
-     "Title": "Issue#1464",
-     "Number": 1464,
-     "Label": "#1464",
+     "Title": "Issue#1582",
+     "Number": 1582,
+     "Label": "#1582",
      "PRs": [
       {
-       "Label": "#1570"
+       "Label": "#1598"
       }
      ]
     },
     {
      "Category": "feature",
-     "Title": "Issue#1254",
-     "Number": 1254,
-     "Label": "#1254",
+     "Title": "Issue#1490",
+     "Number": 1490,
+     "Label": "#1490",
      "PRs": [
       {
-       "Label": "#1468"
+       "Label": "#1615"
+      },
+      {
+       "Label": "#1532"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1506",
+     "Number": 1506,
+     "Label": "#1506",
+     "PRs": [
+      {
+       "Label": "#1534"
+      },
+      {
+       "Label": "#1512"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1509",
+     "Number": 1509,
+     "Label": "#1509",
+     "PRs": [
+      {
+       "Label": "#1511"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1421",
+     "Number": 1421,
+     "Label": "#1421",
+     "PRs": [
+      {
+       "Label": "#1485"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1446",
+     "Number": 1446,
+     "Label": "#1446",
+     "PRs": [
+      {
+       "Label": "#1473"
       }
      ]
     },
@@ -63,26 +113,70 @@
     },
     {
      "Category": "feature",
-     "Title": "Issue#1509",
-     "Number": 1509,
-     "Label": "#1509",
+     "Title": "Issue#1503",
+     "Number": 1503,
+     "Label": "#1503",
      "PRs": [
       {
-       "Label": "#1511"
+       "Label": "#1622"
       }
      ]
     },
     {
      "Category": "feature",
-     "Title": "Issue#1490",
-     "Number": 1490,
-     "Label": "#1490",
+     "Title": "Issue#1584",
+     "Number": 1584,
+     "Label": "#1584",
      "PRs": [
       {
-       "Label": "#1615"
+       "Label": "#1596"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1488",
+     "Number": 1488,
+     "Label": "#1488",
+     "PRs": [
+      {
+       "Label": "#1520"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1590",
+     "Number": 1590,
+     "Label": "#1590",
+     "PRs": [
+      {
+       "Label": "#1604"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#1521",
+     "Number": 1521,
+     "Label": "#1521",
+     "PRs": [
+      {
+       "Label": "#1536"
+      }
+     ]
+    },
+    {
+     "Category": "feature",
+     "Title": "Issue#947",
+     "Number": 947,
+     "Label": "#947",
+     "PRs": [
+      {
+       "Label": "#1601"
       },
       {
-       "Label": "#1532"
+       "Label": "#1586"
       }
      ]
     },
@@ -114,95 +208,12 @@
     },
     {
      "Category": "feature",
-     "Title": "Issue#1506",
-     "Number": 1506,
-     "Label": "#1506",
+     "Title": "Issue#712",
+     "Number": 712,
+     "Label": "#712",
      "PRs": [
       {
-       "Label": "#1534"
-      },
-      {
-       "Label": "#1512"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#1421",
-     "Number": 1421,
-     "Label": "#1421",
-     "PRs": [
-      {
-       "Label": "#1485"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#1503",
-     "Number": 1503,
-     "Label": "#1503",
-     "PRs": [
-      {
-       "Label": "#1622"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#1590",
-     "Number": 1590,
-     "Label": "#1590",
-     "PRs": [
-      {
-       "Label": "#1604"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#1582",
-     "Number": 1582,
-     "Label": "#1582",
-     "PRs": [
-      {
-       "Label": "#1598"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#947",
-     "Number": 947,
-     "Label": "#947",
-     "PRs": [
-      {
-       "Label": "#1601"
-      },
-      {
-       "Label": "#1586"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#1584",
-     "Number": 1584,
-     "Label": "#1584",
-     "PRs": [
-      {
-       "Label": "#1596"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#1446",
-     "Number": 1446,
-     "Label": "#1446",
-     "PRs": [
-      {
-       "Label": "#1473"
+       "Label": "#1496"
       }
      ]
     },
@@ -222,34 +233,23 @@
     },
     {
      "Category": "feature",
-     "Title": "Issue#1521",
-     "Number": 1521,
-     "Label": "#1521",
+     "Title": "Issue#1464",
+     "Number": 1464,
+     "Label": "#1464",
      "PRs": [
       {
-       "Label": "#1536"
+       "Label": "#1570"
       }
      ]
     },
     {
      "Category": "feature",
-     "Title": "Issue#1488",
-     "Number": 1488,
-     "Label": "#1488",
+     "Title": "Issue#1254",
+     "Number": 1254,
+     "Label": "#1254",
      "PRs": [
       {
-       "Label": "#1520"
-      }
-     ]
-    },
-    {
-     "Category": "feature",
-     "Title": "Issue#712",
-     "Number": 712,
-     "Label": "#712",
-     "PRs": [
-      {
-       "Label": "#1496"
+       "Label": "#1468"
       }
      ]
     }
@@ -261,12 +261,34 @@
    "Issues": [
     {
      "Category": "bug",
+     "Title": "Issue#1493",
+     "Number": 1493,
+     "Label": "#1493",
+     "PRs": [
+      {
+       "Label": "#1505"
+      }
+     ]
+    },
+    {
+     "Category": "bug",
      "Title": "Issue#1527",
      "Number": 1527,
      "Label": "#1527",
      "PRs": [
       {
        "Label": "#1528"
+      }
+     ]
+    },
+    {
+     "Category": "bug",
+     "Title": "Issue#1445",
+     "Number": 1445,
+     "Label": "#1445",
+     "PRs": [
+      {
+       "Label": "#1474"
       }
      ]
     },
@@ -286,12 +308,12 @@
     },
     {
      "Category": "bug",
-     "Title": "Issue#1493",
-     "Number": 1493,
-     "Label": "#1493",
+     "Title": "Issue#978",
+     "Number": 978,
+     "Label": "#978",
      "PRs": [
       {
-       "Label": "#1505"
+       "Label": "#1595"
       }
      ]
     },
@@ -320,28 +342,6 @@
        "Label": "#1548"
       }
      ]
-    },
-    {
-     "Category": "bug",
-     "Title": "Issue#1445",
-     "Number": 1445,
-     "Label": "#1445",
-     "PRs": [
-      {
-       "Label": "#1474"
-      }
-     ]
-    },
-    {
-     "Category": "bug",
-     "Title": "Issue#978",
-     "Number": 978,
-     "Label": "#978",
-     "PRs": [
-      {
-       "Label": "#1595"
-      }
-     ]
     }
    ]
   },
@@ -362,45 +362,23 @@
     },
     {
      "Category": "refactor",
-     "Title": "Issue#1587",
-     "Number": 1587,
-     "Label": "#1587",
-     "PRs": [
-      {
-       "Label": "#1600"
-      }
-     ]
-    },
-    {
-     "Category": "refactor",
-     "Title": "Issue#1475",
-     "Number": 1475,
-     "Label": "#1475",
-     "PRs": [
-      {
-       "Label": "#1495"
-      }
-     ]
-    },
-    {
-     "Category": "refactor",
-     "Title": "Issue#1606",
-     "Number": 1606,
-     "Label": "#1606",
-     "PRs": [
-      {
-       "Label": "#1607"
-      }
-     ]
-    },
-    {
-     "Category": "refactor",
      "Title": "Issue#139",
      "Number": 139,
      "Label": "#139",
      "PRs": [
       {
        "Label": "#1489"
+      }
+     ]
+    },
+    {
+     "Category": "refactor",
+     "Title": "Issue#1591",
+     "Number": 1591,
+     "Label": "#1591",
+     "PRs": [
+      {
+       "Label": "#1602"
       }
      ]
     },
@@ -417,12 +395,34 @@
     },
     {
      "Category": "refactor",
-     "Title": "Issue#1591",
-     "Number": 1591,
-     "Label": "#1591",
+     "Title": "Issue#1475",
+     "Number": 1475,
+     "Label": "#1475",
      "PRs": [
       {
-       "Label": "#1602"
+       "Label": "#1495"
+      }
+     ]
+    },
+    {
+     "Category": "refactor",
+     "Title": "Issue#1587",
+     "Number": 1587,
+     "Label": "#1587",
+     "PRs": [
+      {
+       "Label": "#1600"
+      }
+     ]
+    },
+    {
+     "Category": "refactor",
+     "Title": "Issue#1606",
+     "Number": 1606,
+     "Label": "#1606",
+     "PRs": [
+      {
+       "Label": "#1607"
       }
      ]
     }
@@ -461,6 +461,224 @@
      ]
     }
    ]
+  }
+ ],
+ "ExtraPRs": [
+  {
+   "Title": "core/consensus: fix nil map panic (#1469)",
+   "Number": 1469,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "readme: mark attestation duty as completed for vouch (#1476)",
+   "Number": 1476,
+   "Category": "docs",
+   "Issue": 0
+  },
+  {
+   "Title": "app/eth2wrap: fix block attestation request (#1480)",
+   "Number": 1480,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "app/eth2wrap: handle block attestations 404 (#1482)",
+   "Number": 1482,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "app/errors: add sentinel error without stacktrace (#1483)",
+   "Number": 1483,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "core/validatorapi: improve query param handling and errors (#1498)",
+   "Number": 1498,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "testutil/trackpr: automate assigning pr to author (#1507)",
+   "Number": 1507,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "app: fix flapping InfoSync test (#1508)",
+   "Number": 1508,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "docs: add declartions section to go guidelines (#1513)",
+   "Number": 1513,
+   "Category": "docs",
+   "Issue": 0
+  },
+  {
+   "Title": "core/consensus: add QBFT decided round gauge (#1514)",
+   "Number": 1514,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "p2p: add option to disable port reuse (#1529)",
+   "Number": 1529,
+   "Category": "feature",
+   "Issue": 0
+  },
+  {
+   "Title": "app: fix failing teku exits (#1530)",
+   "Number": 1530,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "core/priority: fix flapping test (#1535)",
+   "Number": 1535,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "cmd: redact address flag passwords (#1541)",
+   "Number": 1541,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "p2p: instrument network throughput (#1545)",
+   "Number": 1545,
+   "Category": "feature",
+   "Issue": 0
+  },
+  {
+   "Title": "app: increase sniffed message buffer (#1546)",
+   "Number": 1546,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "workflows: upload artefacts always (#1547)",
+   "Number": 1547,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "app: increase sniffed buffer even more (#1549)",
+   "Number": 1549,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "app/eth2wrap: decrease synth block sizes (#1550)",
+   "Number": 1550,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "dkg/sync: add disconnect log to server (#1551)",
+   "Number": 1551,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "core/consensus: improve logging (#1557)",
+   "Number": 1557,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "cmd: require name in create cluster (#1559)",
+   "Number": 1559,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "p2p: add duration labels to receive errors (#1560)",
+   "Number": 1560,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "app/log: increase loki batch send timeout to 10s (#1563)",
+   "Number": 1563,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "cmd/bootnode: refactor metrics (#1564)",
+   "Number": 1564,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "app/bootnode: fix missing cluster hash in metrics (#1568)",
+   "Number": 1568,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "app: revert VC health statuses (#1571)",
+   "Number": 1571,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "testutil/validatormock: fix getSubcommittees bug (#1579)",
+   "Number": 1579,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "core/aggsigdb: fix flapping test (#1605)",
+   "Number": 1605,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "app/eth2wrap: instrument custom endpoint latency (#1614)",
+   "Number": 1614,
+   "Category": "misc",
+   "Issue": 0
+  },
+  {
+   "Title": "core/scheduler: trim duties after 3 epochs (#1616)",
+   "Number": 1616,
+   "Category": "bug",
+   "Issue": 0
+  },
+  {
+   "Title": "dkg: fix error handling in TestSyncFlow (#1618)",
+   "Number": 1618,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "core/scheduler: fix flapping test (#1619)",
+   "Number": 1619,
+   "Category": "test",
+   "Issue": 0
+  },
+  {
+   "Title": "cmd: update default relay address (#1636)",
+   "Number": 1636,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "cmd: re-add previous relay address for backwards compatibility (#1639)",
+   "Number": 1639,
+   "Category": "refactor",
+   "Issue": 0
+  },
+  {
+   "Title": "app/version: bump to v0.13 (#1641)",
+   "Number": 1641,
+   "Category": "misc",
+   "Issue": 0
   }
  ]
 }


### PR DESCRIPTION
This PR:

- filters out pre-releases (i.e. `-rcX`) when automatically gathering tags
- modify changelog template to also output all the PRs that have been merged between two tags

category: refactor
ticket: none