### PR TITLE
cmd/combine: allow threshold number of keys to combine

### DIFF
--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -88,11 +88,11 @@ func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bo
 	for valIdx := 0; valIdx < len(privkeys); valIdx++ {
 		pkSet := privkeys[valIdx]
 
-		if len(pkSet) != len(cluster.Operators) {
+		if len(pkSet) < int(cluster.Threshold) {
 			return errors.New(
-				"not all private key shares found for validator",
+				"insufficient private key shares found for validator",
 				z.Int("validator_index", valIdx),
-				z.Int("expected", len(cluster.Operators)),
+				z.Int("expected", int(cluster.Threshold)),
 				z.Int("actual", len(pkSet)),
 			)
 		}

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -88,7 +88,7 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "node1")))
 
 	err := combine.Combine(context.Background(), dir, od, false, false, combine.WithInsecureKeysForT(t))
-	require.Error(t, err)
+	require.ErrorContains(t, err, "insufficient private key shares found for validator")
 }
 
 func TestCombineAllManifest(t *testing.T) {

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -85,6 +85,7 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 	}
 
 	require.NoError(t, os.RemoveAll(filepath.Join(dir, "node0")))
+	require.NoError(t, os.RemoveAll(filepath.Join(dir, "node1")))
 
 	err := combine.Combine(context.Background(), dir, od, false, false, combine.WithInsecureKeysForT(t))
 	require.Error(t, err)


### PR DESCRIPTION
Allows threshold number of keys to combine private keyshares into single validator keystore.

category: refactor
ticket: #2663 
