### PR TITLE
cmd/createcluster: fix pre-gen builder registrations

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -224,7 +224,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		return err
 	}
 
-	valRegs, err := createValidatorRegistrations(def.WithdrawalAddresses(), secrets, def.ForkVersion)
+	valRegs, err := createValidatorRegistrations(def.FeeRecipientAddresses(), secrets, def.ForkVersion)
 	if err != nil {
 		return err
 	}

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -189,6 +189,24 @@ func TestCreateCluster(t *testing.T) {
 				return data
 			},
 		},
+		{
+			Name: "test with fee recipient and withdrawal addresses",
+			Config: clusterConfig{
+				Name:      "test_cluster",
+				NumNodes:  3,
+				Threshold: 4,
+				NumDVs:    5,
+				Network:   "goerli",
+			},
+			Prep: func(t *testing.T, config clusterConfig) clusterConfig {
+				t.Helper()
+
+				config.FeeRecipientAddrs = []string{testutil.RandomChecksummedETHAddress(t, 1)}
+				config.WithdrawalAddrs = []string{testutil.RandomChecksummedETHAddress(t, 2)}
+
+				return config
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
@@ -203,13 +221,13 @@ func TestCreateCluster(t *testing.T) {
 
 				test.Config.DefFile = srv.URL
 			}
-			if test.Prep != nil {
-				test.Config = test.Prep(t, test.Config)
-			}
-
 			test.Config.InsecureKeys = true
 			test.Config.WithdrawalAddrs = []string{zeroAddress}
 			test.Config.FeeRecipientAddrs = []string{zeroAddress}
+
+			if test.Prep != nil {
+				test.Config = test.Prep(t, test.Config)
+			}
 
 			testCreateCluster(t, test.Config, def, test.expectedErr)
 		})
@@ -413,9 +431,9 @@ func TestSplitKeys(t *testing.T) {
 	}{
 		{
 			name:         "split keys from local definition",
-			numSplitKeys: 1,
+			numSplitKeys: 2,
 			conf: clusterConfig{
-				DefFile:    "../cluster/examples/cluster-definition-002.json",
+				DefFile:    "../cluster/examples/cluster-definition-004.json",
 				ClusterDir: t.TempDir(),
 				NumNodes:   4,
 				Network:    defaultNetwork,

--- a/cmd/testdata/TestCreateCluster_test_with_fee_recipient_and_withdrawal_addresses_files.golden
+++ b/cmd/testdata/TestCreateCluster_test_with_fee_recipient_and_withdrawal_addresses_files.golden
@@ -1,0 +1,17 @@
+[
+ "node0",
+ "node1",
+ "node2",
+ "node0/charon-enr-private-key",
+ "node0/cluster-lock.json",
+ "node0/deposit-data.json",
+ "node0/validator_keys",
+ "node1/charon-enr-private-key",
+ "node1/cluster-lock.json",
+ "node1/deposit-data.json",
+ "node1/validator_keys",
+ "node2/charon-enr-private-key",
+ "node2/cluster-lock.json",
+ "node2/deposit-data.json",
+ "node2/validator_keys"
+]

--- a/cmd/testdata/TestCreateCluster_test_with_fee_recipient_and_withdrawal_addresses_output.golden
+++ b/cmd/testdata/TestCreateCluster_test_with_fee_recipient_and_withdrawal_addresses_output.golden
@@ -1,0 +1,11 @@
+Created charon cluster:
+ --split-existing-keys=false
+
+charon/
+├─ node[0-2]/			Directory for each node
+│  ├─ charon-enr-private-key	Charon networking private key for node authentication
+│  ├─ cluster-lock.json		Cluster lock defines the cluster lock file which is signed by all nodes
+│  ├─ deposit-data.json		Deposit data file is used to activate a Distributed Validator on DV Launchpad
+│  ├─ validator_keys		Validator keystores and password
+│  │  ├─ keystore-*.json	Validator private share key for duty signing
+│  │  ├─ keystore-*.txt		Keystore password files for keystore-*.json

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -785,6 +785,19 @@ func RandomETHAddress() string {
 	return fmt.Sprintf("%#x", RandomBytes32()[:20])
 }
 
+func RandomChecksummedETHAddress(t *testing.T, seed int) string {
+	t.Helper()
+
+	// Generate a new random private key
+	privatekey := GenerateInsecureK1Key(t, seed)
+
+	// Get the corresponding public key
+	publicKey := privatekey.PubKey()
+
+	// Derive the Ethereum address from the public key
+	return eth2util.PublicKeyToAddress(publicKey)
+}
+
 func RandomBytes96() []byte {
 	var resp [96]byte
 	_, _ = rand.Read(resp[:])


### PR DESCRIPTION
This PR fixes a bug in the `create cluster` command that was generating incorrect builder registrations in cluster-lock.json. The issue stemmed from the usage of withdrawal addresses instead of fee recipient addresses, which resulted in signature verification failures when the command was used for the 'charon run' operation.

Here's the error log caused by this bug:
![image](https://github.com/ObolNetwork/charon/assets/37813203/42f3fa00-cff8-4107-b8c1-55d91f485a42)


category: bug
ticket: #2674 