### PR TITLE
core/bcast: fix builder registrations delays

### DIFF
--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -309,7 +309,7 @@ func newDelayFunc(ctx context.Context, eth2Cl eth2wrap.Client) (func(slot uint64
 }
 
 // firstSlotInCurrentEpoch calculates first slot number of the current ongoing epoch.
-func firstSlotInCurrentEpoch(ctx context.Context, eth2Cl eth2wrap.Client) (int64, error) {
+func firstSlotInCurrentEpoch(ctx context.Context, eth2Cl eth2wrap.Client) (uint64, error) {
 	genesis, err := eth2Cl.Genesis(ctx)
 	if err != nil {
 		return 0, errors.Wrap(err, "fetch genesis")
@@ -329,5 +329,5 @@ func firstSlotInCurrentEpoch(ctx context.Context, eth2Cl eth2wrap.Client) (int64
 	currentSlot := chainAge / slotDuration
 	currentEpoch := uint64(currentSlot) / slotsPerEpoch
 
-	return int64(currentEpoch * slotsPerEpoch), nil
+	return currentEpoch * slotsPerEpoch, nil
 }


### PR DESCRIPTION
This PR fixes delay reports by bcast for builder registration duty. As reported multiple times:

```
12:32:23.134 INFO bcast      Successfully submitted validator registration to beacon node {"delay": "25416h32m0.13494757s", "pubkey": "858_9bf", "duty": "0/builder_registration"}
```

category: bug
ticket: #2681 
