### PR TITLE
app/version: bump to `v0.19-dev`

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 // version a string since it is overwritten at build-time with the git tag for official releases.
-var version = "v0.18-dev"
+var version = "v0.19-dev"
 
 // Version is the branch version of the codebase.
 //   - Main branch: v0.X-dev
@@ -26,6 +26,7 @@ var Version, _ = Parse(version) // Error is caught in tests.
 func Supported() []SemVer {
 	return []SemVer{
 		// Current minor version always goes first.
+		{major: 0, minor: 19},
 		{major: 0, minor: 18},
 		{major: 0, minor: 17},
 		{major: 0, minor: 16},


### PR DESCRIPTION
Bumps current version to `v0.19-dev` and adds it to the supported versions.

category: misc
ticket: none