### PR TITLE
eth2wrap: fix synthetic block proposals

### DIFF
--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -149,7 +149,7 @@ func (h *synthWrapper) syntheticProposal(ctx context.Context, slot eth2p0.Slot, 
 		}
 		signed, err := h.Client.SignedBeaconBlock(ctx, opts)
 		if err != nil {
-			if apiErr := new(eth2api.Error); errors.As(err, apiErr) {
+			if apiErr := new(eth2api.Error); errors.As(err, apiErr) { // Continue if block is not found in the given slot.
 				if apiErr.StatusCode == http.StatusNotFound {
 					continue
 				}

--- a/testutil/compose/static/lighthouse/run.sh
+++ b/testutil/compose/static/lighthouse/run.sh
@@ -23,5 +23,5 @@ done
 echo "Starting lighthouse validator client for ${NODE}"
 exec lighthouse validator \
   --testnet-dir "/tmp/testnet" \
-  --beacon-node "http://${NODE}:3600" \
+  --beacon-nodes "http://${NODE}:3600" \
   --suggested-fee-recipient "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
Continue looking for signed beacon blocks if a block for a given slot is not found when proposing synthetic blocks.

This solves recurrent logs when synthetic block proposal feature is switched on:
```
{"code":404,"message":"NOT_FOUND: beacon block at slot 6916888","stacktraces":[]}
```

category: bug 
ticket: none 
