### PR TITLE
*: bump to go 1.21.4

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -14,6 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck -show=stacks -test ./...

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: pre-commit/action@v2.0.3
 
       - name: notify failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         fetch-depth: 0 # Disable shallow checkout
     - uses: actions/setup-go@v4
       with:
-        go-version: '1.21.3'
+        go-version: '1.21.4'
     - run: go run . --help > cli-reference.txt
     - run: go run testutil/genchangelog/main.go
     - uses: softprops/action-gh-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: actions/cache@v3
         with:
           path: |
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: actions/cache@v3
         with:
           path: |
@@ -51,7 +51,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: actions/cache@v3
         with:
           path: |
@@ -78,7 +78,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2 # For compose to build images
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
       - uses: actions/cache@v3
         with:
           path: |

--- a/.github/workflows/verify-pr.yml
+++ b/.github/workflows/verify-pr.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
-          go-version: '1.21.3'
+          go-version: '1.21.4'
 
       - name: "Verify PR"
         run: go run github.com/obolnetwork/charon/testutil/verifypr

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.21.3"
+  go: "1.21.4"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -99,7 +99,7 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.21.3"
+    go: "1.21.4"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container for building Go binary.
-FROM golang:1.21.3-bullseye AS builder
+FROM golang:1.21.4-bullseye AS builder
 # Install dependencies
 RUN apt-get update && apt-get install -y build-essential git
 # Prep and copy source

--- a/testutil/promrated/Dockerfile
+++ b/testutil/promrated/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine AS builder
+FROM golang:1.21.4-alpine AS builder
 
 # Install dependencies
 RUN apk add --no-cache build-base git


### PR DESCRIPTION
Bump go version to `1.21.4`.

This resolves failing govulncheck in https://github.com/ObolNetwork/charon/actions/runs/6809276170/job/18515227544?pr=2693.

category: fixbuild
ticket: none 
