### PR TITLE
obolapi: update publish lock timeout to 30s

### DIFF
--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -49,9 +49,10 @@ func (c Client) url() *url.URL {
 	return baseURL
 }
 
-// PublishLock posts the lockfile to obol-api.
+// PublishLock posts the lockfile to obol-api. It has a 30s timeout.
 func (c Client) PublishLock(ctx context.Context, lock cluster.Lock) error {
-	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	// TODO(xenowits): Reduce the timeout once the obol-api is optimised for publishing large lock files.
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	addr := c.url()


### PR DESCRIPTION
CHERRY-PICKED PR

Update timeout to 30s for publishing lock to obol-api. This ensures that DKG doesn't error if lock files are large enough (>200kb) whose publishing takes more than 5s. 

30s is an empirical timeout value which is safe for publishing large lock files (1.5MB)  to obol-api.

category: refactor 
ticket: none
