### PR TITLE
compose: fix version matrix test

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -29,7 +29,6 @@ func Supported() []SemVer {
 		{major: 0, minor: 19},
 		{major: 0, minor: 18},
 		{major: 0, minor: 17},
-		{major: 0, minor: 16},
 	}
 }
 

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -98,7 +98,7 @@ func TestSmoke(t *testing.T) {
 			},
 			RunTmplFunc: func(data *compose.TmplData) {
 				// Node 0 is local build
-				pegImageTag(data.Nodes, 1, version.Version.String()) // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
+				pegImageTag(data.Nodes, 1, nth(version.Supported()[1:], 0)+"-dev") // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
 				pegImageTag(data.Nodes, 2, nth(version.Supported()[1:], 1)+"-rc")
 				pegImageTag(data.Nodes, 3, nth(version.Supported()[1:], 2)+"-rc")
 			},

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -98,7 +98,7 @@ func TestSmoke(t *testing.T) {
 			},
 			RunTmplFunc: func(data *compose.TmplData) {
 				// Node 0 is local build
-				pegImageTag(data.Nodes, 1, nth(version.Supported()[1:], 0)+"-dev") // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
+				pegImageTag(data.Nodes, 1, nth(version.Supported(), 0)+"-dev") // Node 1 is previous commit on this branch (v0.X-dev/rc) Note this will fail for first commit on new branch version.
 				pegImageTag(data.Nodes, 2, nth(version.Supported()[1:], 1)+"-rc")
 				pegImageTag(data.Nodes, 3, nth(version.Supported()[1:], 2)+"-rc")
 			},


### PR DESCRIPTION
Fixes version matrix smoke test. It was expected `v0.19.0-dev` image while it should expect `v0.19-dev` which is tagged on every commit to main. Also removes v0.16.0 from supported versions as it is not compatible with v0.18.0.

category: bug
ticket: none
