### PR TITLE
app/eth2wrap: fix error comparison for synthetic blocks

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -330,7 +330,7 @@ func incError(endpoint string) {
 // wrapError returns the error as a wrapped structured error.
 func wrapError(ctx context.Context, err error, label string, fields ...z.Field) error {
 	// Decompose go-eth2-client http errors
-	if apiErr := new(eth2api.Error); errors.As(err, apiErr) {
+	if apiErr := new(eth2api.Error); errors.As(err, &apiErr) {
 		err = errors.New("nok http response",
 			z.Int("status_code", apiErr.StatusCode),
 			z.Str("endpoint", apiErr.Endpoint),

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -20,9 +20,11 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	shuffle "github.com/protolambda/eth2-shuffle"
+	"go.uber.org/zap"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 const (
@@ -149,10 +151,8 @@ func (h *synthWrapper) syntheticProposal(ctx context.Context, slot eth2p0.Slot, 
 		}
 		signed, err := h.Client.SignedBeaconBlock(ctx, opts)
 		if err != nil {
-			if apiErr := new(eth2api.Error); errors.As(err, apiErr) { // Continue if block is not found in the given slot.
-				if apiErr.StatusCode == http.StatusNotFound {
-					continue
-				}
+			if fieldExists(err, zap.Int("status_code", http.StatusNotFound)) {
+				continue
 			}
 
 			return nil, err
@@ -202,6 +202,34 @@ func (h *synthWrapper) syntheticProposal(ctx context.Context, slot eth2p0.Slot, 
 	}
 
 	return proposal, nil
+}
+
+// fieldExists checks if the given field exists as part of the given error.
+func fieldExists(err error, field zap.Field) bool {
+	type structErr interface {
+		Fields() []z.Field
+	}
+
+	sterr, ok := err.(structErr) //nolint:errorlint
+	if !ok {
+		return false
+	}
+
+	zfs := sterr.Fields()
+	var zapFs []zap.Field
+	for _, field := range zfs {
+		field(func(zp zap.Field) {
+			zapFs = append(zapFs, zp)
+		})
+	}
+
+	for _, zaps := range zapFs {
+		if zaps.Equals(field) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // fraction returns a fraction of the transactions in the block.


### PR DESCRIPTION
This PR cherry-picks #2702 onto `main-v0.18`

---

There was a small issue when comparing eth2api errors when searching for signed beacon block. The error returned should be part of eth2wrap multi implementation which was not able to decompose eth2 errors properly. This PR fixes decomposition of eth2 errors and adds a function to check if the relevant field is present as part of the error chain.

category: bug
ticket: #2695