### PR TITLE
github/workflows: split tests

### DIFF
--- a/.github/workflows/heavy-test.yml
+++ b/.github/workflows/heavy-test.yml
@@ -23,6 +23,7 @@ jobs:
       - run: go test -v -timeout=10m -race github.com/obolnetwork/charon/testutil/integration -integration
 
   compose_tests:
+    needs: integration_tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -50,6 +51,7 @@ jobs:
           retention-days: 3
 
   fuzz_tests:
+    needs: [integration_tests, compose_tests]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/heavy-test.yml
+++ b/.github/workflows/heavy-test.yml
@@ -1,32 +1,10 @@
-name: go tests
+name: Integration/fuzzing tests
 on:
-  pull_request:
   push:
     branches:
       - main*
-jobs:
-  unit_tests:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v4
-        with:
-          go-version: '1.21.4'
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-      - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m -race ./...
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage.out
 
+jobs:
   integration_tests:
     runs-on: ubuntu-latest
     steps:
@@ -97,22 +75,3 @@ jobs:
           name: fuzz-test-logs
           path: testutil/compose/fuzz/*.log
           retention-days: 3
-
-  notify_failure:
-    runs-on: ubuntu-latest
-    needs: [ unit_tests, integration_tests, compose_tests ]
-    # Syntax ref: https://github.com/actions/runner/issues/1251
-    if: always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure')
-    steps:
-      - name: notify failure
-        uses: Ilshidur/action-discord@0.3.2
-        env:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
-          DISCORD_USERNAME: GitHub
-          DISCORD_AVATAR: https://avatars.githubusercontent.com/u/583231
-          DISCORD_EMBEDS: |
-            [{
-              "title": "🚨  Main branch workflow failed: ${{ github.workflow }}",
-              "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}",
-              "color": 10038562
-            }]

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,8 +1,7 @@
 name: go tests
 on:
   pull_request:
-    paths:
-      - '**.go'
+
 jobs:
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,0 +1,27 @@
+name: go tests
+on:
+  pull_request:
+    paths:
+      - '**.go'
+jobs:
+  unit_tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21.4'
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - run: go test -coverprofile=coverage.out -covermode=atomic -timeout=5m -race ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3.1.1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.out


### PR DESCRIPTION
This PR splits Go unit tests from integration, compose and fuzz testing.

PR CI will always run unit tests if said PR contains modifications to Go code.

Integration, compose and fuzz testing will be executed once the PR has been merged on a main branch.

We still run those tests on release branches (those that begin with `main-v`) because cherry-picking might add incompatibilities.

Also remove `notify_failure` step, since we're not using Discord anymore.

category: misc
ticket: none
