### PR TITLE
scheduler: check for activation epoch

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -247,7 +247,7 @@ func delaySlotOffset(ctx context.Context, slot core.Slot, duty core.Duty, delayF
 
 // resolveDuties resolves the duties for the slot's epoch, caching the results.
 func (s *Scheduler) resolveDuties(ctx context.Context, slot core.Slot) error {
-	vals, err := resolveActiveValidators(ctx, s.eth2Cl, s.pubkeys, s.metricSubmitter)
+	vals, err := resolveActiveValidators(ctx, s.eth2Cl, s.pubkeys, s.metricSubmitter, slot.Epoch())
 	if err != nil {
 		return err
 	}
@@ -624,7 +624,7 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.
 
 // resolveActiveValidators returns the active validators (including their validator index) for the slot.
 func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
-	pubkeys []core.PubKey, submitter metricSubmitter,
+	pubkeys []core.PubKey, submitter metricSubmitter, epoch uint64,
 ) (validators, error) {
 	var e2pks []eth2p0.BLSPubKey
 	for _, pubkey := range pubkeys {
@@ -659,7 +659,9 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client,
 
 		submitter(pubkey, val.Balance, val.Status.String())
 
-		if !val.Status.IsActive() {
+		// Check for active validators for the given epoch.
+		// The activation epoch needs to be checked in cases where this function is called before the epoch starts.
+		if !val.Status.IsActive() && val.Validator.ActivationEpoch != eth2p0.Epoch(epoch) {
 			continue
 		}
 


### PR DESCRIPTION
Adds a check for activation epoch to filter active validators before resolving duties.

category: bug
ticket: #2721 
