### PR TITLE
validatorapi: handling duties response metadata

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -429,9 +429,19 @@ func proposerDuties(p eth2client.ProposerDutiesProvider) handlerFunc {
 			data = []*eth2v1.ProposerDuty{}
 		}
 
+		executionOptimistic, err := getExecutionOptimisticFromMetadata(eth2Resp.Metadata)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to decode ProposerDuties response metadata")
+		}
+
+		dependentRoot, err := getDependentRootFromMetadata(eth2Resp.Metadata)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to decode ProposerDuties response metadata")
+		}
+
 		return proposerDutiesResponse{
-			ExecutionOptimistic: false,           // TODO(dhruv): Fill this properly
-			DependentRoot:       stubRoot(epoch), // TODO(corver): Fill this properly
+			ExecutionOptimistic: executionOptimistic,
+			DependentRoot:       dependentRoot,
 			Data:                data,
 		}, nil, nil
 	}
@@ -464,9 +474,19 @@ func attesterDuties(p eth2client.AttesterDutiesProvider) handlerFunc {
 			data = []*eth2v1.AttesterDuty{}
 		}
 
+		executionOptimistic, err := getExecutionOptimisticFromMetadata(eth2Resp.Metadata)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to decode AttesterDuties response metadata")
+		}
+
+		dependentRoot, err := getDependentRootFromMetadata(eth2Resp.Metadata)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "failed to decode AttesterDuties response metadata")
+		}
+
 		return attesterDutiesResponse{
-			ExecutionOptimistic: false,           // TODO(dhruv): Fill this properly
-			DependentRoot:       stubRoot(epoch), // TODO(corver): Fill this properly
+			ExecutionOptimistic: executionOptimistic,
+			DependentRoot:       dependentRoot,
 			Data:                data,
 		}, nil, nil
 	}
@@ -1308,4 +1328,48 @@ func getCtxDuration(ctx context.Context) z.Field {
 	}
 
 	return z.Str("duration", time.Since(t0).String())
+}
+
+// getExecutionOptimisticFromMetadata returns execution_optimistic value from metadata,
+// or error if it is missing or has a wrong type.
+func getExecutionOptimisticFromMetadata(metadata map[string]any) (bool, error) {
+	if metadata == nil {
+		return false, errors.New("metadata is nil")
+	}
+
+	if v, has := metadata["execution_optimistic"]; has {
+		if b, ok := v.(bool); ok {
+			return b, nil
+		}
+
+		return false, errors.New("metadata has malformed execution_optimistic value", z.Any("execution_optimistic", v))
+	}
+
+	return false, errors.New("metadata has missing execution_optimistic value")
+}
+
+// getDependentRootFromMetadata returns dependent_root value from metadata,
+// or error if it is missing, has a wrong type or a malformed value.
+func getDependentRootFromMetadata(metadata map[string]any) (root, error) {
+	if metadata == nil {
+		return root{}, errors.New("metadata is nil")
+	}
+
+	if v, has := metadata["dependent_root"]; has {
+		if s, ok := v.(string); ok {
+			bytes, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
+			if err == nil {
+				var dependentRoot root
+				copy(dependentRoot[:], bytes)
+
+				return dependentRoot, nil
+			}
+
+			return root{}, errors.Wrap(err, "metadata has malformed dependent_root value", z.Str("dependent_root", s))
+		}
+
+		return root{}, errors.New("metadata has non-string dependent_root value", z.Any("dependent_root", v))
+	}
+
+	return root{}, errors.New("metadata has missing dependent_root value")
 }

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -451,6 +451,11 @@ func TestRawRouter(t *testing.T) {
 
 //nolint:maintidx // This function is a test of tests, so analysed as "complex".
 func TestRouter(t *testing.T) {
+	metadata := map[string]any{
+		"execution_optimistic": true,
+		"dependent_root":       "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69",
+	}
+
 	t.Run("attesterduty", func(t *testing.T) {
 		handler := testHandler{
 			AttesterDutiesFunc: func(ctx context.Context, opts *eth2api.AttesterDutiesOpts) (*eth2api.Response[[]*eth2v1.AttesterDuty], error) {
@@ -464,7 +469,7 @@ func TestRouter(t *testing.T) {
 					})
 				}
 
-				return wrapResponse(res), nil
+				return wrapResponseWithMetadata(res, metadata), nil
 			},
 		}
 
@@ -488,6 +493,11 @@ func TestRouter(t *testing.T) {
 			require.Equal(t, int(res[0].ValidatorIndex), index0)
 			require.Equal(t, int(res[1].Slot), slotEpoch*slotsPerEpoch)
 			require.Equal(t, int(res[1].ValidatorIndex), index1)
+
+			metadata := resp.Metadata
+			require.Len(t, metadata, 2)
+			require.Equal(t, true, metadata["execution_optimistic"])
+			require.Equal(t, "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69", metadata["dependent_root"].(eth2p0.Root).String())
 		}
 
 		testRouter(t, handler, callback)
@@ -506,7 +516,7 @@ func TestRouter(t *testing.T) {
 					})
 				}
 
-				return wrapResponse(res), nil
+				return wrapResponseWithMetadata(res, metadata), nil
 			},
 		}
 
@@ -526,6 +536,11 @@ func TestRouter(t *testing.T) {
 			require.Len(t, res, 1)
 			require.Equal(t, int(res[0].Slot), epoch*slotsPerEpoch+validator)
 			require.Equal(t, int(res[0].ValidatorIndex), validator)
+
+			metadata := resp.Metadata
+			require.Len(t, metadata, 2)
+			require.Equal(t, true, metadata["execution_optimistic"])
+			require.Equal(t, "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69", metadata["dependent_root"].(eth2p0.Root).String())
 		}
 
 		testRouter(t, handler, callback)
@@ -700,7 +715,7 @@ func TestRouter(t *testing.T) {
 	t.Run("empty attester duties", func(t *testing.T) {
 		handler := testHandler{
 			AttesterDutiesFunc: func(ctx context.Context, opts *eth2api.AttesterDutiesOpts) (*eth2api.Response[[]*eth2v1.AttesterDuty], error) {
-				return &eth2api.Response[[]*eth2v1.AttesterDuty]{}, nil
+				return &eth2api.Response[[]*eth2v1.AttesterDuty]{Metadata: metadata}, nil
 			},
 		}
 
@@ -740,7 +755,7 @@ func TestRouter(t *testing.T) {
 	t.Run("empty proposer duties", func(t *testing.T) {
 		handler := testHandler{
 			ProposerDutiesFunc: func(ctx context.Context, opts *eth2api.ProposerDutiesOpts) (*eth2api.Response[[]*eth2v1.ProposerDuty], error) {
-				return &eth2api.Response[[]*eth2v1.ProposerDuty]{}, nil
+				return &eth2api.Response[[]*eth2v1.ProposerDuty]{Metadata: metadata}, nil
 			},
 		}
 
@@ -1212,6 +1227,90 @@ func TestSubmitAggregateAttestations(t *testing.T) {
 	eth2Cl := eth2wrap.AdaptEth2HTTP(eth2Svc.(*eth2http.Service), time.Second)
 	err = eth2Cl.SubmitAggregateAttestations(ctx, []*eth2p0.SignedAggregateAndProof{agg})
 	require.NoError(t, err)
+}
+
+func TestGetExecutionOptimisticFromMetadata(t *testing.T) {
+	t.Run("metadata is nil", func(t *testing.T) {
+		_, err := getExecutionOptimisticFromMetadata(nil)
+
+		require.ErrorContains(t, err, "metadata is nil")
+	})
+
+	t.Run("missing execution_optimistic", func(t *testing.T) {
+		metadata := map[string]any{}
+
+		_, err := getExecutionOptimisticFromMetadata(metadata)
+
+		require.ErrorContains(t, err, "metadata has missing execution_optimistic value")
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		metadata := map[string]any{
+			"execution_optimistic": "not-a-bool",
+		}
+
+		_, err := getExecutionOptimisticFromMetadata(metadata)
+
+		require.ErrorContains(t, err, "metadata has malformed execution_optimistic value")
+	})
+
+	t.Run("valid value", func(t *testing.T) {
+		metadata := map[string]any{
+			"execution_optimistic": true,
+		}
+
+		executionOptimistic, err := getExecutionOptimisticFromMetadata(metadata)
+
+		require.NoError(t, err)
+		require.True(t, executionOptimistic)
+	})
+}
+
+func TestGetDependentRootFromMetadata(t *testing.T) {
+	t.Run("metadata is nil", func(t *testing.T) {
+		_, err := getDependentRootFromMetadata(nil)
+
+		require.ErrorContains(t, err, "metadata is nil")
+	})
+
+	t.Run("missing dependent_root", func(t *testing.T) {
+		metadata := map[string]any{}
+
+		_, err := getDependentRootFromMetadata(metadata)
+
+		require.ErrorContains(t, err, "metadata has missing dependent_root value")
+	})
+
+	t.Run("wrong type", func(t *testing.T) {
+		metadata := map[string]any{
+			"dependent_root": 123, // not a string
+		}
+
+		_, err := getDependentRootFromMetadata(metadata)
+
+		require.ErrorContains(t, err, "metadata has non-string dependent_root value")
+	})
+
+	t.Run("malformed value", func(t *testing.T) {
+		metadata := map[string]any{
+			"dependent_root": "not-a-hex",
+		}
+
+		_, err := getDependentRootFromMetadata(metadata)
+
+		require.ErrorContains(t, err, "metadata has malformed dependent_root value")
+	})
+
+	t.Run("valid value", func(t *testing.T) {
+		metadata := map[string]any{
+			"dependent_root": "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69",
+		}
+
+		dependentRoot, err := getDependentRootFromMetadata(metadata)
+
+		require.NoError(t, err)
+		require.Equal(t, "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69", eth2p0.Root(dependentRoot).String())
+	})
 }
 
 // testRouter is a helper function to test router endpoints with an eth2http client. The outer test

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -1204,3 +1204,8 @@ func (c Component) ProposerConfig(ctx context.Context) (*eth2exp.ProposerConfigR
 func wrapResponse[T any](data T) *eth2api.Response[T] {
 	return &eth2api.Response[T]{Data: data}
 }
+
+// wrapResponseWithMetadata wraps the provided data and metadata into an API Response and returns the response.
+func wrapResponseWithMetadata[T any](data T, metadata map[string]any) *eth2api.Response[T] {
+	return &eth2api.Response[T]{Data: data, Metadata: metadata}
+}

--- a/core/validatorapi/validatorapi_internal_test.go
+++ b/core/validatorapi/validatorapi_internal_test.go
@@ -73,3 +73,23 @@ func TestMismatchKeysFunc(t *testing.T) {
 		require.ErrorContains(t, err, "unknown public key")
 	})
 }
+
+func TestWrapResponse(t *testing.T) {
+	resp := wrapResponse(123)
+
+	require.NotNil(t, resp)
+	require.Equal(t, 123, resp.Data)
+	require.Nil(t, resp.Metadata)
+}
+
+func TestWrapResponseWithMetadata(t *testing.T) {
+	metadata := map[string]any{
+		"foo": 123,
+	}
+
+	resp := wrapResponseWithMetadata(123, metadata)
+
+	require.NotNil(t, resp)
+	require.Equal(t, 123, resp.Data)
+	require.Equal(t, metadata, resp.Metadata)
+}


### PR DESCRIPTION
As part of recent go-eth2-client upgrade, `ProposerDuties` and `AttesterDuties` calls started to return Metadata fields: 
```
  "dependent_root": "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69",
  "execution_optimistic": false,
```

This change updates the corresponding handlers of validator API to properly parse and propagate these new fields. 

category: feature
ticket: #2736

