### PR TITLE
validatorapi: fixed dependent_root metadata type

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1349,19 +1349,11 @@ func getDependentRootFromMetadata(metadata map[string]any) (root, error) {
 	}
 
 	if v, has := metadata["dependent_root"]; has {
-		if s, ok := v.(string); ok {
-			bytes, err := hex.DecodeString(strings.TrimPrefix(s, "0x"))
-			if err == nil {
-				var dependentRoot root
-				copy(dependentRoot[:], bytes)
-
-				return dependentRoot, nil
-			}
-
-			return root{}, errors.Wrap(err, "metadata has malformed dependent_root value", z.Str("dependent_root", s))
+		if r, ok := v.(eth2p0.Root); ok {
+			return root(r), nil
 		}
 
-		return root{}, errors.New("metadata has non-string dependent_root value", z.Any("dependent_root", v))
+		return root{}, errors.New("metadata has wrong dependent_root type", z.Any("dependent_root", v))
 	}
 
 	return root{}, errors.New("metadata has missing dependent_root value")

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -5,6 +5,7 @@ package validatorapi
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -451,9 +452,12 @@ func TestRawRouter(t *testing.T) {
 
 //nolint:maintidx // This function is a test of tests, so analysed as "complex".
 func TestRouter(t *testing.T) {
+	var dependentRoot eth2p0.Root
+	_, _ = rand.Read(dependentRoot[:])
+
 	metadata := map[string]any{
 		"execution_optimistic": true,
-		"dependent_root":       "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69",
+		"dependent_root":       dependentRoot,
 	}
 
 	t.Run("attesterduty", func(t *testing.T) {
@@ -497,7 +501,7 @@ func TestRouter(t *testing.T) {
 			metadata := resp.Metadata
 			require.Len(t, metadata, 2)
 			require.Equal(t, true, metadata["execution_optimistic"])
-			require.Equal(t, "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69", metadata["dependent_root"].(eth2p0.Root).String())
+			require.Equal(t, dependentRoot, metadata["dependent_root"].(eth2p0.Root))
 		}
 
 		testRouter(t, handler, callback)
@@ -540,7 +544,7 @@ func TestRouter(t *testing.T) {
 			metadata := resp.Metadata
 			require.Len(t, metadata, 2)
 			require.Equal(t, true, metadata["execution_optimistic"])
-			require.Equal(t, "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69", metadata["dependent_root"].(eth2p0.Root).String())
+			require.Equal(t, dependentRoot, metadata["dependent_root"].(eth2p0.Root))
 		}
 
 		testRouter(t, handler, callback)
@@ -1271,33 +1275,26 @@ func TestGetDependentRootFromMetadata(t *testing.T) {
 
 	t.Run("wrong type", func(t *testing.T) {
 		metadata := map[string]any{
-			"dependent_root": 123, // not a string
+			"dependent_root": 123,
 		}
 
 		_, err := getDependentRootFromMetadata(metadata)
 
-		require.ErrorContains(t, err, "metadata has non-string dependent_root value")
-	})
-
-	t.Run("malformed value", func(t *testing.T) {
-		metadata := map[string]any{
-			"dependent_root": "not-a-hex",
-		}
-
-		_, err := getDependentRootFromMetadata(metadata)
-
-		require.ErrorContains(t, err, "metadata has malformed dependent_root value")
+		require.ErrorContains(t, err, "metadata has wrong dependent_root type")
 	})
 
 	t.Run("valid value", func(t *testing.T) {
+		var r eth2p0.Root
+		_, _ = rand.Read(r[:])
+
 		metadata := map[string]any{
-			"dependent_root": "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69",
+			"dependent_root": r,
 		}
 
 		dependentRoot, err := getDependentRootFromMetadata(metadata)
 
 		require.NoError(t, err)
-		require.Equal(t, "0xc01a8003a974cea31fd9e91c7d2cec8120ea3cc71edcbb836b6fbede6c289a69", eth2p0.Root(dependentRoot).String())
+		require.Equal(t, r, eth2p0.Root(dependentRoot))
 	})
 }
 

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -367,7 +367,7 @@ func wrapResponseWithMetadata[T any](data T) *eth2api.Response[T] {
 		Data: data,
 		Metadata: map[string]any{
 			"execution_optimistic": false,
-			"dependent_root":       eth2p0.Root{}.String(),
+			"dependent_root":       eth2p0.Root{},
 		},
 	}
 }


### PR DESCRIPTION
go-eth2-client handles `dependent_root` metadata as a special case and produces a `Root` object rather than hex string.
  
https://github.com/attestantio/go-eth2-client/blob/a05485e0e75749f2b6912db2972a35ec2ec37c3b/http/json.go#L32C25-L32C25

category: bug
ticket: #2736

