### PR TITLE
cluster/manifest: correct load cluster error

### DIFF
--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -60,9 +60,13 @@ func LoadDAG(manifestFile, legacyLockFile string, lockCallback func(cluster.Lock
 	case errLegacy == nil:
 		// Legacy cluster lock loaded successfully
 		return dagLegacy, nil
+	case errors.Is(errLegacy, os.ErrNotExist) && errors.Is(errManifest, os.ErrNotExist):
+		return nil, errors.New("no file found", z.Str("lock-file", legacyLockFile), z.Str("manifest-file", manifestFile))
+	case !errors.Is(errLegacy, os.ErrNotExist):
+		// Return legacy lock error as it exists but failed to load.
+		return nil, errors.Wrap(errLegacy, "couldn't load cluster from legacy lock file")
 	default:
-		// None of the files were loaded successfully, so return an error
-		return nil, errors.New("couldn't load cluster dag from either manifest or legacy lock file", z.Err(errManifest), z.Err(errLegacy))
+		return nil, errors.Wrap(errManifest, "couldn't load cluster from manifest file")
 	}
 }
 

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -56,7 +56,7 @@ func TestLoadManifest(t *testing.T) {
 	}{
 		{
 			name:     "no file",
-			errorMsg: "couldn't load cluster dag from either manifest or legacy lock file",
+			errorMsg: "no file found",
 		},
 		{
 			name:         "only manifest",


### PR DESCRIPTION
Corrects the load cluster error switch as default one was always returning the first z.Err field even if something went wrong with cluster-lock load.

```
charon-1      | 12:00:07.840 INFO app-start  Charon starting                          {"version": "v0.18.0", "git_commit_hash": "67725e4", "git_commit_time": "2023-11-10T15:18:42Z"}
charon-1      | 12:00:07.849 ERRO cmd        Fatal error: load cluster manifest: load dag from disk: couldn't load cluster dag from either manifest or legacy lock file {"error": "read manifest file: open .charon/cluster-manifest.pb: no such file or directory", "file": ".charon/cluster-manifest.pb"}
charon-1      |         cluster/manifest/load.go:65 .LoadDAG
charon-1      |         cluster/manifest/load.go:26 .LoadCluster
charon-1      |         app/disk.go:37 .loadClusterManifest
charon-1      |         app/app.go:155 .Run
charon-1      |         cmd/run.go:37 .func1
charon-1      |         cmd/cmd.go:80 .func1
charon-1      |         main.go:19 .main
charon-1 exited with code 1
``` 

category: bug
ticket: none
