### PR TITLE
app/featureset: split `qbft_timers_ab_test` feature flag

### DIFF
--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -28,16 +28,20 @@ const (
 	// MockAlpha is a mock feature in alpha status for testing.
 	MockAlpha Feature = "mock_alpha"
 
-	// QBFTTimersABTest enables a round-robin mixed timer selection for A/B testing
-	// the affects of different round timers.
-	QBFTTimersABTest Feature = "qbft_timers_ab_test"
+	// EagerDoubleLinear enables Eager Double Linear round timer for consensus rounds.
+	EagerDoubleLinear Feature = "eager_double_linear"
+
+	// ConsensusParticipate enables consensus participate feature in order to participate in an ongoing consensus
+	// round while still waiting for an unsigned data from beacon node.
+	ConsensusParticipate Feature = "consensus_participate"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
-		MockAlpha:        statusAlpha,
-		QBFTTimersABTest: statusAlpha,
+		MockAlpha:            statusAlpha,
+		EagerDoubleLinear:    statusAlpha,
+		ConsensusParticipate: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/app/featureset/featureset_internal_test.go
+++ b/app/featureset/featureset_internal_test.go
@@ -12,7 +12,8 @@ func TestAllFeatureStatus(t *testing.T) {
 	// Add all features to this test
 	features := []Feature{
 		MockAlpha,
-		QBFTTimersABTest,
+		EagerDoubleLinear,
+		ConsensusParticipate,
 	}
 
 	for _, feature := range features {

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
@@ -382,8 +383,8 @@ func (c *Component) Participate(ctx context.Context, duty core.Duty) error {
 		return nil // No eager consensus for potential no-op aggregation duties.
 	}
 
-	if !c.timerFunc(duty).Type().Eager() {
-		return nil // Not an eager start timer, wait for Propose to start.
+	if featureset.Enabled(featureset.ConsensusParticipate) {
+		return nil // Wait for Propose to start.
 	}
 
 	inst := c.getInstanceIO(duty)

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -375,15 +375,16 @@ func (c *Component) propose(ctx context.Context, duty core.Duty, value proto.Mes
 	return c.runInstance(ctx, duty)
 }
 
-// Participate runs a new a consensus instance if an eager timer is defined and Propose not already called.
+// Participate runs a new a consensus instance to participate while still waiting for
+// unsigned data from beacon node and Propose not already called.
 // Note Propose must still be called for this peer to propose a value when leading a round.
 // Note this errors if called multiple times for the same duty.
 func (c *Component) Participate(ctx context.Context, duty core.Duty) error {
 	if duty.Type == core.DutyAggregator || duty.Type == core.DutySyncContribution {
-		return nil // No eager consensus for potential no-op aggregation duties.
+		return nil // No consensus participate for potential no-op aggregation duties.
 	}
 
-	if featureset.Enabled(featureset.ConsensusParticipate) {
+	if !featureset.Enabled(featureset.ConsensusParticipate) {
 		return nil // Wait for Propose to start.
 	}
 

--- a/core/consensus/roundtimer.go
+++ b/core/consensus/roundtimer.go
@@ -3,7 +3,6 @@
 package consensus
 
 import (
-	"math/rand"
 	"strings"
 	"sync"
 	"time"
@@ -25,15 +24,9 @@ type timerFunc func(core.Duty) roundTimer
 
 // getTimerFunc returns a timer function based on the enabled features.
 func getTimerFunc() timerFunc {
-	if featureset.Enabled(featureset.QBFTTimersABTest) {
-		abTimers := []func() roundTimer{
-			newIncreasingRoundTimer,
-			newDoubleEagerLinearRoundTimer,
-		}
-
+	if featureset.Enabled(featureset.EagerDoubleLinear) {
 		return func(duty core.Duty) roundTimer {
-			random := rand.New(rand.NewSource(int64(uint64(duty.Type) + duty.Slot))) //nolint:gosec // Required for consistent pseudo-randomness.
-			return abTimers[random.Intn(len(abTimers))]()
+			return newDoubleEagerLinearRoundTimer()
 		}
 	}
 

--- a/core/consensus/roundtimer_internal_test.go
+++ b/core/consensus/roundtimer_internal_test.go
@@ -113,10 +113,10 @@ func TestDoubleEagerLinearRoundTimer(t *testing.T) {
 }
 
 func TestGetTimerFunc(t *testing.T) {
-	featureset.EnableForT(t, featureset.QBFTTimersABTest)
+	featureset.EnableForT(t, featureset.EagerDoubleLinear)
 
 	timerFunc := getTimerFunc()
-	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(0)).Type())
-	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(1)).Type())
+	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(0)).Type())
+	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(1)).Type())
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(2)).Type())
 }

--- a/core/consensus/roundtimer_internal_test.go
+++ b/core/consensus/roundtimer_internal_test.go
@@ -113,9 +113,14 @@ func TestDoubleEagerLinearRoundTimer(t *testing.T) {
 }
 
 func TestGetTimerFunc(t *testing.T) {
+	timerFunc := getTimerFunc()
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(0)).Type())
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(1)).Type())
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(2)).Type())
+
 	featureset.EnableForT(t, featureset.EagerDoubleLinear)
 
-	timerFunc := getTimerFunc()
+	timerFunc = getTimerFunc()
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(0)).Type())
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(1)).Type())
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(2)).Type())


### PR DESCRIPTION
This PR splits `qbft_timers_ab_test` feature flag into two feature flags to enable consensus participate and eager double linear round timer separately. 

category: misc
ticket: none
