### PR TITLE
app/version: bump version to v0.20-dev

### DIFF
--- a/app/version/version.go
+++ b/app/version/version.go
@@ -15,7 +15,7 @@ import (
 )
 
 // version a string since it is overwritten at build-time with the git tag for official releases.
-var version = "v0.19-dev"
+var version = "v0.20-dev"
 
 // Version is the branch version of the codebase.
 //   - Main branch: v0.X-dev
@@ -26,9 +26,8 @@ var Version, _ = Parse(version) // Error is caught in tests.
 func Supported() []SemVer {
 	return []SemVer{
 		// Current minor version always goes first.
+		{major: 0, minor: 20},
 		{major: 0, minor: 19},
-		{major: 0, minor: 18},
-		{major: 0, minor: 17},
 	}
 }
 


### PR DESCRIPTION
Only support v0.19 and 0.20 series versions.

category: misc
ticket: none
