### PR TITLE
core: removed leadercast leftovers

### DIFF
--- a/core/proto.go
+++ b/core/proto.go
@@ -212,7 +212,7 @@ func UnsignedDataSetFromProto(typ DutyType, set *pbv1.UnsignedDataSet) (Unsigned
 	resp := make(UnsignedDataSet)
 	for pubkey, data := range set.Set {
 		var err error
-		resp[PubKey(pubkey)], err = UnmarshalUnsignedData(typ, data)
+		resp[PubKey(pubkey)], err = unmarshalUnsignedData(typ, data)
 		if err != nil {
 			return nil, err
 		}

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -420,9 +420,8 @@ func (s *SyncContribution) UnmarshalSSZ(b []byte) error {
 	return s.SyncCommitteeContribution.UnmarshalSSZ(b)
 }
 
-// UnmarshalUnsignedData returns an instantiated unsigned data based on the duty type.
-// TODO(corver): Unexport once leadercast is removed or uses protobufs.
-func UnmarshalUnsignedData(typ DutyType, data []byte) (UnsignedData, error) {
+// unmarshalUnsignedData returns an instantiated unsigned data based on the duty type.
+func unmarshalUnsignedData(typ DutyType, data []byte) (UnsignedData, error) {
 	switch typ {
 	case DutyAttester:
 		var resp AttestationData

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -32,7 +32,6 @@ charon/             # project root
 │  │                # core workflow component implementations
 │  ├─ scheduler/    # scheduler
 │  ├─ fetcher/      # fetcher
-│  ├─ leadercast/   # consensus implementation (will add qbft later)
 │  ├─ dutydb/       # dutydb
 │  ├─ validatorapi/ # validatorapi
 │  ├─ parsigdb/     # parsigdb


### PR DESCRIPTION
After removing the leadercast component, some leftovers were remaining the code, hence the cleanup.

category: misc
ticket: none
