### PR TITLE
keymanager: require addr to use https scheme

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -850,6 +850,12 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 		return errors.New("insufficient no of keymanager addresses", z.Int("expected", len(def.Operators)), z.Int("got", len(keymanagerAddrs)))
 	}
 
+	for _, addr := range keymanagerAddrs {
+		if err := keymanager.VerifyKeymanagerAddr(addr); err != nil {
+			return err
+		}
+	}
+
 	network, err := eth2util.ForkVersionToNetwork(def.ForkVersion)
 	if err != nil {
 		return err

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -394,6 +394,19 @@ func TestValidateDef(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("keymanager address must use https scheme", func(t *testing.T) {
+		conf := conf
+		conf.KeymanagerAddrs = []string{
+			"https://foo.bar",
+			"https://foo.bar",
+			"https://foo.bar",
+			"http://not.https",
+		}
+
+		err = validateDef(ctx, true, conf.KeymanagerAddrs, definition)
+		require.ErrorContains(t, err, "keymanager address must use https scheme")
+	})
+
 	t.Run("insecure keys", func(t *testing.T) {
 		conf := conf
 		err = validateDef(ctx, true, conf.KeymanagerAddrs, definition) // Validate with insecure keys set to true

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -1047,6 +1047,12 @@ func validateKeymanagerFlags(addr, authToken string) error {
 		return errors.New("--keymanager-auth-token provided but --keymanager-address absent. Please fix configuration flags")
 	}
 
+	if addr != "" {
+		if err := keymanager.VerifyKeymanagerAddr(addr); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/dkg/dkg_internal_test.go
+++ b/dkg/dkg_internal_test.go
@@ -179,6 +179,12 @@ func TestValidateKeymanagerFlags(t *testing.T) {
 			authToken: "keymanager-auth-token",
 			errMsg:    "--keymanager-auth-token provided but --keymanager-address absent. Please fix configuration flags",
 		},
+		{
+			name:      "Address must use https scheme",
+			addr:      "http://keymanager@example.com",
+			authToken: "keymanager-auth-token",
+			errMsg:    "keymanager address must use https scheme",
+		},
 	}
 
 	for _, tt := range tests {

--- a/eth2util/keymanager/url.go
+++ b/eth2util/keymanager/url.go
@@ -1,0 +1,27 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package keymanager
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+func VerifyKeymanagerAddr(addr string) error {
+	parsedURL, err := url.Parse(addr)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse keymanager address", z.Str("addr", addr))
+	}
+	if parsedURL.Scheme != "https" {
+		if parsedURL.Host != "127.0.0.1" && !strings.HasPrefix(parsedURL.Host, "127.0.0.1:") {
+			return errors.New("keymanager address must use https scheme", z.Str("addr", addr))
+		}
+	}
+
+	return nil
+}

--- a/eth2util/keymanager/url_test.go
+++ b/eth2util/keymanager/url_test.go
@@ -1,0 +1,58 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package keymanager_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/eth2util/keymanager"
+)
+
+func TestVerifyKeymanagerAddr(t *testing.T) {
+	tests := []struct {
+		name   string
+		addr   string
+		errMsg string
+	}{
+		{
+			name:   "Valid address",
+			addr:   "https://keymanager@example.com",
+			errMsg: "",
+		},
+		{
+			name:   "Valid localhost",
+			addr:   "http://127.0.0.1",
+			errMsg: "",
+		},
+		{
+			name:   "Valid localhost with port",
+			addr:   "http://127.0.0.1:3756",
+			errMsg: "",
+		},
+		{
+			name:   "Address must use https scheme",
+			addr:   "http://keymanager@example.com",
+			errMsg: "keymanager address must use https scheme",
+		},
+		{
+			name:   "Malformed address",
+			addr:   "https://example.com:-80/",
+			errMsg: "failed to parse keymanager address",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := keymanager.VerifyKeymanagerAddr(tt.addr)
+			if tt.errMsg == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.errMsg)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Keymanager address must use https scheme but tests and localhost.

category: misc
ticket: none
