### PR TITLE
core: fixing DutyDB Store function

### DIFF
--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -127,8 +127,8 @@ func (db *MemDB) Store(_ context.Context, duty core.Duty, unsignedSet core.Unsig
 			if err != nil {
 				return err
 			}
-			db.resolveContribQueriesUnsafe()
 		}
+		db.resolveContribQueriesUnsafe()
 	default:
 		return errors.New("unsupported duty type", z.Str("type", duty.Type.String()))
 	}


### PR DESCRIPTION
DutyDB's `Store()` function has inconsistent handling for `DutySyncContribution`.

category: bug
ticket: none
