### PR TITLE
core: removed unused allowlist and denylist flags

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -61,10 +61,8 @@ func TestCmdFlags(t *testing.T) {
 					LokiService: "charon",
 				},
 				P2P: p2p.Config{
-					Relays:    []string{"https://0.relay.obol.tech"},
-					TCPAddrs:  nil,
-					Allowlist: "",
-					Denylist:  "",
+					Relays:   []string{"https://0.relay.obol.tech"},
+					TCPAddrs: nil,
 				},
 				Feature: featureset.Config{
 					MinStatus: "stable",
@@ -89,10 +87,8 @@ func TestCmdFlags(t *testing.T) {
 			Args:    slice("create", "enr"),
 			Datadir: ".charon",
 			P2PConfig: &p2p.Config{
-				Relays:    []string{"https://0.relay.obol.tech"},
-				TCPAddrs:  nil,
-				Allowlist: "",
-				Denylist:  "",
+				Relays:   []string{"https://0.relay.obol.tech"},
+				TCPAddrs: nil,
 			},
 		},
 		{
@@ -114,10 +110,8 @@ func TestCmdFlags(t *testing.T) {
 					LokiService: "charon",
 				},
 				P2P: p2p.Config{
-					Relays:    []string{"https://0.relay.obol.tech"},
-					TCPAddrs:  nil,
-					Allowlist: "",
-					Denylist:  "",
+					Relays:   []string{"https://0.relay.obol.tech"},
+					TCPAddrs: nil,
 				},
 				Feature: featureset.Config{
 					MinStatus: "stable",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -116,8 +116,6 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	cmd.Flags().StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
 	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")
-	cmd.Flags().StringVar(&config.Allowlist, "p2p-allowlist", "", "Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.")
-	cmd.Flags().StringVar(&config.Denylist, "p2p-denylist", "", "Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.")
 	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,8 +155,6 @@ Flags:
       --manifest-file string               The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence. (default ".charon/cluster-manifest.pb")
       --monitoring-address string          Listening address (ip and port) for the monitoring API (prometheus, pprof). (default "127.0.0.1:3620")
       --no-verify                          Disables cluster definition and lock file verification.
-      --p2p-allowlist string               Comma-separated list of CIDR subnets for allowing only certain peer connections. Example: 192.168.0.0/16 would permit connections to peers on your local network only. The default is to accept all connections.
-      --p2p-denylist string                Comma-separated list of CIDR subnets for disallowing certain peer connections. Example: 192.168.0.0/16 would disallow connections to peers on your local network. The default is to accept all connections.
       --p2p-disable-reuseport              Disables TCP port reuse for outgoing libp2p connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.

--- a/p2p/config.go
+++ b/p2p/config.go
@@ -20,10 +20,6 @@ type Config struct {
 	ExternalHost string
 	// TCPAddrs defines the lib-p2p tcp listen addresses.
 	TCPAddrs []string
-	// Allowlist defines csv CIDR blocks for lib-p2p allowed connections.
-	Allowlist string
-	// Allowlist defines csv CIDR blocks for lib-p2p denied connections.
-	Denylist string
 	// DisableReuseport disables TCP port reuse for libp2p.
 	DisableReuseport bool
 }


### PR DESCRIPTION
Removed unused p2p's allowlist and denylist flags to avoid user confusion and false assumptions.

category: bug
ticket: none
