### PR TITLE
core: remove unimportant todos

### DIFF
--- a/core/proto.go
+++ b/core/proto.go
@@ -45,7 +45,7 @@ func DutyFromProto(duty *pbv1.Duty) Duty {
 }
 
 // ParSignedDataFromProto returns the data from a protobuf.
-func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (odata ParSignedData, oerr error) {
+func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSignedData, oerr error) {
 	defer func() {
 		// This is to respect the technical possibility of unmarshalling to panic.
 		// However, our protobuf generated types do not have custom marshallers that may panic.

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -855,8 +855,6 @@ func TestRouter(t *testing.T) {
 			}
 			res, err := cl.Proposal(ctx, opts)
 			require.Error(t, err)
-			// TODO(xenowits): Fix this test prior to merging. Debug why res is nil.
-			// require.ErrorContains(t, err, "not implemented")
 			require.Nil(t, res)
 		}
 
@@ -882,7 +880,6 @@ func TestRouter(t *testing.T) {
 			}
 			res, err := cl.BlindedProposal(ctx, opts)
 			require.Error(t, err)
-			// TODO(xenowits): Fix this test prior to merging. Debug why res is nil.
 			require.Nil(t, res)
 		}
 


### PR DESCRIPTION
Remove unimportant todos from router tests.

category: misc
ticket: none 