### PR TITLE
cmd: fixing builder registration timestamp

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -236,7 +237,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		return err
 	}
 
-	valRegs, err := createValidatorRegistrations(def.FeeRecipientAddresses(), secrets, def.ForkVersion)
+	valRegs, err := createValidatorRegistrations(def.FeeRecipientAddresses(), secrets, def.ForkVersion, conf.SplitKeys)
 	if err != nil {
 		return err
 	}
@@ -405,7 +406,7 @@ func signDepositDatas(secrets []tbls.PrivateKey, withdrawalAddresses []string, n
 }
 
 // signValidatorRegistrations returns a slice of validator registrations for each private key in secrets.
-func signValidatorRegistrations(secrets []tbls.PrivateKey, feeAddresses []string, forkVersion []byte) ([]core.VersionedSignedValidatorRegistration, error) {
+func signValidatorRegistrations(secrets []tbls.PrivateKey, feeAddresses []string, forkVersion []byte, useNowTimestamp bool) ([]core.VersionedSignedValidatorRegistration, error) {
 	if len(secrets) != len(feeAddresses) {
 		return nil, errors.New("insufficient fee addresses")
 	}
@@ -422,9 +423,15 @@ func signValidatorRegistrations(secrets []tbls.PrivateKey, feeAddresses []string
 			return nil, errors.Wrap(err, "secret to pubkey")
 		}
 
-		timestamp, err := eth2util.ForkVersionToGenesisTime(forkVersion)
-		if err != nil {
-			return nil, err
+		var timestamp time.Time
+		if useNowTimestamp {
+			// Used in --split-existing-keys mode
+			timestamp = time.Now().UTC()
+		} else {
+			timestamp, err = eth2util.ForkVersionToGenesisTime(forkVersion)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		unsignedReg, err := registration.NewMessage(
@@ -566,12 +573,12 @@ func writeDepositData(depositDatas []eth2p0.DepositData, network string, cluster
 }
 
 // createValidatorRegistrations creates a slice of builder validator registrations using the provided parameters and returns it.
-func createValidatorRegistrations(feeAddresses []string, secrets []tbls.PrivateKey, forkVersion []byte) ([]core.VersionedSignedValidatorRegistration, error) {
+func createValidatorRegistrations(feeAddresses []string, secrets []tbls.PrivateKey, forkVersion []byte, useNowTimestamp bool) ([]core.VersionedSignedValidatorRegistration, error) {
 	if len(feeAddresses) != len(secrets) {
 		return nil, errors.New("insufficient fee addresses")
 	}
 
-	return signValidatorRegistrations(secrets, feeAddresses, forkVersion)
+	return signValidatorRegistrations(secrets, feeAddresses, forkVersion, useNowTimestamp)
 }
 
 // writeLock creates a cluster lock and writes it to disk for all peers.

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -406,7 +406,7 @@ func signDepositDatas(secrets []tbls.PrivateKey, withdrawalAddresses []string, n
 }
 
 // signValidatorRegistrations returns a slice of validator registrations for each private key in secrets.
-func signValidatorRegistrations(secrets []tbls.PrivateKey, feeAddresses []string, forkVersion []byte, useNowTimestamp bool) ([]core.VersionedSignedValidatorRegistration, error) {
+func signValidatorRegistrations(secrets []tbls.PrivateKey, feeAddresses []string, forkVersion []byte, useCurrentTimestamp bool) ([]core.VersionedSignedValidatorRegistration, error) {
 	if len(secrets) != len(feeAddresses) {
 		return nil, errors.New("insufficient fee addresses")
 	}
@@ -424,7 +424,7 @@ func signValidatorRegistrations(secrets []tbls.PrivateKey, feeAddresses []string
 		}
 
 		var timestamp time.Time
-		if useNowTimestamp {
+		if useCurrentTimestamp {
 			// Used in --split-existing-keys mode
 			timestamp = time.Now().UTC()
 		} else {
@@ -573,12 +573,12 @@ func writeDepositData(depositDatas []eth2p0.DepositData, network string, cluster
 }
 
 // createValidatorRegistrations creates a slice of builder validator registrations using the provided parameters and returns it.
-func createValidatorRegistrations(feeAddresses []string, secrets []tbls.PrivateKey, forkVersion []byte, useNowTimestamp bool) ([]core.VersionedSignedValidatorRegistration, error) {
+func createValidatorRegistrations(feeAddresses []string, secrets []tbls.PrivateKey, forkVersion []byte, useCurrentTimestamp bool) ([]core.VersionedSignedValidatorRegistration, error) {
 	if len(feeAddresses) != len(secrets) {
 		return nil, errors.New("insufficient fee addresses")
 	}
 
-	return signValidatorRegistrations(secrets, feeAddresses, forkVersion, useNowTimestamp)
+	return signValidatorRegistrations(secrets, feeAddresses, forkVersion, useCurrentTimestamp)
 }
 
 // writeLock creates a cluster lock and writes it to disk for all peers.

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -318,6 +318,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 		}
 
 		previousVersions := []string{"v1.0.0", "v1.1.0", "v1.2.0", "v1.3.0", "v1.4.0", "v1.5.0"}
+		nowUTC := time.Now().UTC()
 		for _, val := range lock.Validators {
 			if isAnyVersion(lock.Version, previousVersions...) {
 				break
@@ -329,6 +330,13 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 
 			if isAnyVersion(lock.Version, "v1.7.0") {
 				require.NotEmpty(t, val.BuilderRegistration)
+			}
+
+			if conf.SplitKeys {
+				// For SplitKeys mode, builder registration timestamp must be close to Now().
+				// This assumes the test does not execute longer than five minutes.
+				// We just need to make sure the message timestamp is not a genesis time.
+				require.Less(t, nowUTC.Sub(val.BuilderRegistration.Message.Timestamp), 5*time.Minute, "likely a genesis timestamp")
 			}
 		}
 


### PR DESCRIPTION
Use the current timestamp for builder registration messages when using `--split-existing-keys` mode.

See [the issue](https://github.com/ObolNetwork/charon/issues/2770) for the full context.

category: bug
ticket: #2770
