### PR TITLE
*: more warnings on HTTP URLs

### DIFF
--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
@@ -34,8 +35,14 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 
 	// Fetch definition from URI or disk
 
+	parsedURL, err := url.ParseRequestURI(conf.DefFile)
+
 	var def cluster.Definition
-	if validURI(conf.DefFile) {
+	if err == nil {
+		if strings.HasPrefix(parsedURL.Scheme, "https") {
+			log.Warn(ctx, "Definition file URL does not use https protocol", nil, z.Str("addr", conf.DefFile))
+		}
+
 		var err error
 		def, err = cluster.FetchDefinition(ctx, conf.DefFile)
 		if err != nil {
@@ -245,13 +252,6 @@ func checkWrites(dataDir string) error {
 	}
 
 	return nil
-}
-
-// validURI returns true if the input string is a valid HTTP/HTTPS URI.
-func validURI(str string) bool {
-	u, err := url.Parse(str)
-
-	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }
 
 // randomHex64 returns a random 64 character hex string. It uses crypto/rand.

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -39,7 +39,7 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 
 	var def cluster.Definition
 	if err == nil && parsedURL.Host != "" {
-		if strings.HasPrefix(parsedURL.Scheme, "https") {
+		if !strings.HasPrefix(parsedURL.Scheme, "https") {
 			log.Warn(ctx, "Definition file URL does not use https protocol", nil, z.Str("addr", conf.DefFile))
 		}
 

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -38,7 +38,7 @@ func loadDefinition(ctx context.Context, conf Config) (cluster.Definition, error
 	parsedURL, err := url.ParseRequestURI(conf.DefFile)
 
 	var def cluster.Definition
-	if err == nil {
+	if err == nil && parsedURL.Host != "" {
 		if strings.HasPrefix(parsedURL.Scheme, "https") {
 			log.Warn(ctx, "Definition file URL does not use https protocol", nil, z.Str("addr", conf.DefFile))
 		}

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -29,6 +29,9 @@ func NewRelays(ctx context.Context, relayAddrs []string, lockHashHex string,
 	var resp []*MutablePeer
 	for _, relayAddr := range relayAddrs {
 		if strings.HasPrefix(relayAddr, "http") {
+			if !strings.HasPrefix(relayAddr, "https") {
+				log.Warn(ctx, "Relay URL does not use https protocol", nil, z.Str("addr", relayAddr))
+			}
 			mutable := new(MutablePeer)
 			go resolveRelay(ctx, relayAddr, lockHashHex, mutable.Set)
 			resp = append(resp, mutable)


### PR DESCRIPTION
Warn if relay or definition file URLs are HTTP.

category: refactor
ticket: none