### PR TITLE
cmd: add secondary charon relay

### DIFF
--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -61,7 +61,7 @@ func TestCmdFlags(t *testing.T) {
 					LokiService: "charon",
 				},
 				P2P: p2p.Config{
-					Relays:   []string{"https://0.relay.obol.tech"},
+					Relays:   []string{"https://0.relay.obol.tech", "https://1.relay.obol.tech"},
 					TCPAddrs: nil,
 				},
 				Feature: featureset.Config{
@@ -110,7 +110,7 @@ func TestCmdFlags(t *testing.T) {
 					LokiService: "charon",
 				},
 				P2P: p2p.Config{
-					Relays:   []string{"https://0.relay.obol.tech"},
+					Relays:   []string{"https://0.relay.obol.tech", "https://1.relay.obol.tech"},
 					TCPAddrs: nil,
 				},
 				Feature: featureset.Config{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -113,7 +113,7 @@ func bindLogFlags(flags *pflag.FlagSet, config *log.Config) {
 }
 
 func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
-	cmd.Flags().StringSliceVar(&config.Relays, "p2p-relays", []string{"https://0.relay.obol.tech"}, "Comma-separated list of libp2p relay URLs or multiaddrs.")
+	cmd.Flags().StringSliceVar(&config.Relays, "p2p-relays", []string{"https://0.relay.obol.tech", "https://1.relay.obol.tech"}, "Comma-separated list of libp2p relay URLs or multiaddrs.")
 	cmd.Flags().StringVar(&config.ExternalIP, "p2p-external-ip", "", "The IP address advertised by libp2p. This may be used to advertise an external IP.")
 	cmd.Flags().StringVar(&config.ExternalHost, "p2p-external-hostname", "", "The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.")
 	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,7 +159,7 @@ Flags:
       --p2p-disable-reuseport              Disables TCP port reuse for outgoing libp2p connections.
       --p2p-external-hostname string       The DNS hostname advertised by libp2p. This may be used to advertise an external DNS.
       --p2p-external-ip string             The IP address advertised by libp2p. This may be used to advertise an external IP.
-      --p2p-relays strings                 Comma-separated list of libp2p relay URLs or multiaddrs. (default [https://0.relay.obol.tech])
+      --p2p-relays strings                 Comma-separated list of libp2p relay URLs or multiaddrs. (default [https://0.relay.obol.tech,https://1.relay.obol.tech])
       --p2p-tcp-address strings            Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.
       --private-key-file string            The path to the charon enr private key file. (default ".charon/charon-enr-private-key")
       --private-key-file-lock              Enables private key locking to prevent multiple instances using the same key.


### PR DESCRIPTION
Add a secondary relay "https://1.relay.obol.tech" to the `--p2p-relays` flag default values.

category: feature 
ticket: none 
