### PR TITLE
cmd/relay: bind debug and monitoring address separately

### DIFF
--- a/cmd/debug_tools.go
+++ b/cmd/debug_tools.go
@@ -1,0 +1,13 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// bindDebugMonitoringFlags binds Prometheus monitoring and debug address CLI flags.
+func bindDebugMonitoringFlags(cmd *cobra.Command, monitorAddr, debugAddr *string, defaultMonitorAddr string) {
+	cmd.Flags().StringVar(monitorAddr, "monitoring-address", defaultMonitorAddr, "Listening address (ip and port) for the monitoring API (prometheus).")
+	cmd.Flags().StringVar(debugAddr, "debug-address", "", "Listening address (ip and port) for the pprof and QBFT debug API.")
+}

--- a/cmd/debug_tools.go
+++ b/cmd/debug_tools.go
@@ -9,5 +9,5 @@ import (
 // bindDebugMonitoringFlags binds Prometheus monitoring and debug address CLI flags. The debug address defaults to an empty address.
 func bindDebugMonitoringFlags(cmd *cobra.Command, monitorAddr, debugAddr *string, defaultMonitorAddr string) {
 	cmd.Flags().StringVar(monitorAddr, "monitoring-address", defaultMonitorAddr, "Listening address (ip and port) for the monitoring API (prometheus).")
-	cmd.Flags().StringVar(debugAddr, "debug-address", "", "Listening address (ip and port) for the pprof and QBFT debug API.")
+	cmd.Flags().StringVar(debugAddr, "debug-address", "", "Listening address (ip and port) for the pprof and QBFT debug API. It is not enabled by default.")
 }

--- a/cmd/debug_tools.go
+++ b/cmd/debug_tools.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// bindDebugMonitoringFlags binds Prometheus monitoring and debug address CLI flags.
+// bindDebugMonitoringFlags binds Prometheus monitoring and debug address CLI flags. The debug address defaults to an empty address.
 func bindDebugMonitoringFlags(cmd *cobra.Command, monitorAddr, debugAddr *string, defaultMonitorAddr string) {
 	cmd.Flags().StringVar(monitorAddr, "monitoring-address", defaultMonitorAddr, "Listening address (ip and port) for the monitoring API (prometheus).")
 	cmd.Flags().StringVar(debugAddr, "debug-address", "", "Listening address (ip and port) for the pprof and QBFT debug API.")

--- a/cmd/debug_tools_internal_test.go
+++ b/cmd/debug_tools_internal_test.go
@@ -1,0 +1,110 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app"
+)
+
+func genTestCmd(t *testing.T, f func(config app.Config)) *cobra.Command {
+	t.Helper()
+
+	var conf app.Config
+
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "test",
+	}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		f(conf)
+	}
+
+	bindDebugMonitoringFlags(cmd, &conf.MonitoringAddr, &conf.DebugAddr, "")
+
+	return cmd
+}
+
+func Test_bindDebugMonitoringFlags(t *testing.T) {
+	cmd := &cobra.Command{
+		Use: "testcmd",
+	}
+
+	t.Run("both present", func(t *testing.T) {
+		var (
+			mAddr = "127.0.0.1:9999"
+			dAddr = "127.0.0.1:8888"
+		)
+
+		cmd.ResetCommands()
+
+		testCmd := genTestCmd(t, func(config app.Config) {
+			require.Equal(t, mAddr, config.MonitoringAddr)
+			require.Equal(t, dAddr, config.DebugAddr)
+		})
+
+		cmd.AddCommand(testCmd)
+
+		cmd.SetArgs([]string{
+			"test",
+			"--monitoring-address",
+			mAddr,
+			"--debug-address",
+			dAddr,
+		})
+
+		require.NoError(t, cmd.Execute())
+	})
+
+	t.Run("only monitor", func(t *testing.T) {
+		var (
+			mAddr = "127.0.0.1:9999"
+			dAddr = ""
+		)
+		cmd.ResetCommands()
+
+		testCmd := genTestCmd(t, func(config app.Config) {
+			require.Equal(t, mAddr, config.MonitoringAddr)
+			require.Equal(t, dAddr, config.DebugAddr)
+		})
+
+		cmd.AddCommand(testCmd)
+
+		cmd.SetArgs([]string{
+			"test",
+			"--monitoring-address",
+			mAddr,
+		})
+
+		require.NoError(t, cmd.Execute())
+	})
+
+	t.Run("only debug", func(t *testing.T) {
+		var (
+			mAddr = ""
+			dAddr = "127.0.0.1:8888"
+		)
+
+		cmd.ResetCommands()
+
+		testCmd := genTestCmd(t, func(config app.Config) {
+			require.Equal(t, mAddr, config.MonitoringAddr)
+			require.Equal(t, dAddr, config.DebugAddr)
+		})
+
+		cmd.AddCommand(testCmd)
+
+		cmd.SetArgs([]string{
+			"test",
+			"--debug-address",
+			dAddr,
+		})
+
+		require.NoError(t, cmd.Execute())
+	})
+}

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -34,6 +34,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
 	bindRelayFlag(cmd, &config)
+	bindDebugMonitoringFlags(cmd, &config.MonitoringAddr, &config.DebugAddr, "")
 	bindP2PFlags(cmd, &config.P2PConfig)
 	bindLogFlags(cmd.Flags(), &config.LogConfig)
 	bindLokiFlags(cmd.Flags(), &config.LogConfig)
@@ -43,7 +44,6 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 
 func bindRelayFlag(cmd *cobra.Command, config *relay.Config) {
 	cmd.Flags().StringVar(&config.HTTPAddr, "http-address", "127.0.0.1:3640", "Listening address (ip and port) for the relay http server serving runtime ENR.")
-	cmd.Flags().StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the prometheus and pprof monitoring http server.")
 	cmd.Flags().BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (secp256k1 private key used for p2p authentication and ENR) if none found in data directory.")
 	cmd.Flags().StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error.")
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -44,6 +44,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error, unsafe bool) *co
 
 	bindPrivKeyFlag(cmd, &conf.PrivKeyFile, &conf.PrivKeyLocking)
 	bindRunFlags(cmd, &conf)
+	bindDebugMonitoringFlags(cmd, &conf.MonitoringAddr, &conf.DebugAddr, "127.0.0.1:3620")
 	bindNoVerifyFlag(cmd.Flags(), &conf.NoVerify)
 	bindP2PFlags(cmd, &conf.P2P)
 	bindLogFlags(cmd.Flags(), &conf.Log)
@@ -70,8 +71,6 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringVar(&config.ManifestFile, "manifest-file", ".charon/cluster-manifest.pb", "The path to the cluster manifest file. If both cluster manifest and cluster lock files are provided, the cluster manifest file takes precedence.")
 	cmd.Flags().StringSliceVar(&config.BeaconNodeAddrs, "beacon-node-endpoints", nil, "Comma separated list of one or more beacon node endpoint URLs.")
 	cmd.Flags().StringVar(&config.ValidatorAPIAddr, "validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API.")
-	cmd.Flags().StringVar(&config.MonitoringAddr, "monitoring-address", "127.0.0.1:3620", "Listening address (ip and port) for the monitoring API (prometheus).")
-	cmd.Flags().StringVar(&config.DebugAddr, "debug-address", "", "Listening address (ip and port) for the pprof and QBFT debug API.")
 	cmd.Flags().StringVar(&config.JaegerAddr, "jaeger-address", "", "Listening address for jaeger tracing.")
 	cmd.Flags().StringVar(&config.JaegerService, "jaeger-service", "charon", "Service name used for jaeger tracing.")
 	cmd.Flags().BoolVar(&config.SimnetBMock, "simnet-beacon-mock", false, "Enables an internal mock beacon node for running a simnet.")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,7 +139,7 @@ Usage:
 Flags:
       --beacon-node-endpoints strings      Comma separated list of one or more beacon node endpoint URLs.
       --builder-api                        Enables the builder api. Will only produce builder blocks. Builder API must also be enabled on the validator client. Beacon node must be connected to a builder-relay to access the builder network.
-      --debug-address string               Listening address (ip and port) for the pprof and QBFT debug API.
+      --debug-address string               Listening address (ip and port) for the pprof and QBFT debug API. It is not enabled by default.
       --feature-set string                 Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings        Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings         Comma-separated list of features to enable, overriding the default minimum feature set.


### PR DESCRIPTION
Same principle as #2808.

Refactor the binding functions to be usable across multiple commands.

category: refactor
ticket: none