### PR TITLE
eth2util: remove legacy signed epoch

### DIFF
--- a/eth2util/types_test.go
+++ b/eth2util/types_test.go
@@ -47,12 +47,6 @@ func TestUnmarshallingSignedEpoch(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	require.Equal(t, string(b), string(b2))
 
-	type legacySig [96]byte
-	sigB, err := json.Marshal(legacySig(sig))
-	require.NoError(t, err)
-	oldTmpl := `{"epoch": %d,"signature": %s}`
-	b = []byte(fmt.Sprintf(oldTmpl, epoch, sigB))
-
 	var e2 eth2util.SignedEpoch
 	err = e2.UnmarshalJSON(b)
 	testutil.RequireNoError(t, err)


### PR DESCRIPTION
Removes legacy signed epoch as part of migration.

category: refactor
ticket: #2593
