### PR TITLE
core: using `url.ParseRequestURI`

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
-	"net/url"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -402,8 +401,7 @@ func TestLazy(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	target, err := url.Parse(bmock.Address())
-	require.NoError(t, err)
+	target := testutil.MustParseURL(t, bmock.Address())
 
 	// Start two proxys that we can enable/disable.
 	var enabled1, enabled2 atomic.Bool

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -209,7 +209,7 @@ func httpPost(ctx context.Context, base string, endpoint string, body io.Reader,
 		return nil, errors.Wrap(err, "invalid address")
 	}
 
-	url, err := url.Parse(addr)
+	url, err := url.ParseRequestURI(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid endpoint")
 	}
@@ -247,7 +247,7 @@ func httpGet(ctx context.Context, base string, endpoint string, timeout time.Dur
 		return nil, 0, errors.Wrap(err, "invalid address")
 	}
 
-	u, err := url.Parse(addr)
+	u, err := url.ParseRequestURI(addr)
 	if err != nil {
 		return nil, 0, errors.Wrap(err, "invalid endpoint")
 	}

--- a/app/obolapi/api_test.go
+++ b/app/obolapi/api_test.go
@@ -9,13 +9,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/obolapi"
 	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 // TestLockPublish tests.
@@ -84,8 +84,7 @@ func TestLaunchpadDashURL(t *testing.T) {
 
 		require.NotEmpty(t, result)
 
-		parsedRes, err := url.ParseRequestURI(result)
-		require.NoError(t, err)
+		parsedRes := testutil.MustParseRequestURI(t, result)
 
 		require.Equal(t, "safe.today", parsedRes.Host)
 		require.Equal(

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -193,7 +193,7 @@ func redact(flag, val string) string {
 		return val
 	}
 
-	u, err := url.Parse(val)
+	u, err := url.ParseRequestURI(val)
 	if err != nil {
 		return val
 	}

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -322,7 +322,7 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 	}
 
 	for _, addr := range conf.KeymanagerAddrs {
-		keymanagerURL, err := url.Parse(addr)
+		keymanagerURL, err := url.ParseRequestURI(addr)
 		if err != nil {
 			return errors.Wrap(err, "failed to parse keymanager addr", z.Str("addr", addr))
 		}
@@ -964,7 +964,7 @@ func loadDefinition(ctx context.Context, defFile string) (cluster.Definition, er
 
 // validURI returns true if the input string is a valid HTTP/HTTPS URI.
 func validURI(str string) bool {
-	u, err := url.Parse(str)
+	u, err := url.ParseRequestURI(str)
 
 	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1029,7 +1029,7 @@ func proxyHandler(ctx context.Context, addrProvider addressProvider) http.Handle
 // getBeaconNodeAddress returns an active beacon node proxy target address.
 func getBeaconNodeAddress(addrProvider addressProvider) (*url.URL, error) {
 	addr := addrProvider.Address()
-	targetURL, err := url.Parse(addr)
+	targetURL, err := url.ParseRequestURI(addr)
 	if err != nil {
 		return nil, errors.Wrap(err, "invalid beacon node address", z.Str("address", addr))
 	}

--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -41,7 +41,7 @@ func (c Client) ImportKeystores(ctx context.Context, keystores []keystore.Keysto
 			z.Int("keystores", len(keystores)), z.Int("passwords", len(passwords)))
 	}
 
-	keymanagerURL, err := url.Parse(c.baseURL)
+	keymanagerURL, err := url.ParseRequestURI(c.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "parse address", z.Str("addr", c.baseURL))
 	}

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -126,7 +126,7 @@ func resolveRelay(ctx context.Context, rawURL, lockHashHex string, callback func
 //
 // It retries until the context is cancelled.
 func queryRelayAddrs(ctx context.Context, relayURL string, backoff func(), lockHashHex string) ([]ma.Multiaddr, error) {
-	parsedURL, err := url.Parse(relayURL)
+	parsedURL, err := url.ParseRequestURI(relayURL)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse relay url")
 	} else if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {

--- a/testutil/beaconmock/headproducer_internal_test.go
+++ b/testutil/beaconmock/headproducer_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -17,6 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 func TestHeadProducer(t *testing.T) {
@@ -25,8 +25,7 @@ func TestHeadProducer(t *testing.T) {
 
 	defer bmock.Close()
 
-	base, err := url.Parse(bmock.Address())
-	require.NoError(t, err)
+	base := testutil.MustParseURL(t, bmock.Address())
 
 	unsupportedTopicErr := errors.New("unknown topic requested")
 
@@ -61,9 +60,8 @@ func TestHeadProducer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			endpoint, err := url.Parse(fmt.Sprintf("eth/v1/events?topics=%s", strings.Join(test.topics, "&topics=")))
-			require.NoError(t, err)
-
+			rawURL := fmt.Sprintf("eth/v1/events?topics=%s", strings.Join(test.topics, "&topics="))
+			endpoint := testutil.MustParseURL(t, rawURL)
 			addr := base.ResolveReference(endpoint).String()
 
 			requiredTopics := make(map[string]bool)

--- a/testutil/promrated/prometheus.go
+++ b/testutil/promrated/prometheus.go
@@ -54,7 +54,7 @@ func serveMonitoring(addr string, registry *prometheus.Registry) error {
 func getValidators(ctx context.Context, promEndpoint string, promAuth string) ([]validator, error) {
 	client := new(http.Client)
 
-	url, err := url.Parse(promEndpoint)
+	url, err := url.ParseRequestURI(promEndpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse prometheus endpoint")
 	}

--- a/testutil/url.go
+++ b/testutil/url.go
@@ -1,0 +1,28 @@
+// Copyright © 2022-2023 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package testutil
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func MustParseURL(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+
+	url, err := url.Parse(rawURL)
+	require.NoError(t, err)
+
+	return url
+}
+
+func MustParseRequestURI(t *testing.T, rawURL string) *url.URL {
+	t.Helper()
+
+	url, err := url.ParseRequestURI(rawURL)
+	require.NoError(t, err)
+
+	return url
+}

--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -192,7 +192,7 @@ func verifyBody(body string) error {
 			}
 
 			if strings.HasPrefix(ticket, "https://") {
-				if u, err := url.Parse(ticket); err != nil || u.Path == "" {
+				if u, err := url.ParseRequestURI(ticket); err != nil || u.Path == "" {
 					return errors.New("ticket tag invalid url")
 				}
 				// URL is fine


### PR DESCRIPTION
Replacing `url.Parse` with `url.ParseRequestURI` where appropriate. 

category: refactor
ticket: #2796 

