### PR TITLE
cmd: fix create cluster bug

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -321,6 +321,15 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 		return errors.New("missing --nodes flag")
 	}
 
+	if conf.DefFile != "" {
+		def, err := loadDefinition(ctx, conf.DefFile)
+		if err != nil {
+			return err
+		}
+
+		conf.NumNodes = len(def.Operators)
+	}
+
 	// Check for valid network configuration.
 	if err := validateNetworkConfig(conf); err != nil {
 		return errors.Wrap(err, "get network config")

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -739,7 +739,7 @@ func TestValidateCreateConfig(t *testing.T) {
 	defBytes, err := lock.Definition.MarshalJSON()
 	require.NoError(t, err)
 
-	err = os.WriteFile(defFilePath, defBytes, 0o777)
+	err = os.WriteFile(defFilePath, defBytes, 0o666)
 	require.NoError(t, err)
 
 	conf := clusterConfig{}
@@ -752,7 +752,7 @@ func TestValidateCreateConfig(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("not ok", func(t *testing.T) {
+	t.Run("existing directory found", func(t *testing.T) {
 		node := nodeDir(tmpDir, 0)
 		err := os.Mkdir(node, 0o777)
 		require.NoError(t, err)

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -730,41 +730,6 @@ func TestPublish(t *testing.T) {
 	})
 }
 
-func TestValidateCreateConfig(t *testing.T) {
-	tmpDir := t.TempDir()
-	defFilePath := path.Join(tmpDir, "cluster-definition.json")
-
-	lock, _, _ := cluster.NewForT(t, 2, 3, 4, 5)
-
-	defBytes, err := lock.Definition.MarshalJSON()
-	require.NoError(t, err)
-
-	err = os.WriteFile(defFilePath, defBytes, 0o666)
-	require.NoError(t, err)
-
-	conf := clusterConfig{}
-	conf.ClusterDir = tmpDir
-	conf.DefFile = defFilePath
-	conf.Network = "sepolia"
-
-	t.Run("ok", func(t *testing.T) {
-		err = validateCreateConfig(context.Background(), conf)
-		require.NoError(t, err)
-	})
-
-	t.Run("existing directory found", func(t *testing.T) {
-		node := nodeDir(tmpDir, 0)
-		err := os.Mkdir(node, 0o777)
-		require.NoError(t, err)
-
-		err = os.WriteFile(path.Join(node, "cluster-lock.json"), []byte{}, 0o666)
-		require.NoError(t, err)
-
-		err = validateCreateConfig(context.Background(), conf)
-		require.ErrorContains(t, err, "existing node directory found, please delete it before running this command")
-	})
-}
-
 // mockKeymanagerReq is a mock keymanager request for use in tests.
 type mockKeymanagerReq struct {
 	Keystores []string `json:"keystores"`


### PR DESCRIPTION
Fix bug in `create cluster` command.

--

From @xenowits's explanation on slack:

> When create cluster command is run twice in the same directory, it doesn’t error out with “Fatal error: existing node directory found, please delete it before running this command” while it should

> Explanation: When we provide a definition file to the create cluster command, we don’t set the "conf.NumNodes" field when verifying the config

```go
//.....
func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
    if conf.NumNodes == 0 && conf.DefFile == "" { // if there's a definition file, infer this value from it later
       return errors.New("missing --nodes flag")
    }

    // Check for valid network configuration.
    if err := validateNetworkConfig(conf); err != nil {
       return errors.Wrap(err, "get network config")
    }

    // BUG: conf.NumNodes is zero here!!
    if err := detectNodeDirs(conf.ClusterDir, conf.NumNodes); err != nil {
       return err
    }
```

category: bug 
ticket: #2851 
