### PR TITLE
cmd: fix create cluster bug

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -132,6 +132,16 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 		conf.Network = eth2util.Goerli.Name
 	}
 
+	var def cluster.Definition
+	if conf.DefFile != "" { // Load definition from DefFile
+		def, err = loadDefinition(ctx, conf.DefFile)
+		if err != nil {
+			return err
+		}
+
+		conf.NumNodes = len(def.Operators)
+	}
+
 	if err = validateCreateConfig(ctx, conf); err != nil {
 		return err
 	}
@@ -153,13 +163,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	}
 
 	// Get a cluster definition, either from a definition file or from the config.
-	var def cluster.Definition
-	if conf.DefFile != "" { // Load definition from DefFile
-		def, err = loadDefinition(ctx, conf.DefFile)
-		if err != nil {
-			return err
-		}
-
+	if conf.DefFile != "" {
 		// Validate the provided definition.
 		err = validateDef(ctx, conf.InsecureKeys, conf.KeymanagerAddrs, def)
 		if err != nil {
@@ -310,7 +314,6 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 	if err := validateNetworkConfig(conf); err != nil {
 		return errors.Wrap(err, "get network config")
 	}
-
 	if err := detectNodeDirs(conf.ClusterDir, conf.NumNodes); err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherrypick of [2852](https://github.com/ObolNetwork/charon/pull/2852) on `main-v0.19`.

--

Fix bug in `create cluster` command.

--

From @xenowits's explanation on slack:

> When create cluster command is run twice in the same directory, it doesn’t error out with “Fatal error: existing node directory found, please delete it before running this command” while it should

> Explanation: When we provide a definition file to the create cluster command, we don’t set the "conf.NumNodes" field when verifying the config

```go
//.....
func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
    if conf.NumNodes == 0 && conf.DefFile == "" { // if there's a definition file, infer this value from it later
       return errors.New("missing --nodes flag")
    }

    // Check for valid network configuration.
    if err := validateNetworkConfig(conf); err != nil {
       return errors.Wrap(err, "get network config")
    }

    // BUG: conf.NumNodes is zero here!!
    if err := detectNodeDirs(conf.ClusterDir, conf.NumNodes); err != nil {
       return err
    }
```

category: bug 
ticket: #2851 
