### PR TITLE
workflows: tag latest on git tags

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -30,8 +30,8 @@ jobs:
           # Tag "git short sha" on all git events
           type=sha,prefix=
 
-          # Tag "latest" on git-push-to-main-branch events
-          type=raw,value=latest,event=branch,enable={{is_default_branch}}
+          # Tag "latest" on git-tag events
+          type=raw,value=latest,event=tag
 
           # Tag "$APP_VERSION" on git-push-to-branch events
           type=raw,value=${{ env.APP_VERSION }},event=branch

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -30,6 +30,9 @@ jobs:
           # Tag "git short sha" on all git events
           type=sha,prefix=
 
+          # Tag "next" on git-push-to-main-branch events
+          type=raw,value=next,event=branch,enable={{is_default_branch}}
+
           # Tag "latest" on git-tag events
           type=raw,value=latest,event=tag
 


### PR DESCRIPTION
Tag `latest` Docker images to the latest git tag.

Also tag `next` Docker images to the latest commit on `main.

Previously, we tagged `latest` to latest commit on `main` only.

category: misc
ticket: #2359 

Closes #2359
