### PR TITLE
cmd/combine: support testnet config

### DIFF
--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -74,9 +74,11 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 			opt(&def)
 		}
 
-		networkName, _ := eth2util.ForkVersionToNetwork(def.ForkVersion)
-		if networkName == "" {
-			networkName = eth2util.Goerli.Name
+		networkName := eth2util.Goerli.Name
+
+		if len(def.ForkVersion) != 0 {
+			networkName, err = eth2util.ForkVersionToNetwork(def.ForkVersion)
+			require.NoError(t, err)
 		}
 
 		reg := getSignedRegistration(t, rootSecret, feeRecipientAddr, networkName)

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -67,7 +67,19 @@ func NewForT(t *testing.T, dv, k, n, seed int, opts ...func(*Definition)) (Lock,
 		}
 
 		feeRecipientAddr := testutil.RandomETHAddress()
-		reg := getSignedRegistration(t, rootSecret, feeRecipientAddr, eth2util.Goerli.Name)
+
+		// get the forkHash to retrieve the network name
+		var def Definition
+		for _, opt := range opts {
+			opt(&def)
+		}
+
+		networkName, _ := eth2util.ForkVersionToNetwork(def.ForkVersion)
+		if networkName == "" {
+			networkName = eth2util.Goerli.Name
+		}
+
+		reg := getSignedRegistration(t, rootSecret, feeRecipientAddr, networkName)
 
 		vals = append(vals, DistValidator{
 			PubKey:              rootPublic[:],

--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -9,14 +9,17 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/obolnetwork/charon/cmd/combine"
+	"github.com/obolnetwork/charon/eth2util"
 )
 
-func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir string, force, noverify bool) error) *cobra.Command {
+func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir string, force, noverify bool, testnetConfig eth2util.Network) error) *cobra.Command {
 	var (
 		clusterDir string
 		outputDir  string
 		force      bool
 		noverify   bool
+
+		testnetConfig eth2util.Network
 	)
 
 	cmd := &cobra.Command{
@@ -31,6 +34,7 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir strin
 				outputDir,
 				force,
 				noverify,
+				testnetConfig,
 			)
 		},
 	}
@@ -40,6 +44,7 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir strin
 		&clusterDir,
 		&outputDir,
 		&force,
+		&testnetConfig,
 	)
 
 	bindNoVerifyFlag(cmd.Flags(), &noverify)
@@ -47,12 +52,16 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir strin
 	return cmd
 }
 
-func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force, noverify bool) error {
-	return combine.Combine(ctx, clusterDir, outputDir, force, noverify)
+func newCombineFunc(ctx context.Context, clusterDir, outputDir string, force, noverify bool, testnetConfig eth2util.Network) error {
+	return combine.Combine(ctx, clusterDir, outputDir, force, noverify, testnetConfig)
 }
 
-func bindCombineFlags(flags *pflag.FlagSet, clusterDir, outputDir *string, force *bool) {
+func bindCombineFlags(flags *pflag.FlagSet, clusterDir, outputDir *string, force *bool, config *eth2util.Network) {
 	flags.StringVar(clusterDir, "cluster-dir", ".charon/cluster", `Parent directory containing a number of .charon subdirectories from the required threshold of nodes in the cluster.`)
 	flags.StringVar(outputDir, "output-dir", "./validator_keys", "Directory to output the combined private keys to.")
 	flags.BoolVar(force, "force", false, "Overwrites private keys with the same name if present.")
+	flags.StringVar(&config.Name, "testnet-name", "", "Name of the custom test network.")
+	flags.StringVar(&config.GenesisForkVersionHex, "testnet-fork-version", "", "Genesis fork version of the custom test network (in hex).")
+	flags.Uint64Var(&config.ChainID, "testnet-chain-id", 0, "Chain ID of the custom test network.")
+	flags.Int64Var(&config.GenesisTimestamp, "testnet-genesis-timestamp", 0, "Genesis timestamp of the custom test network.")
 }

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -15,6 +15,7 @@ import (
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/cluster/manifest"
 	manifestpb "github.com/obolnetwork/charon/cluster/manifestpb/v1"
+	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -26,13 +27,19 @@ import (
 // Note all nodes directories must be preset and all validator private key shares must be present.
 //
 // Combine will create a new directory named after "outputDir", which will contain Keystore files.
-func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bool, opts ...func(*options)) error {
+func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bool, testnetConfig eth2util.Network, opts ...func(*options)) error {
 	o := options{
 		keyStoreFunc: keystore.StoreKeys,
 	}
 
 	for _, opt := range opts {
 		opt(&o)
+	}
+
+	// Check if custom testnet configuration is provided.
+	if testnetConfig.IsNonZero() {
+		// Add testnet config to supported networks.
+		eth2util.AddTestNetwork(testnetConfig)
 	}
 
 	if !filepath.IsAbs(outputDir) {


### PR DESCRIPTION
Add `--testnet-*` flags to `combine` command.

Users must specify custom network name, chain ID genesis timestamp and fork version as hex string to allow for a custom testnet configuration to work.

category: bug
ticket: #2838 

Closes #2838.