### PR TITLE
*: fix flappy tests

### DIFF
--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -57,7 +57,6 @@ func TestComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			testComponent(t, tt.threshold, tt.nodes)
 		})
 	}

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -57,6 +57,7 @@ func TestComponent(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			testComponent(t, tt.threshold, tt.nodes)
 		})
 	}

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -42,12 +42,12 @@ func TestQBFT(t *testing.T) {
 		})
 	})
 
-	t.Run("prepare round 2, decide round 23", func(t *testing.T) {
+	t.Run("prepare round 2, decide round 3", func(t *testing.T) {
 		testQBFT(t, test{
 			Instance:     0,
 			CommitsAfter: 2,
 			ValueDelay: map[int64]time.Duration{
-				1: time.Second,
+				1: 2 * time.Second,
 			},
 			DecideRound: 3,
 			PreparedVal: 2,
@@ -433,14 +433,14 @@ func testQBFT(t *testing.T, test test) {
 			for _, commit := range qCommit {
 				// Ensure that all results are the same
 				for _, previous := range results {
-					require.EqualValues(t, previous.Value(), commit.Value())
+					require.EqualValues(t, previous.Value(), commit.Value(), "commit values")
 				}
 				if !test.RandomRound {
-					require.EqualValues(t, test.DecideRound, commit.Round())
+					require.EqualValues(t, test.DecideRound, commit.Round(), "wrong decide round")
 					if test.PreparedVal != 0 { // Check prepared value if set
-						require.EqualValues(t, test.PreparedVal, commit.Value())
+						require.EqualValues(t, test.PreparedVal, commit.Value(), "wrong prepared value")
 					} else { // Otherwise check that leader value was used.
-						require.True(t, isLeader(test.Instance, commit.Round(), commit.Value()))
+						require.True(t, isLeader(test.Instance, commit.Round(), commit.Value()), "not leader")
 					}
 				}
 				results[commit.Source()] = commit


### PR DESCRIPTION
This PR:
 - fixes a data race in p2p.Sender which was flapping in integration and compose tests
 - makes "prepare round 2, decide round 3" QBFT internal test more reliable; tested empirically by running the test 100.000 times, usually the flapping issue manifested itself after a couple runs

category: bug
ticket: #2763

Closes #2763.