### PR TITLE
p2p: fix data race in test

### DIFF
--- a/p2p/sender_internal_test.go
+++ b/p2p/sender_internal_test.go
@@ -34,7 +34,7 @@ func TestSenderAddResult(t *testing.T) {
 		if val, ok := sender.states.Load(peerID); ok {
 			state = val.(*peerState)
 		}
-		require.Equal(t, expect, state.failing)
+		require.Equal(t, expect, state.failing.Load())
 	}
 
 	add := func(result error) {


### PR DESCRIPTION
`peerState.failing` can be accessed concurrently by integration tests.

Make sure to guard its access with an `atomic.Bool`.

category: bug
ticket: #2784 