### PR TITLE
core/validatorapi: propose block v3

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -442,7 +442,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	if err := wireVAPIRouter(ctx, life, conf.ValidatorAPIAddr, eth2Cl, vapi, vapiCalls); err != nil {
+	if err := wireVAPIRouter(ctx, life, conf.ValidatorAPIAddr, eth2Cl, vapi, vapiCalls, mutableConf); err != nil {
 		return err
 	}
 
@@ -896,9 +896,11 @@ func createMockValidators(pubkeys []eth2p0.BLSPubKey) beaconmock.ValidatorSet {
 
 // wireVAPIRouter constructs the validator API router and registers it with the life cycle manager.
 func wireVAPIRouter(ctx context.Context, life *lifecycle.Manager, vapiAddr string, eth2Cl eth2wrap.Client,
-	handler validatorapi.Handler, vapiCalls func(),
+	handler validatorapi.Handler, vapiCalls func(), mutableConf *mutableConfig,
 ) error {
-	vrouter, err := validatorapi.NewRouter(ctx, handler, eth2Cl)
+	vrouter, err := validatorapi.NewRouter(ctx, handler, eth2Cl, func(slot uint64) bool {
+		return mutableConf.BuilderAPI(slot)
+	})
 	if err != nil {
 		return errors.Wrap(err, "new monitoring server")
 	}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -48,8 +48,8 @@ type contentType string
 const (
 	contentTypeJSON               contentType = "application/json"
 	contentTypeSSZ                contentType = "application/octet-stream"
-	VersionHeader                             = "Eth-Consensus-Version"
-	ExecutionPayloadBlindedHeader             = "Eth-Execution-Payload-Blinded"
+	versionHeader                             = "Eth-Consensus-Version"
+	executionPayloadBlindedHeader             = "Eth-Execution-Payload-Blinded"
 )
 
 // Handler defines the request handler providing the business logic
@@ -653,9 +653,8 @@ func proposeBlockV3(p proposeBlockV3Provider, getBuilderAPI core.BuilderEnabled)
 				return nil, nil, err
 			}
 
-			block := eth2Resp.Data
-			version = block.Version.String()
-			proposedBlock, err = createProposeBlockResponse(block)
+			version = eth2Resp.Data.Version.String()
+			proposedBlock, err = createProposeBlockResponse(eth2Resp.Data)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -671,18 +670,17 @@ func proposeBlockV3(p proposeBlockV3Provider, getBuilderAPI core.BuilderEnabled)
 				return nil, nil, err
 			}
 
-			block := eth2Resp.Data
 			blinded = true
-			version = block.Version.String()
-			proposedBlock, err = createProposeBlindedBlockResponse(block)
+			version = eth2Resp.Data.Version.String()
+			proposedBlock, err = createProposeBlindedBlockResponse(eth2Resp.Data)
 			if err != nil {
 				return nil, nil, err
 			}
 		}
 
 		resHeaders := make(http.Header)
-		resHeaders.Add(VersionHeader, version)
-		resHeaders.Add(ExecutionPayloadBlindedHeader, strconv.FormatBool(blinded))
+		resHeaders.Add(versionHeader, version)
+		resHeaders.Add(executionPayloadBlindedHeader, strconv.FormatBool(blinded))
 
 		// TODO: Support "Eth-Execution-Payload-Value" & "Eth-Consensus-Block-Value" headers.
 
@@ -711,7 +709,7 @@ func proposeBlock(p eth2client.ProposalProvider) handlerFunc {
 		block := eth2Resp.Data
 
 		resHeaders := make(http.Header)
-		resHeaders.Add(VersionHeader, block.Version.String())
+		resHeaders.Add(versionHeader, block.Version.String())
 
 		proposedBlock, err := createProposeBlockResponse(block)
 
@@ -740,7 +738,7 @@ func proposeBlindedBlock(p eth2client.BlindedProposalProvider) handlerFunc {
 		block := eth2Resp.Data
 
 		resHeaders := make(http.Header)
-		resHeaders.Add(VersionHeader, block.Version.String())
+		resHeaders.Add(versionHeader, block.Version.String())
 
 		proposedBlindedBlock, err := createProposeBlindedBlockResponse(block)
 

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -1568,13 +1568,13 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 }
 
 // testRawRouterEX is a helper function same as testRawRouter() but accepts GetBuilderAPIFlagFunc.
-func testRawRouterEx(t *testing.T, handler testHandler, callback func(context.Context, string), builderEnabledFunc GetBuilderAPIFlagFunc) {
+func testRawRouterEx(t *testing.T, handler testHandler, callback func(context.Context, string), isBuilderEnabled IsBuilderEnabledFunc) {
 	t.Helper()
 
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))
 	defer proxy.Close()
 
-	r, err := NewRouter(context.Background(), handler, testBeaconAddr{addr: proxy.URL}, builderEnabledFunc)
+	r, err := NewRouter(context.Background(), handler, testBeaconAddr{addr: proxy.URL}, isBuilderEnabled)
 	require.NoError(t, err)
 
 	server := httptest.NewServer(r)

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -523,7 +523,7 @@ func TestRawRouter(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify response header.
-			require.Equal(t, block.Version.String(), res.Header.Get(VersionHeader))
+			require.Equal(t, block.Version.String(), res.Header.Get(versionHeader))
 
 			var blockRes proposeBlockResponseCapella
 			err = json.NewDecoder(res.Body).Decode(&blockRes)
@@ -556,7 +556,7 @@ func TestRawRouter(t *testing.T) {
 			require.NoError(t, err)
 
 			// Verify response header.
-			require.Equal(t, block.Version.String(), res.Header.Get(VersionHeader))
+			require.Equal(t, block.Version.String(), res.Header.Get(versionHeader))
 
 			var blockRes proposeBlindedBlockResponseCapella
 			err = json.NewDecoder(res.Body).Decode(&blockRes)
@@ -610,8 +610,8 @@ func TestRawRouter(t *testing.T) {
 			res := mustGetRequest(baseURL, blindedExpectedSlot, blindedRandao)
 
 			// Verify response header.
-			require.Equal(t, blindedBlock.Version.String(), res.Header.Get(VersionHeader))
-			require.Equal(t, "true", res.Header.Get(ExecutionPayloadBlindedHeader))
+			require.Equal(t, blindedBlock.Version.String(), res.Header.Get(versionHeader))
+			require.Equal(t, "true", res.Header.Get(executionPayloadBlindedHeader))
 
 			var blockRes proposeBlindedBlockResponseCapella
 			err = json.NewDecoder(res.Body).Decode(&blockRes)
@@ -626,8 +626,8 @@ func TestRawRouter(t *testing.T) {
 			res := mustGetRequest(baseURL, expectedSlot, randao)
 
 			// Verify response header.
-			require.Equal(t, block.Version.String(), res.Header.Get(VersionHeader))
-			require.Equal(t, "false", res.Header.Get(ExecutionPayloadBlindedHeader))
+			require.Equal(t, block.Version.String(), res.Header.Get(versionHeader))
+			require.Equal(t, "false", res.Header.Get(executionPayloadBlindedHeader))
 
 			var blockRes proposeBlockResponseCapella
 			err = json.NewDecoder(res.Body).Decode(&blockRes)
@@ -1726,7 +1726,7 @@ func (h testHandler) newBeaconHandler(t *testing.T) http.Handler {
 	})
 	mux.HandleFunc("/eth/v2/debug/beacon/states/head", func(w http.ResponseWriter, r *http.Request) {
 		res := testutil.RandomBeaconState(t)
-		w.Header().Add(VersionHeader, res.Version.String())
+		w.Header().Add(versionHeader, res.Version.String())
 
 		writeResponse(ctx, w, "", nest(res.Capella, "data"), nil)
 	})

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
 	"github.com/obolnetwork/charon/testutil"
 )
@@ -619,7 +620,7 @@ func TestRawRouter(t *testing.T) {
 		}
 
 		// BuilderAPI is disabled, we expect to get the blinded block
-		testRawRouterEx(t, handler, blindedCallback, func(_ uint64) bool { return false })
+		testRawRouterEx(t, handler, blindedCallback, func(_ uint64) bool { return true })
 
 		callback := func(ctx context.Context, baseURL string) {
 			res := mustGetRequest(baseURL, expectedSlot, randao)
@@ -635,7 +636,7 @@ func TestRawRouter(t *testing.T) {
 		}
 
 		// BuilderAPI is enabled, we expect to get the full block
-		testRawRouterEx(t, handler, callback, func(_ uint64) bool { return true })
+		testRawRouterEx(t, handler, callback, func(_ uint64) bool { return false })
 	})
 }
 
@@ -1570,7 +1571,7 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 }
 
 // testRawRouterEX is a helper function same as testRawRouter() but accepts GetBuilderAPIFlagFunc.
-func testRawRouterEx(t *testing.T, handler testHandler, callback func(context.Context, string), isBuilderEnabled IsBuilderEnabledFunc) {
+func testRawRouterEx(t *testing.T, handler testHandler, callback func(context.Context, string), isBuilderEnabled core.BuilderEnabled) {
 	t.Helper()
 
 	proxy := httptest.NewServer(handler.newBeaconHandler(t))

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -1564,6 +1564,8 @@ func testRouter(t *testing.T, handler testHandler, callback func(context.Context
 // provides the mocked test handler and a callback that does the client side test.
 // The router is configured with BuilderAPI always enabled.
 func testRawRouter(t *testing.T, handler testHandler, callback func(context.Context, string)) {
+	t.Helper()
+
 	testRawRouterEx(t, handler, callback, func(_ uint64) bool { return true })
 }
 


### PR DESCRIPTION
Initial implementation of `/eth/v3/validator/blocks/{slot}` endpoint in according with the design doc.
Introduced some refactoring to the existing v1/v2 endpoints to reduce code duplication.

category: feature
ticket: #2749
