### PR TITLE
cmd: create dkg cli to support partial deposits

### DIFF
--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -17,6 +17,7 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/deposit"
 	"github.com/obolnetwork/charon/eth2util/enr"
 )
 
@@ -29,6 +30,7 @@ type createDKGConfig struct {
 	WithdrawalAddrs   []string
 	Network           string
 	DKGAlgo           string
+	DepositAmounts    []int // Amounts specified in ETH (integers).
 	OperatorENRs      []string
 }
 
@@ -61,6 +63,7 @@ func bindCreateDKGFlags(cmd *cobra.Command, config *createDKGConfig) {
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
 	cmd.Flags().StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia, holesky.")
 	cmd.Flags().StringVar(&config.DKGAlgo, "dkg-algorithm", "default", "DKG algorithm to use; default, frost")
+	cmd.Flags().IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to exactly 32ETH.")
 	cmd.Flags().StringSliceVar(&config.OperatorENRs, operatorENRs, nil, "[REQUIRED] Comma-separated list of each operator's Charon ENR address.")
 
 	mustMarkFlagRequired(cmd, operatorENRs)
@@ -79,7 +82,7 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 		conf.Network = eth2util.Goerli.Name
 	}
 
-	if err = validateDKGConfig(conf.Threshold, len(conf.OperatorENRs), conf.Network); err != nil {
+	if err = validateDKGConfig(conf.Threshold, len(conf.OperatorENRs), conf.Network, conf.DepositAmounts); err != nil {
 		return err
 	}
 
@@ -124,7 +127,7 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 	def, err := cluster.NewDefinition(
 		conf.Name, conf.NumValidators, conf.Threshold,
 		conf.FeeRecipientAddrs, conf.WithdrawalAddrs,
-		forkVersion, cluster.Creator{}, operators, nil, crand.Reader,
+		forkVersion, cluster.Creator{}, operators, conf.DepositAmounts, crand.Reader,
 		func(d *cluster.Definition) {
 			d.DKGAlgorithm = conf.DKGAlgo
 		})
@@ -175,7 +178,7 @@ func validateWithdrawalAddrs(addrs []string, network string) error {
 }
 
 // validateDKGConfig returns an error if any of the provided config parameter is invalid.
-func validateDKGConfig(threshold, numOperators int, network string) error {
+func validateDKGConfig(threshold, numOperators int, network string, depositAmounts []int) error {
 	if threshold > numOperators {
 		return errors.New("threshold cannot be greater than length of operators",
 			z.Int("threshold", threshold), z.Int("operators", numOperators))
@@ -188,6 +191,14 @@ func validateDKGConfig(threshold, numOperators int, network string) error {
 
 	if !eth2util.ValidNetwork(network) {
 		return errors.New("unsupported network", z.Str("network", network))
+	}
+
+	if len(depositAmounts) > 0 {
+		amounts := deposit.EthsToGweis(depositAmounts)
+
+		if err := deposit.VerifyDepositAmounts(amounts); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -29,6 +29,7 @@ func TestCreateDkgValid(t *testing.T) {
 		WithdrawalAddrs:   []string{validEthAddr},
 		Network:           defaultNetwork,
 		DKGAlgo:           "default",
+		DepositAmounts:    []int{8, 16, 4, 4},
 		OperatorENRs: []string{
 			"enr:-JG4QFI0llFYxSoTAHm24OrbgoVx77dL6Ehl1Ydys39JYoWcBhiHrRhtGXDTaygWNsEWFb1cL7a1Bk0klIdaNuXplKWGAYGv0Gt7gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL6bcis0tFXnbqG4KuywxT5BLhtmijPFApKCDJNl3mXFYN0Y3CCDhqDdWRwgg4u",
 			"enr:-JG4QPnqHa7FU3PBqGxpV5L0hjJrTUqv8Wl6_UTHt-rELeICWjvCfcVfwmax8xI_eJ0ntI3ly9fgxAsmABud6-yBQiuGAYGv0iYPgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMLLCMZ5Oqi_sdnBfdyhmysZMfFm78PgF7Y9jitTJPSroN0Y3CCPoODdWRwgj6E",
@@ -182,21 +183,26 @@ func TestValidateDKGConfig(t *testing.T) {
 	t.Run("invalid threshold", func(t *testing.T) {
 		threshold := 5
 		numOperators := 4
-		err := validateDKGConfig(threshold, numOperators, "")
+		err := validateDKGConfig(threshold, numOperators, "", nil)
 		require.ErrorContains(t, err, "threshold cannot be greater than length of operators")
 	})
 
 	t.Run("insufficient ENRs", func(t *testing.T) {
 		threshold := 1
 		numOperators := 2
-		err := validateDKGConfig(threshold, numOperators, "")
+		err := validateDKGConfig(threshold, numOperators, "", nil)
 		require.ErrorContains(t, err, "insufficient operator ENRs")
 	})
 
 	t.Run("invalid network", func(t *testing.T) {
 		threshold := 3
 		numOperators := 4
-		err := validateDKGConfig(threshold, numOperators, "cosmos")
+		err := validateDKGConfig(threshold, numOperators, "cosmos", nil)
 		require.ErrorContains(t, err, "unsupported network")
+	})
+
+	t.Run("wrong deposit amounts sum", func(t *testing.T) {
+		err := validateDKGConfig(3, 4, "goerli", []int{8, 16})
+		require.ErrorContains(t, err, "sum of partial deposit amounts must sum up to 32ETH")
 	})
 }

--- a/docs/dkg.md
+++ b/docs/dkg.md
@@ -64,7 +64,7 @@ No user input is required, charon does the work and outputs the following files 
 ./cluster-lock.json         # New lockfile based on cluster-definition.json with validator group public keys and public shares included with the initial cluster config
 ./charon/enr_private_key    # Created before the ceremony took place [Back this up]
 ./charon/validator_keys/    # Folder of key shares to be backed up and moved to validator client [Back this up]
-./charon/deposit_data       # JSON file of deposit data for the distributed validators
+./charon/deposit_data*      # JSON files of deposit data for the distributed validators
 ./charon/exit_data          # JSON file of exit data that ethdo can broadcast
 ```
 


### PR DESCRIPTION
Added `--deposit-amounts` flag to `create dkg` command. DKG procedure itself does not respect the partial amounts yet. This PR only introduces the flag, validation and a bug fix in the previous validation logic.

category: feature
ticket: none
