### PR TITLE
cmd: fixing builder registration timestamp

### DIFF
--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -318,6 +318,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 		}
 
 		previousVersions := []string{"v1.0.0", "v1.1.0", "v1.2.0", "v1.3.0", "v1.4.0", "v1.5.0"}
+		nowUTC := time.Now().UTC()
 		for _, val := range lock.Validators {
 			if isAnyVersion(lock.Version, previousVersions...) {
 				break
@@ -329,6 +330,13 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 
 			if isAnyVersion(lock.Version, "v1.7.0") {
 				require.NotEmpty(t, val.BuilderRegistration)
+			}
+
+			if conf.SplitKeys {
+				// For SplitKeys mode, builder registration timestamp must be close to Now().
+				// This assumes the test does not execute longer than five minutes.
+				// We just need to make sure the message timestamp is not a genesis time.
+				require.Less(t, nowUTC.Sub(val.BuilderRegistration.Message.Timestamp), 5*time.Minute, "likely a genesis timestamp")
 			}
 		}
 


### PR DESCRIPTION
Cherrypick of #2810 

---

Use the current timestamp for builder registration messages when using `--split-existing-keys` mode.

See [the issue](https://github.com/ObolNetwork/charon/issues/2770) for the full context.

category: bug
ticket: #2770
