### PR TITLE
*: add Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ go-setup:
 	go mod tidy
 
 charon: go-setup
-	go build -ldflags="-X github.com/obolnetwork/charon/app/version.version=$(shell bash charon_version.sh)"
+	go build -trimpath -ldflags="-buildid= -s -w -X github.com/obolnetwork/charon/app/version.version=$(shell bash charon_version.sh)"
 
 clean:
 	$(RM) charon

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: charon go-setup clean
+
+all: clean charon
+
+go-setup:
+	go mod tidy
+
+charon: go-setup
+	go build -ldflags="-X github.com/obolnetwork/charon/app/version.version=$(shell bash charon_version.sh)"
+
+clean:
+	$(RM) charon

--- a/charon_version.sh
+++ b/charon_version.sh
@@ -1,0 +1,23 @@
+GIT_TAG=$(git describe --exact-match --tags HEAD 2>/dev/null)
+APP_VERSION=$(grep 'var version' app/version/version.go | cut -d'"' -f2)
+
+git diff-files --quiet
+DIRTY=$?
+
+FINAL_TAG=""
+if [[ ${#GIT_TAG} == 0 ]]; then
+    FINAL_TAG=$APP_VERSION
+
+    if [[ $DIRTY == 1 ]]; then
+        FINAL_TAG="${FINAL_TAG}-DIRTY"
+    fi
+else
+    FINAL_TAG=$GIT_TAG
+
+    if [[ $DIRTY == 1 ]]; then
+        FINAL_TAG="${FINAL_TAG}-DIRTY"
+    fi
+
+fi
+
+echo $FINAL_TAG


### PR DESCRIPTION
Add a Makefile to make compiling a release-ready Charon binary easier.

The `charon_version.sh` script generates a version string based on the current git status:

 - if the repo has a git tag selected, the version string in that binary will be that
 - if the repo does not have a git tag selected, the version string is whatever is written in `app/version/version.go`
 - if the repo is dirty (i.e. there are uncommitted changes) the version string will have `-DIRTY` appended at the end

This information will be baked in the final binary, and can be viewed with `charon version`.

For a given architecture/OS combo, multiple invocation of `make` will produce binaries with the same SHA-256 hash.

category: misc
ticket: none
