### PR TITLE
cluster: handle definition download error

### DIFF
--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -37,6 +37,11 @@ func FetchDefinition(ctx context.Context, url string) (Definition, error) {
 	if err != nil {
 		return Definition{}, errors.Wrap(err, "fetch file")
 	}
+
+	if resp.StatusCode/100 != 2 {
+		return Definition{}, errors.New("http error", z.Int("status_code", resp.StatusCode))
+	}
+
 	defer resp.Body.Close()
 
 	buf, err := io.ReadAll(resp.Body)

--- a/cluster/helpers_internal_test.go
+++ b/cluster/helpers_internal_test.go
@@ -87,6 +87,8 @@ func TestFetchDefinition(t *testing.T) {
 		case "/invalidDef":
 			b, _ := invalidDef.MarshalJSON()
 			_, _ = w.Write(b)
+		case "/nonok":
+			w.WriteHeader(http.StatusInternalServerError)
 		}
 	}))
 	defer server.Close()
@@ -106,6 +108,12 @@ func TestFetchDefinition(t *testing.T) {
 		{
 			name:    "Fetch invalid definition",
 			url:     fmt.Sprintf("%s/%s", server.URL, "invalidDef"),
+			want:    invalidDef,
+			wantErr: true,
+		},
+		{
+			name:    "HTTP status is not in the 200 range",
+			url:     fmt.Sprintf("%s/%s", server.URL, "nonok"),
 			want:    invalidDef,
 			wantErr: true,
 		},


### PR DESCRIPTION
Handle non-200 HTTP status code in a graceful way, returning it instead of potentially unmarshalling-related errors.

category: bug
ticket: #2897

Closes #2897.