### PR TITLE
cmd: remove todos

### DIFF
--- a/cluster/manifest/helpers.go
+++ b/cluster/manifest/helpers.go
@@ -131,8 +131,6 @@ func SignK1(m *manifestpb.Mutation, secret *k1.PrivateKey) (*manifestpb.SignedMu
 }
 
 // verifyK1SignedMutation verifies that the signed mutation is signed by a k1 key.
-//
-// TODO(corver): Figure out no-verify case.
 func verifyK1SignedMutation(signed *manifestpb.SignedMutation) error {
 	pubkey, err := k1.ParsePubKey(signed.Signer)
 	if err != nil {

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -104,7 +104,6 @@ func TestValidateConfigAddValidators(t *testing.T) {
 	}
 }
 
-// TODO(xenowits): Add more extensive tests, this is just a very simple unit test.
 func TestRunAddValidators(t *testing.T) {
 	const (
 		n        = 3

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -77,7 +77,6 @@ func mustMarkFlagRequired(cmd *cobra.Command, flag string) {
 
 func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 	// Map prater to goerli to ensure backwards compatibility with older cluster definitions.
-	// TODO(xenowits): Remove the mapping later.
 	if conf.Network == eth2util.Prater {
 		conf.Network = eth2util.Goerli.Name
 	}

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -45,7 +45,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 func bindRelayFlag(cmd *cobra.Command, config *relay.Config) {
 	cmd.Flags().StringVar(&config.HTTPAddr, "http-address", "127.0.0.1:3640", "Listening address (ip and port) for the relay http server serving runtime ENR.")
 	cmd.Flags().BoolVar(&config.AutoP2PKey, "auto-p2pkey", true, "Automatically create a p2pkey (secp256k1 private key used for p2p authentication and ENR) if none found in data directory.")
-	cmd.Flags().StringVar(&config.RelayLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error.")
+	cmd.Flags().StringVar(&config.LibP2PLogLevel, "p2p-relay-loglevel", "", "Libp2p circuit relay log level. E.g., debug, info, warn, error.")
 
 	// Decrease defaults after this has been addressed https://github.com/libp2p/go-libp2p/issues/1713
 	cmd.Flags().IntVar(&config.MaxResPerPeer, "p2p-max-reservations", 512, "Updates max circuit reservations per peer (each valid for 30min)")

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -30,11 +30,11 @@ func startP2P(ctx context.Context, config Config, key *k1.PrivateKey, reporter m
 		return nil, errors.New("p2p TCP addresses required")
 	}
 
-	if config.RelayLogLevel != "" {
-		if err := libp2plog.SetLogLevel("relay", config.RelayLogLevel); err != nil {
+	if config.LibP2PLogLevel != "" {
+		if err := libp2plog.SetLogLevel("relay", config.LibP2PLogLevel); err != nil {
 			return nil, errors.Wrap(err, "set relay log level")
 		}
-		if err := libp2plog.SetLogLevel("rcmgr", config.RelayLogLevel); err != nil {
+		if err := libp2plog.SetLogLevel("rcmgr", config.LibP2PLogLevel); err != nil {
 			return nil, errors.Wrap(err, "set rcmgr log level")
 		}
 	}

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -41,7 +41,7 @@ type Config struct {
 	MaxResPerPeer   int
 	MaxConns        int
 	FilterPrivAddrs bool
-	RelayLogLevel   string // TODO(corver): Rename to LibP2PLogLevel.
+	LibP2PLogLevel  string
 }
 
 // Run starts an Obol libp2p-tcp-relay and udp-discv5 bootnode.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -94,7 +94,6 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	})
 }
 
-// TODO(dhruv): add more test only flags to this function.
 func bindUnsafeRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().BoolVar(&config.TestConfig.P2PFuzz, "p2p-fuzz", false, "Configures charon to send fuzzed data via p2p network to its peers.")
 }


### PR DESCRIPTION
Removes TODOs in the `cmd` package.

category: misc
ticket: none 
