### PR TITLE
app/obolapi: add exit endpoints

### DIFF
--- a/app/obolapi/exit.go
+++ b/app/obolapi/exit.go
@@ -1,0 +1,238 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package obolapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"strings"
+
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/k1util"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/tbls/tblsconv"
+)
+
+const (
+	lockHashPath     = "{lock_hash}"
+	valPubkeyPath    = "{validator_pubkey}"
+	shareIndexPath   = "{share_index}"
+	fullExitBaseTmpl = "/exp/exit"
+	fullExitEndTmp   = "/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
+
+	partialExitTmpl = "/exp/partial_exits/" + lockHashPath
+	fullExitTmpl    = fullExitBaseTmpl + fullExitEndTmp
+)
+
+var ErrNoExit = errors.New("no exit for the given validator public key")
+
+// partialExitURL returns the partial exit Obol API URL for a given lock hash.
+func partialExitURL(lockHash string) string {
+	return strings.NewReplacer(
+		lockHashPath,
+		lockHash,
+	).Replace(partialExitTmpl)
+}
+
+// bearerString returns the bearer token authentication string given a token.
+func bearerString(data []byte) string {
+	return fmt.Sprintf("Bearer %#x", data)
+}
+
+// fullExitURL returns the full exit Obol API URL for a given validator public key.
+func fullExitURL(valPubkey, lockHash string, shareIndex uint64) string {
+	return strings.NewReplacer(
+		valPubkeyPath,
+		valPubkey,
+		lockHashPath,
+		lockHash,
+		shareIndexPath,
+		strconv.FormatUint(shareIndex, 10),
+	).Replace(fullExitTmpl)
+}
+
+// PostPartialExit POSTs the set of msg's to the Obol API, for a given lock hash.
+func (c Client) PostPartialExit(ctx context.Context, lockHash []byte, shareIndex uint64, identityKey *k1.PrivateKey, exitBlobs ...ExitBlob) error {
+	lockHashStr := "0x" + hex.EncodeToString(lockHash)
+
+	path := partialExitURL(lockHashStr)
+
+	u, err := url.ParseRequestURI(c.baseURL)
+	if err != nil {
+		return errors.Wrap(err, "bad obol api url")
+	}
+
+	u.Path = path
+
+	// sort by validator index ascending
+	sort.Slice(exitBlobs, func(i, j int) bool {
+		return exitBlobs[i].SignedExitMessage.Message.ValidatorIndex < exitBlobs[j].SignedExitMessage.Message.ValidatorIndex
+	})
+
+	msg := UnsignedPartialExitRequest{
+		ShareIdx:     shareIndex,
+		PartialExits: exitBlobs,
+	}
+
+	msgRoot, err := msg.HashTreeRoot()
+	if err != nil {
+		return errors.Wrap(err, "partial exits hash tree root")
+	}
+
+	signature, err := k1util.Sign(identityKey, msgRoot[:])
+	if err != nil {
+		return errors.Wrap(err, "k1 sign")
+	}
+
+	data, err := json.Marshal(PartialExitRequest{
+		UnsignedPartialExitRequest: msg,
+		Signature:                  signature,
+	})
+	if err != nil {
+		return errors.Wrap(err, "json marshal error")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(data))
+	if err != nil {
+		return errors.Wrap(err, "http new post request")
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "http post error")
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	if resp.StatusCode != http.StatusCreated {
+		return errors.New("http error", z.Int("status_code", resp.StatusCode))
+	}
+
+	return nil
+}
+
+// GetFullExit gets the full exit message for a given validator public key, lock hash and share index.
+func (c Client) GetFullExit(ctx context.Context, valPubkey string, lockHash []byte, shareIndex uint64, identityKey *k1.PrivateKey) (ExitBlob, error) {
+	valPubkeyBytes, err := from0x(valPubkey, 48) // public key is 48 bytes long
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "validator pubkey to bytes")
+	}
+
+	path := fullExitURL(valPubkey, "0x"+hex.EncodeToString(lockHash), shareIndex)
+
+	u, err := url.ParseRequestURI(c.baseURL)
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "bad obol api url")
+	}
+
+	u.Path = path
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "http new get request")
+	}
+
+	exitAuthData := FullExitAuthBlob{
+		LockHash:        lockHash,
+		ValidatorPubkey: valPubkeyBytes,
+		ShareIndex:      shareIndex,
+	}
+
+	exitAuthDataRoot, err := exitAuthData.HashTreeRoot()
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "exit auth data root")
+	}
+
+	// sign the lockHash *bytes* with identity key
+	lockHashSignature, err := k1util.Sign(identityKey, exitAuthDataRoot[:])
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "k1 sign")
+	}
+
+	req.Header.Set("Authorization", bearerString(lockHashSignature))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "http get error")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		if resp.StatusCode == http.StatusNotFound {
+			return ExitBlob{}, ErrNoExit
+		}
+
+		return ExitBlob{}, errors.New("http error", z.Int("status_code", resp.StatusCode))
+	}
+
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	var er FullExitResponse
+	if err := json.NewDecoder(resp.Body).Decode(&er); err != nil {
+		return ExitBlob{}, errors.Wrap(err, "json unmarshal error")
+	}
+
+	// do aggregation
+	rawSignatures := make(map[int]tbls.Signature)
+
+	for sigIdx, sigStr := range er.Signatures {
+		if len(sigStr) == 0 {
+			// ignore, the associated share index didn't push a partial signature yet
+			continue
+		}
+
+		if len(sigStr) < 2 {
+			return ExitBlob{}, errors.New("signature string has invalid size", z.Int("size", len(sigStr)))
+		}
+
+		sigBytes, err := from0x(sigStr, 96) // a signature is 96 bytes long
+		if err != nil {
+			return ExitBlob{}, errors.Wrap(err, "partial signature unmarshal")
+		}
+
+		sig, err := tblsconv.SignatureFromBytes(sigBytes)
+		if err != nil {
+			return ExitBlob{}, errors.Wrap(err, "invalid partial signature")
+		}
+
+		rawSignatures[sigIdx+1] = sig
+	}
+
+	fullSig, err := tbls.ThresholdAggregate(rawSignatures)
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "partial signatures threshold aggregate")
+	}
+
+	epochUint64, err := strconv.ParseUint(er.Epoch, 10, 64)
+	if err != nil {
+		return ExitBlob{}, errors.Wrap(err, "epoch parsing")
+	}
+
+	return ExitBlob{
+		PublicKey: valPubkey,
+		SignedExitMessage: eth2p0.SignedVoluntaryExit{
+			Message: &eth2p0.VoluntaryExit{
+				Epoch:          eth2p0.Epoch(epochUint64),
+				ValidatorIndex: er.ValidatorIndex,
+			},
+			Signature: eth2p0.BLSSignature(fullSig),
+		},
+	}, nil
+}

--- a/app/obolapi/exit_model.go
+++ b/app/obolapi/exit_model.go
@@ -1,0 +1,277 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package obolapi
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+const (
+	// sszMaxExits is the maximum amount of exit messages in an array.
+	sszMaxExits = 65536
+
+	// sszLenPubKey is the length of a BLS validator public key.
+	sszLenPubKey = 48
+)
+
+// PartialExitRequest represents the blob of data sent to the Obol API server, which is stored in the backend awaiting
+// aggregation.
+// Signature is the EC signature of PartialExits's hash tree root done with the Charon node identity key.
+type PartialExitRequest struct {
+	UnsignedPartialExitRequest
+	Signature []byte `json:"signature"`
+}
+
+// partialExitRequestDTO is PartialExitRequest, but for serialization on the wire.
+type partialExitRequestDTO struct {
+	UnsignedPartialExitRequest
+	Signature string `json:"signature"`
+}
+
+func (p *PartialExitRequest) UnmarshalJSON(bytes []byte) error {
+	var dto partialExitRequestDTO
+
+	if err := json.Unmarshal(bytes, &dto); err != nil {
+		//nolint: wrapcheck // caller will wrap this error
+		return err
+	}
+
+	// a signature is 96 bytes long
+	sigBytes, err := from0x(dto.Signature, 65)
+	if err != nil {
+		return err
+	}
+
+	p.UnsignedPartialExitRequest = dto.UnsignedPartialExitRequest
+	p.Signature = sigBytes
+
+	return nil
+}
+
+func (p PartialExitRequest) MarshalJSON() ([]byte, error) {
+	dto := partialExitRequestDTO{
+		UnsignedPartialExitRequest: p.UnsignedPartialExitRequest,
+		Signature:                  fmt.Sprintf("%#x", p.Signature),
+	}
+
+	//nolint: wrapcheck // caller will wrap this error
+	return json.Marshal(dto)
+}
+
+// UnsignedPartialExitRequest represents an unsigned blob of data sent to the Obol API server, which is stored in the backend awaiting
+// aggregation.
+type UnsignedPartialExitRequest struct {
+	PartialExits PartialExits `json:"partial_exits"`
+	ShareIdx     uint64       `json:"share_idx,omitempty"`
+}
+
+func (p UnsignedPartialExitRequest) GetTree() (*ssz.Node, error) {
+	node, err := ssz.ProofTree(p)
+	if err != nil {
+		return nil, errors.Wrap(err, "proof tree")
+	}
+
+	return node, nil
+}
+
+func (p UnsignedPartialExitRequest) HashTreeRoot() ([32]byte, error) {
+	hash, err := ssz.HashWithDefaultHasher(p)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash with default hasher")
+	}
+
+	return hash, nil
+}
+
+func (p UnsignedPartialExitRequest) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+
+	if err := p.PartialExits.HashTreeRootWith(hh); err != nil {
+		return errors.Wrap(err, "hash tree root with")
+	}
+
+	hh.PutUint64(p.ShareIdx)
+
+	hh.Merkleize(indx)
+
+	return nil
+}
+
+// PartialExits is an array of ExitMessage that have been signed with a partial key.
+type PartialExits []ExitBlob
+
+func (p PartialExits) GetTree() (*ssz.Node, error) {
+	hash, err := ssz.ProofTree(p)
+	if err != nil {
+		return nil, errors.Wrap(err, "proof tree")
+	}
+
+	return hash, nil
+}
+
+func (p PartialExits) HashTreeRoot() ([32]byte, error) {
+	hash, err := ssz.HashWithDefaultHasher(p)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash with default hasher")
+	}
+
+	return hash, nil
+}
+
+func (p PartialExits) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+
+	num := uint64(len(p))
+	for _, pe := range p {
+		if err := pe.HashTreeRootWith(hh); err != nil {
+			return err
+		}
+	}
+
+	hh.MerkleizeWithMixin(indx, num, sszMaxExits)
+
+	return nil
+}
+
+// FullExitResponse contains all partial signatures, epoch and validator index to construct a full exit message for
+// a validator.
+// Signatures are ordered by share index.
+type FullExitResponse struct {
+	Epoch          string                `json:"epoch"`
+	ValidatorIndex eth2p0.ValidatorIndex `json:"validator_index"`
+	Signatures     []string              `json:"signatures"`
+}
+
+// FullExitAuthBlob represents the data required by Obol API to download the full exit blobs.
+type FullExitAuthBlob struct {
+	LockHash        []byte
+	ValidatorPubkey []byte
+	ShareIndex      uint64
+}
+
+func (f FullExitAuthBlob) GetTree() (*ssz.Node, error) {
+	node, err := ssz.ProofTree(f)
+	if err != nil {
+		return nil, errors.Wrap(err, "proof tree")
+	}
+
+	return node, nil
+}
+
+func (f FullExitAuthBlob) HashTreeRoot() ([32]byte, error) {
+	hash, err := ssz.HashWithDefaultHasher(f)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash with default hasher")
+	}
+
+	return hash, nil
+}
+
+func (f FullExitAuthBlob) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+
+	hh.PutBytes(f.LockHash)
+	if err := putBytesN(hh, f.ValidatorPubkey, sszLenPubKey); err != nil {
+		return errors.Wrap(err, "validator pubkey ssz")
+	}
+	hh.PutUint64(f.ShareIndex)
+
+	hh.Merkleize(indx)
+
+	return nil
+}
+
+// ExitBlob is an exit message alongside its BLS12-381 hex-encoded signature.
+type ExitBlob struct {
+	PublicKey         string                     `json:"public_key,omitempty"`
+	SignedExitMessage eth2p0.SignedVoluntaryExit `json:"signed_exit_message"`
+}
+
+func (e ExitBlob) GetTree() (*ssz.Node, error) {
+	node, err := ssz.ProofTree(e)
+	if err != nil {
+		return nil, errors.Wrap(err, "proof tree")
+	}
+
+	return node, nil
+}
+
+func (e ExitBlob) HashTreeRoot() ([32]byte, error) {
+	hash, err := ssz.HashWithDefaultHasher(e)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash with default hasher")
+	}
+
+	return hash, nil
+}
+
+func (e ExitBlob) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+
+	pkBytes, err := from0x(e.PublicKey, 48) // public key is 48 bytes long
+	if err != nil {
+		return errors.Wrap(err, "pubkey to bytes")
+	}
+
+	// Field (0) 'PublicKey'
+	hh.PutBytes(pkBytes)
+
+	// Field (1) 'SignedExitMessage'
+	if err := e.SignedExitMessage.HashTreeRootWith(hh); err != nil {
+		return errors.Wrap(err, "signed exit message hash tree root")
+	}
+
+	hh.Merkleize(indx)
+
+	return nil
+}
+
+// leftPad returns the byte slice left padded with zero to ensure a length of at least l.
+func leftPad(b []byte, l int) []byte {
+	for len(b) < l {
+		b = append([]byte{0x00}, b...)
+	}
+
+	return b
+}
+
+// putByteList appends b as a ssz fixed size byte array of length n.
+func putBytesN(h ssz.HashWalker, b []byte, n int) error {
+	if len(b) > n {
+		return errors.New("bytes too long", z.Int("n", n), z.Int("l", len(b)))
+	}
+
+	h.PutBytes(leftPad(b, n))
+
+	return nil
+}
+
+// from0x decodes hex-encoded data and expects it to be exactly of len(length).
+// Accepts both 0x-prefixed strings or not.
+func from0x(data string, length int) ([]byte, error) {
+	if data == "" {
+		return nil, errors.New("empty data")
+	}
+
+	b, err := hex.DecodeString(strings.TrimPrefix(data, "0x"))
+	if err != nil {
+		return nil, errors.Wrap(err, "decode hex")
+	} else if len(b) != length {
+		return nil, errors.Wrap(err,
+			"invalid hex length",
+			z.Int("expect", length),
+			z.Int("actual", len(b)),
+		)
+	}
+
+	return b, nil
+}

--- a/app/obolapi/exit_model_test.go
+++ b/app/obolapi/exit_model_test.go
@@ -1,0 +1,139 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package obolapi_test
+
+import (
+	"testing"
+
+	ssz "github.com/ferranbt/fastssz"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/obolapi"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func Test_PartialExitRequest(t *testing.T) {
+	pr := obolapi.PartialExitRequest{
+		UnsignedPartialExitRequest: obolapi.UnsignedPartialExitRequest{
+			PartialExits: []obolapi.ExitBlob{
+				{
+					PublicKey:         string(testutil.RandomCorePubKey(t)),
+					SignedExitMessage: *testutil.RandomExit(),
+				},
+			},
+			ShareIdx: 0,
+		},
+		Signature: testutil.RandomSecp256k1Signature(),
+	}
+
+	htr, err := pr.HashTreeRoot()
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+
+	node, err := pr.GetTree()
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	jbytes, err := pr.MarshalJSON()
+	require.NoError(t, err)
+
+	var other obolapi.PartialExitRequest
+	err = other.UnmarshalJSON(jbytes)
+	require.NoError(t, err)
+	require.EqualValues(t, other, pr)
+
+	err = pr.HashTreeRootWith(ssz.DefaultHasherPool.Get())
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+}
+
+func Test_UnsignedPartialExitRequest(t *testing.T) {
+	pr := obolapi.UnsignedPartialExitRequest{
+		PartialExits: []obolapi.ExitBlob{
+			{
+				PublicKey:         string(testutil.RandomCorePubKey(t)),
+				SignedExitMessage: *testutil.RandomExit(),
+			},
+		},
+		ShareIdx: 0,
+	}
+
+	htr, err := pr.HashTreeRoot()
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+
+	node, err := pr.GetTree()
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	err = pr.HashTreeRootWith(ssz.DefaultHasherPool.Get())
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+}
+
+func Test_PartialExits(t *testing.T) {
+	pr := obolapi.PartialExits{
+		{
+			PublicKey:         string(testutil.RandomCorePubKey(t)),
+			SignedExitMessage: *testutil.RandomExit(),
+		},
+		{
+			PublicKey:         string(testutil.RandomCorePubKey(t)),
+			SignedExitMessage: *testutil.RandomExit(),
+		},
+	}
+
+	htr, err := pr.HashTreeRoot()
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+
+	node, err := pr.GetTree()
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	err = pr.HashTreeRootWith(ssz.DefaultHasherPool.Get())
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+}
+
+func Test_FullExitAuthBlob(t *testing.T) {
+	vp, err := testutil.RandomCorePubKey(t).Bytes()
+	require.NoError(t, err)
+
+	pr := obolapi.FullExitAuthBlob{
+		LockHash:        testutil.RandomBytes32(),
+		ValidatorPubkey: vp,
+		ShareIndex:      0,
+	}
+
+	htr, err := pr.HashTreeRoot()
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+
+	node, err := pr.GetTree()
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	err = pr.HashTreeRootWith(ssz.DefaultHasherPool.Get())
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+}
+
+func Test_ExitBlob(t *testing.T) {
+	pr := obolapi.ExitBlob{
+		PublicKey:         string(testutil.RandomCorePubKey(t)),
+		SignedExitMessage: *testutil.RandomExit(),
+	}
+
+	htr, err := pr.HashTreeRoot()
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+
+	node, err := pr.GetTree()
+	require.NoError(t, err)
+	require.NotNil(t, node)
+
+	err = pr.HashTreeRootWith(ssz.DefaultHasherPool.Get())
+	require.NoError(t, err)
+	require.NotEmpty(t, htr)
+}

--- a/app/obolapi/exit_server_test.go
+++ b/app/obolapi/exit_server_test.go
@@ -1,0 +1,381 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package obolapi_test
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/k1util"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/obolapi"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/eth2util/enr"
+)
+
+const (
+	lockHashPath     = "{lock_hash}"
+	valPubkeyPath    = "{validator_pubkey}"
+	shareIndexPath   = "{share_index}"
+	fullExitBaseTmpl = "/exp/exit"
+	fullExitEndTmp   = "/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
+
+	partialExitTmpl = "/exp/partial_exits/" + lockHashPath
+)
+
+type contextKey string
+
+const (
+	tokenContextKey contextKey = "token"
+)
+
+type tsError struct {
+	Message string
+}
+
+func writeErr(wr http.ResponseWriter, status int, msg string) {
+	resp, err := json.Marshal(tsError{Message: msg})
+	if err != nil {
+		panic(err) // never happens
+	}
+
+	wr.WriteHeader(status)
+	_, _ = wr.Write(resp)
+}
+
+// exitBlob represents an Obol API ExitBlob with its share index.
+type exitBlob struct {
+	obolapi.ExitBlob
+	shareIdx uint64
+}
+
+// testServer is a mock implementation (but that actually does cryptography) of the Obol API side,
+// which will handle storing and recollecting partial signatures.
+type testServer struct {
+	// for convenience, this thing handles one request at a time
+	lock sync.Mutex
+
+	// store the partial exits by the validator pubkey
+	partialExits map[string][]exitBlob
+
+	// store the lock file by its lock hash
+	lockFiles map[string]cluster.Lock
+
+	// drop one partial signature when returning the full set
+	dropOnePsig bool
+}
+
+// addLockFiles adds a set of lock files to ts.
+func (ts *testServer) addLockFiles(lock cluster.Lock) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	ts.lockFiles["0x"+hex.EncodeToString(lock.LockHash)] = lock
+}
+
+func (ts *testServer) HandlePartialExit(writer http.ResponseWriter, request *http.Request) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	vars := mux.Vars(request)
+
+	var data obolapi.PartialExitRequest
+
+	if err := json.NewDecoder(request.Body).Decode(&data); err != nil {
+		writeErr(writer, http.StatusBadRequest, "invalid body")
+		return
+	}
+
+	lockHash := vars[cleanTmpl(lockHashPath)]
+	if lockHash == "" {
+		writeErr(writer, http.StatusBadRequest, "invalid lock hash")
+		return
+	}
+
+	lock, ok := ts.lockFiles[lockHash]
+	if !ok {
+		writeErr(writer, http.StatusNotFound, "lock not found")
+		return
+	}
+
+	// check that data has been signed with ShareIdx-th identity key
+	if data.ShareIdx == 0 || data.ShareIdx > uint64(len(lock.Operators)) {
+		writeErr(writer, http.StatusBadRequest, "invalid share index")
+		return
+	}
+
+	signedExitsRoot, err := data.HashTreeRoot()
+	if err != nil {
+		writeErr(writer, http.StatusInternalServerError, "cannot calculate hash tree root for provided signed exits")
+		return
+	}
+
+	if err := verifyIdentitySignature(lock.Operators[data.ShareIdx-1], data.Signature, signedExitsRoot[:]); err != nil {
+		writeErr(writer, http.StatusBadRequest, "cannot verify signature: "+err.Error())
+		return
+	}
+
+	for _, exit := range data.PartialExits {
+		exit := exit
+		valFound := false
+
+		for _, lockVal := range lock.Validators {
+			if strings.EqualFold(exit.PublicKey, lockVal.PublicKeyHex()) {
+				valFound = true
+				break
+			}
+		}
+
+		if !valFound {
+			continue
+		}
+
+		// check that the last partial exit's data is the same as the new one
+		if len(ts.partialExits[exit.PublicKey]) > 0 && !ts.partialExitsMatch(exit) {
+			writeErr(writer, http.StatusBadRequest, "wrong partial exit for the selected validator")
+			return
+		}
+
+		if len(ts.partialExits[exit.PublicKey])+1 > len(lock.Operators) { // we're already at threshold, ignore
+			continue
+		}
+
+		ts.partialExits[exit.PublicKey] = append(ts.partialExits[exit.PublicKey], exitBlob{
+			ExitBlob: exit,
+			shareIdx: data.ShareIdx,
+		})
+	}
+
+	writer.WriteHeader(http.StatusCreated)
+}
+
+func (ts *testServer) HandleFullExit(writer http.ResponseWriter, request *http.Request) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	authToken, ok := request.Context().Value(tokenContextKey).([]byte)
+	if !ok {
+		log.Error(request.Context(), "received context without token, that's impossible!", nil)
+		return
+	}
+
+	vars := mux.Vars(request)
+
+	valPubkey := vars[cleanTmpl(valPubkeyPath)]
+	lockHash := vars[cleanTmpl(lockHashPath)]
+	shareIndexStr := vars[cleanTmpl(shareIndexPath)]
+	shareIndex, err := strconv.ParseUint(shareIndexStr, 10, 64)
+	if err != nil {
+		writeErr(writer, http.StatusBadRequest, "malformed share index")
+		return
+	}
+
+	valPubkeyBytes, err := from0x(valPubkey, 48)
+	if err != nil {
+		writeErr(writer, http.StatusBadRequest, "invalid public key")
+		return
+	}
+
+	lockHashBytes, err := from0x(lockHash, 32)
+	if err != nil {
+		writeErr(writer, http.StatusBadRequest, "invalid lock hash")
+		return
+	}
+
+	lock, ok := ts.lockFiles[lockHash]
+	if !ok {
+		writeErr(writer, http.StatusNotFound, "lock not found")
+		return
+	}
+
+	partialExits, ok := ts.partialExits[valPubkey]
+	if !ok {
+		writeErr(writer, http.StatusNotFound, "validator not found")
+		return
+	}
+
+	if len(partialExits) < lock.Threshold {
+		writeErr(writer, http.StatusUnauthorized, "not enough partial exits stored")
+		return
+	}
+
+	// check that data has been signed with ShareIdx-th identity key
+	if shareIndex == 0 || shareIndex > uint64(len(lock.Operators)) {
+		writeErr(writer, http.StatusBadRequest, "invalid share index")
+		return
+	}
+
+	exitAuthData := obolapi.FullExitAuthBlob{
+		LockHash:        lockHashBytes,
+		ValidatorPubkey: valPubkeyBytes,
+		ShareIndex:      shareIndex,
+	}
+
+	exitAuthDataRoot, err := exitAuthData.HashTreeRoot()
+	if err != nil {
+		writeErr(writer, http.StatusInternalServerError, "cannot calculate exit auth data root")
+		return
+	}
+
+	if err := verifyIdentitySignature(lock.Operators[shareIndex-1], authToken, exitAuthDataRoot[:]); err != nil {
+		writeErr(writer, http.StatusBadRequest, "cannot verify signature: "+err.Error())
+		return
+	}
+
+	var ret obolapi.FullExitResponse
+
+	// order partial exits by share index
+	sort.Slice(partialExits, func(i, j int) bool {
+		return partialExits[i].shareIdx < partialExits[j].shareIdx
+	})
+
+	for _, pExit := range partialExits {
+		ret.Signatures = append(ret.Signatures, "0x"+hex.EncodeToString(pExit.SignedExitMessage.Signature[:]))
+		ret.Epoch = strconv.FormatUint(uint64(pExit.SignedExitMessage.Message.Epoch), 10)
+		ret.ValidatorIndex = pExit.SignedExitMessage.Message.ValidatorIndex
+	}
+
+	if ts.dropOnePsig {
+		ret.Signatures[0] = "" // blank out the first signature, as if the API didn't receive the partial exit for it
+	}
+
+	if err := json.NewEncoder(writer).Encode(ret); err != nil {
+		writeErr(writer, http.StatusInternalServerError, errors.Wrap(err, "cannot marshal exit message").Error())
+		return
+	}
+}
+
+func (ts *testServer) partialExitsMatch(newOne obolapi.ExitBlob) bool {
+	// get the last one
+	exitsLen := len(ts.partialExits[newOne.PublicKey])
+	last := ts.partialExits[newOne.PublicKey][exitsLen-1]
+
+	return *last.SignedExitMessage.Message == *newOne.SignedExitMessage.Message
+}
+
+// verifyIdentitySignature verifies that sig for hash has been created with operator's identity key.
+func verifyIdentitySignature(operator cluster.Operator, sig, hash []byte) error {
+	opENR, err := enr.Parse(operator.ENR)
+	if err != nil {
+		return errors.Wrap(err, "operator enr")
+	}
+
+	verified, err := k1util.Verify65(opENR.PubKey, hash, sig)
+	if err != nil {
+		return errors.Wrap(err, "k1 signature verify")
+	}
+
+	if !verified {
+		return errors.New("identity signature verification failed")
+	}
+
+	return nil
+}
+
+// cleanTmpl cleans tmpl from '{' and '}', used in path definitions.
+func cleanTmpl(tmpl string) string {
+	return strings.NewReplacer(
+		"{",
+		"",
+		"}",
+		"").Replace(tmpl)
+}
+
+// MockServer returns a obol API mock test server.
+// It returns a http.Handler to be served over HTTP, and a function to add cluster lock files to its database.
+func MockServer(dropOnePsig bool) (http.Handler, func(lock cluster.Lock)) {
+	ts := testServer{
+		lock:         sync.Mutex{},
+		partialExits: map[string][]exitBlob{},
+		lockFiles:    map[string]cluster.Lock{},
+		dropOnePsig:  dropOnePsig,
+	}
+
+	router := mux.NewRouter()
+
+	full := router.PathPrefix(fullExitBaseTmpl).Subrouter()
+	full.Use(authMiddleware)
+	full.HandleFunc(fullExitEndTmp, ts.HandleFullExit).Methods(http.MethodGet)
+
+	router.HandleFunc(partialExitTmpl, ts.HandlePartialExit).Methods(http.MethodPost)
+
+	return router, ts.addLockFiles
+}
+
+// Run runs obol api mock on the provided bind port.
+func Run(_ context.Context, bind string, locks []cluster.Lock, dropOnePsig bool) error {
+	ms, addLock := MockServer(dropOnePsig)
+
+	for _, lock := range locks {
+		addLock(lock)
+	}
+
+	srv := http.Server{
+		ReadTimeout:       1 * time.Second,
+		WriteTimeout:      1 * time.Second,
+		IdleTimeout:       30 * time.Second,
+		ReadHeaderTimeout: 2 * time.Second,
+		Handler:           ms,
+		Addr:              bind,
+	}
+
+	if err := srv.ListenAndServe(); err != nil {
+		return errors.Wrap(err, "obol api mock error")
+	}
+
+	return nil
+}
+
+func authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer")
+		bearer = strings.TrimSpace(bearer)
+		if bearer == "" {
+			writeErr(w, http.StatusUnauthorized, "missing authorization header")
+			return
+		}
+
+		bearerBytes, err := from0x(bearer, 65)
+		if err != nil {
+			writeErr(w, http.StatusBadRequest, "bearer token must be hex-encoded")
+			return
+		}
+
+		r = r.WithContext(context.WithValue(r.Context(), tokenContextKey, bearerBytes))
+
+		// compare the return-value to the authMW
+		next.ServeHTTP(w, r)
+	})
+}
+
+// from0x decodes hex-encoded data and expects it to be exactly of len(length).
+// Accepts both 0x-prefixed strings or not.
+func from0x(data string, length int) ([]byte, error) {
+	if data == "" {
+		return nil, errors.New("empty data")
+	}
+
+	b, err := hex.DecodeString(strings.TrimPrefix(data, "0x"))
+	if err != nil {
+		return nil, errors.Wrap(err, "decode hex")
+	} else if len(b) != length {
+		return nil, errors.Wrap(err,
+			"invalid hex length",
+			z.Int("expect", length),
+			z.Int("actual", len(b)),
+		)
+	}
+
+	return b, nil
+}

--- a/app/obolapi/exit_test.go
+++ b/app/obolapi/exit_test.go
@@ -1,0 +1,223 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package obolapi_test
+
+import (
+	"context"
+	"math/rand"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	eth2http "github.com/attestantio/go-eth2-client/http"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/app/obolapi"
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/eth2util/signing"
+	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/tbls/tblsconv"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+)
+
+const exitEpoch = eth2p0.Epoch(162304)
+
+func TestAPIFlow(t *testing.T) {
+	kn := 4
+
+	handler, addLockFiles := MockServer(false)
+	srv := httptest.NewServer(handler)
+
+	defer srv.Close()
+
+	beaconMock, err := beaconmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, beaconMock.Close())
+	}()
+
+	mockEth2Cl := eth2Client(t, context.Background(), beaconMock.Address())
+
+	random := rand.New(rand.NewSource(int64(0)))
+
+	lock, identityKeys, shares := cluster.NewForT(
+		t,
+		1,
+		kn,
+		kn,
+		0,
+		random,
+	)
+
+	addLockFiles(lock)
+
+	exitMsg := eth2p0.SignedVoluntaryExit{
+		Message: &eth2p0.VoluntaryExit{
+			Epoch:          42,
+			ValidatorIndex: 42,
+		},
+		Signature: eth2p0.BLSSignature{},
+	}
+
+	sigRoot, err := exitMsg.Message.HashTreeRoot()
+	require.NoError(t, err)
+
+	domain, err := signing.GetDomain(context.Background(), mockEth2Cl, signing.DomainExit, exitEpoch)
+	require.NoError(t, err)
+
+	sigData, err := (&eth2p0.SigningData{ObjectRoot: sigRoot, Domain: domain}).HashTreeRoot()
+	require.NoError(t, err)
+
+	for idx := 0; idx < len(shares); idx++ {
+		var exits []obolapi.ExitBlob
+
+		for _, shareSet := range shares[idx] {
+			signature, err := tbls.Sign(shareSet, sigData[:])
+			require.NoError(t, err)
+
+			exitMsg := exitMsg
+			exitMsg.Signature = eth2p0.BLSSignature(signature)
+
+			exit := obolapi.ExitBlob{
+				PublicKey:         lock.Validators[0].PublicKeyHex(),
+				SignedExitMessage: exitMsg,
+			}
+
+			exits = append(exits, exit)
+		}
+
+		cl, err := obolapi.New(srv.URL)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		// send all the partial exits
+		for idx, exit := range exits {
+			require.NoError(t, cl.PostPartialExit(ctx, lock.LockHash, uint64(idx+1), identityKeys[idx], exit), "share index: %d", idx+1)
+		}
+
+		for idx := range exits {
+			// get full exit
+			fullExit, err := cl.GetFullExit(ctx, lock.Validators[0].PublicKeyHex(), lock.LockHash, uint64(idx+1), identityKeys[idx])
+			require.NoError(t, err, "share index: %d", idx+1)
+
+			valPubk, err := lock.Validators[0].PublicKey()
+			require.NoError(t, err, "share index: %d", idx+1)
+
+			sig, err := tblsconv.SignatureFromBytes(fullExit.SignedExitMessage.Signature[:])
+			require.NoError(t, err, "share index: %d", idx+1)
+
+			// verify that the aggregated signature works
+			require.NoError(t, tbls.Verify(valPubk, sigData[:], sig), "share index: %d", idx+1)
+		}
+	}
+}
+
+func TestAPIFlowMissingSig(t *testing.T) {
+	kn := 4
+
+	handler, addLockFiles := MockServer(true)
+	srv := httptest.NewServer(handler)
+
+	defer srv.Close()
+
+	beaconMock, err := beaconmock.New()
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, beaconMock.Close())
+	}()
+
+	mockEth2Cl := eth2Client(t, context.Background(), beaconMock.Address())
+
+	random := rand.New(rand.NewSource(int64(0)))
+
+	lock, identityKeys, shares := cluster.NewForT(
+		t,
+		1,
+		kn-1,
+		kn,
+		0,
+		random,
+	)
+
+	addLockFiles(lock)
+
+	exitMsg := eth2p0.SignedVoluntaryExit{
+		Message: &eth2p0.VoluntaryExit{
+			Epoch:          42,
+			ValidatorIndex: 42,
+		},
+		Signature: eth2p0.BLSSignature{},
+	}
+
+	sigRoot, err := exitMsg.Message.HashTreeRoot()
+	require.NoError(t, err)
+
+	domain, err := signing.GetDomain(context.Background(), mockEth2Cl, signing.DomainExit, exitEpoch)
+	require.NoError(t, err)
+
+	sigData, err := (&eth2p0.SigningData{ObjectRoot: sigRoot, Domain: domain}).HashTreeRoot()
+	require.NoError(t, err)
+
+	for idx := 0; idx < len(shares); idx++ {
+		var exits []obolapi.ExitBlob
+
+		for _, shareSet := range shares[idx] {
+			signature, err := tbls.Sign(shareSet, sigData[:])
+			require.NoError(t, err)
+
+			exitMsg := exitMsg
+			exitMsg.Signature = eth2p0.BLSSignature(signature)
+
+			exit := obolapi.ExitBlob{
+				PublicKey:         lock.Validators[0].PublicKeyHex(),
+				SignedExitMessage: exitMsg,
+			}
+
+			exits = append(exits, exit)
+		}
+
+		cl, err := obolapi.New(srv.URL)
+		require.NoError(t, err)
+
+		ctx := context.Background()
+
+		// send all the partial exits
+		for idx, exit := range exits {
+			require.NoError(t, cl.PostPartialExit(ctx, lock.LockHash, uint64(idx+1), identityKeys[idx], exit), "share index: %d", idx+1)
+		}
+
+		for idx := range exits {
+			// get full exit
+			fullExit, err := cl.GetFullExit(ctx, lock.Validators[0].PublicKeyHex(), lock.LockHash, uint64(idx+1), identityKeys[idx])
+			require.NoError(t, err, "share index: %d", idx+1)
+
+			valPubk, err := lock.Validators[0].PublicKey()
+			require.NoError(t, err, "share index: %d", idx+1)
+
+			sig, err := tblsconv.SignatureFromBytes(fullExit.SignedExitMessage.Signature[:])
+			require.NoError(t, err, "share index: %d", idx+1)
+
+			// verify that the aggregated signature works
+			require.NoError(t, tbls.Verify(valPubk, sigData[:], sig), "share index: %d", idx+1)
+		}
+	}
+}
+
+func eth2Client(t *testing.T, ctx context.Context, bnURL string) eth2wrap.Client {
+	t.Helper()
+
+	bnHTTPClient, err := eth2http.New(ctx,
+		eth2http.WithAddress(bnURL),
+		eth2http.WithLogLevel(zerolog.InfoLevel),
+	)
+
+	require.NoError(t, err)
+
+	bnClient := bnHTTPClient.(*eth2http.Service)
+
+	return eth2wrap.AdaptEth2HTTP(bnClient, 1*time.Second)
+}

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/protolambda/eth2-shuffle v1.1.0
 	github.com/prysmaticlabs/go-bitfield v0.0.0-20210809151128-385d8c5e3fb7
 	github.com/r3labs/sse/v2 v2.10.0
+	github.com/rs/zerolog v1.29.1
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.18.2
@@ -163,7 +164,6 @@ require (
 	github.com/quic-go/webtransport-go v0.5.3 // indirect
 	github.com/raulk/go-watchdog v1.3.0 // indirect
 	github.com/rs/cors v1.10.1 // indirect
-	github.com/rs/zerolog v1.29.1 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sagikazarmark/locafero v0.4.0 // indirect
 	github.com/sagikazarmark/slog-shim v0.1.0 // indirect


### PR DESCRIPTION
Add partial exit endpoints handlers to Charon's Obol API client package.

Added unit tests and a mock server.

This code was taken and adapted from lido-dv-exit: once this PR gets merged, we'll remove it from there.

category: feature
ticket: #2848 
