### PR TITLE
*: bumped golangci-lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint # See .golangci.yml for config
-    rev: v1.54.2
+    rev: v1.56.2
     hooks:
       - id: golangci-lint
 


### PR DESCRIPTION
On MacOS the current version of golangci-lint is constantly failing:

```
ERRO [runner] Panic: atomicalign: package "z" (isInitialPkg: true, needAnalyzeSource: true): runtime error: invalid memory address or nil pointer dereference: goroutine 15917 [running]:
```

After upgrading to the latest version, the issue has gone.

category: fixbuild
ticket: none
