### PR TITLE
codecov: ignore tests and testutil

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,6 @@ coverage:
       default:
         only_pulls: true # No patch status on single commits in main.
         informational: true
+ignore:
+  - "**/*_test.go"
+  - "testutil"


### PR DESCRIPTION
Explicitly ignore Go test files and the `testutil` directory, which contain utilities to aid testing.

category: test
ticket: none