### PR TITLE
core/aggsigdb: refactor MemDB

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -465,7 +465,12 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	aggSigDB := aggsigdb.NewMemDB(deadlinerFunc("aggsigdb"))
+	var aggSigDB core.AggSigDB
+	if featureset.Enabled(featureset.AggSigDBV2) {
+		aggSigDB = aggsigdb.NewMemDBV2(deadlinerFunc("aggsigdb"))
+	} else {
+		aggSigDB = aggsigdb.NewMemDB(deadlinerFunc("aggsigdb"))
+	}
 
 	broadcaster, err := bcast.New(ctx, eth2Cl)
 	if err != nil {

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -34,6 +34,8 @@ const (
 	// ConsensusParticipate enables consensus participate feature in order to participate in an ongoing consensus
 	// round while still waiting for an unsigned data from beacon node.
 	ConsensusParticipate Feature = "consensus_participate"
+
+	AggSigDBV2 Feature = "aggsigdb_v2"
 )
 
 var (
@@ -42,6 +44,7 @@ var (
 		MockAlpha:            statusAlpha,
 		EagerDoubleLinear:    statusAlpha,
 		ConsensusParticipate: statusAlpha,
+		AggSigDBV2:           statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/core/aggsigdb/memory_v2.go
+++ b/core/aggsigdb/memory_v2.go
@@ -1,0 +1,144 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package aggsigdb
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/core"
+)
+
+// MemDBV2 is a basic memory implementation of core.AggSigDB.
+type MemDBV2 struct {
+	data       sync.Map // map[memDBKey]core.SignedData
+	keysByDuty sync.Map // map[core.Duty][]memDBKey,  Key index by duty for fast deletion.
+	deadliner  core.Deadliner
+	closed     chan struct{}
+}
+
+// NewMemDBV2 creates a basic memory based AggSigDB.
+func NewMemDBV2(deadliner core.Deadliner) *MemDBV2 {
+	return &MemDBV2{
+		// data, keysByDuty are okay to use without explicit initialization
+		deadliner: deadliner,
+		closed:    make(chan struct{}),
+	}
+}
+
+func (m *MemDBV2) store(duty core.Duty, pubKey core.PubKey, data core.SignedData) error {
+	data, err := data.Clone()
+	if err != nil {
+		return err
+	}
+
+	_ = m.deadliner.Add(duty) // TODO(corver): Distinguish between no deadline supported vs already expired.
+
+	key := memDBKey{duty, pubKey}
+
+	if rawExisting, ok := m.data.Load(key); ok {
+		existing, ok := rawExisting.(core.SignedData)
+		if !ok {
+			return errors.New("data stored in aggsigdb not of core.SignedData type", z.Str("key", fmt.Sprintf("%+v", key)))
+		}
+
+		equal, err := dataEqual(existing, data)
+		if err != nil {
+			return err
+		} else if !equal {
+			return errors.New("mismatching data")
+		}
+	} else {
+		m.data.Store(key, data)
+		rawKbd, _ := m.keysByDuty.Load(duty)
+
+		if rawKbd == nil {
+			rawKbd = []memDBKey{}
+		}
+
+		kbd, ok := rawKbd.([]memDBKey)
+		if !ok {
+			return errors.New("indexing key data stored in aggsigdb not of []memDBKey type", z.Str("duty", duty.String()))
+		}
+
+		kbd = append(kbd, key)
+		m.keysByDuty.Store(duty, kbd)
+	}
+
+	return nil
+}
+
+func (m *MemDBV2) Store(ctx context.Context, duty core.Duty, set core.SignedDataSet) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.closed:
+		return ErrStopped
+	default:
+	}
+
+	for pubKey, data := range set {
+		if err := m.store(duty, pubKey, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *MemDBV2) Await(ctx context.Context, duty core.Duty, pubKey core.PubKey) (core.SignedData, error) {
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-m.closed:
+			return nil, ErrStopped
+		default:
+			maybeDataRaw, ok := m.data.Load(memDBKey{duty, pubKey})
+			if !ok {
+				runtime.Gosched() // yield to runtime to avoid trashing
+				continue
+			}
+
+			maybeData, ok := maybeDataRaw.(core.SignedData)
+			if !ok {
+				return nil, errors.New("data stored in aggsigdb not of core.SignedData type", z.Str("key", fmt.Sprintf("%+v", memDBKey{duty, pubKey})))
+			}
+
+			return maybeData.Clone()
+		}
+	}
+}
+
+// Run blocks and runs the database process until the context is cancelled.
+func (m *MemDBV2) Run(ctx context.Context) {
+	defer close(m.closed)
+
+	for {
+		select {
+		case duty := <-m.deadliner.C():
+			rawKeys, ok := m.keysByDuty.Load(duty)
+			if !ok {
+				continue
+			}
+
+			keys, ok := rawKeys.([]memDBKey)
+			if !ok {
+				log.Warn(ctx, "Indexing key data stored in aggsigdb not of []memDBKey type", nil, z.Str("duty", duty.String()))
+			}
+
+			for _, key := range keys {
+				m.data.Delete(key)
+			}
+
+			m.keysByDuty.Delete(duty)
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/core/aggsigdb/memory_v2_internal_test.go
+++ b/core/aggsigdb/memory_v2_internal_test.go
@@ -1,0 +1,97 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package aggsigdb
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestDutyExpirationV2(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	deadliner := newTestDeadliner()
+	db := NewMemDBV2(deadliner)
+	go db.Run(ctx)
+
+	slot := uint64(99)
+	duty := core.NewAttesterDuty(slot)
+	pubkey := testutil.RandomCorePubKey(t)
+	sig := testutil.RandomCoreSignature()
+
+	err := db.Store(ctx, duty, core.SignedDataSet{pubkey: sig})
+	require.NoError(t, err)
+
+	resp, err := db.Await(ctx, duty, pubkey)
+	require.NoError(t, err)
+	require.Equal(t, sig, resp)
+
+	deadliner.Expire()
+
+	var dataLen int
+	var keysByDutyLen int
+
+	db.data.Range(func(_, _ any) bool {
+		dataLen++
+		return true
+	})
+
+	db.keysByDuty.Range(func(_, _ any) bool {
+		keysByDutyLen++
+		return true
+	})
+
+	require.Zero(t, dataLen)
+	require.Zero(t, keysByDutyLen)
+}
+
+func TestCancelledQueryV2(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	db := NewMemDBV2(newTestDeadliner())
+
+	go db.Run(ctx)
+
+	slot := uint64(99)
+	duty := core.NewAttesterDuty(slot)
+	pubkey := testutil.RandomCorePubKey(t)
+	sig := testutil.RandomCoreSignature()
+
+	// Enqueue 2 queries and wait for them to be blocked.
+	qctx, qcancel := context.WithCancel(ctx)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	awaitAmt := 2
+
+	errStore := make([]error, awaitAmt)
+	for idx := 0; idx < awaitAmt; idx++ {
+		idx := idx
+		go func() {
+			_, err := db.Await(qctx, duty, pubkey)
+			errStore[idx] = err
+			wg.Done()
+		}()
+	}
+
+	// Cancel queries
+	qcancel()
+	wg.Wait()
+
+	for _, err := range errStore {
+		require.ErrorIs(t, err, context.Canceled)
+	}
+
+	// Store something and ensure no blocked queries
+	err := db.Store(ctx, duty, core.SignedDataSet{pubkey: sig})
+	require.NoError(t, err)
+}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -151,10 +151,13 @@ type SigAgg interface {
 // AggSigDB persists aggregated signed duty data.
 type AggSigDB interface {
 	// Store stores aggregated signed duty data set.
-	Store(context.Context, Duty, SignedDataSet) error
+	Store(context context.Context, duty Duty, data SignedDataSet) error
 
 	// Await blocks and returns the aggregated signed duty data when available.
-	Await(context.Context, Duty, PubKey) (SignedData, error)
+	Await(context context.Context, duty Duty, pubKey PubKey) (SignedData, error)
+
+	// Run runs AggSigDB lifecycle until context is cancelled.
+	Run(context context.Context)
 }
 
 // Broadcaster broadcasts aggregated signed duty data set to the beacon node.


### PR DESCRIPTION
Introduce MemDBV2: instead of relying on a complex system based on channels and read/write queries, simply store objects in a `sync/map`.

Simpler to read and potentially faster in systems in which there's a high rate of goroutine contention.

Add the `aggsigdb_v2` feature flag to enable/disable this feature.

category: refactor
ticket: #1951  
feature_flag: aggsigdb_v2
