### PR TITLE
testutil/compose: custom timeout for fuzzer

### DIFF
--- a/testutil/compose/fuzz/fuzz_test.go
+++ b/testutil/compose/fuzz/fuzz_test.go
@@ -21,6 +21,7 @@ var (
 	fuzzer    = flag.Bool("fuzzer", false, "Enables docker based fuzz tests")
 	sudoPerms = flag.Bool("sudo-perms", false, "Enables changing all compose artefacts file permissions using sudo.")
 	logDir    = flag.String("log-dir", "", "Specifies the directory to store test docker-compose logs. Empty defaults to stdout.")
+	timeout   = flag.Duration("fuzz-timeout", time.Minute*20, "Timeout after which, if there were no failures, the fuzzing will stop.")
 )
 
 func TestFuzzers(t *testing.T) {
@@ -46,7 +47,7 @@ func TestFuzzers(t *testing.T) {
 
 				return config
 			},
-			timeout: time.Minute * 20,
+			timeout: *timeout,
 		},
 		{
 			name: "p2p_fuzz_tests",
@@ -55,7 +56,7 @@ func TestFuzzers(t *testing.T) {
 
 				return config
 			},
-			timeout: time.Minute * 20,
+			timeout: *timeout,
 		},
 	}
 


### PR DESCRIPTION
Add `fuzz-timeout` CLI parameter for `TestFuzzer` test, that replaces the 20 minutes constant fuzz duration.

Defaults to 20 minutes.

category: feature
ticket: none
