### PR TITLE
cluster: unique validator_keys dir

### DIFF
--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -10,6 +10,9 @@ import (
 	"io"
 	"math"
 	"net/http"
+	"os"
+	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -55,6 +58,26 @@ func FetchDefinition(ctx context.Context, url string) (Definition, error) {
 	}
 
 	return res, nil
+}
+
+// CreateValidatorKeysDir creates a new directory for validator keys.
+// If default directory "validator_keys" exists, it will attempt to create
+// a directory having unique prefix.
+func CreateValidatorKeysDir(parentDir string) (string, error) {
+	const defaultDirName = "validator_keys"
+
+	vkdir := path.Join(parentDir, defaultDirName)
+	for {
+		err := os.Mkdir(vkdir, os.ModePerm)
+		if err == nil {
+			return vkdir, nil
+		}
+		if !os.IsExist(err) {
+			return "", errors.Wrap(err, "mkdir", z.Str("path", vkdir))
+		}
+		prefix := strconv.FormatInt(time.Now().UnixMilli(), 10)
+		vkdir = path.Join(parentDir, fmt.Sprintf("%s_%s", prefix, defaultDirName))
+	}
 }
 
 // uuid returns a random uuid.

--- a/cluster/helpers_internal_test.go
+++ b/cluster/helpers_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/http/httptest"
+	"path"
 	"strings"
 	"testing"
 
@@ -129,4 +130,28 @@ func TestFetchDefinition(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestCreateValidatorKeysDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	// First attempt must succeed.
+	dir, err := CreateValidatorKeysDir(tmp)
+
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(dir, tmp))
+	require.True(t, strings.HasSuffix(dir, "validator_keys"))
+
+	// Second attempt shall add a unique prefix.
+	dir, err = CreateValidatorKeysDir(tmp)
+	require.NoError(t, err)
+	require.True(t, strings.HasPrefix(dir, tmp))
+	require.True(t, strings.HasSuffix(dir, "validator_keys"))
+	require.NotEqual(t, "validator_keys", path.Base(dir))
+
+	t.Run("mkdir error", func(t *testing.T) {
+		// Parent directory does not exist
+		_, err := CreateValidatorKeysDir(path.Join(tmp, "nonexistent"))
+		require.ErrorContains(t, err, "mkdir")
+	})
 }

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -758,9 +758,9 @@ func writeKeysToDisk(numNodes int, clusterDir string, insecureKeys bool, shareSe
 			secrets = append(secrets, shares[i])
 		}
 
-		keysDir := path.Join(nodeDir(clusterDir, i), "/validator_keys")
-		if err := os.MkdirAll(keysDir, 0o755); err != nil {
-			return errors.Wrap(err, "mkdir validator_keys")
+		keysDir, err := cluster.CreateValidatorKeysDir(nodeDir(clusterDir, i))
+		if err != nil {
+			return err
 		}
 
 		if insecureKeys {

--- a/dkg/disk.go
+++ b/dkg/disk.go
@@ -130,10 +130,9 @@ func writeKeysToDisk(conf Config, shares []share) error {
 		secrets = append(secrets, s.SecretShare)
 	}
 
-	keysDir := path.Join(conf.DataDir, "/validator_keys")
-
-	if err := os.Mkdir(keysDir, os.ModePerm); err != nil {
-		return errors.Wrap(err, "mkdir /validator_keys")
+	keysDir, err := cluster.CreateValidatorKeysDir(conf.DataDir)
+	if err != nil {
+		return err
 	}
 
 	storeKeysFunc := keystore.StoreKeys


### PR DESCRIPTION
In according with the issue description #2881, this is UX improvement - if the target validator_keys folder exists, the implementation checks if the folder is empty. If the existing directory is not empty, or in case of any IO error, the process fails.

category: feature
ticket: #2881