### PR TITLE
testutil/compose: fixed smoke dkg test

### DIFF
--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -70,6 +70,7 @@ func TestSmoke(t *testing.T) {
 			Name: "dkg",
 			ConfigFunc: func(conf *compose.Config) {
 				conf.KeyGen = compose.KeyGenDKG
+				conf.VCs = []compose.VCType{compose.VCMock}
 			},
 		},
 		{


### PR DESCRIPTION
`SmokeTest/dkg` was running by default with Teku VC, which caused a weird (yet unknown) error and the test to fail.
I verified all `main` commits for the past month trying to find where this was introduced and found that all the commits are failing reliably. I suspect this has something to do with docker engine update (I also updated mine locally and therefore could 100% reproduce the issue).
Even though we still don't know what was wrong with Teku in that specific test, in order to make our builds passing compose tests, I enabled Mock VC for this test, similar to what we do for other DKG tests in the same suite.

category: test
ticket: #2964
