### PR TITLE
app/health: app_health_metrics_high_cardinality

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -261,7 +261,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 
 	wireMonitoringAPI(ctx, life, conf.MonitoringAddr, conf.DebugAddr, tcpNode, eth2Cl, peerIDs,
-		promRegistry, qbftDebug, pubkeys, seenPubkeys, vapiCalls)
+		promRegistry, qbftDebug, pubkeys, seenPubkeys, vapiCalls, len(cluster.GetValidators()))
 
 	err = wireCoreWorkflow(ctx, life, conf, cluster, nodeIdx, tcpNode, p2pKey, eth2Cl,
 		peerIDs, sender, qbftDebug.AddInstance, seenPubkeysFunc, vapiCallsFunc)

--- a/app/health/checks.go
+++ b/app/health/checks.go
@@ -135,6 +135,19 @@ var checks = []check{
 			return increase > 0, nil
 		},
 	},
+	{
+		Name:        "metrics_high_cardinality",
+		Description: "Metrics reached high cardinality threshold. Please check metrics reported by app_health_metrics_high_cardinality.",
+		Severity:    severityWarning,
+		Func: func(q query, _ Metadata) (bool, error) {
+			max, err := q("app_health_metrics_high_cardinality", sumLabels(), gaugeMax)
+			if err != nil {
+				return false, err
+			}
+
+			return max > 0, nil
+		},
+	},
 }
 
 // l is a concise convenience function to create a label pair.

--- a/app/health/checks_internal_test.go
+++ b/app/health/checks_internal_test.go
@@ -376,6 +376,25 @@ func TestHighRegistrationFailuresRateCheck(t *testing.T) {
 	})
 }
 
+func TestMetricsHighCardinalityCheck(t *testing.T) {
+	m := Metadata{}
+	checkName := "metrics_high_cardinality"
+	metricName := "app_health_metrics_high_cardinality"
+
+	t.Run("no data", func(t *testing.T) {
+		testCheck(t, m, checkName, false, nil)
+	})
+
+	t.Run("high cardinality", func(t *testing.T) {
+		testCheck(t, m, checkName, true,
+			genFam(metricName,
+				genGauge(genLabels("name", "metric1"), 1, 1, 1),
+				genGauge(genLabels("name", "metric2"), 3, 5, 0),
+			),
+		)
+	})
+}
+
 func testCheck(t *testing.T, m Metadata, checkName string, expect bool, metrics []*pb.MetricFamily) {
 	t.Helper()
 

--- a/app/health/metrics.go
+++ b/app/health/metrics.go
@@ -14,3 +14,10 @@ var checkGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name:      "checks",
 	Help:      "Application health checks by name and severity. Set to 1 for failing, 0 for ok.",
 }, []string{"severity", "name"})
+
+var highCardinalityGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+	Namespace: "app",
+	Subsystem: "health",
+	Name:      "metrics_high_cardinality",
+	Help:      "Metrics with high cardinality by name.",
+}, []string{"name"})

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -48,6 +48,7 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, d
 	tcpNode host.Host, eth2Cl eth2wrap.Client,
 	peerIDs []peer.ID, registry *prometheus.Registry, qbftDebug http.Handler,
 	pubkeys []core.PubKey, seenPubkeys <-chan core.PubKey, vapiCalls <-chan struct{},
+	numValidators int,
 ) {
 	beaconNodeVersionMetric(ctx, eth2Cl, clockwork.NewRealClock())
 
@@ -87,7 +88,7 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, d
 		NumValidators: len(pubkeys),
 		NumPeers:      len(peerIDs),
 		QuorumPeers:   cluster.Threshold(len(peerIDs)),
-	}, registry)
+	}, registry, numValidators)
 
 	if debugAddr != "" {
 		debugMux := http.NewServeMux()

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -19,6 +19,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_eth2_latency_seconds` | Histogram | Latency in seconds for eth2 beacon node requests | `endpoint` |
 | `app_git_commit` | Gauge | Constant gauge with label set to current git commit hash | `git_hash` |
 | `app_health_checks` | Gauge | Application health checks by name and severity. Set to 1 for failing, 0 for ok. | `severity, name` |
+| `app_health_metrics_high_cardinality` | Gauge | Metrics with high cardinality by name. | `name` |
 | `app_log_error_total` | Counter | Total count of logged errors by topic | `topic` |
 | `app_log_warn_total` | Counter | Total count of logged warnings by topic | `topic` |
 | `app_monitoring_readyz` | Gauge | Set to 1 if the node is operational and monitoring api `/readyz` endpoint is returning 200s. Else `/readyz` is returning 500s and this metric is either set to 2 if the beacon node is down, or3 if the beacon node is syncing, or4 if quorum peers are not connected. |  |


### PR DESCRIPTION
This is to monitor metrics high cardinality, when a given metric gets too many distinct labels which results in high memory consumption in charon.
To this end this PR introduces one new metric: `app_health_metrics_high_cardinality` (gauge) which renders metric names => max labels count, if this metric exceeded the threshold (100 * num_of_validators).
In addition to the above metric which can be used in alerting, this also adds a new "health check" named `metrics_high_cardinality` which is triggered when `app_health_metrics_high_cardinality` reported any offense.

Note: `app_health_metrics_high_cardinality` will not "reset", because the purpose of this feature is to detect and signal an opportunity of memory leak.

category: feature
ticket: #2446