### PR TITLE
workflows: avoid unknown/unknown architecture in ghcr

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -14,6 +14,8 @@ jobs:
       with:
         fetch-depth: 0
     - uses: docker/setup-buildx-action@v2
+      with:
+        driver-opts: "image=moby/buildkit:v0.10.5" # avoid unknown/unknown arch in ghcr
 
     - name: Get app/version.Version from the code
       if: github.ref_type == 'branch'

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2 # For compose to build images
+        with:
+          driver-opts: "image=moby/buildkit:v0.10.5" # avoid unknown/unknown arch in ghcr
       - uses: actions/setup-go@v4
         with:
           go-version: '1.22.1'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: docker/setup-buildx-action@v2 # For compose to build images
+        with:
+          driver-opts: "image=moby/buildkit:v0.10.5" # avoid unknown/unknown arch in ghcr
       - uses: actions/setup-go@v4
         with:
           go-version: '1.22.1'

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.vscode/
 # JIRA plugin
 atlassian-ide-plugin.xml
 # User-specific files (MonoDevelop/Xamarin Studio)


### PR DESCRIPTION
Pin buildkit version in all `docker/setup-buildx-action@v2` steps (N.B.: at one place v1 is used, which is using buildkit version <0.10.5, so I haven't pinned it there). Other proposed solutions didn't seem to work currently (tested on private repo).

Included as well .vscode in .gitignore.

category: bug
ticket: #2654 

Closes #2654