### PR TITLE
app: logging lock hash and enr

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -203,9 +203,9 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Info(ctx, "Lock file loaded",
 		z.Str("peer_name", p2p.PeerName(tcpNode.ID())),
 		z.Int("peer_index", nodeIdx.PeerIdx),
-		z.Str("cluster_hash", lockHashHex),
 		z.Str("cluster_name", cluster.Name),
-		z.Str("lock_hash", hex.EncodeToString(cluster.GetInitialMutationHash())),
+		z.Str("cluster_hash", lockHashHex),
+		z.Str("cluster_hash_full", hex.EncodeToString(cluster.GetInitialMutationHash())),
 		z.Str("enr", enrRec.String()),
 		z.Int("peers", len(cluster.Operators)))
 

--- a/app/app.go
+++ b/app/app.go
@@ -58,6 +58,7 @@ import (
 	"github.com/obolnetwork/charon/core/tracker"
 	"github.com/obolnetwork/charon/core/validatorapi"
 	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/enr"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -194,11 +195,18 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.Wrap(err, "private key not matching cluster manifest file")
 	}
 
+	enrRec, err := enr.New(p2pKey)
+	if err != nil {
+		return errors.Wrap(err, "creating enr record from privkey")
+	}
+
 	log.Info(ctx, "Lock file loaded",
 		z.Str("peer_name", p2p.PeerName(tcpNode.ID())),
 		z.Int("peer_index", nodeIdx.PeerIdx),
 		z.Str("cluster_hash", lockHashHex),
 		z.Str("cluster_name", cluster.Name),
+		z.Str("lock_hash", hex.EncodeToString(cluster.GetInitialMutationHash())),
+		z.Str("enr", enrRec.String()),
 		z.Int("peers", len(cluster.Operators)))
 
 	// Metric and logging labels.

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -162,6 +162,13 @@ func printFlags(ctx context.Context, flags *pflag.FlagSet) {
 	log.Info(ctx, "Parsed config", flagsToLogFields(flags)...)
 }
 
+// printLicense INFO logs the license notice.
+func printLicense(ctx context.Context) {
+	log.Info(ctx, "This software is licensed under the Maria DB Business Source License 1.1; "+
+		"you may not use this software except in compliance with this license. "+
+		"You may obtain a copy of this license at https://github.com/ObolNetwork/charon/blob/main/LICENSE")
+}
+
 // flagsToLogFields converts the given flags to log fields.
 func flagsToLogFields(flags *pflag.FlagSet) []z.Field {
 	var fields []z.Field

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -30,6 +30,7 @@ this command at the same time.`,
 			}
 			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
 
+			printLicense(cmd.Context())
 			printFlags(cmd.Context(), cmd.Flags())
 
 			return runFunc(cmd.Context(), config)

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -26,6 +26,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 			}
 			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
 
+			printLicense(cmd.Context())
 			printFlags(cmd.Context(), cmd.Flags())
 
 			return runFunc(cmd.Context(), config)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,6 +32,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error, unsafe bool) *co
 			}
 			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
 
+			printLicense(cmd.Context())
 			printFlags(cmd.Context(), cmd.Flags())
 
 			return runFunc(cmd.Context(), conf)


### PR DESCRIPTION
Added logging of full lock_hash and node's enr when charon starts.

category: refactor
ticket: #2778

