### PR TITLE
workflows: add QEMU for arm64 builds

### DIFF
--- a/.github/workflows/build-push-deploy-promrated.yaml
+++ b/.github/workflows/build-push-deploy-promrated.yaml
@@ -12,6 +12,9 @@ jobs:
     name: Build Docker Image
     steps:
     - uses: actions/checkout@v3
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v1
     - uses: docker/setup-buildx-action@v1
 
     - name: Define docker image meta data tags

--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -13,6 +13,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Set up QEMU
+      id: qemu
+      uses: docker/setup-qemu-action@v2
     - uses: docker/setup-buildx-action@v2
       with:
         driver-opts: "image=moby/buildkit:v0.10.5" # avoid unknown/unknown arch in ghcr

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -26,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2 # For compose to build images
         with:
           driver-opts: "image=moby/buildkit:v0.10.5" # avoid unknown/unknown arch in ghcr

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set up QEMU
+        id: qemu
+        uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2 # For compose to build images
         with:
           driver-opts: "image=moby/buildkit:v0.10.5" # avoid unknown/unknown arch in ghcr


### PR DESCRIPTION
Some packages installed from the Dockerfile failed after #2971 was merged. Reason was it used default pre-installed version of qemu - the emulator used from amd64 architecture to build the arm64 images. Qemu is suggested by Dockerhub as well.

[Dockerhub](https://docs.docker.com/build/ci/github-actions/multi-platform/)
[Github Issue](https://github.com/docker/buildx/issues/495#issuecomment-918925854)

category: fixbuild
ticket: none
