### PR TITLE
workflows: govulncheck to master

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -15,5 +15,6 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version: '1.22.1'
-      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      # TODO(kalo): revert to @latest once v1.0.5 is released
+      - run: go install golang.org/x/vuln/cmd/govulncheck@master
       - run: govulncheck -show=stacks -test ./...


### PR DESCRIPTION
We have encountered unexpected `govulncheck: invalid finding: if Frame.Function is set, Frame.Package must also be ` error in the pipelines. Seems like an issue on govulncheck's side which is fixed on master and to be released in the upcoming v1.0.5. Bumping the version to master branch in the meantime.

Related: https://github.com/golang/go/issues/66139

category: bug
