### PR TITLE
app/featureset: stabilise more features

### DIFF
--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -35,15 +35,16 @@ const (
 	// round while still waiting for an unsigned data from beacon node.
 	ConsensusParticipate Feature = "consensus_participate"
 
+	// AggSigDBV2 enables a newer, simpler implementation of `aggsigdb`.
 	AggSigDBV2 Feature = "aggsigdb_v2"
 )
 
 var (
 	// state defines the current rollout status of each feature.
 	state = map[Feature]status{
+		EagerDoubleLinear:    statusStable,
+		ConsensusParticipate: statusStable,
 		MockAlpha:            statusAlpha,
-		EagerDoubleLinear:    statusAlpha,
-		ConsensusParticipate: statusAlpha,
 		AggSigDBV2:           statusAlpha,
 		// Add all features and there status here.
 	}

--- a/core/consensus/roundtimer_internal_test.go
+++ b/core/consensus/roundtimer_internal_test.go
@@ -114,14 +114,15 @@ func TestDoubleEagerLinearRoundTimer(t *testing.T) {
 
 func TestGetTimerFunc(t *testing.T) {
 	timerFunc := getTimerFunc()
-	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(0)).Type())
-	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(1)).Type())
-	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(2)).Type())
-
-	featureset.EnableForT(t, featureset.EagerDoubleLinear)
-
-	timerFunc = getTimerFunc()
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(0)).Type())
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(1)).Type())
 	require.Equal(t, timerEagerDoubleLinear, timerFunc(core.NewAttesterDuty(2)).Type())
+
+	featureset.DisableForT(t, featureset.EagerDoubleLinear)
+
+	timerFunc = getTimerFunc()
+
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(0)).Type())
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(1)).Type())
+	require.Equal(t, timerIncreasing, timerFunc(core.NewAttesterDuty(2)).Type())
 }


### PR DESCRIPTION
Promote `eager_dlinear`, `consensus_participate` to stable.

They can still be overridden by passing `eager_double_linear` and `consensus_participate` to the `--feature-set-disable` flag of `charon run`.

category: refactor
ticket: #3001

Closes #3001.