### PR TITLE
app/eth2wrap: sign domain for `VOLUNTARY_EXIT`

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -764,7 +764,7 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 
 	if conf.SimnetBMockFuzz {
 		log.Info(ctx, "Beaconmock fuzz configured!")
-		bmock, err := beaconmock.New(beaconmock.WithBeaconMockFuzzer())
+		bmock, err := beaconmock.New(beaconmock.WithBeaconMockFuzzer(), beaconmock.WithForkVersion([4]byte(forkVersion)))
 		if err != nil {
 			return nil, err
 		}
@@ -825,6 +825,8 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager,
 	if err != nil {
 		return nil, errors.Wrap(err, "new eth2 http client")
 	}
+
+	eth2Cl.SetForkVersion([4]byte(forkVersion))
 
 	if conf.SyntheticBlockProposals {
 		log.Info(ctx, "Synthetic block proposals enabled")

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -133,6 +133,12 @@ func (m multi) SetValidatorCache(valCache func(context.Context) (ActiveValidator
 	}
 }
 
+func (m multi) SetForkVersion(forkVersion [4]byte) {
+	for _, c := range m.clients {
+		c.SetForkVersion(forkVersion)
+	}
+}
+
 func (m multi) ActiveValidators(ctx context.Context) (ActiveValidators, error) {
 	const label = "active_validators"
 	// No latency since this is a cached endpoint.

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -29,6 +29,8 @@ type Client interface {
 	ActiveValidatorsProvider
 	SetValidatorCache(func(context.Context) (ActiveValidators, error))
 
+	SetForkVersion(forkVersion [4]byte)
+
 	eth2client.AggregateAttestationProvider
 	eth2client.AggregateAttestationsSubmitter
 	eth2client.AttestationDataProvider

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -51,6 +51,8 @@ type Client interface {
     ActiveValidatorsProvider
     SetValidatorCache(func(context.Context) (ActiveValidators, error))
 
+	SetForkVersion(forkVersion [4]byte)
+
     {{range .Providers}} eth2client.{{.}}
     {{end -}}
 }
@@ -128,6 +130,7 @@ type Client interface {
 		"ValidatorsProvider":                    true,
 		"ValidatorRegistrationsSubmitter":       true,
 		"VoluntaryExitSubmitter":                true,
+		"SetForkVersion":                        true,
 	}
 
 	// addImport indicates which types need hardcoded imports.

--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -80,6 +80,15 @@ func (l *lazy) getOrCreateClient(ctx context.Context) (Client, error) {
 	return cl, err
 }
 
+func (l *lazy) SetForkVersion(forkVersion [4]byte) {
+	cl, ok := l.getClient()
+	if !ok {
+		return
+	}
+
+	cl.SetForkVersion(forkVersion)
+}
+
 func (l *lazy) Name() string {
 	cl, ok := l.getClient()
 	if !ok {

--- a/eth2util/helper_capella.go
+++ b/eth2util/helper_capella.go
@@ -1,0 +1,134 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2util
+
+import (
+	"context"
+	"encoding/hex"
+	"strings"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	eth2api "github.com/attestantio/go-eth2-client/api"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	ssz "github.com/ferranbt/fastssz"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+var capellaForkMap = map[string]string{
+	"0x00000000": "0x03000000",
+	"0x00001020": "0x03001020",
+	"0x00000064": "0x03000064",
+	"0x90000069": "0x90000072",
+	"0x01017000": "0x04017000",
+}
+
+// CapellaFork maps generic fork hashes to their specific Capella hardfork
+// values.
+func CapellaFork(forkHash string) (string, error) {
+	d, ok := capellaForkMap[forkHash]
+	if !ok {
+		return "", errors.New("no capella fork for specified fork")
+	}
+
+	return d, nil
+}
+
+type forkDataType struct {
+	CurrentVersion        [4]byte
+	GenesisValidatorsRoot [32]byte
+}
+
+func (e forkDataType) GetTree() (*ssz.Node, error) {
+	node, err := ssz.ProofTree(e)
+	if err != nil {
+		return nil, errors.Wrap(err, "proof tree")
+	}
+
+	return node, nil
+}
+
+func (e forkDataType) HashTreeRoot() ([32]byte, error) {
+	hash, err := ssz.HashWithDefaultHasher(e)
+	if err != nil {
+		return [32]byte{}, errors.Wrap(err, "hash with default hasher")
+	}
+
+	return hash, nil
+}
+
+func (e forkDataType) HashTreeRootWith(hh ssz.HashWalker) error {
+	indx := hh.Index()
+
+	// Field (0) 'CurrentVersion'
+	hh.PutBytes(e.CurrentVersion[:])
+
+	// Field (1) 'GenesisValidatorsRoot'
+	hh.PutBytes(e.GenesisValidatorsRoot[:])
+
+	hh.Merkleize(indx)
+
+	return nil
+}
+
+// ComputeDomain computes the domain for a given domainType, genesisValidatorRoot at the specified fork hash.
+func ComputeDomain(forkHash string, domainType eth2p0.DomainType, genesisValidatorRoot eth2p0.Root) (eth2p0.Domain, error) {
+	fb, err := hex.DecodeString(strings.TrimPrefix(forkHash, "0x"))
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "fork hash hex")
+	}
+
+	_, err = CapellaFork(forkHash)
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "invalid fork hash")
+	}
+
+	rawFdt := forkDataType{GenesisValidatorsRoot: genesisValidatorRoot, CurrentVersion: [4]byte(fb)}
+	fdt, err := rawFdt.HashTreeRoot()
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "fork data type hash tree root")
+	}
+
+	var domain []byte
+	domain = append(domain, domainType[:]...)
+	domain = append(domain, fdt[:28]...)
+
+	return eth2p0.Domain(domain), nil
+}
+
+// CapellaDomain returns the Capella signature domain, calculating it given the fork hash string.
+func CapellaDomain(
+	ctx context.Context,
+	forkHash string,
+	specProvider eth2client.SpecProvider,
+	genesisProvider eth2client.GenesisProvider,
+) (eth2p0.Domain, error) {
+	rawSpec, err := specProvider.Spec(ctx, &eth2api.SpecOpts{})
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "fetch spec")
+	}
+
+	genesis, err := genesisProvider.Genesis(ctx, &eth2api.GenesisOpts{})
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "fetch genesis")
+	}
+
+	spec := rawSpec.Data
+
+	domainType, ok := spec["DOMAIN_VOLUNTARY_EXIT"]
+	if !ok {
+		return eth2p0.Domain{}, errors.New("domain type not found in spec")
+	}
+
+	domainTyped, ok := domainType.(eth2p0.DomainType)
+	if !ok {
+		return [32]byte{}, errors.New("invalid domain type")
+	}
+
+	domain, err := ComputeDomain(forkHash, domainTyped, genesis.Data.GenesisValidatorsRoot)
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "compute domain")
+	}
+
+	return domain, nil
+}

--- a/eth2util/helper_capella_test.go
+++ b/eth2util/helper_capella_test.go
@@ -1,0 +1,193 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2util_test
+
+import (
+	"context"
+	"testing"
+
+	eth2api "github.com/attestantio/go-eth2-client/api"
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+func TestCapellaFork(t *testing.T) {
+	tests := []struct {
+		name      string
+		forkHash  string
+		want      string
+		errAssert require.ErrorAssertionFunc
+	}{
+		{
+			"bad fork hash string",
+			"bad",
+			"",
+			require.Error,
+		},
+		{
+			"ok fork hash but nonexistent",
+			"0x12345678",
+			"",
+			require.Error,
+		},
+		{
+			"existing ok fork hash",
+			"0x00000000",
+			"0x03000000",
+			require.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := eth2util.CapellaFork(tt.forkHash)
+			tt.errAssert(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestComputeDomain(t *testing.T) {
+	_, err := eth2util.ComputeDomain("bad", eth2p0.DomainType{0, 0, 0, 0}, eth2p0.Root{})
+	require.Error(t, err)
+
+	ret, err := eth2util.ComputeDomain("0x00000000", eth2p0.DomainType{0, 0, 0, 0}, eth2p0.Root{})
+	require.NoError(t, err)
+	require.NotEmpty(t, ret)
+}
+
+type specGenesisProvider struct {
+	sp func(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error)
+	gp func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error)
+}
+
+func (sgp *specGenesisProvider) Genesis(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+	return sgp.gp(ctx, opts)
+}
+
+func (sgp *specGenesisProvider) Spec(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error) {
+	return sgp.sp(ctx, opts)
+}
+
+func TestCapellaDomain(t *testing.T) {
+	tests := []struct {
+		name      string
+		forkHash  string
+		providers *specGenesisProvider
+		err       string
+		resFunc   require.ValueAssertionFunc
+	}{
+		{
+			"spec returns error",
+			"0x00000000",
+			&specGenesisProvider{
+				sp: func(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error) {
+					return &eth2api.Response[map[string]any]{}, errors.New("spec error")
+				},
+				gp: func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+					return &eth2api.Response[*eth2v1.Genesis]{}, nil
+				},
+			},
+			"fetch spec",
+			require.Empty,
+		},
+		{
+			"genesis returns error",
+			"0x00000000",
+			&specGenesisProvider{
+				sp: func(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error) {
+					return &eth2api.Response[map[string]any]{}, nil
+				},
+				gp: func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+					return &eth2api.Response[*eth2v1.Genesis]{}, errors.New("genesis error")
+				},
+			},
+			"fetch genesis",
+			require.Empty,
+		},
+		{
+			name:     "bad fork hash",
+			forkHash: "bad",
+			providers: &specGenesisProvider{
+				sp: func(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error) {
+					return &eth2api.Response[map[string]any]{
+						Data: map[string]any{
+							"DOMAIN_VOLUNTARY_EXIT": eth2p0.DomainType{0, 1, 2, 3},
+						},
+					}, nil
+				},
+				gp: func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+					return &eth2api.Response[*eth2v1.Genesis]{
+						Data: &eth2v1.Genesis{
+							GenesisValidatorsRoot: testutil.RandomRoot(),
+						},
+					}, nil
+				},
+			},
+			err:     "encoding/hex",
+			resFunc: require.Empty,
+		},
+		{
+			name:     "ok",
+			forkHash: "0x00000000",
+			providers: &specGenesisProvider{
+				sp: func(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error) {
+					return &eth2api.Response[map[string]any]{
+						Data: map[string]any{
+							"DOMAIN_VOLUNTARY_EXIT": eth2p0.DomainType{0, 1, 2, 3},
+						},
+					}, nil
+				},
+				gp: func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+					return &eth2api.Response[*eth2v1.Genesis]{
+						Data: &eth2v1.Genesis{
+							GenesisValidatorsRoot: testutil.RandomRoot(),
+						},
+					}, nil
+				},
+			},
+			err:     "",
+			resFunc: require.NotEmpty,
+		},
+		{
+			name:     "fork hash non existent",
+			forkHash: "0x12345678",
+			providers: &specGenesisProvider{
+				sp: func(ctx context.Context, opts *eth2api.SpecOpts) (*eth2api.Response[map[string]any], error) {
+					return &eth2api.Response[map[string]any]{
+						Data: map[string]any{
+							"DOMAIN_VOLUNTARY_EXIT": eth2p0.DomainType{0, 1, 2, 3},
+						},
+					}, nil
+				},
+				gp: func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+					return &eth2api.Response[*eth2v1.Genesis]{
+						Data: &eth2v1.Genesis{
+							GenesisValidatorsRoot: testutil.RandomRoot(),
+						},
+					}, nil
+				},
+			},
+			err:     "no capella fork",
+			resFunc: require.Empty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			res, err := eth2util.CapellaDomain(ctx, tt.forkHash, tt.providers, tt.providers)
+
+			if tt.err == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.err)
+			}
+			tt.resFunc(t, res)
+		})
+	}
+}

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -101,6 +101,13 @@ func defaultHTTPMock() Mock {
 	}
 }
 
+// WithForkVersion sets the fork version provided in the Mock instance.
+func WithForkVersion(forkVersion [4]byte) Option {
+	return func(mock *Mock) {
+		mock.forkVersion = forkVersion
+	}
+}
+
 // Mock provides a mock beacon client and implements eth2wrap.Client.
 // Create a new instance with default behaviour via New and then override any function.
 type Mock struct {
@@ -110,6 +117,7 @@ type Mock struct {
 	overrides    []staticOverride
 	clock        clockwork.Clock
 	headProducer *headProducer
+	forkVersion  [4]byte
 
 	ActiveValidatorsFunc                   func(ctx context.Context) (eth2wrap.ActiveValidators, error)
 	AttestationDataFunc                    func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
@@ -335,6 +343,10 @@ func (m Mock) SlotsPerEpoch(ctx context.Context) (uint64, error) {
 
 func (m Mock) ProposerConfig(ctx context.Context) (*eth2exp.ProposerConfigResponse, error) {
 	return m.ProposerConfigFunc(ctx)
+}
+
+func (Mock) SetForkVersion([4]byte) {
+	// This function is a no-op, since we mock the fork version at beaconmock initialization.
 }
 
 func (Mock) Name() string {


### PR DESCRIPTION
Instead of returning the latest Domain available when the DomainName requested is VOLUNTARY_EXIT, returns the Capella one as detailed in EIP-7044.

Doing so fixes both `exit` commands generating wrong signatures and voluntary exits sent over the VC.

category: bug
ticket: #2981

Closes #2981.
