### PR TITLE
cmd/relay: enabled new libp2p relay metrics

### DIFF
--- a/cmd/relay/relay_internal_test.go
+++ b/cmd/relay/relay_internal_test.go
@@ -224,3 +224,48 @@ func testServeAddrs(t *testing.T, p2pConfig p2p.Config, path string, asserter fu
 
 	require.NoError(t, eg.Wait())
 }
+
+func TestRelayMetricsExported(t *testing.T) {
+	temp := t.TempDir()
+
+	config := Config{
+		DataDir:        temp,
+		LogConfig:      log.DefaultConfig(),
+		P2PConfig:      p2p.Config{TCPAddrs: []string{testutil.AvailableAddr(t).String()}},
+		HTTPAddr:       testutil.AvailableAddr(t).String(),
+		MonitoringAddr: testutil.AvailableAddr(t).String(),
+	}
+
+	_, err := p2p.NewSavedPrivKey(temp)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	go func() {
+		err := Run(ctx, config)
+		testutil.SkipIfBindErr(t, err)
+		assert.NoError(t, err)
+	}()
+
+	fetchMetrics := func() string {
+		resp, err := http.Get(fmt.Sprintf("http://%s/metrics", config.MonitoringAddr))
+		if err == nil {
+			var body []byte
+			body, err = io.ReadAll(resp.Body)
+			if err == nil {
+				return string(body)
+			}
+		}
+
+		return ""
+	}
+
+	require.Eventually(t, func() bool {
+		m := fetchMetrics()
+
+		return assert.Contains(t, m, "libp2p_relaysvc_")
+	}, 10*time.Second, time.Second, "waiting for relay service to start")
+
+	cancel()
+}


### PR DESCRIPTION
libp2p introduced set of new metrics for relay:
https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/circuitv2/relay/metrics.go

This work integrates these metrics into our instrumentation flow.

Note: metrics reported by libp2p will be prefixed: `libp2p_relaysvc` whereas metrics reported by charon code are prefixed: `relay_p2p`. This distinction seems useful for clear separation and avoiding clashes. Therefore, `metrics.md` remains intact. This only enriches libp2p metrics with charon cluster labels.

category: feature
ticket: #2544