### PR TITLE
cmd: exit beacon node custom timeout

### DIFF
--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -54,6 +54,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 		{validatorPubkey, true},
 		{beaconNodeURL, true},
 		{exitFromFile, false},
+		{beaconNodeTimeout, false},
 	})
 
 	bindLogFlags(cmd.Flags(), &config.Log)
@@ -79,7 +80,7 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 
 	ctx = log.WithCtx(ctx, z.Str("validator", validator.String()))
 
-	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL)
+	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL, config.BeaconNodeTimeout)
 	if err != nil {
 		return errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}

--- a/cmd/exit_broadcast_internal_test.go
+++ b/cmd/exit_broadcast_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -109,13 +110,14 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
 
 		config := exitConfig{
-			BeaconNodeURL:    beaconMock.Address(),
-			ValidatorPubkey:  lock.Validators[0].PublicKeyHex(),
-			PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-			PublishAddress:   srv.URL,
-			ExitEpoch:        194048,
+			BeaconNodeURL:     beaconMock.Address(),
+			ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
+			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+			PublishAddress:    srv.URL,
+			ExitEpoch:         194048,
+			BeaconNodeTimeout: 30 * time.Second,
 		}
 
 		require.NoError(t, runSignPartialExit(ctx, config), "operator index: %v", idx)
@@ -124,13 +126,14 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 	baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 	config := exitConfig{
-		BeaconNodeURL:    beaconMock.Address(),
-		ValidatorPubkey:  lock.Validators[0].PublicKeyHex(),
-		PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-		ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-		LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-		PublishAddress:   srv.URL,
-		ExitEpoch:        194048,
+		BeaconNodeURL:     beaconMock.Address(),
+		ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
+		PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+		PublishAddress:    srv.URL,
+		ExitEpoch:         194048,
+		BeaconNodeTimeout: 30 * time.Second,
 	}
 
 	if fromFile {
@@ -273,13 +276,14 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 			baseDir := filepath.Join(root, "op0") // one operator is enough
 
 			config := exitConfig{
-				BeaconNodeURL:    bnURL,
-				ValidatorPubkey:  valAddr,
-				PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-				ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-				LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-				PublishAddress:   oapiURL,
-				ExitEpoch:        0,
+				BeaconNodeURL:     bnURL,
+				ValidatorPubkey:   valAddr,
+				PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+				ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+				LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:    oapiURL,
+				ExitEpoch:         0,
+				BeaconNodeTimeout: 30 * time.Second,
 			}
 
 			if test.badExistingExitPath {

--- a/cmd/exit_fetch_internal_test.go
+++ b/cmd/exit_fetch_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -93,13 +94,14 @@ func Test_runFetchExitFullFlow(t *testing.T) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
 
 		config := exitConfig{
-			BeaconNodeURL:    beaconMock.Address(),
-			ValidatorPubkey:  lock.Validators[0].PublicKeyHex(),
-			PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-			PublishAddress:   srv.URL,
-			ExitEpoch:        194048,
+			BeaconNodeURL:     beaconMock.Address(),
+			ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
+			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+			PublishAddress:    srv.URL,
+			ExitEpoch:         194048,
+			BeaconNodeTimeout: 30 * time.Second,
 		}
 
 		require.NoError(t, runSignPartialExit(ctx, config), "operator index: %v", idx)

--- a/cmd/exit_list.go
+++ b/cmd/exit_list.go
@@ -42,6 +42,7 @@ func newListActiveValidatorsCmd(runFunc func(context.Context, exitConfig) error)
 	bindExitFlags(cmd, &config, []exitCLIFlag{
 		{lockFilePath, false},
 		{beaconNodeURL, true},
+		{beaconNodeTimeout, false},
 	})
 
 	bindLogFlags(cmd.Flags(), &config.Log)
@@ -74,7 +75,7 @@ func listActiveVals(ctx context.Context, config exitConfig) ([]string, error) {
 		return nil, errors.Wrap(err, "could not load cluster-lock.json")
 	}
 
-	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL)
+	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL, config.BeaconNodeTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}

--- a/cmd/exit_list_internal_test.go
+++ b/cmd/exit_list_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"path/filepath"
 	"testing"
+	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -75,11 +76,12 @@ func Test_runListActiveVals(t *testing.T) {
 	baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 	config := exitConfig{
-		BeaconNodeURL:    beaconMock.Address(),
-		PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-		ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-		LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-		PlaintextOutput:  true,
+		BeaconNodeURL:     beaconMock.Address(),
+		PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+		PlaintextOutput:   true,
+		BeaconNodeTimeout: 30 * time.Second,
 	}
 
 	require.NoError(t, runListActiveValidatorsCmd(ctx, config))
@@ -141,11 +143,12 @@ func Test_listActiveVals(t *testing.T) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 		config := exitConfig{
-			BeaconNodeURL:    beaconMock.Address(),
-			PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-			PlaintextOutput:  true,
+			BeaconNodeURL:     beaconMock.Address(),
+			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+			PlaintextOutput:   true,
+			BeaconNodeTimeout: 30 * time.Second,
 		}
 
 		vals, err := listActiveVals(ctx, config)
@@ -181,11 +184,12 @@ func Test_listActiveVals(t *testing.T) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 		config := exitConfig{
-			BeaconNodeURL:    beaconMock.Address(),
-			PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-			PlaintextOutput:  true,
+			BeaconNodeURL:     beaconMock.Address(),
+			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+			PlaintextOutput:   true,
+			BeaconNodeTimeout: 30 * time.Second,
 		}
 
 		vals, err := listActiveVals(ctx, config)

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -47,6 +47,7 @@ func newSubmitPartialExitCmd(runFunc func(context.Context, exitConfig) error) *c
 		{exitEpoch, false},
 		{validatorPubkey, true},
 		{beaconNodeURL, true},
+		{beaconNodeTimeout, false},
 	})
 
 	bindLogFlags(cmd.Flags(), &config.Log)
@@ -99,7 +100,7 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		return errors.New("validator not present in cluster lock", z.Str("validator", validator.String()))
 	}
 
-	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL)
+	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL, config.BeaconNodeTimeout)
 	if err != nil {
 		return errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -120,13 +121,14 @@ func Test_runSubmitPartialExitFlow(t *testing.T) {
 	baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 	config := exitConfig{
-		BeaconNodeURL:    beaconMock.Address(),
-		ValidatorPubkey:  lock.Validators[0].PublicKeyHex(),
-		PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-		ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-		LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-		PublishAddress:   srv.URL,
-		ExitEpoch:        194048,
+		BeaconNodeURL:     beaconMock.Address(),
+		ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
+		PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+		PublishAddress:    srv.URL,
+		ExitEpoch:         194048,
+		BeaconNodeTimeout: 30 * time.Second,
 	}
 
 	require.NoError(t, runSignPartialExit(ctx, config))
@@ -258,13 +260,14 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 			baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 			config := exitConfig{
-				BeaconNodeURL:    bnURL,
-				ValidatorPubkey:  valAddr,
-				PrivateKeyPath:   filepath.Join(baseDir, "charon-enr-private-key"),
-				ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
-				LockFilePath:     filepath.Join(baseDir, "cluster-lock.json"),
-				PublishAddress:   oapiURL,
-				ExitEpoch:        0,
+				BeaconNodeURL:     bnURL,
+				ValidatorPubkey:   valAddr,
+				PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
+				ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
+				LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:    oapiURL,
+				ExitEpoch:         0,
+				BeaconNodeTimeout: 30 * time.Second,
 			}
 
 			require.ErrorContains(t, runSignPartialExit(ctx, config), test.errData)


### PR DESCRIPTION
Allow users to specify a custom beacon node HTTP communications timeout.

Defaults to 30 seconds.

category: misc
ticket: none
