### PR TITLE
cmd: alpha test peers tests self

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -92,7 +92,7 @@ type testResult struct {
 	Measurement  string
 	Suggestion   string
 	Error        testResultError
-	IsCompatible bool
+	IsAcceptable bool
 }
 
 func (s *testResultError) UnmarshalText(data []byte) error {
@@ -225,7 +225,7 @@ func calculateScore(results []testResult) categoryScore {
 		case testVerdictAvg:
 			avg--
 		case testVerdictFail:
-			if !t.IsCompatible {
+			if !t.IsAcceptable {
 				return categoryScoreC
 			}
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -102,6 +102,9 @@ func (s *testResultError) UnmarshalText(data []byte) error {
 
 // MarshalText implements encoding.TextMarshaler
 func (s testResultError) MarshalText() ([]byte, error) {
+	if s.error == nil {
+		return []byte{}, nil
+	}
 	return []byte(s.Error()), nil
 }
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -87,11 +87,12 @@ const (
 type testResultError struct{ error }
 
 type testResult struct {
-	Name        string
-	Verdict     testVerdict
-	Measurement string
-	Suggestion  string
-	Error       testResultError
+	Name         string
+	Verdict      testVerdict
+	Measurement  string
+	Suggestion   string
+	Error        testResultError
+	IsCompatible bool
 }
 
 func (s *testResultError) UnmarshalText(data []byte) error {
@@ -214,12 +215,18 @@ func calculateScore(results []testResult) categoryScore {
 	avg := 0
 	for _, t := range results {
 		switch t.Verdict {
-		case testVerdictBad, testVerdictFail:
+		case testVerdictBad:
 			return categoryScoreC
 		case testVerdictGood:
 			avg++
 		case testVerdictAvg:
 			avg--
+		case testVerdictFail:
+			if !t.IsCompatible {
+				return categoryScoreC
+			}
+
+			continue
 		case testVerdictOk:
 			continue
 		}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -105,6 +105,7 @@ func (s testResultError) MarshalText() ([]byte, error) {
 	if s.error == nil {
 		return []byte{}, nil
 	}
+
 	return []byte(s.Error()), nil
 }
 

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -570,8 +570,9 @@ func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.H
 	return testRes
 }
 
-func dialTCPIP(address string, timeout time.Duration) error {
-	conn, err := net.DialTimeout("tcp", address, timeout)
+func dialTCPIP(ctx context.Context, address string) error {
+	d := net.Dialer{Timeout: time.Second}
+	conn, err := d.DialContext(ctx, "tcp", address)
 	if err != nil {
 		return errors.Wrap(err, "net dial")
 	}
@@ -593,7 +594,7 @@ func libp2pTCPPortOpenTest(ctx context.Context, cfg *testPeersConfig) testResult
 
 	for _, addr := range cfg.P2P.TCPAddrs {
 		addrVal := addr
-		group.Go(func() error { return dialTCPIP(addrVal, time.Second) })
+		group.Go(func() error { return dialTCPIP(ctx, addrVal) })
 	}
 
 	err := group.Wait()

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -576,9 +576,6 @@ func dialTCPIP(ctx context.Context, address string) error {
 	if err != nil {
 		return errors.Wrap(err, "net dial")
 	}
-	if conn == nil {
-		return errors.New("could not establish connection to address", z.Str("address", address))
-	}
 	err = conn.Close()
 	if err != nil {
 		return errors.Wrap(err, "close conn")

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -576,6 +576,7 @@ func dialLibp2pTCPIP(ctx context.Context, address string) error {
 	if err != nil {
 		return errors.Wrap(err, "net dial")
 	}
+	defer conn.Close()
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, conn)
 	if err != nil {

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -578,7 +578,7 @@ func dialLibp2pTCPIP(ctx context.Context, address string) error {
 	}
 	defer conn.Close()
 	buf := new(strings.Builder)
-	_, err = io.Copy(buf, conn)
+	_, err = io.CopyN(buf, conn, 19)
 	if err != nil {
 		return errors.Wrap(err, "io copy")
 	}

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -51,7 +51,7 @@ func TestPeersTest(t *testing.T) {
 				CategoryName: "peers",
 				Targets: map[string][]testResult{
 					"self": {
-						{Name: "natOpen", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented},
+						{Name: "libp2pTCPPortOpenTest", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{nil}},
 					},
 					"frantic-colony - enr:-JG4QFI0llFYxSoTAHm24OrbgoVx77dL6Ehl1Ydys39JYoWcBhiHrRhtGXDTaygWNsEWFb1cL7a1Bk0klIdaNuXplKWGAYGv0Gt7gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL6bcis0tFXnbqG4KuywxT5BLhtmijPFApKCDJNl3mXFYN0Y3CCDhqDdWRwgg4u": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
@@ -87,7 +87,7 @@ func TestPeersTest(t *testing.T) {
 				CategoryName: "peers",
 				Targets: map[string][]testResult{
 					"self": {
-						{Name: "natOpen", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented},
+						{Name: "libp2pTCPPortOpenTest", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{nil}},
 					},
 					"frantic-colony - enr:-JG4QFI0llFYxSoTAHm24OrbgoVx77dL6Ehl1Ydys39JYoWcBhiHrRhtGXDTaygWNsEWFb1cL7a1Bk0klIdaNuXplKWGAYGv0Gt7gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL6bcis0tFXnbqG4KuywxT5BLhtmijPFApKCDJNl3mXFYN0Y3CCDhqDdWRwgg4u": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
@@ -175,7 +175,7 @@ func TestPeersTest(t *testing.T) {
 				CategoryName: "peers",
 				Targets: map[string][]testResult{
 					"self": {
-						{Name: "natOpen", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented},
+						{Name: "libp2pTCPPortOpenTest", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{nil}},
 					},
 					"frantic-colony - enr:-JG4QFI0llFYxSoTAHm24OrbgoVx77dL6Ehl1Ydys39JYoWcBhiHrRhtGXDTaygWNsEWFb1cL7a1Bk0klIdaNuXplKWGAYGv0Gt7gmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQL6bcis0tFXnbqG4KuywxT5BLhtmijPFApKCDJNl3mXFYN0Y3CCDhqDdWRwgg4u": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},


### PR DESCRIPTION
Add alpha peers tests for the TCP node started. Currently only port opened is tested. Test for whether NAT is open is skipped for now as it makes more sense to be added to the peers' tests.

category: feature
ticket: #3076 