### PR TITLE
cmd: proper exit Capella domain handling

### DIFF
--- a/app/obolapi/exit_test.go
+++ b/app/obolapi/exit_test.go
@@ -29,11 +29,6 @@ const exitEpoch = eth2p0.Epoch(162304)
 func TestAPIFlow(t *testing.T) {
 	kn := 4
 
-	handler, addLockFiles := obolapimock.MockServer(false)
-	srv := httptest.NewServer(handler)
-
-	defer srv.Close()
-
 	beaconMock, err := beaconmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -41,6 +36,11 @@ func TestAPIFlow(t *testing.T) {
 	}()
 
 	mockEth2Cl := eth2Client(t, context.Background(), beaconMock.Address())
+
+	handler, addLockFiles := obolapimock.MockServer(false, mockEth2Cl)
+	srv := httptest.NewServer(handler)
+
+	defer srv.Close()
 
 	random := rand.New(rand.NewSource(int64(0)))
 
@@ -120,11 +120,6 @@ func TestAPIFlow(t *testing.T) {
 func TestAPIFlowMissingSig(t *testing.T) {
 	kn := 4
 
-	handler, addLockFiles := obolapimock.MockServer(true)
-	srv := httptest.NewServer(handler)
-
-	defer srv.Close()
-
 	beaconMock, err := beaconmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -132,6 +127,11 @@ func TestAPIFlowMissingSig(t *testing.T) {
 	}()
 
 	mockEth2Cl := eth2Client(t, context.Background(), beaconMock.Address())
+
+	handler, addLockFiles := obolapimock.MockServer(true, mockEth2Cl)
+	srv := httptest.NewServer(handler)
+
+	defer srv.Close()
 
 	random := rand.New(rand.NewSource(int64(0)))
 

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -85,6 +85,8 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}
 
+	eth2Cl.SetForkVersion([4]byte(cl.GetForkVersion()))
+
 	var fullExit eth2p0.SignedVoluntaryExit
 	maybeExitFilePath := strings.TrimSpace(config.ExitFromFilePath)
 

--- a/cmd/exit_broadcast_internal_test.go
+++ b/cmd/exit_broadcast_internal_test.go
@@ -76,11 +76,6 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 	mBytes, err := json.Marshal(lock)
 	require.NoError(t, err)
 
-	handler, addLockFiles := obolapimock.MockServer(false)
-	srv := httptest.NewServer(handler)
-	addLockFiles(lock)
-	defer srv.Close()
-
 	validatorSet := beaconmock.ValidatorSet{}
 
 	for idx, v := range lock.Validators {
@@ -103,6 +98,16 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 	defer func() {
 		require.NoError(t, beaconMock.Close())
 	}()
+
+	eth2Cl, err := eth2Client(ctx, beaconMock.Address(), 10*time.Second)
+	require.NoError(t, err)
+
+	eth2Cl.SetForkVersion([4]byte(lock.ForkVersion))
+
+	handler, addLockFiles := obolapimock.MockServer(false, eth2Cl)
+	srv := httptest.NewServer(handler)
+	addLockFiles(lock)
+	defer srv.Close()
 
 	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
 

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -105,6 +105,8 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}
 
+	eth2Cl.SetForkVersion([4]byte(cl.GetForkVersion()))
+
 	oAPI, err := obolapi.New(config.PublishAddress)
 	if err != nil {
 		return errors.Wrap(err, "could not create obol api client")

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -91,11 +91,6 @@ func Test_runSubmitPartialExitFlow(t *testing.T) {
 	mBytes, err := json.Marshal(lock)
 	require.NoError(t, err)
 
-	handler, addLockFiles := obolapimock.MockServer(false)
-	srv := httptest.NewServer(handler)
-	addLockFiles(lock)
-	defer srv.Close()
-
 	validatorSet := beaconmock.ValidatorSet{}
 
 	for idx, v := range lock.Validators {
@@ -115,6 +110,16 @@ func Test_runSubmitPartialExitFlow(t *testing.T) {
 	defer func() {
 		require.NoError(t, beaconMock.Close())
 	}()
+
+	eth2Cl, err := eth2Client(ctx, beaconMock.Address(), 10*time.Second)
+	require.NoError(t, err)
+
+	eth2Cl.SetForkVersion([4]byte(lock.ForkVersion))
+
+	handler, addLockFiles := obolapimock.MockServer(false, eth2Cl)
+	srv := httptest.NewServer(handler)
+	addLockFiles(lock)
+	defer srv.Close()
 
 	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
 

--- a/eth2util/helper_capella.go
+++ b/eth2util/helper_capella.go
@@ -75,7 +75,7 @@ func (e forkDataType) HashTreeRootWith(hh ssz.HashWalker) error {
 func ComputeDomain(forkHash string, domainType eth2p0.DomainType, genesisValidatorRoot eth2p0.Root) (eth2p0.Domain, error) {
 	_, err := hex.DecodeString(strings.TrimPrefix(forkHash, "0x"))
 	if err != nil {
-		return eth2p0.Domain{}, errors.Wrap(err, "invalid fork hash")
+		return eth2p0.Domain{}, errors.Wrap(err, "malformed fork hash")
 	}
 
 	cfork, err := CapellaFork(forkHash)

--- a/eth2util/helper_capella.go
+++ b/eth2util/helper_capella.go
@@ -73,17 +73,22 @@ func (e forkDataType) HashTreeRootWith(hh ssz.HashWalker) error {
 
 // ComputeDomain computes the domain for a given domainType, genesisValidatorRoot at the specified fork hash.
 func ComputeDomain(forkHash string, domainType eth2p0.DomainType, genesisValidatorRoot eth2p0.Root) (eth2p0.Domain, error) {
-	fb, err := hex.DecodeString(strings.TrimPrefix(forkHash, "0x"))
-	if err != nil {
-		return eth2p0.Domain{}, errors.Wrap(err, "fork hash hex")
-	}
-
-	_, err = CapellaFork(forkHash)
+	_, err := hex.DecodeString(strings.TrimPrefix(forkHash, "0x"))
 	if err != nil {
 		return eth2p0.Domain{}, errors.Wrap(err, "invalid fork hash")
 	}
 
-	rawFdt := forkDataType{GenesisValidatorsRoot: genesisValidatorRoot, CurrentVersion: [4]byte(fb)}
+	cfork, err := CapellaFork(forkHash)
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "invalid fork hash")
+	}
+
+	cforkHex, err := hex.DecodeString(strings.TrimPrefix(cfork, "0x"))
+	if err != nil {
+		return eth2p0.Domain{}, errors.Wrap(err, "capella fork hash hex")
+	}
+
+	rawFdt := forkDataType{GenesisValidatorsRoot: genesisValidatorRoot, CurrentVersion: [4]byte(cforkHex)}
 	fdt, err := rawFdt.HashTreeRoot()
 	if err != nil {
 		return eth2p0.Domain{}, errors.Wrap(err, "fork data type hash tree root")


### PR DESCRIPTION
Handle capella domain calculation for exits the correct way.

Fixes issues noticed during the offsite, that is, not being able to exit through API.

category: bug
ticket: none