### PR TITLE
cmd: exit UX tweak

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -92,25 +92,33 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 	for _, f := range flags {
 		flag := f.flag
 
+		maybeRequired := func(s string) string {
+			if f.required {
+				return s + " [REQUIRED]"
+			}
+
+			return s
+		}
+
 		switch flag {
 		case publishAddress:
-			cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech", "The URL of the remote API.")
+			cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech", maybeRequired("The URL of the remote API."))
 		case beaconNodeURL:
-			cmd.Flags().StringVar(&config.BeaconNodeURL, beaconNodeURL.String(), "", "Beacon node URL.")
+			cmd.Flags().StringVar(&config.BeaconNodeURL, beaconNodeURL.String(), "", maybeRequired("Beacon node URL."))
 		case privateKeyPath:
-			cmd.Flags().StringVar(&config.PrivateKeyPath, privateKeyPath.String(), ".charon/charon-enr-private-key", "The path to the charon enr private key file. ")
+			cmd.Flags().StringVar(&config.PrivateKeyPath, privateKeyPath.String(), ".charon/charon-enr-private-key", maybeRequired("The path to the charon enr private key file. "))
 		case lockFilePath:
-			cmd.Flags().StringVar(&config.LockFilePath, lockFilePath.String(), ".charon/cluster-lock.json", "The path to the cluster lock file defining the distributed validator cluster.")
+			cmd.Flags().StringVar(&config.LockFilePath, lockFilePath.String(), ".charon/cluster-lock.json", maybeRequired("The path to the cluster lock file defining the distributed validator cluster."))
 		case validatorKeysDir:
-			cmd.Flags().StringVar(&config.ValidatorKeysDir, validatorKeysDir.String(), ".charon/validator_keys", "Path to the directory containing the validator private key share files and passwords.")
+			cmd.Flags().StringVar(&config.ValidatorKeysDir, validatorKeysDir.String(), ".charon/validator_keys", maybeRequired("Path to the directory containing the validator private key share files and passwords."))
 		case validatorPubkey:
-			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", "Public key of the validator to exit, must be present in the cluster lock manifest.")
+			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", maybeRequired("Public key of the validator to exit, must be present in the cluster lock manifest."))
 		case exitEpoch:
-			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 162304, "Exit epoch at which the validator will exit, must be the same across all the partial exits.")
+			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 162304, maybeRequired("Exit epoch at which the validator will exit, must be the same across all the partial exits."))
 		case exitFromFile:
-			cmd.Flags().StringVar(&config.ExitFromFilePath, exitFromFile.String(), "", "Retrieves a signed exit message from a pre-prepared file instead of --publish-address.")
+			cmd.Flags().StringVar(&config.ExitFromFilePath, exitFromFile.String(), "", maybeRequired("Retrieves a signed exit message from a pre-prepared file instead of --publish-address."))
 		case beaconNodeTimeout:
-			cmd.Flags().DurationVar(&config.BeaconNodeTimeout, beaconNodeTimeout.String(), 30*time.Second, "Timeout for beacon node HTTP calls.")
+			cmd.Flags().DurationVar(&config.BeaconNodeTimeout, beaconNodeTimeout.String(), 30*time.Second, maybeRequired("Timeout for beacon node HTTP calls."))
 		}
 
 		if f.required {

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -31,7 +31,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 	cmd := &cobra.Command{
 		Use:   "broadcast",
 		Short: "Submit partial exit message for a distributed validator",
-		Long:  `Retrieves and broadcasts a fully signed validator exit message, aggregated with the available partial signatures retrieved from the publish-address.`,
+		Long:  `Retrieves and broadcasts to the configured beacon node a fully signed validator exit message, aggregated with the available partial signatures retrieved from the publish-address. Can also read a signed exit message from disk, in order to be broadcasted to the configured beacon node.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := log.InitLogger(config.Log); err != nil {

--- a/cmd/exit_fetch.go
+++ b/cmd/exit_fetch.go
@@ -27,7 +27,7 @@ func newFetchExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Com
 	cmd := &cobra.Command{
 		Use:   "fetch",
 		Short: "Fetch a signed exit message from the remote API",
-		Long:  `Fetches a fully signed exit message for a given validator from the remote API.`,
+		Long:  `Fetches a fully signed exit message for a given validator from the remote API and writes it to disk.`,
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := log.InitLogger(config.Log); err != nil {

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -68,7 +68,7 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 
 	rawValKeys, err := keystore.LoadFilesUnordered(config.ValidatorKeysDir)
 	if err != nil {
-		return errors.Wrap(err, "could not load keystore")
+		return errors.Wrap(err, "could not load keystore, check if path exists", z.Str("path", config.ValidatorKeysDir))
 	}
 
 	valKeys, err := rawValKeys.SequencedKeys()


### PR DESCRIPTION
Implement several UX tweaks on the `charon exit` subcommands:
 - Instead of printing "Fatal error: could not load keystore: no keys found", add some more context and point the user to the culprit of the issue: "Fatal error: could not load keystore, check if path exists: no keys found {"path": ".charon/validator_keys"}".
 - Add `[REQUIRED]` suffix to all the required CLI flags.
 - Clarified what's the purpose of `fetch` and `broadcast`.

category: misc
ticket: none
