### PR TITLE
workflows: use self-hosted runners

### DIFF
--- a/.github/workflows/build-push-deploy.yml
+++ b/.github/workflows/build-push-deploy.yml
@@ -7,7 +7,7 @@ on:
 name: Build and Publish Docker Image
 jobs:
   build-docker:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
     name: Build Docker Image
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   golangci:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
     steps:
       # Config options can be found in README here: https://github.com/golangci/golangci-lint-action
       - uses: actions/setup-go@v4

--- a/.github/workflows/nightly-tests.yml
+++ b/.github/workflows/nightly-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   nightly_test:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -6,7 +6,7 @@ on:
       - main*
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
     env:
       SKIP: golangci-lint,run-go-tests,no-commit-to-branch
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       - main*
 jobs:
   unit_tests:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -28,7 +28,10 @@ jobs:
           files: coverage.out
 
   integration_tests:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
+    if: ${{ always() }} # makes this step always execute, even if unit_tests fails
+    needs:
+      - unit_tests
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -45,7 +48,11 @@ jobs:
       - run: go test -v -timeout=10m -race github.com/obolnetwork/charon/testutil/integration -integration
 
   compose_tests:
-    runs-on: ubuntu-latest
+    runs-on: charon-ci
+    if: ${{ always() }} # makes this step always execute, even if unit_tests or integration_tests fails
+    needs:
+      - unit_tests
+      - integration_tests
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU


### PR DESCRIPTION
Use self-hosted runners for compute-heavy actions like tests and Docker image builds.

Streamline the `test.yml` action so that its steps aren't executed in parallel but rather sequentially from top to bottom.

category: misc
ticket: none