### PR TITLE
cmd: alpha test beacon

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -94,6 +94,13 @@ type testResult struct {
 	Error       testResultError
 }
 
+func failedTestResult(testRes testResult, err error) testResult {
+	testRes.Verdict = testVerdictFail
+	testRes.Error = testResultError{err}
+
+	return testRes
+}
+
 func (s *testResultError) UnmarshalText(data []byte) error {
 	s.error = errors.New(string(data))
 	return nil

--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -162,11 +162,11 @@ func testAllBeacons(ctx context.Context, queuedTestCases []testCaseName, allTest
 }
 
 func testSingleBeacon(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseBeacon, cfg testBeaconConfig, target string, resCh chan map[string][]testResult) error {
-	singkeTestResCh := make(chan testResult)
+	singleTestResCh := make(chan testResult)
 	allTestRes := []testResult{}
 
 	// run all beacon tests for a beacon node, pushing each completed test to the channel until all are complete or timeout occurs
-	go runBeaconTest(ctx, queuedTestCases, allTestCases, cfg, target, singkeTestResCh)
+	go runBeaconTest(ctx, queuedTestCases, allTestCases, cfg, target, singleTestResCh)
 	testCounter := 0
 	finished := false
 	for !finished {
@@ -176,7 +176,7 @@ func testSingleBeacon(ctx context.Context, queuedTestCases []testCaseName, allTe
 			testName = queuedTestCases[testCounter].name
 			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
 			finished = true
-		case result, ok := <-singkeTestResCh:
+		case result, ok := <-singleTestResCh:
 			if !ok {
 				finished = true
 				break

--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"time"
 
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
@@ -273,16 +274,8 @@ func beaconPingMeasureTest(ctx context.Context, _ *testBeaconConfig, target stri
 func beaconIsSyncedTest(ctx context.Context, _ *testBeaconConfig, target string) testResult {
 	testRes := testResult{Name: "isSynced"}
 
-	type isSyncedResponseData struct {
-		HeadSlot     string `json:"head_slot"`
-		SyncDistance string `json:"sync_distance"`
-		IsSyncing    bool   `json:"is_syncing"`
-		IsOptimistic bool   `json:"is_optimistic"`
-		ElOffline    bool   `json:"el_offline"`
-	}
-
 	type isSyncedResponse struct {
-		Data isSyncedResponseData `json:"data"`
+		Data eth2v1.SyncState `json:"data"`
 	}
 
 	client := http.Client{}

--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -202,25 +202,16 @@ func beaconPingTest(ctx context.Context, _ *testBeaconConfig, target string) tes
 	targetEndpoint := fmt.Sprintf("%v/eth/v1/node/health", target)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetEndpoint, nil)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode > 399 {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{errors.New("status code %v", z.Int("status_code", resp.StatusCode))}
-
-		return testRes
+		return failedTestResult(testRes, errors.New("status code %v", z.Int("status_code", resp.StatusCode)))
 	}
 
 	testRes.Verdict = testVerdictOk
@@ -244,26 +235,17 @@ func beaconPingMeasureTest(ctx context.Context, _ *testBeaconConfig, target stri
 	targetEndpoint := fmt.Sprintf("%v/eth/v1/node/health", target)
 	req, err := http.NewRequestWithContext(httptrace.WithClientTrace(ctx, trace), http.MethodGet, targetEndpoint, nil)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 
 	resp, err := http.DefaultTransport.RoundTrip(req)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode > 399 {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{errors.New("status code %v", z.Int("status_code", resp.StatusCode))}
-
-		return testRes
+		return failedTestResult(testRes, errors.New("status code %v", z.Int("status_code", resp.StatusCode)))
 	}
 
 	if firstByte > thresholdMeasureBad {
@@ -297,47 +279,31 @@ func beaconIsSyncedTest(ctx context.Context, _ *testBeaconConfig, target string)
 	targetEndpoint := fmt.Sprintf("%v/eth/v1/node/syncing", target)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetEndpoint, nil)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 
 	if resp.StatusCode > 399 {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{errors.New("status code %v", z.Int("status_code", resp.StatusCode))}
-
-		return testRes
+		return failedTestResult(testRes, errors.New("status code %v", z.Int("status_code", resp.StatusCode)))
 	}
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	defer resp.Body.Close()
 
 	var respUnmarshaled isSyncedResponse
 	err = json.Unmarshal(b, &respUnmarshaled)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 
 	if respUnmarshaled.Data.IsSyncing {
 		testRes.Verdict = testVerdictFail
-
 		return testRes
 	}
 
@@ -361,42 +327,27 @@ func beaconPeerCountTest(ctx context.Context, _ *testBeaconConfig, target string
 	targetEndpoint := fmt.Sprintf("%v/eth/v1/node/peers?state=connected", target)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, targetEndpoint, nil)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 
 	if resp.StatusCode > 399 {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{errors.New("status code %v", z.Int("status_code", resp.StatusCode))}
-
-		return testRes
+		return failedTestResult(testRes, errors.New("status code %v", z.Int("status_code", resp.StatusCode)))
 	}
 
 	b, err := io.ReadAll(resp.Body)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 	defer resp.Body.Close()
 
 	var respUnmarshaled peerCountResponse
 	err = json.Unmarshal(b, &respUnmarshaled)
 	if err != nil {
-		testRes.Verdict = testVerdictFail
-		testRes.Error = testResultError{err}
-
-		return testRes
+		return failedTestResult(testRes, err)
 	}
 
 	testRes.Measurement = strconv.Itoa(respUnmarshaled.Meta.Count)

--- a/cmd/testbeacon_internal_test.go
+++ b/cmd/testbeacon_internal_test.go
@@ -252,7 +252,7 @@ func StartHealthyMockedBeaconNode(t *testing.T) *httptest.Server {
 		switch r.URL.Path {
 		case "/eth/v1/node/health":
 		case "/eth/v1/node/syncing":
-			_, err := w.Write([]byte(`{"data":{"is_syncing":false}}`))
+			_, err := w.Write([]byte(`{"data":{"head_slot":"0","sync_distance":"0","is_optimistic":false,"is_syncing":false}}`))
 			require.NoError(t, err)
 		case "/eth/v1/node/peers":
 			_, err := w.Write([]byte(`{"meta":{"count":500}}`))

--- a/cmd/testbeacon_internal_test.go
+++ b/cmd/testbeacon_internal_test.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 //go:generate go test . -run=TestBeaconTest -update
@@ -33,12 +35,22 @@ func TestBeaconTest(t *testing.T) {
 					TestCases:  nil,
 					Timeout:    time.Minute,
 				},
-				Endpoints: []string{"beacon-endpoint-1", "beacon-endpoint-2"},
+				Endpoints: []string{"http://localhost:8080", "http://localhost:8081"},
 			},
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
-					"beacon-endpoint-1": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
-					"beacon-endpoint-2": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
+					"http://localhost:8080": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8080/eth/v1/node/syncing": dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8080/eth/v1/node/peers?state=connected": dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+					},
+					"http://localhost:8081": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8081/eth/v1/node/syncing": dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8081/eth/v1/node/peers?state=connected": dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+					},
 				},
 			},
 			expectedErr: "",
@@ -52,12 +64,16 @@ func TestBeaconTest(t *testing.T) {
 					TestCases:  nil,
 					Timeout:    time.Nanosecond,
 				},
-				Endpoints: []string{"beacon-endpoint-1", "beacon-endpoint-2"},
+				Endpoints: []string{"http://localhost:8080", "http://localhost:8081"},
 			},
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
-					"beacon-endpoint-1": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted}},
-					"beacon-endpoint-2": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted}},
+					"http://localhost:8080": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
+					},
+					"http://localhost:8081": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
+					},
 				},
 			},
 			expectedErr: "",
@@ -71,12 +87,22 @@ func TestBeaconTest(t *testing.T) {
 					TestCases:  nil,
 					Timeout:    time.Minute,
 				},
-				Endpoints: []string{"beacon-endpoint-1", "beacon-endpoint-2"},
+				Endpoints: []string{"http://localhost:8080", "http://localhost:8081"},
 			},
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
-					"beacon-endpoint-1": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
-					"beacon-endpoint-2": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
+					"http://localhost:8080": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8080/eth/v1/node/syncing": dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8080/eth/v1/node/peers?state=connected": dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+					},
+					"http://localhost:8081": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8081/eth/v1/node/syncing": dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8081/eth/v1/node/peers?state=connected": dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+					},
 				},
 			},
 			expectedErr: "",
@@ -90,7 +116,7 @@ func TestBeaconTest(t *testing.T) {
 					TestCases:  []string{"notSupportedTest"},
 					Timeout:    time.Minute,
 				},
-				Endpoints: []string{"beacon-endpoint-1", "beacon-endpoint-2"},
+				Endpoints: []string{"http://localhost:8080", "http://localhost:8081"},
 			},
 			expected:    testCategoryResult{},
 			expectedErr: "test case not supported",
@@ -104,17 +130,20 @@ func TestBeaconTest(t *testing.T) {
 					TestCases:  []string{"ping"},
 					Timeout:    time.Minute,
 				},
-				Endpoints: []string{"beacon-endpoint-1", "beacon-endpoint-2"},
+				Endpoints: []string{"http://localhost:8080", "http://localhost:8081"},
 			},
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
-					"beacon-endpoint-1": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
-					"beacon-endpoint-2": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
+					"http://localhost:8080": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+					},
+					"http://localhost:8081": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+					},
 				},
 			},
 			expectedErr: "",
 		},
-
 		{
 			name: "write to file",
 			config: testBeaconConfig{
@@ -124,15 +153,25 @@ func TestBeaconTest(t *testing.T) {
 					TestCases:  nil,
 					Timeout:    time.Minute,
 				},
-				Endpoints: []string{"beacon-endpoint-1", "beacon-endpoint-2"},
+				Endpoints: []string{"http://localhost:8080", "http://localhost:8081"},
 			},
 			expected: testCategoryResult{
-				CategoryName: "beacon",
 				Targets: map[string][]testResult{
-					"beacon-endpoint-1": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
-					"beacon-endpoint-2": {{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errNotImplemented}},
+					"http://localhost:8080": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8080/eth/v1/node/syncing": dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8080/eth/v1/node/peers?state=connected": dial tcp 127.0.0.1:8080: connect: connection refused`)}},
+					},
+					"http://localhost:8081": {
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8081/eth/v1/node/syncing": dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(`Get "http://localhost:8081/eth/v1/node/peers?state=connected": dial tcp 127.0.0.1:8081: connect: connection refused`)}},
+					},
 				},
-				Score: categoryScoreC,
+				Score:        categoryScoreC,
+				CategoryName: "beacon",
 			},
 			expectedErr: "",
 			cleanup: func(t *testing.T, p string) {

--- a/cmd/testbeacon_internal_test.go
+++ b/cmd/testbeacon_internal_test.go
@@ -24,10 +24,8 @@ import (
 func TestBeaconTest(t *testing.T) {
 	port1 := testutil.GetFreePort(t)
 	endpoint1 := fmt.Sprintf("http://localhost:%v", port1)
-	ip1 := fmt.Sprintf("127.0.0.1:%v", port1)
 	port2 := testutil.GetFreePort(t)
 	endpoint2 := fmt.Sprintf("http://localhost:%v", port2)
-	ip2 := fmt.Sprintf("127.0.0.1:%v", port2)
 
 	mockedBeaconNode := StartHealthyMockedBeaconNode(t)
 	defer mockedBeaconNode.Close()
@@ -76,16 +74,16 @@ func TestBeaconTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					endpoint1: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
-						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
-						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/syncing": dial tcp %v: connect: connection refused`, endpoint1, ip1))}},
-						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/peers?state=connected": dial tcp %v: connect: connection refused`, endpoint1, ip1))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
 					},
 					endpoint2: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
-						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
-						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/syncing": dial tcp %v: connect: connection refused`, endpoint2, ip2))}},
-						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/peers?state=connected": dial tcp %v: connect: connection refused`, endpoint2, ip2))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
 					},
 				},
 			},
@@ -128,16 +126,16 @@ func TestBeaconTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					endpoint1: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
-						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
-						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/syncing": dial tcp %v: connect: connection refused`, endpoint1, ip1))}},
-						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/peers?state=connected": dial tcp %v: connect: connection refused`, endpoint1, ip1))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
 					},
 					endpoint2: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
-						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
-						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/syncing": dial tcp %v: connect: connection refused`, endpoint2, ip2))}},
-						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/peers?state=connected": dial tcp %v: connect: connection refused`, endpoint2, ip2))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
 					},
 				},
 			},
@@ -171,10 +169,10 @@ func TestBeaconTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					endpoint1: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
 					},
 					endpoint2: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
 					},
 				},
 			},
@@ -194,16 +192,16 @@ func TestBeaconTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					endpoint1: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
-						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip1))}},
-						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/syncing": dial tcp %v: connect: connection refused`, endpoint1, ip1))}},
-						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/peers?state=connected": dial tcp %v: connect: connection refused`, endpoint1, ip1))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port1))}},
 					},
 					endpoint2: {
-						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
-						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`dial tcp %v: connect: connection refused`, ip2))}},
-						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/syncing": dial tcp %v: connect: connection refused`, endpoint2, ip2))}},
-						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`Get "%v/eth/v1/node/peers?state=connected": dial tcp %v: connect: connection refused`, endpoint2, ip2))}},
+						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "pingMeasure", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "isSynced", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
+						{Name: "peerCount", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: testResultError{errors.New(fmt.Sprintf(`%v: connect: connection refused`, port2))}},
 					},
 				},
 				Score:        categoryScoreC,

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -318,7 +318,7 @@ func testWriteFile(t *testing.T, expectedRes testCategoryResult, path string) {
 			require.Equal(t, expectedRes.Targets[targetName][idx].Measurement, testRes.Measurement)
 			require.Equal(t, expectedRes.Targets[targetName][idx].Suggestion, testRes.Suggestion)
 			if expectedRes.Targets[targetName][idx].Error.error != nil {
-				require.ErrorContains(t, expectedRes.Targets[targetName][idx].Error.error, testRes.Error.error.Error())
+				require.ErrorContains(t, testRes.Error.error, expectedRes.Targets[targetName][idx].Error.error.Error())
 			}
 		}
 	}

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -3,6 +3,7 @@
 package testutil
 
 import (
+	"net"
 	"sync"
 	"testing"
 
@@ -40,4 +41,17 @@ func NewTCPNodeCallback(t *testing.T, protocols ...protocol.ID) func(host host.H
 
 		tcpNodes = append(tcpNodes, tcpNode)
 	}
+}
+
+// GetFreePort returns a free port on the machine on which the test is ran.
+func GetFreePort(t *testing.T) int {
+	t.Helper()
+	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
+	require.NoError(t, err)
+	l, err := net.ListenTCP("tcp", addr)
+	require.NoError(t, err)
+	defer l.Close()
+	port := l.Addr().(*net.TCPAddr).Port
+
+	return port
 }


### PR DESCRIPTION
Charon alpha beacon node testing. Structure is identical to what we have in peers tests, with the exception that here we do not have separation between self and external (peers). The 4 test cases can be fired against multiple beacon nodes.

To test on your own machine:
```
make charon && ./charon alpha test beacon --endpoints="https://ethereum-holesky-beacon-api.publicnode.com,https://ethereum-sepolia-beacon-api.publicnode.com"
```

Similarly to peers tests, const values used to determine whether a measured test result is average or bad are nothing more than estimates for now on my side. I am open to suggestions on that front.

category: feature
ticket: #2998 
