### PR TITLE
dkg: increase test timeout for `TestSigsExchange`

### DIFF
--- a/dkg/nodesigs_internal_test.go
+++ b/dkg/nodesigs_internal_test.go
@@ -25,10 +25,10 @@ import (
 )
 
 func TestSigsExchange(t *testing.T) {
-	n := 10
+	n := 7
 
 	var (
-		ctx, cancel = context.WithTimeout(context.Background(), 15*time.Second)
+		ctx, cancel = context.WithTimeout(context.Background(), 45*time.Second)
 
 		secrets      []*k1.PrivateKey
 		tcpNodes     []host.Host


### PR DESCRIPTION
`TestSigsExchange` is a network-intensive test, that exchanges `n^n` messages at a given time.

While it runs fine on development machines, even our more powerful self-hosted runners need more time for it to finish properly.

Increase the timeout from 15 seconds to 45 seconds as well as reduce the amount of nodes from 10 to 7, in hope to reduce the chances of false positives failures in our CI.

category: fixbuild
ticket: none