### PR TITLE
cmd: increase timeout of timeout test

### DIFF
--- a/cmd/testbeacon_internal_test.go
+++ b/cmd/testbeacon_internal_test.go
@@ -96,7 +96,7 @@ func TestBeaconTest(t *testing.T) {
 					OutputToml: "",
 					Quiet:      false,
 					TestCases:  nil,
-					Timeout:    time.Nanosecond,
+					Timeout:    100 * time.Nanosecond,
 				},
 				Endpoints: []string{endpoint1, endpoint2},
 			},


### PR DESCRIPTION
Sometimes timeout is so little that the test doesn't even reach the second instance, as observed in the pipeline [here](https://github.com/ObolNetwork/charon/actions/runs/9002400755/job/24730617672?pr=3078).

category: bug
ticket: none
