### PR TITLE
cmd: add full unit test for test peers command

### DIFF
--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -237,11 +237,6 @@ func sleepWithContext(ctx context.Context, d time.Duration) {
 }
 
 func runTestPeers(ctx context.Context, w io.Writer, conf testPeersConfig) error {
-	err := log.InitLogger(conf.Log)
-	if err != nil {
-		return err
-	}
-
 	peerTestCases := supportedPeerTestCases()
 	queuedTestsPeer := filterTests(maps.Keys(peerTestCases), conf.testConfig)
 	sortTests(queuedTestsPeer)


### PR DESCRIPTION
Add proper unit test for peers - spinning up multiple peers and local relay and running the peer tests between them.

Some other minor improvements:
 - use enrs of the deterministic private keys created in the beginning;
 - remove logger init in `testpeers.go`;
 - add prepare func;
 - rename cfg to conf to be consistent with the rest of the codebase.

`testpeers.go` coverage has been increased to 86.4%.

category: test
ticket: #3064 