### PR TITLE
cmd: add validator ping tests

### DIFF
--- a/cmd/test.go
+++ b/cmd/test.go
@@ -22,7 +22,6 @@ import (
 
 var (
 	errTimeoutInterrupted = testResultError{errors.New("timeout/interrupted")}
-	errNotImplemented     = testResultError{errors.New("not implemented")}
 	errNoTicker           = testResultError{errors.New("no ticker")}
 )
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -103,7 +103,12 @@ func failedTestResult(testRes testResult, err error) testResult {
 }
 
 func (s *testResultError) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		return nil
+	}
+
 	s.error = errors.New(string(data))
+
 	return nil
 }
 

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
@@ -190,7 +191,7 @@ func writeResultToWriter(res testCategoryResult, w io.Writer) error {
 			testOutput := ""
 			testOutput += fmt.Sprintf("%-60s", singleTestRes.Name)
 			if singleTestRes.Measurement != "" {
-				testOutput = strings.TrimSuffix(testOutput, strings.Repeat(" ", len(singleTestRes.Measurement)+1))
+				testOutput = strings.TrimSuffix(testOutput, strings.Repeat(" ", utf8.RuneCountInString(singleTestRes.Measurement)+1))
 				testOutput = testOutput + singleTestRes.Measurement + " "
 			}
 			testOutput += string(singleTestRes.Verdict)

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -314,12 +314,14 @@ func testWriteFile(t *testing.T, expectedRes testCategoryResult, path string) {
 	for targetName, testResults := range res.Targets {
 		for idx, testRes := range testResults {
 			require.Equal(t, expectedRes.Targets[targetName][idx].Verdict, testRes.Verdict)
-			require.Equal(t, expectedRes.Targets[targetName][idx].Verdict, testRes.Verdict)
-			require.Equal(t, expectedRes.Targets[targetName][idx].Measurement, testRes.Measurement)
-			require.Equal(t, expectedRes.Targets[targetName][idx].Suggestion, testRes.Suggestion)
+			require.Equal(t, expectedRes.Targets[targetName][idx].IsAcceptable, testRes.IsAcceptable)
 			if expectedRes.Targets[targetName][idx].Error.error != nil {
 				require.ErrorContains(t, testRes.Error.error, expectedRes.Targets[targetName][idx].Error.error.Error())
+			} else {
+				require.NoError(t, testRes.Error.error)
 			}
+			require.Equal(t, expectedRes.Targets[targetName][idx].Name, testRes.Name)
+			require.Equal(t, expectedRes.Targets[targetName][idx].Suggestion, testRes.Suggestion)
 		}
 	}
 }


### PR DESCRIPTION
- Add 3 ping tests for validator client (tested them against local Teku VC).
- Updated the generic functions to be similar to what we have in peers and beacon tests.

N.B.: VC tests are not expected to be as used and as vital as peers and beacon. 

category: feature
ticket: #2999 
