### PR TITLE
cmd: remove nil context check on test command

### DIFF
--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -78,9 +78,6 @@ func runTestBeacon(ctx context.Context, w io.Writer, cfg testBeaconConfig) (err 
 	}
 	sortTests(queuedTests)
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -249,9 +249,6 @@ func runTestPeers(ctx context.Context, w io.Writer, conf testPeersConfig) error 
 		return errors.New("test case not supported")
 	}
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, conf.Timeout)
 	defer cancel()
 

--- a/cmd/testvalidator.go
+++ b/cmd/testvalidator.go
@@ -68,9 +68,6 @@ func runTestValidator(ctx context.Context, w io.Writer, cfg testValidatorConfig)
 	}
 	sortTests(queuedTests)
 
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	timeoutCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
 	defer cancel()
 


### PR DESCRIPTION
Context nil check is not necessary, as [cobra is always checking on their end](https://github.com/spf13/cobra/blob/v1.8.0/command.go#L1053) if the context is nil and if so, assigning background context to it.

category: refactor
ticket: none
