### PR TITLE
*: bump go to version 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/obolnetwork/charon
 
-go 1.21
+go 1.22
 
 require (
 	github.com/attestantio/go-eth2-client v0.21.4


### PR DESCRIPTION
Bump go version. Should be safe, as we are already using go 1.22 in the pipelines without any issues.

category: misc
ticket: none
