### PR TITLE
Update license for the next `rc` 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -7,17 +7,19 @@ License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 
 Parameters
 
-Licensor:             Obol Labs, Inc.
+Licensor:             Obol GmbH.
 
 Licensed Work:        Charon, the Distributed Validator Client
-                      The Licensed Work is © 2022-2024 Obol Labs, Inc.
+                      The Licensed Work is The Licensed Work is 
+                      © 2022-2023 Obol Labs, Inc. 
+                      © 2024-2024 Obol GmbH.
 
 Additional Use Grant: The use of the Licensed Work by the Licensee is limited
                       to one (1) Distributed Validator on a production network.
                       Further additional use grants may be specified at
                       charon-additional-use-grants.obol.eth.
 
-Change Date:          7th of November 2027 or such earlier date as may be specified
+Change Date:          24th of May 2028 or such earlier date as may be specified
                       by the Licensor
 
 Change Licence:       GNU General Public License Version 3.0


### PR DESCRIPTION
Updates the license ahead of the next RC candidate. 

category: misc
ticket: none
