### PR TITLE
cmd: exit with validator index, allow BN URLs 

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -22,6 +22,7 @@ type exitConfig struct {
 	ValidatorPubkey       string
 	ValidatorIndex        uint64
 	ValidatorIndexPresent bool
+	ExpertMode            bool
 	PrivateKeyPath        string
 	ValidatorKeysDir      string
 	LockFilePath          string
@@ -124,7 +125,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		case validatorKeysDir:
 			cmd.Flags().StringVar(&config.ValidatorKeysDir, validatorKeysDir.String(), ".charon/validator_keys", maybeRequired("Path to the directory containing the validator private key share files and passwords."))
 		case validatorPubkey:
-			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", maybeRequired("Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, that flag takes precedence."))
+			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", maybeRequired("Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, validator liveliness won't be checked on the beacon chain."))
 		case exitEpoch:
 			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 162304, maybeRequired("Exit epoch at which the validator will exit, must be the same across all the partial exits."))
 		case exitFromFile:
@@ -136,7 +137,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		case publishTimeout:
 			cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 30*time.Second, "Timeout for publishing a signed exit to the publish-address API.")
 		case validatorIndex:
-			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-pubkey is also provided, this flag takes precedence.")
+			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-pubkey is also provided, validator liveliness won't be checked on the beacon chain.")
 		}
 
 		if f.required {

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -6,7 +6,7 @@ import (
 	"context"
 	"time"
 
-	eth2http "github.com/attestantio/go-eth2-client/http"
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/spf13/cobra"
 
@@ -18,19 +18,21 @@ import (
 )
 
 type exitConfig struct {
-	BeaconNodeURL     string
-	ValidatorPubkey   string
-	PrivateKeyPath    string
-	ValidatorKeysDir  string
-	LockFilePath      string
-	PublishAddress    string
-	PublishTimeout    time.Duration
-	ExitEpoch         uint64
-	FetchedExitPath   string
-	PlaintextOutput   bool
-	BeaconNodeTimeout time.Duration
-	ExitFromFilePath  string
-	Log               log.Config
+	BeaconNodeEndpoints   []string
+	ValidatorPubkey       string
+	ValidatorIndex        uint64
+	ValidatorIndexPresent bool
+	PrivateKeyPath        string
+	ValidatorKeysDir      string
+	LockFilePath          string
+	PublishAddress        string
+	PublishTimeout        time.Duration
+	ExitEpoch             uint64
+	FetchedExitPath       string
+	PlaintextOutput       bool
+	BeaconNodeTimeout     time.Duration
+	ExitFromFilePath      string
+	Log                   log.Config
 }
 
 func newExitCmd(cmds ...*cobra.Command) *cobra.Command {
@@ -49,7 +51,7 @@ type exitFlag int
 
 const (
 	publishAddress exitFlag = iota
-	beaconNodeURL
+	beaconNodeEndpoints
 	privateKeyPath
 	lockFilePath
 	validatorKeysDir
@@ -59,14 +61,15 @@ const (
 	beaconNodeTimeout
 	fetchedExitPath
 	publishTimeout
+	validatorIndex
 )
 
 func (ef exitFlag) String() string {
 	switch ef {
 	case publishAddress:
 		return "publish-address"
-	case beaconNodeURL:
-		return "beacon-node-url"
+	case beaconNodeEndpoints:
+		return "beacon-node-endpoints"
 	case privateKeyPath:
 		return "private-key-file"
 	case lockFilePath:
@@ -85,6 +88,8 @@ func (ef exitFlag) String() string {
 		return "fetched-exit-path"
 	case publishTimeout:
 		return "publish-timeout"
+	case validatorIndex:
+		return "validator-index"
 	default:
 		return "unknown"
 	}
@@ -110,8 +115,8 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		switch flag {
 		case publishAddress:
 			cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech", maybeRequired("The URL of the remote API."))
-		case beaconNodeURL:
-			cmd.Flags().StringVar(&config.BeaconNodeURL, beaconNodeURL.String(), "", maybeRequired("Beacon node URL."))
+		case beaconNodeEndpoints:
+			cmd.Flags().StringSliceVar(&config.BeaconNodeEndpoints, beaconNodeEndpoints.String(), nil, maybeRequired("Comma separated list of one or more beacon node endpoint URLs."))
 		case privateKeyPath:
 			cmd.Flags().StringVar(&config.PrivateKeyPath, privateKeyPath.String(), ".charon/charon-enr-private-key", maybeRequired("The path to the charon enr private key file. "))
 		case lockFilePath:
@@ -119,7 +124,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		case validatorKeysDir:
 			cmd.Flags().StringVar(&config.ValidatorKeysDir, validatorKeysDir.String(), ".charon/validator_keys", maybeRequired("Path to the directory containing the validator private key share files and passwords."))
 		case validatorPubkey:
-			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", maybeRequired("Public key of the validator to exit, must be present in the cluster lock manifest."))
+			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", maybeRequired("Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, that flag takes precedence."))
 		case exitEpoch:
 			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 162304, maybeRequired("Exit epoch at which the validator will exit, must be the same across all the partial exits."))
 		case exitFromFile:
@@ -130,6 +135,8 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 			cmd.Flags().StringVar(&config.FetchedExitPath, fetchedExitPath.String(), "./", maybeRequired("Path to store fetched signed exit messages."))
 		case publishTimeout:
 			cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 30*time.Second, "Timeout for publishing a signed exit to the publish-address API.")
+		case validatorIndex:
+			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-pubkey is also provided, this flag takes precedence.")
 		}
 
 		if f.required {
@@ -138,19 +145,17 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 	}
 }
 
-func eth2Client(ctx context.Context, u string, timeout time.Duration) (eth2wrap.Client, error) {
-	bnHTTPClient, err := eth2http.New(ctx,
-		eth2http.WithAddress(u),
-		eth2http.WithTimeout(timeout),
-		eth2http.WithLogLevel(1), // zerolog.InfoLevel
-	)
+func eth2Client(ctx context.Context, u []string, timeout time.Duration) (eth2wrap.Client, error) {
+	cl, err := eth2wrap.NewMultiHTTP(timeout, u...)
 	if err != nil {
+		return nil, err
+	}
+
+	if _, err = cl.NodeVersion(ctx, &eth2api.NodeVersionOpts{}); err != nil {
 		return nil, errors.Wrap(err, "can't connect to beacon node")
 	}
 
-	bnClient := bnHTTPClient.(*eth2http.Service)
-
-	return eth2wrap.AdaptEth2HTTP(bnClient, timeout), nil
+	return cl, nil
 }
 
 // signExit signs a voluntary exit message for valIdx with the given keyShare.

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -53,7 +53,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 		{validatorKeysDir, false},
 		{exitEpoch, false},
 		{validatorPubkey, true},
-		{beaconNodeURL, true},
+		{beaconNodeEndpoints, true},
 		{exitFromFile, false},
 		{beaconNodeTimeout, false},
 	})
@@ -81,7 +81,7 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 
 	ctx = log.WithCtx(ctx, z.Str("validator", validator.String()))
 
-	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL, config.BeaconNodeTimeout)
+	eth2Cl, err := eth2Client(ctx, config.BeaconNodeEndpoints, config.BeaconNodeTimeout)
 	if err != nil {
 		return errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}

--- a/cmd/exit_broadcast_internal_test.go
+++ b/cmd/exit_broadcast_internal_test.go
@@ -99,7 +99,7 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 		require.NoError(t, beaconMock.Close())
 	}()
 
-	eth2Cl, err := eth2Client(ctx, beaconMock.Address(), 10*time.Second)
+	eth2Cl, err := eth2Client(ctx, []string{beaconMock.Address()}, 10*time.Second)
 	require.NoError(t, err)
 
 	eth2Cl.SetForkVersion([4]byte(lock.ForkVersion))
@@ -115,15 +115,15 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
 
 		config := exitConfig{
-			BeaconNodeURL:     beaconMock.Address(),
-			ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
-			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-			PublishAddress:    srv.URL,
-			ExitEpoch:         194048,
-			BeaconNodeTimeout: 30 * time.Second,
-			PublishTimeout:    10 * time.Second,
+			BeaconNodeEndpoints: []string{beaconMock.Address()},
+			ValidatorPubkey:     lock.Validators[0].PublicKeyHex(),
+			PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+			PublishAddress:      srv.URL,
+			ExitEpoch:           194048,
+			BeaconNodeTimeout:   30 * time.Second,
+			PublishTimeout:      10 * time.Second,
 		}
 
 		require.NoError(t, runSignPartialExit(ctx, config), "operator index: %v", idx)
@@ -132,15 +132,15 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 	baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 	config := exitConfig{
-		BeaconNodeURL:     beaconMock.Address(),
-		ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
-		PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-		ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-		LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-		PublishAddress:    srv.URL,
-		ExitEpoch:         194048,
-		BeaconNodeTimeout: 30 * time.Second,
-		PublishTimeout:    10 * time.Second,
+		BeaconNodeEndpoints: []string{beaconMock.Address()},
+		ValidatorPubkey:     lock.Validators[0].PublicKeyHex(),
+		PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+		PublishAddress:      srv.URL,
+		ExitEpoch:           194048,
+		BeaconNodeTimeout:   30 * time.Second,
+		PublishTimeout:      10 * time.Second,
 	}
 
 	if fromFile {
@@ -162,14 +162,14 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 func Test_runBcastFullExitCmd_Config(t *testing.T) {
 	t.Parallel()
 	type test struct {
-		name                string
-		noIdentity          bool
-		noLock              bool
-		badOAPIURL          bool
-		badBeaconNodeURL    bool
-		badValidatorAddr    bool
-		badExistingExitPath bool
-		errData             string
+		name                   string
+		noIdentity             bool
+		noLock                 bool
+		badOAPIURL             bool
+		badBeaconNodeEndpoints bool
+		badValidatorAddr       bool
+		badExistingExitPath    bool
+		errData                string
 	}
 
 	tests := []test{
@@ -189,9 +189,9 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 			errData:    "could not create obol api client",
 		},
 		{
-			name:             "Bad beacon node URL",
-			badBeaconNodeURL: true,
-			errData:          "cannot create eth2 client for specified beacon node",
+			name:                   "Bad beacon node URLs",
+			badBeaconNodeEndpoints: true,
+			errData:                "cannot create eth2 client for specified beacon node",
 		},
 		{
 			name:             "Bad validator address",
@@ -261,7 +261,7 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 
 			bnURL := badStr
 
-			if !test.badBeaconNodeURL {
+			if !test.badBeaconNodeEndpoints {
 				beaconMock, err := beaconmock.New()
 				require.NoError(t, err)
 				defer func() {
@@ -283,15 +283,15 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 			baseDir := filepath.Join(root, "op0") // one operator is enough
 
 			config := exitConfig{
-				BeaconNodeURL:     bnURL,
-				ValidatorPubkey:   valAddr,
-				PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-				ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-				LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-				PublishAddress:    oapiURL,
-				ExitEpoch:         0,
-				BeaconNodeTimeout: 30 * time.Second,
-				PublishTimeout:    10 * time.Second,
+				BeaconNodeEndpoints: []string{bnURL},
+				ValidatorPubkey:     valAddr,
+				PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+				ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+				LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:      oapiURL,
+				ExitEpoch:           0,
+				BeaconNodeTimeout:   30 * time.Second,
+				PublishTimeout:      10 * time.Second,
 			}
 
 			if test.badExistingExitPath {

--- a/cmd/exit_fetch_internal_test.go
+++ b/cmd/exit_fetch_internal_test.go
@@ -83,7 +83,7 @@ func Test_runFetchExitFullFlow(t *testing.T) {
 		require.NoError(t, beaconMock.Close())
 	}()
 
-	eth2Cl, err := eth2Client(ctx, beaconMock.Address(), 10*time.Second)
+	eth2Cl, err := eth2Client(ctx, []string{beaconMock.Address()}, 10*time.Second)
 	require.NoError(t, err)
 
 	eth2Cl.SetForkVersion([4]byte(lock.ForkVersion))
@@ -99,15 +99,15 @@ func Test_runFetchExitFullFlow(t *testing.T) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
 
 		config := exitConfig{
-			BeaconNodeURL:     beaconMock.Address(),
-			ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
-			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-			PublishAddress:    srv.URL,
-			ExitEpoch:         194048,
-			BeaconNodeTimeout: 30 * time.Second,
-			PublishTimeout:    10 * time.Second,
+			BeaconNodeEndpoints: []string{beaconMock.Address()},
+			ValidatorPubkey:     lock.Validators[0].PublicKeyHex(),
+			PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+			PublishAddress:      srv.URL,
+			ExitEpoch:           194048,
+			BeaconNodeTimeout:   30 * time.Second,
+			PublishTimeout:      10 * time.Second,
 		}
 
 		require.NoError(t, runSignPartialExit(ctx, config), "operator index: %v", idx)

--- a/cmd/exit_list.go
+++ b/cmd/exit_list.go
@@ -41,7 +41,7 @@ func newListActiveValidatorsCmd(runFunc func(context.Context, exitConfig) error)
 
 	bindExitFlags(cmd, &config, []exitCLIFlag{
 		{lockFilePath, false},
-		{beaconNodeURL, true},
+		{beaconNodeEndpoints, true},
 		{beaconNodeTimeout, false},
 	})
 
@@ -75,7 +75,7 @@ func listActiveVals(ctx context.Context, config exitConfig) ([]string, error) {
 		return nil, errors.Wrap(err, "could not load cluster-lock.json")
 	}
 
-	eth2Cl, err := eth2Client(ctx, config.BeaconNodeURL, config.BeaconNodeTimeout)
+	eth2Cl, err := eth2Client(ctx, config.BeaconNodeEndpoints, config.BeaconNodeTimeout)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}

--- a/cmd/exit_list_internal_test.go
+++ b/cmd/exit_list_internal_test.go
@@ -76,12 +76,12 @@ func Test_runListActiveVals(t *testing.T) {
 	baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 	config := exitConfig{
-		BeaconNodeURL:     beaconMock.Address(),
-		PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-		ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-		LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-		PlaintextOutput:   true,
-		BeaconNodeTimeout: 30 * time.Second,
+		BeaconNodeEndpoints: []string{beaconMock.Address()},
+		PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+		PlaintextOutput:     true,
+		BeaconNodeTimeout:   30 * time.Second,
 	}
 
 	require.NoError(t, runListActiveValidatorsCmd(ctx, config))
@@ -143,12 +143,12 @@ func Test_listActiveVals(t *testing.T) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 		config := exitConfig{
-			BeaconNodeURL:     beaconMock.Address(),
-			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-			PlaintextOutput:   true,
-			BeaconNodeTimeout: 30 * time.Second,
+			BeaconNodeEndpoints: []string{beaconMock.Address()},
+			PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+			PlaintextOutput:     true,
+			BeaconNodeTimeout:   30 * time.Second,
 		}
 
 		vals, err := listActiveVals(ctx, config)
@@ -184,12 +184,12 @@ func Test_listActiveVals(t *testing.T) {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 		config := exitConfig{
-			BeaconNodeURL:     beaconMock.Address(),
-			PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-			ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-			LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-			PlaintextOutput:   true,
-			BeaconNodeTimeout: 30 * time.Second,
+			BeaconNodeEndpoints: []string{beaconMock.Address()},
+			PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+			ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+			LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+			PlaintextOutput:     true,
+			BeaconNodeTimeout:   30 * time.Second,
 		}
 
 		vals, err := listActiveVals(ctx, config)

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -61,7 +61,7 @@ func newSubmitPartialExitCmd(runFunc func(context.Context, exitConfig) error) *c
 
 		if strings.TrimSpace(config.ValidatorPubkey) == "" && !valIdxPresent {
 			//nolint:revive // we use our own version of the errors package.
-			return errors.New(fmt.Sprintf("%s or %s must be specified.", validatorIndex.String(), validatorPubkey.String()))
+			return errors.New(fmt.Sprintf("either %s or %s must be specified at least.", validatorIndex.String(), validatorPubkey.String()))
 		}
 
 		config.ValidatorIndexPresent = valIdxPresent

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -56,11 +56,17 @@ func writeAllLockData(
 
 func Test_runSubmitPartialExit(t *testing.T) {
 	t.Parallel()
-	t.Run("main flow", Test_runSubmitPartialExitFlow)
+	t.Run("main flow with pubkey", func(t *testing.T) {
+		runSubmitPartialExitFlowTest(t, false)
+	})
+	t.Run("main flow with validator index", func(t *testing.T) {
+		runSubmitPartialExitFlowTest(t, true)
+	})
 	t.Run("config", Test_runSubmitPartialExit_Config)
 }
 
-func Test_runSubmitPartialExitFlow(t *testing.T) {
+func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool) {
+	t.Helper()
 	t.Parallel()
 	ctx := context.Background()
 
@@ -111,7 +117,7 @@ func Test_runSubmitPartialExitFlow(t *testing.T) {
 		require.NoError(t, beaconMock.Close())
 	}()
 
-	eth2Cl, err := eth2Client(ctx, beaconMock.Address(), 10*time.Second)
+	eth2Cl, err := eth2Client(ctx, []string{beaconMock.Address()}, 10*time.Second)
 	require.NoError(t, err)
 
 	eth2Cl.SetForkVersion([4]byte(lock.ForkVersion))
@@ -126,15 +132,21 @@ func Test_runSubmitPartialExitFlow(t *testing.T) {
 	baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 	config := exitConfig{
-		BeaconNodeURL:     beaconMock.Address(),
-		ValidatorPubkey:   lock.Validators[0].PublicKeyHex(),
-		PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-		ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-		LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-		PublishAddress:    srv.URL,
-		ExitEpoch:         194048,
-		BeaconNodeTimeout: 30 * time.Second,
-		PublishTimeout:    10 * time.Second,
+		BeaconNodeEndpoints: []string{beaconMock.Address()},
+		PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+		PublishAddress:      srv.URL,
+		ExitEpoch:           194048,
+		BeaconNodeTimeout:   30 * time.Second,
+		PublishTimeout:      10 * time.Second,
+	}
+
+	if useValIdx {
+		config.ValidatorIndex = 0
+		config.ValidatorIndexPresent = true
+	} else {
+		config.ValidatorPubkey = lock.Validators[0].PublicKeyHex()
 	}
 
 	require.NoError(t, runSignPartialExit(ctx, config))
@@ -143,14 +155,14 @@ func Test_runSubmitPartialExitFlow(t *testing.T) {
 func Test_runSubmitPartialExit_Config(t *testing.T) {
 	t.Parallel()
 	type test struct {
-		name             string
-		noIdentity       bool
-		noLock           bool
-		noKeystore       bool
-		badOAPIURL       bool
-		badBeaconNodeURL bool
-		badValidatorAddr bool
-		errData          string
+		name                   string
+		noIdentity             bool
+		noLock                 bool
+		noKeystore             bool
+		badOAPIURL             bool
+		badBeaconNodeEndpoints bool
+		badValidatorAddr       bool
+		errData                string
 	}
 
 	tests := []test{
@@ -175,9 +187,9 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 			errData:    "could not create obol api client",
 		},
 		{
-			name:             "Bad beacon node URL",
-			badBeaconNodeURL: true,
-			errData:          "cannot create eth2 client for specified beacon node",
+			name:                   "Bad beacon node URL",
+			badBeaconNodeEndpoints: true,
+			errData:                "cannot create eth2 client for specified beacon node",
 		},
 		{
 			name:             "Bad validator address",
@@ -244,7 +256,7 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 
 			bnURL := badStr
 
-			if !test.badBeaconNodeURL {
+			if !test.badBeaconNodeEndpoints {
 				beaconMock, err := beaconmock.New()
 				require.NoError(t, err)
 				defer func() {
@@ -266,15 +278,15 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 			baseDir := filepath.Join(root, fmt.Sprintf("op%d", 0))
 
 			config := exitConfig{
-				BeaconNodeURL:     bnURL,
-				ValidatorPubkey:   valAddr,
-				PrivateKeyPath:    filepath.Join(baseDir, "charon-enr-private-key"),
-				ValidatorKeysDir:  filepath.Join(baseDir, "validator_keys"),
-				LockFilePath:      filepath.Join(baseDir, "cluster-lock.json"),
-				PublishAddress:    oapiURL,
-				ExitEpoch:         0,
-				BeaconNodeTimeout: 30 * time.Second,
-				PublishTimeout:    10 * time.Second,
+				BeaconNodeEndpoints: []string{bnURL},
+				ValidatorPubkey:     valAddr,
+				PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+				ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+				LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:      oapiURL,
+				ExitEpoch:           0,
+				BeaconNodeTimeout:   30 * time.Second,
+				PublishTimeout:      10 * time.Second,
 			}
 
 			require.ErrorContains(t, runSignPartialExit(ctx, config), test.errData)


### PR DESCRIPTION
Allow specifying more than one beacon node to use with the `--beacon-node-endpoints` flag.

Users can now sign exits directly with a validator index rather than specifying its public key.

If both are specified, validator liveliness (i.e. whether or not the validator exists on the beacon chain) is not checked.

`sign` checks that the specified validator index exists in the cluster lock before proceeding.


category: feature
ticket: #3104 

Closes #3104 