### PR TITLE
core/validatorapi: metrics for user-agent and content-type

### DIFF
--- a/core/validatorapi/metrics.go
+++ b/core/validatorapi/metrics.go
@@ -25,6 +25,20 @@ var (
 		Name:      "request_error_total",
 		Help:      "The total number of validatorapi request errors",
 	}, []string{"endpoint", "status_code"})
+
+	vcContentType = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "core",
+		Subsystem: "validatorapi",
+		Name:      "request_total",
+		Help:      "The total number of requests per content-type and endpoint",
+	}, []string{"endpoint", "content_type"})
+
+	vcUserAgentGauge = promauto.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "core",
+		Subsystem: "validatorapi",
+		Name:      "vc_user_agent",
+		Help:      "Gauge with label set to user agent string of requests made by VC",
+	}, []string{"user_agent"})
 )
 
 func incAPIErrors(endpoint string, statusCode int) {

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -301,6 +301,12 @@ func wrap(endpoint string, handler handlerFunc) http.Handler {
 
 			return
 		}
+		vcContentType.WithLabelValues(endpoint, string(typ)).Inc()
+
+		userAgent := r.Header.Get("User-Agent")
+		if userAgent != "" {
+			vcUserAgentGauge.WithLabelValues(userAgent).Set(1)
+		}
 
 		body, err := io.ReadAll(r.Body)
 		if err != nil {

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -69,6 +69,8 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `core_tracker_unexpected_events_total` | Counter | Total number of unexpected events by peer | `peer` |
 | `core_validatorapi_request_error_total` | Counter | The total number of validatorapi request errors | `endpoint, status_code` |
 | `core_validatorapi_request_latency_seconds` | Histogram | The validatorapi request latencies in seconds by endpoint | `endpoint` |
+| `core_validatorapi_request_total` | Counter | The total number of requests per content-type and endpoint | `endpoint, content_type` |
+| `core_validatorapi_vc_user_agent` | Gauge | Gauge with label set to user agent string of requests made by VC | `user_agent` |
 | `p2p_peer_connection_total` | Counter | Total number of libp2p connections per peer. | `peer` |
 | `p2p_peer_connection_types` | Gauge | Current number of libp2p connections by peer and type (`direct` or `relay`). Note that peers may have multiple connections. | `peer, type` |
 | `p2p_peer_network_receive_bytes_total` | Counter | Total number of network bytes received from the peer by protocol. | `peer, protocol` |


### PR DESCRIPTION
Added two new metrics to VAPI:
* core_validatorapi_request_total
* core_validatorapi_vc_user_agent

These will allows us to track VC's User-Agent strings to determine VC vendor/version implicitly.
And the total number of requests have Content-Type label to track requests' format made by VC.

category: feature
ticket: #3107
