### PR TITLE
*: not https warning to show only on http

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -27,7 +27,9 @@ const (
 	defaultConfigFilename = "charon"
 
 	// The environment variable prefix of all environment variables bound to our command line flags.
-	envPrefix = "charon"
+	envPrefix   = "charon"
+	httpScheme  = "http"
+	httpsScheme = "https"
 )
 
 // New returns a new root cobra command that handles our command line tool.

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -351,7 +351,7 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 			return errors.Wrap(err, "failed to parse keymanager addr", z.Str("addr", addr))
 		}
 
-		if keymanagerURL.Scheme != "https" {
+		if keymanagerURL.Scheme == httpScheme {
 			log.Warn(ctx, "Keymanager URL does not use https protocol", nil, z.Str("addr", addr))
 		}
 	}
@@ -1001,7 +1001,7 @@ func loadDefinition(ctx context.Context, defFile string) (cluster.Definition, er
 func validURI(str string) bool {
 	u, err := url.ParseRequestURI(str)
 
-	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
+	return err == nil && (u.Scheme == httpScheme || u.Scheme == httpsScheme) && u.Host != ""
 }
 
 // safeThreshold logs a warning when a non-standard threshold is provided.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -125,7 +125,7 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 				return errors.Wrap(err, "parse relay address", z.Str("address", relay))
 			}
 
-			if u.Scheme == "http" {
+			if u.Scheme == httpScheme {
 				log.Warn(cmd.Context(), "Insecure relay address provided, not HTTPS", nil, z.Str("address", relay))
 			}
 		}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -1089,7 +1089,7 @@ func validateKeymanagerFlags(ctx context.Context, addr, authToken string) error 
 		return errors.Wrap(err, "failed to parse keymanager addr", z.Str("addr", addr))
 	}
 
-	if keymanagerURL.Scheme != "https" {
+	if keymanagerURL.Scheme == "http" {
 		log.Warn(ctx, "Keymanager URL does not use https protocol", nil, z.Str("addr", addr))
 	}
 


### PR DESCRIPTION
A warning log was output in the case "https" is missing as a scheme. This triggered anytime it was not https, even if the scheme was empty.

Linter complained for repeated "http", so I've moved it to const alongside "https".

category: misc
ticket: none
