### PR TITLE
cmd: bind publish timeout on exit

### DIFF
--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -56,6 +56,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 		{beaconNodeEndpoints, true},
 		{exitFromFile, false},
 		{beaconNodeTimeout, false},
+		{publishTimeout, false},
 	})
 
 	bindLogFlags(cmd.Flags(), &config.Log)

--- a/cmd/exit_fetch.go
+++ b/cmd/exit_fetch.go
@@ -47,6 +47,7 @@ func newFetchExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Com
 		{lockFilePath, false},
 		{validatorPubkey, true},
 		{fetchedExitPath, false},
+		{publishTimeout, false},
 	})
 
 	bindLogFlags(cmd.Flags(), &config.Log)

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -51,6 +51,7 @@ func newSubmitPartialExitCmd(runFunc func(context.Context, exitConfig) error) *c
 		{validatorIndex, false},
 		{beaconNodeEndpoints, true},
 		{beaconNodeTimeout, false},
+		{publishTimeout, false},
 	})
 
 	bindLogFlags(cmd.Flags(), &config.Log)


### PR DESCRIPTION
Allow exit commands to specify a publish timeout.

category: bug
ticket: none
