### PR TITLE
*: capella fork to networks

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -85,6 +85,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringVar(&config.TestnetConfig.GenesisForkVersionHex, "testnet-fork-version", "", "Genesis fork version in hex of the custom test network.")
 	cmd.Flags().Uint64Var(&config.TestnetConfig.ChainID, "testnet-chain-id", 0, "Chain ID of the custom test network.")
 	cmd.Flags().Int64Var(&config.TestnetConfig.GenesisTimestamp, "testnet-genesis-timestamp", 0, "Genesis timestamp of the custom test network.")
+	cmd.Flags().StringVar(&config.TestnetConfig.CapellaHardFork, "testnet-capella-hard-fork", "", "Capella hard fork version of the custom test network.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,7 @@ Flags:
       --simnet-validator-keys-dir string   The directory containing the simnet validator key shares. (default ".charon/validator_keys")
       --simnet-validator-mock              Enables an internal mock validator client when running a simnet. Requires simnet-beacon-mock.
       --synthetic-block-proposals          Enables additional synthetic block proposal duties. Used for testing of rare duties.
+      --testnet-capella-hard-fork string   Capella hard fork version of the custom test network.
       --testnet-chain-id uint              Chain ID of the custom test network.
       --testnet-fork-version string        Genesis fork version in hex of the custom test network.
       --testnet-genesis-timestamp int      Genesis timestamp of the custom test network.

--- a/eth2util/helper_capella.go
+++ b/eth2util/helper_capella.go
@@ -15,23 +15,19 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 )
 
-var capellaForkMap = map[string]string{
-	"0x00000000": "0x03000000",
-	"0x00001020": "0x03001020",
-	"0x00000064": "0x03000064",
-	"0x90000069": "0x90000072",
-	"0x01017000": "0x04017000",
-}
-
 // CapellaFork maps generic fork hashes to their specific Capella hardfork
 // values.
 func CapellaFork(forkHash string) (string, error) {
-	d, ok := capellaForkMap[forkHash]
-	if !ok {
-		return "", errors.New("no capella fork for specified fork")
+	networksMu.Lock()
+	defer networksMu.Unlock()
+
+	for _, n := range supportedNetworks {
+		if n.GenesisForkVersionHex == forkHash {
+			return n.CapellaHardFork, nil
+		}
 	}
 
-	return d, nil
+	return "", errors.New("no capella fork for specified fork")
 }
 
 type forkDataType struct {

--- a/eth2util/network.go
+++ b/eth2util/network.go
@@ -25,6 +25,8 @@ type Network struct {
 	GenesisForkVersionHex string
 	// GenesisTimestamp represents genesis timestamp of the network in unix format
 	GenesisTimestamp int64
+	// CapellaHardFork represents capella fork version, used for computing domains for signatures
+	CapellaHardFork string
 }
 
 // IsNonZero checks if each field in this struct is not equal to its zero value.
@@ -39,24 +41,28 @@ var (
 		Name:                  "mainnet",
 		GenesisForkVersionHex: "0x00000000",
 		GenesisTimestamp:      1606824023,
+		CapellaHardFork:       "0x03000000",
 	}
 	Goerli = Network{
 		ChainID:               5,
 		Name:                  "goerli",
 		GenesisForkVersionHex: "0x00001020",
 		GenesisTimestamp:      1616508000,
+		CapellaHardFork:       "0x03001020",
 	}
 	Gnosis = Network{
 		ChainID:               100,
 		Name:                  "gnosis",
 		GenesisForkVersionHex: "0x00000064",
 		GenesisTimestamp:      1638993340,
+		CapellaHardFork:       "0x03000064",
 	}
 	Sepolia = Network{
 		ChainID:               11155111,
 		Name:                  "sepolia",
 		GenesisForkVersionHex: "0x90000069",
 		GenesisTimestamp:      1655733600,
+		CapellaHardFork:       "0x90000072",
 	}
 	// Holesky metadata taken from https://github.com/eth-clients/holesky#metadata.
 	Holesky = Network{
@@ -64,6 +70,7 @@ var (
 		Name:                  "holesky",
 		GenesisForkVersionHex: "0x01017000",
 		GenesisTimestamp:      1696000704,
+		CapellaHardFork:       "0x04017000",
 	}
 )
 


### PR DESCRIPTION
Add Capella hard fork to networks in `eth2util`. Refactor `CapellaFork` function to use the networks already specified. This way we can use the Capella fork value of a manually added test network through the flags. Useful for testing exits with Kurtosis.

category: refactor
ticket: none