### PR TITLE
cmd: add valIdx to obolapi exit message in expert mode

### DIFF
--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -188,6 +188,8 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		if !valIndexFound {
 			return errors.New("validator index not found in beacon node response")
 		}
+	} else {
+		valIndex = eth2p0.ValidatorIndex(config.ValidatorIndex)
 	}
 
 	exitMsg, err := signExit(ctx, eth2Cl, valIndex, ourShare.Share, eth2p0.Epoch(config.ExitEpoch))

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -148,6 +148,7 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		valAPICallOpts.Indices = []eth2p0.ValidatorIndex{
 			eth2p0.ValidatorIndex(config.ValidatorIndex),
 		}
+		valIndex = eth2p0.ValidatorIndex(config.ValidatorIndex)
 	} else {
 		valAPICallOpts.PubKeys = []eth2p0.BLSPubKey{
 			valEth2,
@@ -188,8 +189,6 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		if !valIndexFound {
 			return errors.New("validator index not found in beacon node response")
 		}
-	} else {
-		valIndex = eth2p0.ValidatorIndex(config.ValidatorIndex)
 	}
 
 	exitMsg, err := signExit(ctx, eth2Cl, valIndex, ourShare.Share, eth2p0.Epoch(config.ExitEpoch))


### PR DESCRIPTION
Setting validx to be the configured index in the case of expert mode

category: bug
ticket: #3147 
