### PR TITLE
core/tracker: track blinded proposals

### DIFF
--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -104,16 +104,39 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 			return errors.Wrap(err, "hash aggregate")
 		}
 	} else if duty.Type == core.DutyProposer {
-		proposal, ok := data.(core.VersionedSignedProposal)
-		if !ok {
-			return errors.New("invalid block")
-		}
-		if eth2wrap.IsSyntheticProposal(&proposal.VersionedSignedProposal) {
-			// Report inclusion for synthetic blocks as it is already included on-chain.
-			i.trackerInclFunc(duty, pubkey, data, nil)
+		var (
+			block        core.VersionedSignedProposal
+			blindedBlock core.VersionedSignedBlindedProposal
 
-			return nil
+			blinded bool
+			ok      bool
+		)
+
+		block, ok = data.(core.VersionedSignedProposal)
+		if !ok {
+			blindedBlock, blinded = data.(core.VersionedSignedBlindedProposal)
+			if !blinded {
+				return errors.New("invalid block")
+			}
 		}
+
+		switch blinded {
+		case true:
+			if eth2wrap.IsSyntheticBlindedBlock(&blindedBlock.VersionedSignedBlindedProposal) {
+				// Report inclusion for synthetic blocks as it is already included on-chain.
+				i.trackerInclFunc(duty, pubkey, data, nil)
+
+				return nil
+			}
+		default:
+			if eth2wrap.IsSyntheticProposal(&block.VersionedSignedProposal) {
+				// Report inclusion for synthetic blocks as it is already included on-chain.
+				i.trackerInclFunc(duty, pubkey, data, nil)
+
+				return nil
+			}
+		}
+
 	} else if duty.Type == core.DutyBuilderProposer {
 		return core.ErrDeprecatedDutyBuilderProposer
 	}

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -136,7 +136,6 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 				return nil
 			}
 		}
-
 	} else if duty.Type == core.DutyBuilderProposer {
 		return core.ErrDeprecatedDutyBuilderProposer
 	}

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -7,7 +7,9 @@ import (
 	"math/rand"
 	"net/http"
 	"reflect"
+	"sync"
 	"testing"
+	"time"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
@@ -1111,12 +1113,26 @@ func TestIsParSigEventExpected(t *testing.T) {
 }
 
 func TestAnalyseParSigs(t *testing.T) {
+	t.Run("full block", func(t *testing.T) {
+		analyseParSigs(t, func() core.SignedData {
+			return testutil.RandomDenebCoreVersionedSignedProposal()
+		})
+	})
+
+	t.Run("blinded block", func(t *testing.T) {
+		analyseParSigs(t, func() core.SignedData {
+			return testutil.RandomDenebVersionedSignedBlindedProposal()
+		})
+	})
+}
+
+func analyseParSigs(t *testing.T, dataGen func() core.SignedData) {
+	t.Helper()
 	require.Empty(t, extractParSigs(context.Background(), nil))
 
 	var events []event
 
-	makeEvents := func(n int, pubkey string) {
-		data := testutil.RandomBellatrixCoreVersionedSignedProposal()
+	makeEvents := func(n int, pubkey string, data core.SignedData) {
 		offset := len(events)
 		for i := 0; i < n; i++ {
 			data, err := data.SetSignature(testutil.RandomCoreSignature())
@@ -1137,7 +1153,8 @@ func TestAnalyseParSigs(t *testing.T) {
 		6: "b",
 	}
 	for n, pubkey := range expect {
-		makeEvents(n, pubkey)
+		data := dataGen()
+		makeEvents(n, pubkey, data)
 	}
 
 	allParSigMsgs := extractParSigs(context.Background(), events)
@@ -1303,4 +1320,17 @@ func TestIgnoreUnsupported(t *testing.T) {
 
 func randomStep() step {
 	return step(rand.Intn(int(sentinel)))
+}
+
+func TestSubmittedProposals(t *testing.T) {
+	ic := inclusionCore{
+		mu:          sync.Mutex{},
+		submissions: make(map[subkey]submission),
+	}
+
+	err := ic.Submitted(core.NewProposerDuty(42), testutil.RandomCorePubKey(t), testutil.RandomDenebCoreVersionedSignedProposal(), 1*time.Millisecond)
+	require.NoError(t, err)
+
+	err = ic.Submitted(core.NewProposerDuty(42), testutil.RandomCorePubKey(t), testutil.RandomDenebVersionedSignedBlindedProposal(), 1*time.Millisecond)
+	require.NoError(t, err)
 }


### PR DESCRIPTION
Do the same type casting we do in core/bcast to switch on the type of block proposal.

Add a test to check for this property.

category: bug
ticket: none