### PR TITLE
core/tracker: harden inclusion proposal checks

### DIFF
--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -76,14 +76,13 @@ type inclusionCore struct {
 
 // Submitted is called when a duty is submitted to the beacon node.
 // It adds the duty to the list of submitted duties.
-func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.SignedData, delay time.Duration) error {
+func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.SignedData, delay time.Duration) (err error) {
 	if !inclSupported[duty.Type] {
 		return nil
 	}
 
 	var (
 		attRoot eth2p0.Root
-		err     error
 	)
 	if duty.Type == core.DutyAttester {
 		att, ok := data.(core.Attestation)
@@ -120,6 +119,20 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 			}
 		}
 
+		defer func() {
+			if r := recover(); r != nil {
+				proposal := fmt.Sprintf("%+v", block)
+				if blinded {
+					proposal = fmt.Sprintf("%+v", blindedBlock)
+				}
+
+				err = errors.New("could not determine if proposal was synthetic or not",
+					z.Str("proposal", proposal),
+					z.Bool("blinded", blinded),
+				)
+			}
+		}()
+
 		switch blinded {
 		case true:
 			if eth2wrap.IsSyntheticBlindedBlock(&blindedBlock.VersionedSignedBlindedProposal) {
@@ -152,7 +165,7 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 		Delay:       delay,
 	}
 
-	return nil
+	return err
 }
 
 // Trim removes all duties that are older than the specified slot.

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -13,6 +13,7 @@ import (
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
@@ -1333,4 +1334,13 @@ func TestSubmittedProposals(t *testing.T) {
 
 	err = ic.Submitted(core.NewProposerDuty(42), testutil.RandomCorePubKey(t), testutil.RandomDenebVersionedSignedBlindedProposal(), 1*time.Millisecond)
 	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		err = ic.Submitted(core.NewProposerDuty(42), testutil.RandomCorePubKey(t), core.VersionedSignedBlindedProposal{
+			VersionedSignedBlindedProposal: eth2api.VersionedSignedBlindedProposal{
+				Version: eth2spec.DataVersionDeneb,
+			},
+		}, 1*time.Millisecond)
+		require.ErrorContains(t, err, "could not determine if proposal was synthetic or not")
+	})
 }


### PR DESCRIPTION
Always recover when dealing with malformed proposals, and log some context to aid debugging.

category: refactor
ticket: none