### PR TITLE
core/validatorapi: propose v1 and v2 returns 404

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -135,6 +135,18 @@ func NewRouter(ctx context.Context, h Handler, eth2Cl eth2wrap.Client, isBuilder
 			Methods: []string{http.MethodGet},
 		},
 		{
+			Name:    "propose_block",
+			Path:    "/eth/v2/validator/blocks/{slot}",
+			Handler: respond404(),
+			Methods: []string{http.MethodGet},
+		},
+		{
+			Name:    "propose_blinded_block",
+			Path:    "/eth/v1/validator/blinded_blocks/{slot}",
+			Handler: respond404(),
+			Methods: []string{http.MethodGet},
+		},
+		{
 			Name:    "propose_block_v3",
 			Path:    "/eth/v3/validator/blocks/{slot}",
 			Handler: proposeBlockV3(h, isBuilderEnabled),
@@ -613,6 +625,16 @@ func submitContributionAndProofs(s eth2client.SyncCommitteeContributionsSubmitte
 		}
 
 		return nil, nil, s.SubmitSyncCommitteeContributions(ctx, contributionAndProofs)
+	}
+}
+
+// respond404 returns a handler function always returning http.StatusNotFound
+func respond404() handlerFunc {
+	return func(_ context.Context, _ map[string]string, _ url.Values, _ contentType, _ []byte) (any, http.Header, error) {
+		return nil, nil, apiError{
+			StatusCode: http.StatusNotFound,
+			Message:    "NotFound",
+		}
 	}
 }
 

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -426,6 +426,30 @@ func TestRawRouter(t *testing.T) {
 
 			testRawRouter(t, handler, callback)
 		})
+
+		t.Run("propose_block returns 404", func(t *testing.T) {
+			handler := testHandler{}
+
+			callback := func(ctx context.Context, baseURL string) {
+				res, err := http.Post(baseURL+"/eth/v2/validator/blocks/123", "application/json", bytes.NewReader([]byte{}))
+				require.NoError(t, err)
+				require.Equal(t, http.StatusNotFound, res.StatusCode)
+			}
+
+			testRawRouter(t, handler, callback)
+		})
+
+		t.Run("propose_blinded_block returns 404", func(t *testing.T) {
+			handler := testHandler{}
+
+			callback := func(ctx context.Context, baseURL string) {
+				res, err := http.Post(baseURL+"/eth/v1/validator/blinded_blocks/123", "application/json", bytes.NewReader([]byte{}))
+				require.NoError(t, err)
+				require.Equal(t, http.StatusNotFound, res.StatusCode)
+			}
+
+			testRawRouter(t, handler, callback)
+		})
 	})
 
 	t.Run("submit bellatrix ssz proposal", func(t *testing.T) {


### PR DESCRIPTION
Endpoints `produce_block` and `produce_blinded_block` must return 404 explicitly to prevent processing as proxy calls. Because previously we removed these from the router.
Also, this ensures all attempts to call these endpoint will increment `core_validatorapi_request_error_total` counter. 

category: feature
ticket: #1255
