### PR TITLE
fixbuild: bump linter version

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54.2
+          version: v1.59.1
       - name: notify failure
         if: failure() && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-go
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           version: v1.59.1
       - name: notify failure

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -86,6 +86,8 @@ linters-settings:
         disabled: true
       - name: comment-spacings
         disabled: true # Doesn't support latest go spec comments
+      - name: range-val-address
+        disabled: true # It is not an issue for go versions >=1.22
       # Some configured revive rules
       - name: unhandled-error
         arguments:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -154,6 +154,7 @@ linters:
     - gomnd
     - gomoddirectives
     - ifshort
+    - inamedparam
     - interfacebloat
     - interfacer
     - ireturn

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,8 @@ linters-settings:
       - 'fmt\.Print.*(# Avoid debug logging)?'
       - 'fmt\.Errorf.*(# Prefer app/errors.Wrap)?'
   gci:
-    local-prefixes: github.com/obolnetwork/charon
+    sections:
+      - prefix(github.com/obolnetwork/charon)
   gocritic:
     disabled-checks:
       - ifElseChain
@@ -101,7 +102,6 @@ linters-settings:
          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
-    go: "1.22.5"
     checks:
      - "all"
      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.
@@ -119,6 +119,8 @@ linters-settings:
 
 issues:
   fix: true
+  max-same-issues: 0
+  max-issues-per-linter: 0
   exclude-rules:
     - path: '(.+)_test\.go'
       linters:
@@ -146,7 +148,6 @@ linters:
     - containedctx
     - contextcheck
     - cyclop
-    - exhaustivestruct
     - exhaustruct
     - exportloopref # It is not an issue for go versions >=1.22
     - funlen
@@ -158,29 +159,30 @@ linters:
     - godot
     - godox
     - goerr113
-    - golint
     - gomnd
     - gomoddirectives
-    - ifshort
     - inamedparam
     - interfacebloat
-    - interfacer
     - ireturn
     - lll # Think about adding this (max line length)
     - maintidx
-    - maligned
     - mnd
     - musttag
     - nestif
     - nonamedreturns
     - paralleltest
     - prealloc
-    - scopelint
     - tagliatelle
     - varnamelen
     - wsl
     # Deprecated
+    - deadcode
+    - exhaustivestruct
+    - golint
+    - ifshort
+    - interfacer
+    - maligned
     - nosnakecase
     - structcheck
+    - scopelint
     - varcheck
-    - deadcode

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -164,6 +164,7 @@ linters:
     - lll # Think about adding this (max line length)
     - maintidx
     - maligned
+    - mnd
     - musttag
     - nestif
     - nonamedreturns

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,6 +143,7 @@ linters:
     - cyclop
     - exhaustivestruct
     - exhaustruct
+    - exportloopref # It is not an issue for go versions >=1.22
     - funlen
     - forcetypeassert
     - gci

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -111,6 +111,11 @@ linters-settings:
     ignoreSigs:
       - github.com/obolnetwork/charon/
       - github.com/attestantio/go-eth2-client
+  testifylint:
+    disable:
+      - expected-actual
+    go-require:
+      ignore-http-handlers: true
 
 issues:
   fix: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
   # Then run code validators (on the formatted code)
 
   - repo: https://github.com/golangci/golangci-lint # See .golangci.yml for config
-    rev: v1.56.2
+    rev: v1.59.1
     hooks:
       - id: golangci-lint
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,13 +41,13 @@ repos:
 
   # Then run code validators (on the formatted code)
 
-  - repo: https://github.com/golangci/golangci-lint # See .golangci.yml for config
-    rev: v1.59.1
-    hooks:
-      - id: golangci-lint
-
   - repo: local
     hooks:
+      - id: golangci-lint
+        name: golangci-lint
+        language: script
+        entry: .pre-commit/run_linter.sh
+        types: [ file, go ]
       - id: run-go-tests
         name: run-go-tests
         language: script

--- a/.pre-commit/run_linter.sh
+++ b/.pre-commit/run_linter.sh
@@ -12,7 +12,6 @@ version_check=$(golangci-lint version)
 if [[ $version_check != *"$VERSION"* ]]; then
     echo $version_check
     echo "golangci-lint version is not $VERSION"
-    exit 1
 fi
 
 golangci-lint run

--- a/.pre-commit/run_linter.sh
+++ b/.pre-commit/run_linter.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+VERSION="1.59.1"
+
+if ! command -v golangci-lint &> /dev/null
+then
+    echo "golangci-lint could not be found"
+    exit 1
+fi
+
+version_check=$(golangci-lint version)
+if [[ $version_check != *"$VERSION"* ]]; then
+    echo $version_check
+    echo "golangci-lint version is not $VERSION"
+    exit 1
+fi
+
+golangci-lint run

--- a/app/disk_internal_test.go
+++ b/app/disk_internal_test.go
@@ -55,7 +55,7 @@ func TestCalculateTrackerDelay(t *testing.T) {
 
 func TestSetFeeRecipient(t *testing.T) {
 	set := beaconmock.ValidatorSetA
-	for i := 0; i < len(set); i++ {
+	for i := range len(set) {
 		clone, err := set.Clone()
 		require.NoError(t, err)
 

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -5,7 +5,6 @@
 package errors
 
 import (
-	//nolint:revive
 	stderrors "errors"
 	"fmt"
 

--- a/app/errors/go113.go
+++ b/app/errors/go113.go
@@ -1,6 +1,6 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-//nolint:wrapcheck,revive
+//nolint:wrapcheck
 package errors
 
 import (

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -136,10 +136,10 @@ func provide[O any](ctx context.Context, clients []Client,
 			}
 
 			return res.Output, nil
-		} else {
-			nokResp = res
-			hasNokResp = true
 		}
+
+		nokResp = res
+		hasNokResp = true
 	}
 
 	if ctx.Err() != nil {

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -73,8 +73,6 @@ func WithSyntheticDuties(cl Client) Client {
 func NewMultiHTTP(timeout time.Duration, forkVersion [4]byte, addresses ...string) (Client, error) {
 	var clients []Client
 	for _, address := range addresses {
-		address := address // Capture range variable.
-
 		parameters := []eth2http.Parameter{
 			eth2http.WithLogLevel(zeroLogInfo),
 			eth2http.WithAddress(address),

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -246,7 +246,7 @@ func TestErrors(t *testing.T) {
 }
 
 func TestCtxCancel(t *testing.T) {
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		bmock, err := beaconmock.New()
@@ -392,7 +392,7 @@ func TestOnlyTimeout(t *testing.T) {
 	const n = 10
 	var wg sync.WaitGroup
 	wg.Add(n)
-	for i := 0; i < n; i++ {
+	for range n {
 		go func() {
 			testCtxCancel(t, time.Millisecond*10)
 			wg.Done()
@@ -444,7 +444,7 @@ func TestLazy(t *testing.T) {
 	enabled2.Store(true)
 
 	// Proxy2 is enabled, so this should succeed.
-	for i := 0; i < 5; i++ { // Do multiple request to make Proxy2 the "best".
+	for range 5 { // Do multiple request to make Proxy2 the "best".
 		_, err = eth2Cl.NodeSyncing(ctx, &eth2api.NodeSyncingOpts{})
 		require.NoError(t, err)
 	}

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -373,7 +373,7 @@ func TestOnlyTimeout(t *testing.T) {
 		if ctx.Err() != nil {
 			return
 		}
-		require.Fail(t, "Expect this only to return after main ctx cancelled")
+		require.Fail(t, "Expect this only to return after main ctx cancelled") //nolint:testifylint // TODO: find a way to do that outside of go routine
 	}()
 
 	// Allow the above goroutine to block on the .Spec() call.

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -296,6 +296,7 @@ func httpPost(ctx context.Context, base string, endpoint string, body io.Reader,
 		return nil, errors.Wrap(err, "failed to read POST response")
 	}
 
+	//nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 	if res.StatusCode/100 != 2 {
 		return nil, errors.New("post failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
 	}

--- a/app/eth2wrap/synthproposer_test.go
+++ b/app/eth2wrap/synthproposer_test.go
@@ -207,7 +207,7 @@ func TestSynthProposerBlockNotFound(t *testing.T) {
 
 		return nil, &eth2api.Error{
 			Method:     http.MethodGet,
-			Endpoint:   fmt.Sprintf("/eth/v2/beacon/blocks/%s", blockID),
+			Endpoint:   "/eth/v2/beacon/blocks/" + blockID,
 			StatusCode: http.StatusNotFound,
 			Data:       []byte(fmt.Sprintf(`{"code":404,"message":"NOT_FOUND: beacon block at slot %s","stacktraces":[]}`, blockID)),
 		}

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -26,7 +26,7 @@ func TestValidatorCache(t *testing.T) {
 	)
 
 	// Create a set of validators, half active, half random state.
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		val := testutil.RandomValidator(t)
 		if rand.Intn(2) == 0 {
 			val.Status = eth2v1.ValidatorState(rand.Intn(10))

--- a/app/expbackoff/expbackoff_test.go
+++ b/app/expbackoff/expbackoff_test.go
@@ -85,7 +85,7 @@ func TestConfigs(t *testing.T) {
 			})
 
 			var resps []string
-			for i := 0; i < len(test.backoffs); i++ {
+			for i := range len(test.backoffs) {
 				resp := expbackoff.Backoff(test.config, i)
 				resps = append(resps, resp.Truncate(time.Millisecond*10).String())
 			}

--- a/app/featureset/featureset_internal_test.go
+++ b/app/featureset/featureset_internal_test.go
@@ -20,6 +20,6 @@ func TestAllFeatureStatus(t *testing.T) {
 	for _, feature := range features {
 		status, ok := state[feature]
 		require.True(t, ok)
-		require.Greater(t, status, 0)
+		require.Positive(t, status)
 	}
 }

--- a/app/forkjoin/forkjoin.go
+++ b/app/forkjoin/forkjoin.go
@@ -184,7 +184,7 @@ func New[I, O any](rootCtx context.Context, work Work[I, O], opts ...Option) (Fo
 		}()
 	}
 
-	for i := 0; i < options.workers; i++ { // Start workers
+	for range options.workers { // Start workers
 		go func() {
 			for in := range input { // Process all inputs (channel closed on Join)
 				if workCtx.Err() != nil { // Skip work if failed fast

--- a/app/forkjoin/forkjoin_test.go
+++ b/app/forkjoin/forkjoin_test.go
@@ -84,7 +84,7 @@ func TestForkJoin(t *testing.T) {
 			defer cancel()
 
 			var allOutput []int
-			for i := 0; i < n; i++ {
+			for i := range n {
 				fork(i)
 				allOutput = append(allOutput, i)
 			}

--- a/app/health/checker.go
+++ b/app/health/checker.go
@@ -140,7 +140,7 @@ func newQueryFunc(metrics [][]*pb.MetricFamily) func(string, labelSelector, seri
 			for _, fam := range fams {
 				if fam.GetName() != name {
 					continue
-				} else if len(fam.Metric) == 0 {
+				} else if len(fam.GetMetric()) == 0 {
 					continue
 				}
 				selected, err := selector(fam)

--- a/app/health/checks.go
+++ b/app/health/checks.go
@@ -69,7 +69,7 @@ var checks = []check{
 		Name:        "beacon_node_syncing",
 		Description: "Beacon Node in syncing state.",
 		Severity:    severityCritical,
-		Func: func(q query, m Metadata) (bool, error) {
+		Func: func(q query, _ Metadata) (bool, error) {
 			max, err := q("app_monitoring_beacon_node_syncing", noLabels, gaugeMax)
 			if err != nil {
 				return false, err
@@ -97,7 +97,7 @@ var checks = []check{
 		Name:        "pending_validators",
 		Description: "Pending validators detected. Activate them to start validating.",
 		Severity:    severityInfo,
-		Func: func(q query, m Metadata) (bool, error) {
+		Func: func(q query, _ Metadata) (bool, error) {
 			max, err := q("core_scheduler_validator_status",
 				countLabels(l("status", "pending")),
 				gaugeMax)
@@ -112,7 +112,7 @@ var checks = []check{
 		Name:        "proposal_failures",
 		Description: "Proposal failures detected. See <link to troubleshoot proposal failures>.",
 		Severity:    severityWarning,
-		Func: func(q query, m Metadata) (bool, error) {
+		Func: func(q query, _ Metadata) (bool, error) {
 			increase, err := q("core_tracker_failed_duties_total",
 				sumLabels(l("duty", ".*proposal")), increase)
 			if err != nil {

--- a/app/health/checks.go
+++ b/app/health/checks.go
@@ -126,7 +126,7 @@ var checks = []check{
 		Name:        "high_registration_failures_rate",
 		Description: "High rate of failed validator registrations. Please check the logs for more details.",
 		Severity:    severityWarning,
-		Func: func(q query, m Metadata) (bool, error) {
+		Func: func(q query, _ Metadata) (bool, error) {
 			increase, err := q("core_bcast_recast_errors_total", sumLabels(), increase)
 			if err != nil {
 				return false, err

--- a/app/health/checks_internal_test.go
+++ b/app/health/checks_internal_test.go
@@ -419,7 +419,7 @@ func testCheck(t *testing.T, m Metadata, checkName string, expect bool, metrics 
 	}
 
 	multiFams := make([][]*pb.MetricFamily, max)
-	for i := 0; i < max; i++ {
+	for i := range max {
 		var fam []*pb.MetricFamily
 		if i < len(metrics) {
 			fam = append(fam, metrics[i])

--- a/app/health/checks_internal_test.go
+++ b/app/health/checks_internal_test.go
@@ -451,7 +451,7 @@ func testCheck(t *testing.T, m Metadata, checkName string, expect bool, metrics 
 
 func genFam(name string, metrics ...[]*pb.Metric) []*pb.MetricFamily {
 	typ := pb.MetricType_COUNTER
-	if metrics[0][0].Gauge != nil {
+	if metrics[0][0].GetGauge() != nil {
 		typ = pb.MetricType_GAUGE
 	}
 

--- a/app/health/reducers.go
+++ b/app/health/reducers.go
@@ -17,12 +17,12 @@ func increase(samples []*pb.Metric) (float64, error) {
 		return 0, nil
 	}
 
-	if samples[0].Counter == nil && samples[0].Gauge == nil {
+	if samples[0].GetCounter() == nil && samples[0].GetGauge() == nil {
 		return 0, errors.New("bug: unsupported metric passed")
 	}
 
-	first := samples[0].Counter.GetValue() + samples[0].Gauge.GetValue()
-	last := samples[len(samples)-1].Counter.GetValue() + samples[len(samples)-1].Gauge.GetValue()
+	first := samples[0].GetCounter().GetValue() + samples[0].GetGauge().GetValue()
+	last := samples[len(samples)-1].GetCounter().GetValue() + samples[len(samples)-1].GetGauge().GetValue()
 
 	return last - first, nil
 }
@@ -31,12 +31,12 @@ func increase(samples []*pb.Metric) (float64, error) {
 func gaugeMax(samples []*pb.Metric) (float64, error) {
 	var max float64
 	for _, sample := range samples {
-		if sample.Gauge == nil {
+		if sample.GetGauge() == nil {
 			return 0, errors.New("bug: non-gauge metric passed")
 		}
 
-		if sample.Gauge.GetValue() > max {
-			max = sample.Gauge.GetValue()
+		if sample.GetGauge().GetValue() > max {
+			max = sample.GetGauge().GetValue()
 		}
 	}
 

--- a/app/k1util/k1util_test.go
+++ b/app/k1util/k1util_test.go
@@ -152,7 +152,7 @@ func BenchmarkRecoverVerify(b *testing.B) {
 	b.StartTimer()
 
 	b.Run("recover", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			recovered, err := k1util.Recover(
 				digest,
 				sig)
@@ -162,7 +162,7 @@ func BenchmarkRecoverVerify(b *testing.B) {
 	})
 
 	b.Run("verify", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
+		for range b.N {
 			ok, err := k1util.Verify64(
 				key.PubKey(),
 				digest,

--- a/app/lifecycle/manager_test.go
+++ b/app/lifecycle/manager_test.go
@@ -102,7 +102,7 @@ func TestManager(t *testing.T) {
 			// Run the lifecycle (async)
 			go func() {
 				err := life.Run(ctx)
-				require.NoError(t, err)
+				require.NoError(t, err) //nolint:testifylint // if there is an err it will be caught right away
 			}()
 
 			// Wait for the hooks to be called.

--- a/app/lifecycle/manager_test.go
+++ b/app/lifecycle/manager_test.go
@@ -107,7 +107,7 @@ func TestManager(t *testing.T) {
 
 			// Wait for the hooks to be called.
 			var calls []string
-			for i := 0; i < len(test.Hooks); i++ {
+			for i := range len(test.Hooks) {
 				if i == starts {
 					// Cancel application context after the starts hooks.
 					cancel()

--- a/app/log/config.go
+++ b/app/log/config.go
@@ -248,7 +248,7 @@ func InitLogger(config Config) error {
 // WithClock returns a function that uses the provided clock to encode log timestamps.
 func WithClock(clock clockwork.Clock) func(config *zapcore.EncoderConfig) {
 	return func(config *zapcore.EncoderConfig) {
-		config.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+		config.EncodeTime = func(_ time.Time, enc zapcore.PrimitiveArrayEncoder) {
 			enc.AppendString(clock.Now().Format("15:04:05.000"))
 		}
 	}

--- a/app/log/config.go
+++ b/app/log/config.go
@@ -196,7 +196,7 @@ func InitLogger(config Config) error {
 		}
 
 		if config.LogOutputPath != "" {
-			fileWriter, _, err := zap.Open(fmt.Sprintf("lumberjack:%s", config.LogOutputPath))
+			fileWriter, _, err := zap.Open("lumberjack:" + config.LogOutputPath)
 			if err != nil {
 				return errors.Wrap(err, "open file writer")
 			}

--- a/app/log/config_internal_test.go
+++ b/app/log/config_internal_test.go
@@ -46,10 +46,10 @@ func TestLokiCaller(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, r.Body.Close())
 		req := decode(t, b)
-		require.Len(t, req.Streams, 1)
-		require.Len(t, req.Streams[0].Entries, 1)
+		require.Len(t, req.GetStreams(), 1)
+		require.Len(t, req.GetStreams()[0].GetEntries(), 1)
 		// Assert caller is this file.
-		require.Contains(t, req.Streams[0].Entries[0].String(), "caller=log/config_internal_test.go:")
+		require.Contains(t, req.GetStreams()[0].GetEntries()[0].String(), "caller=log/config_internal_test.go:")
 		close(done)
 	}))
 

--- a/app/log/config_internal_test.go
+++ b/app/log/config_internal_test.go
@@ -4,10 +4,10 @@ package log
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
 	"github.com/golang/snappy"
@@ -32,7 +32,7 @@ testing.tRunner
 	}
 
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			actual := formatZapStack(test.Input)
 			require.Equal(t, test.Output, actual)
 		})

--- a/app/log/log.go
+++ b/app/log/log.go
@@ -51,13 +51,16 @@ func WithLogger(ctx context.Context, logger zapLogger) context.Context {
 }
 
 func fieldsFromCtx(ctx context.Context) []z.Field {
-	resp, _ := ctx.Value(ctxKey{}).([]z.Field)
+	resp, ok := ctx.Value(ctxKey{}).([]z.Field)
+	if !ok {
+		return []z.Field{}
+	}
 	return resp
 }
 
 func metricsTopicFromCtx(ctx context.Context) string {
-	resp, _ := ctx.Value(topicKey{}).(string)
-	if resp == "" {
+	resp, ok := ctx.Value(topicKey{}).(string)
+	if resp == "" || !ok {
 		return "unknown"
 	}
 

--- a/app/log/log.go
+++ b/app/log/log.go
@@ -192,7 +192,7 @@ func errFields(err error) z.Field {
 	// is used and this avoids exporting the structured error type.
 	ferr, ok := err.(structErr) //nolint:errorlint
 	if !ok {
-		return func(add func(zap.Field)) {}
+		return func(func(zap.Field)) {}
 	}
 
 	return func(add func(zap.Field)) {

--- a/app/log/log.go
+++ b/app/log/log.go
@@ -194,7 +194,7 @@ func errFields(err error) z.Field {
 
 	// Using cast instead of errors.As since no other wrapping library
 	// is used and this avoids exporting the structured error type.
-	ferr, ok := err.(structErr) //nolint:errorlint
+	ferr, ok := err.(structErr)
 	if !ok {
 		return func(func(zap.Field)) {}
 	}

--- a/app/log/log.go
+++ b/app/log/log.go
@@ -55,6 +55,7 @@ func fieldsFromCtx(ctx context.Context) []z.Field {
 	if !ok {
 		return []z.Field{}
 	}
+
 	return resp
 }
 

--- a/app/log/loki/batch.go
+++ b/app/log/loki/batch.go
@@ -37,7 +37,7 @@ func newBatch(entries ...*pbv1.Entry) *batch {
 
 // Add an entry to the batch.
 func (b *batch) Add(entry *pbv1.Entry) {
-	b.bytes += len(entry.Line)
+	b.bytes += len(entry.GetLine())
 	b.entries = append(b.entries, entry)
 }
 

--- a/app/log/loki/client.go
+++ b/app/log/loki/client.go
@@ -210,6 +210,7 @@ func send(ctx context.Context, client *http.Client, endpoint string, batch *batc
 	}
 	defer resp.Body.Close()
 
+	//nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 	if resp.StatusCode/100 != 2 {
 		scanner := bufio.NewScanner(io.LimitReader(resp.Body, maxErrMsgLen))
 		line := ""

--- a/app/log/loki/client_test.go
+++ b/app/log/loki/client_test.go
@@ -59,11 +59,11 @@ func TestLoki(t *testing.T) {
 
 	go cl.Run()
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		cl.Add(fmt.Sprint(i))
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		require.Equal(t, fmt.Sprint(i), <-received)
 	}
 
@@ -124,7 +124,7 @@ func TestLongLines(t *testing.T) {
 
 	cl.Add(normal)
 
-	for i := 0; i < 1000; i++ {
+	for range 1000 {
 		cl.Add(huge)
 	}
 

--- a/app/log/loki/client_test.go
+++ b/app/log/loki/client_test.go
@@ -33,11 +33,11 @@ func TestLoki(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, r.Body.Close())
 		req := decode(t, b)
-		require.Len(t, req.Streams, 1)
-		require.Contains(t, req.Streams[0].Labels, fmt.Sprintf(`service="%s"`, serviceLabel))
-		require.Contains(t, req.Streams[0].Labels, fmt.Sprintf(`%s="%s"`, otherLabelKey, otherLabelValue))
-		for _, entry := range req.Streams[0].Entries {
-			received <- entry.Line
+		require.Len(t, req.GetStreams(), 1)
+		require.Contains(t, req.GetStreams()[0].GetLabels(), fmt.Sprintf(`service="%s"`, serviceLabel))
+		require.Contains(t, req.GetStreams()[0].GetLabels(), fmt.Sprintf(`%s="%s"`, otherLabelKey, otherLabelValue))
+		for _, entry := range req.GetStreams()[0].GetEntries() {
+			received <- entry.GetLine()
 		}
 	}))
 
@@ -104,13 +104,13 @@ func TestLongLines(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, r.Body.Close())
 		req := decode(t, b)
-		require.Len(t, req.Streams, 1)
-		require.Contains(t, req.Streams[0].Labels, fmt.Sprintf(`service="%s"`, serviceLabel))
-		for _, entry := range req.Streams[0].Entries {
+		require.Len(t, req.GetStreams(), 1)
+		require.Contains(t, req.GetStreams()[0].GetLabels(), fmt.Sprintf(`service="%s"`, serviceLabel))
+		for _, entry := range req.GetStreams()[0].GetEntries() {
 			go func(entry string) {
 				entriesChan <- entry
 				close(entriesChan)
-			}(entry.Line)
+			}(entry.GetLine())
 		}
 	}))
 

--- a/app/log/loki/client_test.go
+++ b/app/log/loki/client_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -60,11 +61,11 @@ func TestLoki(t *testing.T) {
 	go cl.Run()
 
 	for i := range n {
-		cl.Add(fmt.Sprint(i))
+		cl.Add(strconv.Itoa(i))
 	}
 
 	for i := range n {
-		require.Equal(t, fmt.Sprint(i), <-received)
+		require.Equal(t, strconv.Itoa(i), <-received)
 	}
 
 	cl.Stop(context.Background())

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -67,7 +67,7 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, d
 	readyErrFunc := startReadyChecker(ctx, tcpNode, eth2Cl, peerIDs, clockwork.NewRealClock(),
 		pubkeys, seenPubkeys, vapiCalls)
 
-	mux.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
 		readyErr := readyErrFunc()
 		if readyErr != nil {
 			writeResponse(w, http.StatusInternalServerError, readyErr.Error())
@@ -173,6 +173,7 @@ func startReadyChecker(ctx context.Context, tcpNode host.Host, eth2Cl eth2wrap.C
 				}
 
 				syncing, syncDistance, err := beaconNodeSyncing(ctx, eth2Cl)
+				//nolint:revive // skip max-control-nesting for monitoring
 				if err != nil {
 					err = errReadyBeaconNodeDown
 					readyzGauge.Set(readyzBeaconNodeDown)

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -125,7 +125,7 @@ func TestStartChecker(t *testing.T) {
 				hostsInfo []peer.AddrInfo
 			)
 
-			for i := 0; i < tt.numPeers; i++ {
+			for range tt.numPeers {
 				h := testutil.CreateHost(t, testutil.AvailableAddr(t))
 				info := peer.AddrInfo{
 					ID:    h.ID(),

--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -96,7 +96,6 @@ func TestStartChecker(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -123,6 +123,7 @@ func httpPost(ctx context.Context, url *url.URL, b []byte) error {
 		return errors.Wrap(err, "failed to read POST response")
 	}
 
+	//nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 	if res.StatusCode/100 != 2 {
 		return errors.New("post failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
 	}

--- a/app/obolapi/exit_test.go
+++ b/app/obolapi/exit_test.go
@@ -72,7 +72,7 @@ func TestAPIFlow(t *testing.T) {
 	sigData, err := (&eth2p0.SigningData{ObjectRoot: sigRoot, Domain: domain}).HashTreeRoot()
 	require.NoError(t, err)
 
-	for idx := 0; idx < len(shares); idx++ {
+	for idx := range len(shares) {
 		var exits []obolapi.ExitBlob
 
 		for _, shareSet := range shares[idx] {
@@ -163,7 +163,7 @@ func TestAPIFlowMissingSig(t *testing.T) {
 	sigData, err := (&eth2p0.SigningData{ObjectRoot: sigRoot, Domain: domain}).HashTreeRoot()
 	require.NoError(t, err)
 
-	for idx := 0; idx < len(shares); idx++ {
+	for idx := range len(shares) {
 		var exits []obolapi.ExitBlob
 
 		for _, shareSet := range shares[idx] {

--- a/app/peerinfo/adhoc_test.go
+++ b/app/peerinfo/adhoc_test.go
@@ -31,8 +31,8 @@ func TestDoOnce(t *testing.T) {
 	info, _, ok, err := peerinfo.DoOnce(context.Background(), client, server.ID())
 	require.NoError(t, err)
 	require.True(t, ok)
-	require.Equal(t, vers.String(), info.CharonVersion)
-	require.Equal(t, gitHash, info.GitHash)
-	require.Equal(t, lockHash, info.LockHash)
-	require.True(t, info.BuilderApiEnabled)
+	require.Equal(t, vers.String(), info.GetCharonVersion())
+	require.Equal(t, gitHash, info.GetGitHash())
+	require.Equal(t, lockHash, info.GetLockHash())
+	require.True(t, info.GetBuilderApiEnabled())
 }

--- a/app/peerinfo/peerinfo_test.go
+++ b/app/peerinfo/peerinfo_test.go
@@ -62,7 +62,7 @@ func TestPeerInfo(t *testing.T) {
 		peerInfos   []*peerinfo.PeerInfo
 	)
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		tcpNode := testutil.CreateHost(t, testutil.AvailableAddr(t))
 		for j, other := range tcpNodes {
 			tcpNode.Peerstore().AddAddrs(other.ID(), other.Addrs(), peerstore.PermanentAddrTTL)
@@ -85,7 +85,7 @@ func TestPeerInfo(t *testing.T) {
 		return func() time.Time { return now.Add(nodes[i].Offset) }
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		node := nodes[i]
 
 		// Most nodes are passive
@@ -137,7 +137,7 @@ func TestPeerInfo(t *testing.T) {
 		peerInfos = append(peerInfos, peerInfo)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		if nodes[i].Ignore {
 			continue
 		}

--- a/app/promauto/promauto_test.go
+++ b/app/promauto/promauto_test.go
@@ -28,7 +28,7 @@ func TestWrapRegisterer(t *testing.T) {
 	require.NoError(t, err)
 	metrics, err := registry.Gather()
 	require.NoError(t, err)
-	require.True(t, len(metrics) > 1)
+	require.Greater(t, len(metrics), 1)
 
 	var foundTest bool
 	for _, metricFam := range metrics {

--- a/app/promauto/promauto_test.go
+++ b/app/promauto/promauto_test.go
@@ -33,23 +33,23 @@ func TestWrapRegisterer(t *testing.T) {
 	var foundTest bool
 	for _, metricFam := range metrics {
 		// All metrics contain own and registered labels.
-		for _, metric := range metricFam.Metric {
+		for _, metric := range metricFam.GetMetric() {
 			notFound := make(prometheus.Labels)
 			for k, v := range labels {
 				notFound[k] = v
 			}
-			for _, label := range metric.Label {
-				v, ok := notFound[*label.Name]
+			for _, label := range metric.GetLabel() {
+				v, ok := notFound[label.GetName()]
 				if !ok {
 					continue
 				}
-				require.Equal(t, v, *label.Value)
-				delete(notFound, *label.Name)
+				require.Equal(t, v, label.GetValue())
+				delete(notFound, label.GetName())
 			}
 
 			require.Empty(t, notFound)
 		}
-		if *metricFam.Name == "test" {
+		if metricFam.GetName() == "test" {
 			foundTest = true
 		}
 	}

--- a/app/promauto/resetgauge_test.go
+++ b/app/promauto/resetgauge_test.go
@@ -61,11 +61,11 @@ func assertVecLen(t *testing.T, registry *prometheus.Registry, name string, l in
 	require.NoError(t, err)
 
 	for _, metricFam := range metrics {
-		if *metricFam.Name != name {
+		if metricFam.GetName() != name {
 			continue
 		}
 
-		require.Len(t, metricFam.Metric, l)
+		require.Len(t, metricFam.GetMetric(), l)
 
 		return
 	}

--- a/app/protonil/protonil.go
+++ b/app/protonil/protonil.go
@@ -75,7 +75,7 @@ func Check(msg proto.Message) error {
 		// Check elements of list fields.
 		if field.IsList() {
 			list := rMsg.Get(field).List()
-			for i := 0; i < list.Len(); i++ {
+			for i := range list.Len() {
 				elem, ok := valueToMsg(list.Get(i))
 				if !ok {
 					// Not a message element type.

--- a/app/protonil/protonil_test.go
+++ b/app/protonil/protonil_test.go
@@ -156,7 +156,7 @@ func TestFuzz(t *testing.T) {
 
 func BenchmarkCheck(b *testing.B) {
 	fuzzer := fuzz.New()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		b.StopTimer()
 		m1 := new(v1.M1)
 		fuzzer.Fuzz(m1)

--- a/app/qbftdebug_internal_test.go
+++ b/app/qbftdebug_internal_test.go
@@ -23,7 +23,7 @@ func TestQBFTDebugger(t *testing.T) {
 		debug     = new(qbftDebugger)
 	)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		instance := &pbv1.SniffedConsensusInstance{
 			Msgs: []*pbv1.SniffedConsensusMsg{
 				{

--- a/app/retry/retry_test.go
+++ b/app/retry/retry_test.go
@@ -116,7 +116,7 @@ func TestShutdown(t *testing.T) {
 	done := make(chan struct{})
 
 	// Start 3 long-running functions
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		go retryer.DoAsync(ctx, core.NewProposerDuty(999999), "test", "test", func(ctx context.Context) error {
 			waiting <- struct{}{}
 			<-stop
@@ -127,7 +127,7 @@ func TestShutdown(t *testing.T) {
 	}
 
 	// Wait for functions to block
-	for i := 0; i < n; i++ {
+	for range n {
 		<-waiting
 	}
 

--- a/app/tracer/trace.go
+++ b/app/tracer/trace.go
@@ -87,7 +87,7 @@ func WithStdOut(w io.Writer) func(*options) {
 // if the address is not empty, else the default noop tracer is retained.
 func WithJaegerOrNoop(jaegerAddr string) func(*options) {
 	if jaegerAddr == "" {
-		return func(o *options) {}
+		return func(*options) {}
 	}
 
 	return WithJaeger(jaegerAddr)

--- a/app/tracer/trace.go
+++ b/app/tracer/trace.go
@@ -25,7 +25,7 @@ var tracer = trace.NewNoopTracerProvider().Tracer("")
 // Start creates a span and a context.Context containing the newly-created span from the global tracer.
 // See go.opentelemetry.io/otel/trace#Start for more details.
 func Start(ctx context.Context, spanName string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
-	return tracer.Start(ctx, spanName, opts...)
+	return tracer.Start(ctx, spanName, opts...) //nolint:spancheck // we defer end span outside of this function
 }
 
 // RootedCtx returns a copy of the parent context containing a tracing span context

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -139,9 +139,9 @@ func Compare(a, b SemVer) int {
 		return 0
 	} else if a.patch < b.patch {
 		return -1
-	} else {
-		return 1
 	}
+
+	return 1
 }
 
 var semverRegex = regexp.MustCompile(`^v(\d+)\.(\d+)(?:\.(\d+))?(?:-(.+))?$`)

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -77,7 +77,7 @@ func newVMockEth2Provider(conf Config, pubshares []eth2p0.BLSPubKey) func() (eth
 
 		// Try three times to reduce test startup issues.
 		var err error
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			var eth2Svc eth2client.Service
 			eth2Svc, err = eth2http.New(context.Background(),
 				eth2http.WithLogLevel(1),

--- a/app/z/zapfield.go
+++ b/app/z/zapfield.go
@@ -138,4 +138,4 @@ func Any(key string, val any) Field {
 }
 
 // Skip is a noop wrapped zap field similar to zap.Skip.
-var Skip = func(add func(zap.Field)) {}
+var Skip = func(func(zap.Field)) {}

--- a/app/z/zapfield.go
+++ b/app/z/zapfield.go
@@ -20,7 +20,7 @@ func Fields(err error) []Field {
 		Fields() []Field
 	}
 
-	serr, ok := err.(structErr) //nolint:errorlint
+	serr, ok := err.(structErr)
 	if !ok {
 		return []Field{}
 	}
@@ -57,7 +57,7 @@ func Err(err error) Field {
 
 	// Using cast instead of errors.As since no other wrapping library
 	// is used and this avoids exporting the structured error type.
-	serr, ok := err.(structErr) //nolint:errorlint
+	serr, ok := err.(structErr)
 	if ok {
 		return func(add func(zap.Field)) {
 			add(zap.Error(err))

--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -243,7 +243,7 @@ func randomDefinition(t *testing.T, cr Creator, op0, op1 Operator, opts ...func(
 	)
 
 	var feeRecipientAddrs, withdrawalAddrs []string
-	for i := 0; i < numVals; i++ {
+	for range numVals {
 		feeRecipientAddrs = append(feeRecipientAddrs, testutil.RandomETHAddress())
 		withdrawalAddrs = append(withdrawalAddrs, testutil.RandomETHAddress())
 	}

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -56,7 +56,7 @@ func TestEncode(t *testing.T) {
 			}
 
 			var feeRecipientAddrs, withdrawalAddrs []string
-			for i := 0; i < numVals; i++ {
+			for range numVals {
 				feeRecipientAddrs = append(feeRecipientAddrs, testutil.RandomETHAddressSeed(r))
 				withdrawalAddrs = append(withdrawalAddrs, testutil.RandomETHAddressSeed(r))
 			}

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -354,7 +354,7 @@ func (d Definition) SetDefinitionHashes() (Definition, error) {
 		return Definition{}, errors.Wrap(err, "config hash")
 	}
 
-	d.ConfigHash = configHash[:]
+	d.ConfigHash = configHash[:] //nolint: revive // okay to assign to by-value receiver as we return the struct
 
 	// Marshal definition hashDefinition
 	defHash, err := hashDefinition(d, false)
@@ -362,7 +362,7 @@ func (d Definition) SetDefinitionHashes() (Definition, error) {
 		return Definition{}, errors.Wrap(err, "definition hashDefinition")
 	}
 
-	d.DefinitionHash = defHash[:]
+	d.DefinitionHash = defHash[:] //nolint: revive // okay to assign to by-value receiver as we return the struct
 
 	return d, nil
 }

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -49,7 +49,7 @@ func WithDKGAlgorithm(algorithm string) func(*Definition) {
 func WithLegacyVAddrs(feeRecipientAddress, withdrawalAddress string) func(*Definition) {
 	return func(d *Definition) {
 		var vAddrs []ValidatorAddresses
-		for i := 0; i < d.NumValidators; i++ {
+		for range d.NumValidators {
 			vAddrs = append(vAddrs, ValidatorAddresses{
 				FeeRecipientAddress: feeRecipientAddress,
 				WithdrawalAddress:   withdrawalAddress,
@@ -86,7 +86,7 @@ func NewDefinition(name string, numVals int, threshold int, feeRecipientAddresse
 		DepositAmounts: deposit.EthsToGweis(depositAmounts),
 	}
 
-	for i := 0; i < numVals; i++ {
+	for i := range numVals {
 		def.ValidatorAddresses = append(def.ValidatorAddresses, ValidatorAddresses{
 			FeeRecipientAddress: feeRecipientAddresses[i],
 			WithdrawalAddress:   withdrawalAddresses[i],
@@ -938,7 +938,7 @@ func validatorAddressesFromJSON(vaddrs []validatorAddressesJSON) []ValidatorAddr
 // repeatVAddrs returns a slice of n identical ValidatorAddresses.
 func repeatVAddrs(addr ValidatorAddresses, n int) []ValidatorAddresses {
 	var resp []ValidatorAddresses
-	for i := 0; i < n; i++ {
+	for range n {
 		resp = append(resp, addr)
 	}
 

--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -40,6 +40,7 @@ func FetchDefinition(ctx context.Context, url string) (Definition, error) {
 		return Definition{}, errors.Wrap(err, "fetch file")
 	}
 
+	//nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 	if resp.StatusCode/100 != 2 {
 		return Definition{}, errors.New("http error", z.Int("status_code", resp.StatusCode))
 	}

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -212,7 +212,7 @@ func (l Lock) verifyNodeSignatures() error {
 	}
 
 	// Verify the node signatures
-	for idx := 0; idx < len(l.Operators); idx++ {
+	for idx := range len(l.Operators) {
 		record, err := enr.Parse(l.Operators[idx].ENR)
 		if err != nil {
 			return errors.Wrap(err, "operator ENR")

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -123,7 +123,7 @@ func (l Lock) SetLockHash() (Lock, error) {
 		return Lock{}, err
 	}
 
-	l.LockHash = lockHash[:]
+	l.LockHash = lockHash[:] //nolint: revive // okay to assign to by-value receiver as we return the struct
 
 	return l, nil
 }

--- a/cluster/manifest/cluster.go
+++ b/cluster/manifest/cluster.go
@@ -17,21 +17,21 @@ import (
 
 // ClusterPeers returns the cluster operators as a slice of p2p peers.
 func ClusterPeers(c *manifestpb.Cluster) ([]p2p.Peer, error) {
-	if c == nil || len(c.Operators) == 0 {
+	if c == nil || len(c.GetOperators()) == 0 {
 		return nil, errors.New("invalid cluster")
 	}
 
 	var resp []p2p.Peer
 	dedup := make(map[string]bool)
-	for i, operator := range c.Operators {
-		if dedup[operator.Enr] {
-			return nil, errors.New("cluster contains duplicate peer enrs", z.Str("enr", operator.Enr))
+	for i, operator := range c.GetOperators() {
+		if dedup[operator.GetEnr()] {
+			return nil, errors.New("cluster contains duplicate peer enrs", z.Str("enr", operator.GetEnr()))
 		}
-		dedup[operator.Enr] = true
+		dedup[operator.GetEnr()] = true
 
-		record, err := enr.Parse(operator.Enr)
+		record, err := enr.Parse(operator.GetEnr())
 		if err != nil {
-			return nil, errors.Wrap(err, "decode enr", z.Str("enr", operator.Enr))
+			return nil, errors.Wrap(err, "decode enr", z.Str("enr", operator.GetEnr()))
 		}
 
 		p, err := p2p.NewPeerFromENR(record, i)
@@ -82,15 +82,15 @@ func ClusterNodeIdx(c *manifestpb.Cluster, pID peer.ID) (cluster.NodeIdx, error)
 
 // ValidatorPublicKey returns the validator BLS group public key.
 func ValidatorPublicKey(v *manifestpb.Validator) (tbls.PublicKey, error) {
-	return tblsconv.PubkeyFromBytes(v.PublicKey)
+	return tblsconv.PubkeyFromBytes(v.GetPublicKey())
 }
 
 // ValidatorPublicKeyHex returns the validator hex group public key.
 func ValidatorPublicKeyHex(v *manifestpb.Validator) string {
-	return to0xHex(v.PublicKey)
+	return to0xHex(v.GetPublicKey())
 }
 
 // ValidatorPublicShare returns the validator's peerIdx'th BLS public share.
 func ValidatorPublicShare(v *manifestpb.Validator, peerIdx int) (tbls.PublicKey, error) {
-	return tblsconv.PubkeyFromBytes(v.PubShares[peerIdx])
+	return tblsconv.PubkeyFromBytes(v.GetPubShares()[peerIdx])
 }

--- a/cluster/manifest/load.go
+++ b/cluster/manifest/load.go
@@ -115,12 +115,12 @@ func loadDAGFromLegacyLock(filename string, lockCallback func(cluster.Lock) erro
 
 // clusterHashesMatch returns an error if the cluster hashes of the provided DAGs don't match.
 func clusterHashesMatch(dagManifest, dagLegacy *manifestpb.SignedMutationList) error {
-	hashManifest, err := Hash(dagManifest.Mutations[0])
+	hashManifest, err := Hash(dagManifest.GetMutations()[0])
 	if err != nil {
 		return errors.Wrap(err, "materialise dag")
 	}
 
-	hashLegacy, err := Hash(dagLegacy.Mutations[0])
+	hashLegacy, err := Hash(dagLegacy.GetMutations()[0])
 	if err != nil {
 		return errors.Wrap(err, "materialise dag")
 	}

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -89,7 +89,7 @@ func TestLoadManifest(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			require.Equal(t, 1, len(dag.Mutations)) // The only mutation is the `legacy_lock` mutation
+			require.Len(t, dag.GetMutations(), 1) // The only mutation is the `legacy_lock` mutation
 
 			clusterFromDAG, err := manifest.Materialise(dag)
 			require.NoError(t, err)
@@ -130,25 +130,25 @@ func testLoadLegacy(t *testing.T, version string) {
 	cluster, err := manifest.LoadCluster("", file, nil)
 	require.NoError(t, err)
 
-	require.Equal(t, lock.LockHash, cluster.InitialMutationHash)
-	require.Equal(t, lock.LockHash, cluster.LatestMutationHash)
-	require.Equal(t, lock.Name, cluster.Name)
-	require.EqualValues(t, lock.Threshold, cluster.Threshold)
-	require.Equal(t, lock.DKGAlgorithm, cluster.DkgAlgorithm)
-	require.Equal(t, lock.ForkVersion, cluster.ForkVersion)
-	require.Equal(t, len(lock.Validators), len(cluster.Validators))
-	require.Equal(t, len(lock.Operators), len(cluster.Operators))
+	require.Equal(t, lock.LockHash, cluster.GetInitialMutationHash())
+	require.Equal(t, lock.LockHash, cluster.GetLatestMutationHash())
+	require.Equal(t, lock.Name, cluster.GetName())
+	require.EqualValues(t, lock.Threshold, cluster.GetThreshold())
+	require.Equal(t, lock.DKGAlgorithm, cluster.GetDkgAlgorithm())
+	require.Equal(t, lock.ForkVersion, cluster.GetForkVersion())
+	require.Equal(t, len(lock.Validators), len(cluster.GetValidators()))
+	require.Equal(t, len(lock.Operators), len(cluster.GetOperators()))
 
-	for i, validator := range cluster.Validators {
-		require.Equal(t, lock.Validators[i].PubKey, validator.PublicKey)
-		require.Equal(t, lock.Validators[i].PubShares, validator.PubShares)
-		require.Equal(t, lock.ValidatorAddresses[i].FeeRecipientAddress, validator.FeeRecipientAddress)
-		require.Equal(t, lock.ValidatorAddresses[i].WithdrawalAddress, validator.WithdrawalAddress)
+	for i, validator := range cluster.GetValidators() {
+		require.Equal(t, lock.Validators[i].PubKey, validator.GetPublicKey())
+		require.Equal(t, lock.Validators[i].PubShares, validator.GetPubShares())
+		require.Equal(t, lock.ValidatorAddresses[i].FeeRecipientAddress, validator.GetFeeRecipientAddress())
+		require.Equal(t, lock.ValidatorAddresses[i].WithdrawalAddress, validator.GetWithdrawalAddress())
 	}
 
-	for i, operator := range cluster.Operators {
-		require.Equal(t, lock.Operators[i].Address, operator.Address)
-		require.Equal(t, lock.Operators[i].ENR, operator.Enr)
+	for i, operator := range cluster.GetOperators() {
+		require.Equal(t, lock.Operators[i].Address, operator.GetAddress())
+		require.Equal(t, lock.Operators[i].ENR, operator.GetEnr())
 	}
 }
 

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -3,8 +3,8 @@
 package manifest_test
 
 import (
+	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"math/rand"
 	"os"
 	"path"
@@ -158,6 +158,6 @@ func testLoadLegacy(t *testing.T, version string) {
 func TestLoadModifiedLegacyLock(t *testing.T) {
 	cluster, err := manifest.LoadCluster("", "testdata/lock3.json", nil)
 	require.NoError(t, err)
-	hashHex := fmt.Sprintf("%x", cluster.InitialMutationHash)
+	hashHex := hex.EncodeToString(cluster.GetInitialMutationHash())
 	require.Equal(t, "4073fe542", hashHex[:9])
 }

--- a/cluster/manifest/materialise.go
+++ b/cluster/manifest/materialise.go
@@ -9,7 +9,7 @@ import (
 
 // Materialise transforms a raw DAG and returns the resulting cluster manifest.
 func Materialise(rawDAG *manifestpb.SignedMutationList) (*manifestpb.Cluster, error) {
-	if rawDAG == nil || len(rawDAG.Mutations) == 0 {
+	if rawDAG == nil || len(rawDAG.GetMutations()) == 0 {
 		return nil, errors.New("empty raw DAG")
 	}
 
@@ -17,7 +17,7 @@ func Materialise(rawDAG *manifestpb.SignedMutationList) (*manifestpb.Cluster, er
 		cluster = new(manifestpb.Cluster)
 		err     error
 	)
-	for _, signed := range rawDAG.Mutations {
+	for _, signed := range rawDAG.GetMutations() {
 		cluster, err = Transform(cluster, signed)
 		if err != nil {
 			return nil, err
@@ -25,13 +25,13 @@ func Materialise(rawDAG *manifestpb.SignedMutationList) (*manifestpb.Cluster, er
 	}
 
 	// InitialMutationHash is the hash of the first mutation.
-	cluster.InitialMutationHash, err = Hash(rawDAG.Mutations[0])
+	cluster.InitialMutationHash, err = Hash(rawDAG.GetMutations()[0])
 	if err != nil {
 		return nil, errors.Wrap(err, "calculate initial hash")
 	}
 
 	// LatestMutationHash is the hash of the last mutation.
-	cluster.LatestMutationHash, err = Hash(rawDAG.Mutations[len(rawDAG.Mutations)-1])
+	cluster.LatestMutationHash, err = Hash(rawDAG.GetMutations()[len(rawDAG.GetMutations())-1])
 	if err != nil {
 		return nil, errors.Wrap(err, "calculate latest hash")
 	}

--- a/cluster/manifest/mutationaddvalidator_test.go
+++ b/cluster/manifest/mutationaddvalidator_test.go
@@ -55,7 +55,7 @@ func TestGenValidators(t *testing.T) {
 		cluster, err := manifest.Transform(new(manifestpb.Cluster), signed)
 		require.NoError(t, err)
 
-		testutil.RequireProtosEqual(t, vals, cluster.Validators)
+		testutil.RequireProtosEqual(t, vals, cluster.GetValidators())
 	})
 
 	t.Run("proto", func(t *testing.T) {
@@ -122,6 +122,6 @@ func TestAddValidators(t *testing.T) {
 		cluster, err = manifest.Transform(cluster, addVals)
 		require.NoError(t, err)
 
-		testutil.RequireProtosEqual(t, vals, cluster.Validators)
+		testutil.RequireProtosEqual(t, vals, cluster.GetValidators())
 	})
 }

--- a/cluster/manifest/mutationlegacylock.go
+++ b/cluster/manifest/mutationlegacylock.go
@@ -80,7 +80,7 @@ func NewLegacyLockForT(_ *testing.T, lock cluster.Lock) (*manifestpb.SignedMutat
 
 // verifyLegacyLock verifies that the signed mutation is a valid legacy lock.
 func verifyLegacyLock(signed *manifestpb.SignedMutation) error {
-	if MutationType(signed.Mutation.Type) != TypeLegacyLock {
+	if MutationType(signed.GetMutation().GetType()) != TypeLegacyLock {
 		return errors.New("invalid mutation type")
 	}
 
@@ -89,12 +89,12 @@ func verifyLegacyLock(signed *manifestpb.SignedMutation) error {
 	}
 
 	legacyLock := new(manifestpb.LegacyLock)
-	if err := signed.Mutation.Data.UnmarshalTo(legacyLock); err != nil {
+	if err := signed.GetMutation().GetData().UnmarshalTo(legacyLock); err != nil {
 		return errors.New("mutation data to legacy lock")
 	}
 
 	var lock cluster.Lock
-	if err := json.Unmarshal(legacyLock.Json, &lock); err != nil {
+	if err := json.Unmarshal(legacyLock.GetJson(), &lock); err != nil {
 		return errors.Wrap(err, "unmarshal lock")
 	}
 	// return lock.VerifySignatures()
@@ -113,12 +113,12 @@ func transformLegacyLock(input *manifestpb.Cluster, signed *manifestpb.SignedMut
 	}
 
 	legacyLock := new(manifestpb.LegacyLock)
-	if err := signed.Mutation.Data.UnmarshalTo(legacyLock); err != nil {
+	if err := signed.GetMutation().GetData().UnmarshalTo(legacyLock); err != nil {
 		return nil, errors.New("mutation data to legacy lock")
 	}
 
 	var lock cluster.Lock
-	if err := json.Unmarshal(legacyLock.Json, &lock); err != nil {
+	if err := json.Unmarshal(legacyLock.GetJson(), &lock); err != nil {
 		return nil, errors.Wrap(err, "unmarshal lock")
 	}
 

--- a/cluster/manifest/mutationlegacylock_test.go
+++ b/cluster/manifest/mutationlegacylock_test.go
@@ -41,8 +41,8 @@ func TestLegacyLock(t *testing.T) {
 	t.Run("cluster", func(t *testing.T) {
 		cluster, err := manifest.Materialise(&manifestpb.SignedMutationList{Mutations: []*manifestpb.SignedMutation{legacyLock}})
 		require.NoError(t, err)
-		require.Equal(t, lock.LockHash, cluster.InitialMutationHash)
-		require.Equal(t, lock.LockHash, cluster.LatestMutationHash)
+		require.Equal(t, lock.LockHash, cluster.GetInitialMutationHash())
+		require.Equal(t, lock.LockHash, cluster.GetLatestMutationHash())
 		testutil.RequireGoldenProto(t, cluster, testutil.WithFilename("TestLegacyLock_cluster.golden"))
 	})
 

--- a/cluster/manifest/mutationnodeapproval.go
+++ b/cluster/manifest/mutationnodeapproval.go
@@ -42,8 +42,8 @@ func NewNodeApprovalsComposite(approvals []*manifestpb.SignedMutation) (*manifes
 	var parent []byte
 	for i, approval := range approvals {
 		if i == 0 {
-			parent = approval.Mutation.Parent
-		} else if !bytes.Equal(parent, approval.Mutation.Parent) {
+			parent = approval.GetMutation().GetParent()
+		} else if !bytes.Equal(parent, approval.GetMutation().GetParent()) {
 			return nil, errors.New("mismatching node approvals parent")
 		}
 
@@ -71,12 +71,12 @@ func NewNodeApprovalsComposite(approvals []*manifestpb.SignedMutation) (*manifes
 
 // verifyNodeApproval returns an error if the input signed mutation is not valid.
 func verifyNodeApproval(signed *manifestpb.SignedMutation) error {
-	if MutationType(signed.Mutation.Type) != TypeNodeApproval {
+	if MutationType(signed.GetMutation().GetType()) != TypeNodeApproval {
 		return errors.New("invalid mutation type")
 	}
 
 	timestamp := new(timestamppb.Timestamp)
-	if err := signed.Mutation.Data.UnmarshalTo(timestamp); err != nil {
+	if err := signed.GetMutation().GetData().UnmarshalTo(timestamp); err != nil {
 		return errors.Wrap(err, "invalid node approval timestamp data")
 	}
 
@@ -85,12 +85,12 @@ func verifyNodeApproval(signed *manifestpb.SignedMutation) error {
 
 // transformNodeApprovals transforms the cluster manifest with the node approvals.
 func transformNodeApprovals(c *manifestpb.Cluster, signed *manifestpb.SignedMutation) (*manifestpb.Cluster, error) {
-	if MutationType(signed.Mutation.Type) != TypeNodeApprovals {
+	if MutationType(signed.GetMutation().GetType()) != TypeNodeApprovals {
 		return c, errors.New("invalid mutation type")
 	}
 
 	list := new(manifestpb.SignedMutationList)
-	if err := signed.Mutation.Data.UnmarshalTo(list); err != nil {
+	if err := signed.GetMutation().GetData().UnmarshalTo(list); err != nil {
 		return c, errors.New("invalid node approval data")
 	}
 
@@ -99,15 +99,15 @@ func transformNodeApprovals(c *manifestpb.Cluster, signed *manifestpb.SignedMuta
 		return c, errors.Wrap(err, "get peers")
 	}
 
-	if len(peers) != len(list.Mutations) {
+	if len(peers) != len(list.GetMutations()) {
 		return c, errors.New("invalid number of node approvals")
 	}
 
 	var parent []byte
-	for i, approval := range list.Mutations {
+	for i, approval := range list.GetMutations() {
 		if i == 0 {
-			parent = approval.Mutation.Parent
-		} else if !bytes.Equal(parent, approval.Mutation.Parent) {
+			parent = approval.GetMutation().GetParent()
+		} else if !bytes.Equal(parent, approval.GetMutation().GetParent()) {
 			return c, errors.New("mismatching node approvals parent")
 		}
 
@@ -116,7 +116,7 @@ func transformNodeApprovals(c *manifestpb.Cluster, signed *manifestpb.SignedMuta
 			return c, errors.Wrap(err, "get peer public key")
 		}
 
-		if !bytes.Equal(pubkey.SerializeCompressed(), approval.Signer) {
+		if !bytes.Equal(pubkey.SerializeCompressed(), approval.GetSigner()) {
 			return c, errors.New("invalid node approval signer")
 		}
 

--- a/cluster/manifest/types.go
+++ b/cluster/manifest/types.go
@@ -12,14 +12,14 @@ import (
 
 func Hash(signed *manifestpb.SignedMutation) ([]byte, error) {
 	// Return legacy lock hash if this is a legacy lock mutation.
-	if signed.Mutation.Type == string(TypeLegacyLock) {
+	if signed.GetMutation().GetType() == string(TypeLegacyLock) {
 		legacyLock := new(manifestpb.LegacyLock)
-		if err := signed.Mutation.Data.UnmarshalTo(legacyLock); err != nil {
+		if err := signed.GetMutation().GetData().UnmarshalTo(legacyLock); err != nil {
 			return nil, errors.Wrap(err, "mutation data to legacy lock")
 		}
 
 		var lock cluster.Lock
-		if err := json.Unmarshal(legacyLock.Json, &lock); err != nil {
+		if err := json.Unmarshal(legacyLock.GetJson(), &lock); err != nil {
 			return nil, errors.Wrap(err, "unmarshal lock")
 		}
 
@@ -40,7 +40,7 @@ func Transform(cluster *manifestpb.Cluster, signed *manifestpb.SignedMutation) (
 		return nil, errors.New("nil cluster")
 	}
 
-	typ := MutationType(signed.Mutation.Type)
+	typ := MutationType(signed.GetMutation().GetType())
 
 	if !typ.Valid() {
 		return cluster, errors.New("invalid mutation type")

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -37,9 +37,9 @@ func getDefinitionHashFunc(version string) (func(Definition, ssz.HashWalker, boo
 		return hashDefinitionV1x5to7, nil
 	} else if isAnyVersion(version, v1_8) {
 		return hashDefinitionV1x8orLater, nil
-	} else {
-		return nil, errors.New("unknown version", z.Str("version", version))
 	}
+
+	return nil, errors.New("unknown version", z.Str("version", version))
 }
 
 // hashDefinition returns a config or definition hash. The config hash excludes operator ENRs and signatures
@@ -607,9 +607,9 @@ func getValidatorHashFunc(version string) (func(DistValidator, ssz.HashWalker, s
 		return hashValidatorV1x5to7, nil
 	} else if isAnyVersion(version, v1_8) {
 		return hashValidatorV1x8OrLater, nil
-	} else {
-		return nil, errors.New("unknown version", z.Str("version", version))
 	}
+
+	return nil, errors.New("unknown version", z.Str("version", version))
 }
 
 func hashValidatorPubsharesField(v DistValidator, hh ssz.HashWalker) error {
@@ -799,9 +799,9 @@ func getDepositDataHashFunc(version string) (func(DepositData, ssz.HashWalker) e
 		return hashDepositDataV1x6, nil
 	} else if isAnyVersion(version, v1_7, v1_8) {
 		return hashDepositDataV1x7OrLater, nil
-	} else {
-		return nil, errors.New("unknown version", z.Str("version", version))
 	}
+
+	return nil, errors.New("unknown version", z.Str("version", version))
 }
 
 // getRegistrationHashFunc returns the function to hash a BuilderRegistration based on the provided version.
@@ -811,9 +811,9 @@ func getRegistrationHashFunc(version string) (func(BuilderRegistration, ssz.Hash
 		return func(BuilderRegistration, ssz.HashWalker) error { return nil }, nil
 	} else if isAnyVersion(version, v1_7, v1_8) {
 		return hashBuilderRegistration, nil
-	} else {
-		return nil, errors.New("unknown version", z.Str("version", version))
 	}
+
+	return nil, errors.New("unknown version", z.Str("version", version))
 }
 
 // hashDepositDataV1x6 hashes the deposit data for version v1.6.0.

--- a/cluster/test_cluster.go
+++ b/cluster/test_cluster.go
@@ -41,7 +41,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, random *rand.Rand, opts ...func(*
 	}
 
 	var feeRecipientAddrs, withdrawalAddrs []string
-	for i := 0; i < dv; i++ {
+	for range dv {
 		rootSecret, err := tbls.GenerateInsecureKey(t, randomReader)
 		require.NoError(t, err)
 
@@ -53,7 +53,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, random *rand.Rand, opts ...func(*
 
 		var pubshares [][]byte
 		var privshares []tbls.PrivateKey
-		for i := 0; i < n; i++ {
+		for i := range n {
 			sharePrivkey := shares[i+1] // Share indexes are 1-indexed.
 
 			sharePub, err := tbls.SecretToPublicKey(sharePrivkey)
@@ -91,7 +91,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, random *rand.Rand, opts ...func(*
 		withdrawalAddrs = append(withdrawalAddrs, testutil.RandomETHAddressSeed(random))
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		// Generate ENR
 		p2pKey := testutil.GenerateInsecureK1Key(t, seed+i)
 
@@ -121,7 +121,7 @@ func NewForT(t *testing.T, dv, k, n, seed int, random *rand.Rand, opts ...func(*
 
 	// Definition version prior to v1.3.0 don't support EIP712 signatures.
 	if supportEIP712Sigs(def.Version) {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			def.Operators[i], err = signOperator(p2pKeys[i], def, def.Operators[i])
 			require.NoError(t, err)
 		}

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -69,7 +69,7 @@ func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) erro
 		Short: "Creates and adds new validators to a solo distributed validator cluster",
 		Long:  `Creates and adds new validators to a distributed validator cluster. It generates keys for the new validators and also generates a new cluster manifest file with the legacy_lock and add_validators mutations. It is executed by a solo operator cluster.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(config.Log); err != nil {
 				return err
 			}

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -275,7 +275,7 @@ func writeDepositDatas(ctx context.Context, clusterDir string, numOps int, secre
 
 	currTime := time.Now().Format("20060102150405")
 	filename := fmt.Sprintf("deposit-data-%s.json", currTime) // Ex: "deposit-data-20060102150405.json"
-	for i := 0; i < numOps; i++ {
+	for i := range numOps {
 		depositPath := filepath.Join(nodeDir(clusterDir, i), filename)
 		//nolint:gosec // File needs to be read-only for everybody
 		err = os.WriteFile(depositPath, bytes, 0o444)
@@ -300,7 +300,7 @@ func writeNewKeystores(clusterDir string, numOps, firstKeystoreIdx int, shareSet
 		}
 	}
 
-	for i := 0; i < numOps; i++ {
+	for i := range numOps {
 		var secrets []tbls.PrivateKey // All partial keys for node<i>
 		for _, shares := range shareSets {
 			secrets = append(secrets, shares[i])
@@ -392,7 +392,7 @@ func genNewVals(numOps, threshold int, forkVersion []byte, conf addValidatorsCon
 		shareSets [][]tbls.PrivateKey
 	)
 
-	for i := 0; i < conf.NumVals; i++ {
+	for i := range conf.NumVals {
 		// Generate private/public keypair
 		secret, err := tbls.GenerateSecretKey()
 		if err != nil {
@@ -491,7 +491,7 @@ func getP2PKeys(clusterDir string, numOps int, testConfig addValidatorTestConfig
 	}
 
 	var p2pKeys []*k1.PrivateKey
-	for i := 0; i < numOps; i++ {
+	for i := range numOps {
 		dir := path.Join(clusterDir, fmt.Sprintf("node%d", i))
 		enrKeyFile := path.Join(dir, "charon-enr-private-key")
 		p2pKey, err := k1util.Load(enrKeyFile)
@@ -533,7 +533,7 @@ func validateP2PKeysOrder(p2pKeys []*k1.PrivateKey, ops []*manifestpb.Operator) 
 // repeatAddr repeats the same address for all the validators.
 func repeatAddr(addr string, numVals int) []string {
 	var addrs []string
-	for i := 0; i < numVals; i++ {
+	for range numVals {
 		addrs = append(addrs, addr)
 	}
 

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -111,7 +111,7 @@ func TestRunAddValidators(t *testing.T) {
 	)
 
 	var nodeDirnames []string
-	for i := 0; i < n; i++ {
+	for i := range n {
 		nodeDirnames = append(nodeDirnames, fmt.Sprintf("node%d", i))
 	}
 
@@ -192,7 +192,7 @@ func TestRunAddValidators(t *testing.T) {
 		// Delete existing deposit data file in each node directory since the deposit file names are same
 		// when add validators command is run twice consecutively. This is because the test finishes in
 		// milliseconds and filenames are named YYYYMMDDHHMMSS which doesn't account for milliseconds.
-		for i := 0; i < n; i++ {
+		for i := range n {
 			entries, err := os.ReadDir(nodeDir(tmp, i))
 			require.NoError(t, err)
 			for _, e := range entries {
@@ -235,7 +235,7 @@ func TestValidateP2PKeysOrder(t *testing.T) {
 			ops     []*manifestpb.Operator
 		)
 
-		for i := 0; i < n; i++ {
+		for i := range n {
 			key, enrStr := testutil.RandomENR(t, seed+i)
 			p2pKeys = append(p2pKeys, key)
 			ops = append(ops, &manifestpb.Operator{Enr: enrStr.String()})
@@ -257,7 +257,7 @@ func TestValidateP2PKeysOrder(t *testing.T) {
 			ops     []*manifestpb.Operator
 		)
 
-		for i := 0; i < n; i++ {
+		for i := range n {
 			key, enrStr := testutil.RandomENR(t, seed+i)
 			p2pKeys = append(p2pKeys, key)
 			ops = append(ops, &manifestpb.Operator{Enr: enrStr.String()})

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -146,7 +146,7 @@ func TestRunAddValidators(t *testing.T) {
 		cluster, err := manifest.LoadCluster(manifestFile, "", nil)
 		require.NoError(t, err)
 
-		require.Equal(t, valCount+1, len(cluster.Validators))
+		require.Len(t, cluster.GetValidators(), valCount+1)
 		require.Equal(t, cluster.Validators[1].FeeRecipientAddress, feeRecipientAddr)
 		require.Equal(t, cluster.Validators[1].WithdrawalAddress, feeRecipientAddr)
 	})
@@ -210,12 +210,12 @@ func TestRunAddValidators(t *testing.T) {
 
 		// The cluster manifest should contain three validators now since the
 		// original cluster already had one validator, and we added two more.
-		require.Equal(t, valCount+2, len(cluster.Validators))
+		require.Len(t, cluster.GetValidators(), valCount+2)
 		require.Equal(t, cluster.InitialMutationHash, lock.LockHash)
 
 		entries, err := os.ReadDir(path.Join(tmp, "node0"))
 		require.NoError(t, err)
-		require.Equal(t, 3, len(entries))
+		require.Len(t, entries, 3)
 
 		require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest"))
 		require.True(t, strings.Contains(entries[1].Name(), "deposit-data"))

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -147,8 +147,8 @@ func TestRunAddValidators(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, cluster.GetValidators(), valCount+1)
-		require.Equal(t, cluster.Validators[1].FeeRecipientAddress, feeRecipientAddr)
-		require.Equal(t, cluster.Validators[1].WithdrawalAddress, feeRecipientAddr)
+		require.Equal(t, cluster.GetValidators()[1].GetFeeRecipientAddress(), feeRecipientAddr)
+		require.Equal(t, cluster.GetValidators()[1].GetWithdrawalAddress(), feeRecipientAddr)
 	})
 
 	t.Run("add validators twice", func(t *testing.T) {
@@ -183,7 +183,7 @@ func TestRunAddValidators(t *testing.T) {
 
 		cluster, err := manifest.Materialise(rawDAG)
 		require.NoError(t, err)
-		require.Equal(t, cluster.InitialMutationHash, lock.LockHash)
+		require.Equal(t, cluster.GetInitialMutationHash(), lock.LockHash)
 
 		// Run the second add validators command using cluster manifest output from the first run
 		conf.TestConfig.Lock = nil
@@ -211,7 +211,7 @@ func TestRunAddValidators(t *testing.T) {
 		// The cluster manifest should contain three validators now since the
 		// original cluster already had one validator, and we added two more.
 		require.Len(t, cluster.GetValidators(), valCount+2)
-		require.Equal(t, cluster.InitialMutationHash, lock.LockHash)
+		require.Equal(t, cluster.GetInitialMutationHash(), lock.LockHash)
 
 		entries, err := os.ReadDir(path.Join(tmp, "node0"))
 		require.NoError(t, err)

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -70,7 +70,7 @@ func newRootCmd(cmds ...*cobra.Command) *cobra.Command {
 		Use:   "charon",
 		Short: "Charon - Proof of Stake Ethereum Distributed Validator Client",
 		Long:  `Charon enables the operation of Ethereum validators in a fault tolerant manner by splitting the validating keys across a group of trusted parties using threshold cryptography.`,
-		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return initializeConfig(cmd)
 		},
 	}

--- a/cmd/combine.go
+++ b/cmd/combine.go
@@ -27,7 +27,7 @@ func newCombineCmd(runFunc func(ctx context.Context, clusterDir, outputDir strin
 		Short: "Combine the private key shares of a distributed validator cluster into a set of standard validator private keys",
 		Long:  "Combines the private key shares from a threshold of operators in a distributed validator cluster into a set of validator private keys that can be imported into a standard Ethereum validator client.\n\nWarning: running the resulting private keys in a validator alongside the original distributed validator cluster *will* result in slashing.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(
 				cmd.Context(),
 				clusterDir,

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -179,7 +179,6 @@ func shareIdxByPubkeys(cluster *manifestpb.Cluster, secrets []tbls.PrivateKey, v
 	pubkMap := make(map[tbls.PublicKey]int)
 
 	for peerIdx := 0; peerIdx < len(cluster.Validators[valIndex].PubShares); peerIdx++ {
-		peerIdx := peerIdx
 		pubShareRaw := cluster.Validators[valIndex].GetPubShares()[peerIdx]
 
 		pubShare, err := tblsconv.PubkeyFromBytes(pubShareRaw)
@@ -194,8 +193,6 @@ func shareIdxByPubkeys(cluster *manifestpb.Cluster, secrets []tbls.PrivateKey, v
 	resp := make(map[int]tbls.PrivateKey)
 
 	for _, secret := range secrets {
-		secret := secret
-
 		pubkey, err := tbls.SecretToPublicKey(secret)
 		if err != nil {
 			return nil, errors.Wrap(err, "pubkey from share")

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -92,7 +92,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bo
 
 	var combinedKeys []tbls.PrivateKey
 
-	for valIdx := 0; valIdx < len(privkeys); valIdx++ {
+	for valIdx := range len(privkeys) {
 		pkSet := privkeys[valIdx]
 
 		if len(pkSet) < int(cluster.Threshold) {
@@ -178,7 +178,7 @@ func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bo
 func shareIdxByPubkeys(cluster *manifestpb.Cluster, secrets []tbls.PrivateKey, valIndex int) (map[int]tbls.PrivateKey, error) {
 	pubkMap := make(map[tbls.PublicKey]int)
 
-	for peerIdx := 0; peerIdx < len(cluster.Validators[valIndex].PubShares); peerIdx++ {
+	for peerIdx := range len(cluster.GetValidators()[valIndex].GetPubShares()) {
 		pubShareRaw := cluster.Validators[valIndex].GetPubShares()[peerIdx]
 
 		pubShare, err := tblsconv.PubkeyFromBytes(pubShareRaw)

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -42,11 +42,8 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 	lock, _, shares := cluster.NewForT(t, 2, 3, 4, seed, random)
 
 	for _, share := range shares {
-		share := share
-
 		sm := make(map[int]tbls.PrivateKey)
 		for idx, shareObj := range share {
-			shareObj := shareObj
 			sm[idx+1] = shareObj
 		}
 	}
@@ -272,11 +269,8 @@ func combineTest(
 	var expectedData []expected
 
 	for _, share := range shares {
-		share := share
-
 		sm := make(map[int]tbls.PrivateKey)
 		for idx, shareObj := range share {
-			shareObj := shareObj
 			sm[idx+1] = shareObj
 		}
 
@@ -315,7 +309,6 @@ func combineTest(
 	}
 
 	for idx, keys := range secrets {
-		idx := idx
 		ep := filepath.Join(dir, fmt.Sprintf("node%d", idx))
 
 		vk := filepath.Join(ep, "validator_keys")
@@ -391,11 +384,8 @@ func runTwice(t *testing.T, force bool, processErr require.ErrorAssertionFunc) {
 	var expectedData []expected
 
 	for _, share := range shares {
-		share := share
-
 		sm := make(map[int]tbls.PrivateKey)
 		for idx, shareObj := range share {
-			shareObj := shareObj
 			sm[idx+1] = shareObj
 		}
 

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -62,9 +62,9 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 	secrets := make([][]tbls.PrivateKey, len(lock.Definition.Operators))
 
 	// populate key sets
-	for enrIdx := 0; enrIdx < len(lock.Definition.Operators); enrIdx++ {
+	for enrIdx := range len(lock.Definition.Operators) {
 		keyIdx := enrIdx
-		for dvIdx := 0; dvIdx < lock.NumValidators; dvIdx++ {
+		for range lock.NumValidators {
 			secrets[enrIdx] = append(secrets[enrIdx], rawSecrets[keyIdx])
 			keyIdx += len(lock.Definition.Operators)
 		}
@@ -300,9 +300,9 @@ func combineTest(
 	secrets := make([][]tbls.PrivateKey, len(lock.Definition.Operators))
 
 	// populate key sets
-	for enrIdx := 0; enrIdx < len(lock.Definition.Operators); enrIdx++ {
+	for enrIdx := range len(lock.Definition.Operators) {
 		keyIdx := enrIdx
-		for dvIdx := 0; dvIdx < lock.NumValidators; dvIdx++ {
+		for range lock.NumValidators {
 			secrets[enrIdx] = append(secrets[enrIdx], rawSecrets[keyIdx])
 			keyIdx += len(lock.Definition.Operators)
 		}
@@ -415,9 +415,9 @@ func runTwice(t *testing.T, force bool, processErr require.ErrorAssertionFunc) {
 	secrets := make([][]tbls.PrivateKey, len(lock.Definition.Operators))
 
 	// populate key sets
-	for enrIdx := 0; enrIdx < len(lock.Definition.Operators); enrIdx++ {
+	for enrIdx := range len(lock.Definition.Operators) {
 		keyIdx := enrIdx
-		for dvIdx := 0; dvIdx < lock.NumValidators; dvIdx++ {
+		for range lock.NumValidators {
 			secrets[enrIdx] = append(secrets[enrIdx], rawSecrets[keyIdx])
 			keyIdx += len(lock.Definition.Operators)
 		}

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -312,7 +312,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	}
 
 	if dashboardURL != "" {
-		log.Info(ctx, fmt.Sprintf("You can find your newly-created cluster dashboard here: %s", dashboardURL))
+		log.Info(ctx, "You can find your newly-created cluster dashboard here: "+dashboardURL)
 	}
 
 	return nil

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -371,7 +371,7 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 
 // detectNodeDirs returns error if there's a `nodeX`-style directory in clusterDir.
 func detectNodeDirs(clusterDir string, nodeAmount int) error {
-	for idx := 0; idx < nodeAmount; idx++ {
+	for idx := range nodeAmount {
 		absPath, err := filepath.Abs(nodeDir(clusterDir, idx))
 		if err != nil {
 			return errors.Wrap(err, "absolute path retrieval")
@@ -564,7 +564,7 @@ func getKeys(splitKeysDir string) ([]tbls.PrivateKey, error) {
 // generateKeys generates numDVs amount of tbls.PrivateKeys.
 func generateKeys(numDVs int) ([]tbls.PrivateKey, error) {
 	var secrets []tbls.PrivateKey
-	for i := 0; i < numDVs; i++ {
+	for range numDVs {
 		secret, err := tbls.GenerateSecretKey()
 		if err != nil {
 			return nil, err
@@ -605,7 +605,7 @@ func writeLock(lock cluster.Lock, clusterDir string, numNodes int) error {
 		return errors.Wrap(err, "marshal cluster lock")
 	}
 
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		lockPath := path.Join(nodeDir(clusterDir, i), "cluster-lock.json")
 		err = os.WriteFile(lockPath, b, 0o400) // read-only
 		if err != nil {
@@ -702,7 +702,7 @@ func getValidators(
 func writeKeysToKeymanager(ctx context.Context, conf clusterConfig, numNodes int, shareSets [][]tbls.PrivateKey) error {
 	// Ping all keymanager addresses to check if they are accessible to avoid partial writes
 	var clients []keymanager.Client
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		cl := keymanager.New(conf.KeymanagerAddrs[i], conf.KeymanagerAuthTokens[i])
 		if err := cl.VerifyConnection(ctx); err != nil {
 			return err
@@ -710,7 +710,7 @@ func writeKeysToKeymanager(ctx context.Context, conf clusterConfig, numNodes int
 		clients = append(clients, cl)
 	}
 
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		var (
 			keystores []keystore.Keystore
 			passwords []string
@@ -750,7 +750,7 @@ func writeKeysToKeymanager(ctx context.Context, conf clusterConfig, numNodes int
 
 // writeKeysToDisk writes validator keyshares to disk. It assumes that the directory for each node already exists.
 func writeKeysToDisk(numNodes int, clusterDir string, insecureKeys bool, shareSets [][]tbls.PrivateKey) error {
-	for i := 0; i < numNodes; i++ {
+	for i := range numNodes {
 		var secrets []tbls.PrivateKey
 		for _, shares := range shareSets {
 			secrets = append(secrets, shares[i])
@@ -781,7 +781,7 @@ func getOperators(n int, clusterDir string) ([]cluster.Operator, []*k1.PrivateKe
 	var ops []cluster.Operator
 	var keys []*k1.PrivateKey
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		record, identityKey, err := newPeer(clusterDir, i)
 		if err != nil {
 			return nil, nil, err
@@ -814,7 +814,7 @@ func newDefFromConfig(ctx context.Context, conf clusterConfig) (cluster.Definiti
 	}
 
 	var ops []cluster.Operator
-	for i := 0; i < conf.NumNodes; i++ {
+	for range conf.NumNodes {
 		ops = append(ops, cluster.Operator{})
 	}
 	threshold := safeThreshold(ctx, conf.NumNodes, conf.Threshold)

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -635,7 +635,6 @@ func getValidators(
 
 	var vals []cluster.DistValidator
 	for idx, dv := range dvsPubkeys {
-		dv := dv
 		privShares := dvPrivShares[idx]
 		var pubshares [][]byte
 		for _, ps := range privShares {
@@ -680,7 +679,6 @@ func getValidators(
 		}
 
 		for _, dd := range depositDatasList {
-			dd := dd
 			partialDepositData = append(partialDepositData, cluster.DepositData{
 				PubKey:                dd.PublicKey[:],
 				WithdrawalCredentials: dd.WithdrawalCredentials,

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -90,7 +90,7 @@ func newCreateClusterCmd(runFunc func(context.Context, io.Writer, clusterConfig)
 		Short: "Create private keys and configuration files needed to run a distributed validator cluster locally",
 		Long: "Creates a local charon cluster configuration including validator keys, charon p2p keys, cluster-lock.json and deposit-data.json file(s). " +
 			"See flags for supported features.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(cmd.Context(), cmd.OutOrStdout(), conf)
 		},
 	}

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -335,7 +335,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 			}
 		}
 
-		require.Equal(t, lock.Definition.NumValidators, len(vals))
+		require.Len(t, vals, lock.Definition.NumValidators)
 
 		if conf.DefFile != "" {
 			// Config hash and creator should remain the same
@@ -782,7 +782,7 @@ func newKeymanagerHandler(ctx context.Context, t *testing.T, id int, results cha
 		require.NoError(t, json.Unmarshal(data, &req))
 
 		require.Equal(t, len(req.Keystores), len(req.Passwords))
-		require.Equal(t, len(req.Keystores), 1) // Since we split only 1 key
+		require.Len(t, req.Keystores, 1) // Since we split only 1 key
 
 		var ks keystore.Keystore
 		require.NoError(t, json.Unmarshal([]byte(req.Keystores[0]), &ks))

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -342,7 +342,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 			require.Equal(t, def.ConfigHash, lock.ConfigHash)
 			require.Equal(t, def.Creator, lock.Creator)
 
-			for i := 0; i < len(def.Operators); i++ {
+			for i := range len(def.Operators) {
 				// ENRs should be populated
 				require.NotEqual(t, lock.Operators[i].ENR, "")
 			}
@@ -390,7 +390,7 @@ func TestValidateDef(t *testing.T) {
 		Network:   "goerli",
 	}
 
-	for i := 0; i < conf.NumDVs; i++ {
+	for range conf.NumDVs {
 		conf.FeeRecipientAddrs = append(conf.FeeRecipientAddrs, testutil.RandomETHAddress())
 		conf.WithdrawalAddrs = append(conf.WithdrawalAddrs, zeroAddress)
 	}
@@ -511,7 +511,7 @@ func TestSplitKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var keys []tbls.PrivateKey
-			for i := 0; i < test.numSplitKeys; i++ {
+			for range test.numSplitKeys {
 				secret, err := tbls.GenerateSecretKey()
 				require.NoError(t, err)
 
@@ -620,7 +620,7 @@ func TestKeymanager(t *testing.T) {
 
 	var addrs, authTokens []string
 	var servers []*httptest.Server
-	for i := 0; i < minNodes; i++ {
+	for i := range minNodes {
 		srv := httptest.NewServer(newKeymanagerHandler(ctx, t, i, results))
 		servers = append(servers, srv)
 		addrs = append(addrs, srv.URL)

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -42,7 +42,7 @@ func newCreateDKGCmd(runFunc func(context.Context, createDKGConfig) error) *cobr
 		Short: "Create the configuration for a new Distributed Key Generation ceremony using charon dkg",
 		Long:  `Create a cluster definition file that will be used by all participants of a DKG.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(cmd.Context(), config)
 		},
 	}

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -140,7 +140,7 @@ func TestExistingClusterDefinition(t *testing.T) {
 	require.NoError(t, os.WriteFile(path.Join(charonDir, "cluster-definition.json"), b, 0o600))
 
 	var enrs []string
-	for i := 0; i < minNodes; i++ {
+	for range minNodes {
 		enrs = append(enrs, "enr:-JG4QG472ZVvl8ySSnUK9uNVDrP_hjkUrUqIxUC75aayzmDVQedXkjbqc7QKyOOS71VmlqnYzri_taV8ZesFYaoQSIOGAYHtv1WsgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKwwq_CAld6oVKOrixE-JzMtvvNgb9yyI-_rwq4NFtajIN0Y3CCDhqDdWRwgg4u")
 	}
 	enrArg := fmt.Sprintf("--operator-enrs=%s", strings.Join(enrs, ","))

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -4,7 +4,6 @@ package cmd
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -143,10 +142,10 @@ func TestExistingClusterDefinition(t *testing.T) {
 	for range minNodes {
 		enrs = append(enrs, "enr:-JG4QG472ZVvl8ySSnUK9uNVDrP_hjkUrUqIxUC75aayzmDVQedXkjbqc7QKyOOS71VmlqnYzri_taV8ZesFYaoQSIOGAYHtv1WsgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKwwq_CAld6oVKOrixE-JzMtvvNgb9yyI-_rwq4NFtajIN0Y3CCDhqDdWRwgg4u")
 	}
-	enrArg := fmt.Sprintf("--operator-enrs=%s", strings.Join(enrs, ","))
-	feeRecipientArg := fmt.Sprintf("--fee-recipient-addresses=%s", validEthAddr)
-	withdrawalArg := fmt.Sprintf("--withdrawal-addresses=%s", validEthAddr)
-	outputDirArg := fmt.Sprintf("--output-dir=%s", charonDir)
+	enrArg := "--operator-enrs=" + strings.Join(enrs, ",")
+	feeRecipientArg := "--fee-recipient-addresses=" + validEthAddr
+	withdrawalArg := "--withdrawal-addresses=" + validEthAddr
+	outputDirArg := "--output-dir=" + charonDir
 
 	cmd := newCreateCmd(newCreateDKGCmd(runCreateDKG))
 	cmd.SetArgs([]string{"dkg", enrArg, feeRecipientArg, withdrawalArg, outputDirArg})

--- a/cmd/createenr.go
+++ b/cmd/createenr.go
@@ -22,7 +22,7 @@ func newCreateEnrCmd(runFunc func(io.Writer, string) error) *cobra.Command {
 		Use:   "enr",
 		Short: "Create an Ethereum Node Record (ENR) private key to identify this charon client",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(cmd.OutOrStdout(), dataDir)
 		},
 	}

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -24,7 +24,7 @@ func newDKGCmd(runFunc func(context.Context, dkg.Config) error) *cobra.Command {
 distributed validator key shares and a final cluster lock configuration. Note that all other cluster operators should run
 this command at the same time.`,
 		Args: cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(config.Log); err != nil {
 				return err
 			}

--- a/cmd/enr.go
+++ b/cmd/enr.go
@@ -29,7 +29,7 @@ func newEnrCmd(runFunc func(io.Writer, string, bool) error) *cobra.Command {
 		Short: "Print the ENR that identifies this client",
 		Long:  `Prints an Ethereum Node Record (ENR) from this client's charon-enr-private-key. This serves as a public key that identifies this client to its peers.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(cmd.OutOrStdout(), dataDir, verbose)
 		},
 	}

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -34,7 +34,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 		Short: "Submit partial exit message for a distributed validator",
 		Long:  `Retrieves and broadcasts to the configured beacon node a fully signed validator exit message, aggregated with the available partial signatures retrieved from the publish-address. Can also read a signed exit message from disk, in order to be broadcasted to the configured beacon node.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(config.Log); err != nil {
 				return err
 			}

--- a/cmd/exit_broadcast_internal_test.go
+++ b/cmd/exit_broadcast_internal_test.go
@@ -62,7 +62,7 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 
 	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-	for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+	for opIdx := range operatorAmt {
 		for _, share := range keyShares {
 			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 		}
@@ -109,7 +109,7 @@ func testRunBcastFullExitCmdFlow(t *testing.T, fromFile bool) {
 
 	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
 
-	for idx := 0; idx < operatorAmt; idx++ {
+	for idx := range operatorAmt {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
 
 		config := exitConfig{
@@ -241,7 +241,7 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 
 			operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-			for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+			for opIdx := range operatorAmt {
 				for _, share := range keyShares {
 					operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 				}
@@ -252,7 +252,7 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 
 			writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
 
-			for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+			for opIdx := range operatorAmt {
 				del(t, test, root, opIdx)
 			}
 

--- a/cmd/exit_broadcast_internal_test.go
+++ b/cmd/exit_broadcast_internal_test.go
@@ -218,7 +218,6 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/exit_fetch_internal_test.go
+++ b/cmd/exit_fetch_internal_test.go
@@ -52,7 +52,7 @@ func Test_runFetchExitFullFlow(t *testing.T) {
 
 	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-	for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+	for opIdx := range operatorAmt {
 		for _, share := range keyShares {
 			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 		}
@@ -93,7 +93,7 @@ func Test_runFetchExitFullFlow(t *testing.T) {
 
 	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
 
-	for idx := 0; idx < operatorAmt; idx++ {
+	for idx := range operatorAmt {
 		baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
 
 		config := exitConfig{

--- a/cmd/exit_list.go
+++ b/cmd/exit_list.go
@@ -82,8 +82,8 @@ func listActiveVals(ctx context.Context, config exitConfig) ([]string, error) {
 
 	var allVals []eth2p0.BLSPubKey
 
-	for _, v := range cl.Validators {
-		allVals = append(allVals, eth2p0.BLSPubKey(v.PublicKey))
+	for _, v := range cl.GetValidators() {
+		allVals = append(allVals, eth2p0.BLSPubKey(v.GetPublicKey()))
 	}
 
 	valData, err := eth2Cl.Validators(ctx, &eth2api.ValidatorsOpts{

--- a/cmd/exit_list.go
+++ b/cmd/exit_list.go
@@ -25,7 +25,7 @@ func newListActiveValidatorsCmd(runFunc func(context.Context, exitConfig) error)
 		Short: "List all active validators",
 		Long:  `Returns a list of all the DV in the specified cluster whose status is ACTIVE_ONGOING, i.e. can be exited.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(config.Log); err != nil {
 				return err
 			}

--- a/cmd/exit_list_internal_test.go
+++ b/cmd/exit_list_internal_test.go
@@ -42,7 +42,7 @@ func Test_runListActiveVals(t *testing.T) {
 
 	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-	for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+	for opIdx := range operatorAmt {
 		for _, share := range keyShares {
 			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 		}
@@ -108,7 +108,7 @@ func Test_listActiveVals(t *testing.T) {
 
 	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-	for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+	for opIdx := range operatorAmt {
 		for _, share := range keyShares {
 			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 		}

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -29,7 +29,7 @@ func newSubmitPartialExitCmd(runFunc func(context.Context, exitConfig) error) *c
 		Short: "Sign partial exit message for a distributed validator",
 		Long:  `Sign a partial exit message for a distributed validator and submit it to a remote API for aggregation.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(config.Log); err != nil {
 				return err
 			}

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -300,7 +300,6 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -40,7 +40,7 @@ func writeAllLockData(
 ) {
 	t.Helper()
 
-	for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+	for opIdx := range operatorAmt {
 		opID := fmt.Sprintf("op%d", opIdx)
 		oDir := filepath.Join(root, opID)
 		keysDir := filepath.Join(oDir, "validator_keys")
@@ -152,7 +152,7 @@ func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, expertMode bool,
 
 	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-	for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+	for opIdx := range operatorAmt {
 		for _, share := range keyShares {
 			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 		}
@@ -323,7 +323,7 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 
 			operatorShares := make([][]tbls.PrivateKey, operatorAmt)
 
-			for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+			for opIdx := range operatorAmt {
 				for _, share := range keyShares {
 					operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
 				}
@@ -334,7 +334,7 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 
 			writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
 
-			for opIdx := 0; opIdx < operatorAmt; opIdx++ {
+			for opIdx := range operatorAmt {
 				del(t, test, root, opIdx)
 			}
 

--- a/cmd/manifest_tools.go
+++ b/cmd/manifest_tools.go
@@ -67,7 +67,7 @@ func writeCluster(clusterDir string, numOps int, dag *manifestpb.SignedMutationL
 	}
 
 	// Write cluster manifest to node directories on disk
-	for i := 0; i < numOps; i++ {
+	for i := range numOps {
 		dir := path.Join(clusterDir, fmt.Sprintf("node%d", i))
 		filename := path.Join(dir, "cluster-manifest.pb")
 		//nolint:gosec // File needs to be read-write since the cluster manifest is modified by mutations.

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -55,7 +55,7 @@ func bindRelayFlag(cmd *cobra.Command, config *relay.Config) {
 	var advertisePriv bool
 	cmd.Flags().BoolVar(&advertisePriv, "p2p-advertise-private-addresses", false, "Enable advertising of libp2p auto-detected private addresses. This doesn't affect manually provided p2p-external-ip/hostname.")
 
-	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
+	wrapPreRunE(cmd, func(*cobra.Command, []string) error {
 		// Invert p2p-advertise-private-addresses flag boolean:
 		// -- Do not ADVERTISE private addresses by default in the binary.
 		// -- Do not FILTER private addresses in unit tests.

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -20,7 +20,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 		Short: "Start a libp2p relay server",
 		Long:  "Starts a libp2p circuit relay that charon clients can use to discover and connect to their peers.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(config.LogConfig); err != nil {
 				return err
 			}

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -195,7 +195,7 @@ func getPeerInfo(ctx context.Context, tcpNode host.Host, pID peer.ID, name strin
 		return unknownCluster, true, nil
 	}
 
-	clusterHash := hex7(info.LockHash)
+	clusterHash := hex7(info.GetLockHash())
 	peerPingLatency.WithLabelValues(name, clusterHash).Observe(rtt.Seconds() / 2)
 
 	return clusterHash, true, nil

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -193,7 +193,7 @@ func newENRHandler(ctx context.Context, tcpNode host.Host, p2pKey *k1.PrivateKey
 		return extHostIP, len(extHostIP) != 0
 	}
 
-	return func(ctx context.Context) ([]byte, error) {
+	return func(context.Context) ([]byte, error) {
 		// Use libp2p configured and detected addresses.
 		addrs := tcpNode.Addrs()
 		if len(addrs) == 0 {
@@ -239,7 +239,7 @@ func newENRHandler(ctx context.Context, tcpNode host.Host, p2pKey *k1.PrivateKey
 
 // newMultiaddrHandler returns a handler that returns the nodes multiaddrs (as json array).
 func newMultiaddrHandler(tcpNode host.Host) func(ctx context.Context) ([]byte, error) {
-	return func(ctx context.Context) ([]byte, error) {
+	return func(context.Context) ([]byte, error) {
 		p2pAddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", tcpNode.ID()))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create p2p multiaddr")

--- a/cmd/relay/relay.go
+++ b/cmd/relay/relay.go
@@ -130,7 +130,7 @@ func Run(ctx context.Context, config Config) error {
 	)
 	if config.HTTPAddr != "" {
 		log.Info(ctx, "Runtime multiaddrs available via http",
-			z.Str("url", fmt.Sprintf("http://%s", config.HTTPAddr)),
+			z.Str("url", "http://"+config.HTTPAddr),
 		)
 	} else {
 		log.Info(ctx, "Runtime multiaddrs not available via http, since http-address flag is not set")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error, unsafe bool) *co
 		Use:   "run",
 		Short: "Run the charon middleware client",
 		Long:  "Starts the long-running Charon middleware process to perform distributed validator duties.",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			if err := log.InitLogger(conf.Log); err != nil {
 				return err
 			}
@@ -124,7 +124,7 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().StringSliceVar(&config.TCPAddrs, "p2p-tcp-address", nil, "Comma-separated list of listening TCP addresses (ip and port) for libP2P traffic. Empty default doesn't bind to local port therefore only supports outgoing connections.")
 	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 
-	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
+	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 		for _, relay := range config.Relays {
 			u, err := url.Parse(relay)
 			if err != nil {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -92,7 +92,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().Int64Var(&config.TestnetConfig.GenesisTimestamp, "testnet-genesis-timestamp", 0, "Genesis timestamp of the custom test network.")
 	cmd.Flags().StringVar(&config.TestnetConfig.CapellaHardFork, "testnet-capella-hard-fork", "", "Capella hard fork version of the custom test network.")
 
-	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error {
+	wrapPreRunE(cmd, func(*cobra.Command, []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {
 			return errors.New("either flag 'beacon-node-endpoints' or flag 'simnet-beacon-mock=true' must be specified")
 		}

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -592,7 +592,7 @@ func peerDirectConnTest(ctx context.Context, conf *testPeersConfig, tcpNode host
 		z.Any("target", p2pPeer.Name))
 
 	var err error
-	for i := 0; i < int(conf.DirectConnectionTimeout); i++ {
+	for range int(conf.DirectConnectionTimeout) {
 		err = tcpNode.Connect(network.WithForceDirectDial(ctx, "relay_to_direct"), peer.AddrInfo{ID: p2pPeer.ID})
 		if err == nil {
 			break

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -181,7 +181,6 @@ func setupP2P(ctx context.Context, privKey *k1.PrivateKey, conf p2p.Config, peer
 	p2p.RegisterConnectionLogger(ctx, tcpNode, peerIDs)
 
 	for _, relay := range relays {
-		relay := relay
 		go p2p.NewRelayReserver(tcpNode, relay)(ctx)
 	}
 

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -329,7 +329,7 @@ func testWriteOut(t *testing.T, expectedRes testCategoryResult, buf bytes.Buffer
 	nTargets := len(maps.Keys(expectedRes.Targets))
 	require.Len(t, bufTests, len(slices.Concat(maps.Values(expectedRes.Targets)...))+nTargets*2)
 
-	for i := 0; i < nTargets; i++ {
+	for range nTargets {
 		bufTests = bufTests[1:]
 		target := strings.Trim(bufTests[0], " ")
 		bufTests = bufTests[1:]

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -400,7 +400,6 @@ func startPeer(t *testing.T, conf testPeersConfig, peerPrivKey *k1.PrivateKey) e
 	require.NoError(t, err)
 
 	for _, relay := range relays {
-		relay := relay
 		go p2p.NewRelayReserver(peerTCPNode, relay)(ctx)
 	}
 

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -30,7 +30,6 @@ import (
 
 //go:generate go test . -run=TestPeersTest -update
 
-//nolint:dupl // code is marked as duplicate currently, as we are testing the same test skeleton, ignore for now
 func TestPeersTest(t *testing.T) {
 	peer1PrivKey := base64ToPrivKey(t, "GCc1IKup3kKVxSd9iSu8iX5hc37coxAXasYpGFd/cwo=")
 	peer2PrivKey := base64ToPrivKey(t, "9PhpdrWEDJugHgoXhpbk2KqR4Gj5QZP/YNxNeJ3Q2+A=")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ func newVersionCmd(runFunc func(io.Writer, versionConfig)) *cobra.Command {
 		Use:   "version",
 		Short: "Print version and exit",
 		Long:  "Output version info",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(cmd *cobra.Command, args []string) { //nolint:revive // keep args variable name for clarity
 			runFunc(cmd.OutOrStdout(), conf)
 		},
 	}

--- a/cmd/view_cluster_manifest.go
+++ b/cmd/view_cluster_manifest.go
@@ -25,7 +25,7 @@ func newViewClusterManifestCmd(runFunc func(io.Writer, string) error) *cobra.Com
 		Short: "Shows cluster manifest contents",
 		Long:  `Opens and shows the specified cluster manifest by printing its content in JSON form.`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(cmd.OutOrStdout(), manifestFilePath)
 		},
 	}

--- a/core/aggsigdb/memory_v2_internal_test.go
+++ b/core/aggsigdb/memory_v2_internal_test.go
@@ -61,7 +61,7 @@ func TestCancelledQueryV2(t *testing.T) {
 	awaitAmt := 2
 
 	errStore := make([]error, awaitAmt)
-	for idx := 0; idx < awaitAmt; idx++ {
+	for idx := range awaitAmt {
 		go func() {
 			_, err := db.Await(qctx, duty, pubkey)
 			errStore[idx] = err

--- a/core/aggsigdb/memory_v2_internal_test.go
+++ b/core/aggsigdb/memory_v2_internal_test.go
@@ -62,7 +62,6 @@ func TestCancelledQueryV2(t *testing.T) {
 
 	errStore := make([]error, awaitAmt)
 	for idx := 0; idx < awaitAmt; idx++ {
-		idx := idx
 		go func() {
 			_, err := db.Await(qctx, duty, pubkey)
 			errStore[idx] = err

--- a/core/bcast/bcast_test.go
+++ b/core/bcast/bcast_test.go
@@ -53,7 +53,7 @@ func TestBroadcast(t *testing.T) {
 			bcaster, err := bcast.New(ctx, mock)
 			require.NoError(t, err)
 
-			for i := 0; i < test.bcastCnt; i++ {
+			for range test.bcastCnt {
 				err := bcaster.Broadcast(ctx,
 					core.Duty{Type: test.duty}, core.SignedDataSet{
 						testutil.RandomCorePubKey(t): test.aggData,

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -91,8 +91,8 @@ func newDefinition(nodes int, subs func() []subscriber, roundTimer roundTimer,
 		},
 
 		// LogRoundChange logs round changes at debug level.
-		LogRoundChange: func(ctx context.Context, duty core.Duty, process,
-			round, newRound int64, uponRule qbft.UponRule, msgs []qbft.Msg[core.Duty, [32]byte],
+		LogRoundChange: func(ctx context.Context, duty core.Duty, process, round, newRound int64, //nolint:revive // keep process variable name for clarity
+			uponRule qbft.UponRule, msgs []qbft.Msg[core.Duty, [32]byte],
 		) {
 			fields := []z.Field{
 				z.Any("rule", uponRule),

--- a/core/consensus/component.go
+++ b/core/consensus/component.go
@@ -655,7 +655,7 @@ func groupRoundMessages(msgs []qbft.Msg[core.Duty, [32]byte], peers int, round i
 	// checkPeers returns two slices of peer indexes, one with peers
 	// present with the message type and one with messing peers.
 	checkPeers := func(typ qbft.MsgType) (present []int, missing []int) {
-		for i := 0; i < peers; i++ {
+		for i := range peers {
 			var included bool
 			for _, msg := range msgs {
 				if msg.Type() == typ && msg.Source() == int64(i) {
@@ -728,7 +728,7 @@ func timeoutReason(steps []roundStep, round int64, quorum int) string {
 // fmtStepPeers returns a string representing the present and missing peers.
 func fmtStepPeers(step roundStep) string {
 	var resp []string
-	for i := 0; i < step.Peers; i++ {
+	for range step.Peers {
 		resp = append(resp, "_")
 	}
 

--- a/core/consensus/component_internal_test.go
+++ b/core/consensus/component_internal_test.go
@@ -155,7 +155,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the base message
-				msgHash, err := hashProto(base.Msg)
+				msgHash, err := hashProto(base.GetMsg())
 				require.NoError(t, err)
 
 				sign, err := k1util.Sign(p2pKey, msgHash[:])
@@ -175,7 +175,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the justification
-				justHash, err := hashProto(base.Justification[0])
+				justHash, err := hashProto(base.GetJustification()[0])
 				require.NoError(t, err)
 
 				justSign, err := k1util.Sign(p2pKey, justHash[:])
@@ -202,7 +202,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the base message
-				msgHash, err := hashProto(base.Msg)
+				msgHash, err := hashProto(base.GetMsg())
 				require.NoError(t, err)
 
 				sign, err := k1util.Sign(p2pKey, msgHash[:])
@@ -241,7 +241,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the base message
-				msgHash, err := hashProto(base.Msg)
+				msgHash, err := hashProto(base.GetMsg())
 				require.NoError(t, err)
 
 				sign, err := k1util.Sign(p2pKey, msgHash[:])
@@ -284,7 +284,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the base message
-				msgHash, err := hashProto(base.Msg)
+				msgHash, err := hashProto(base.GetMsg())
 				require.NoError(t, err)
 
 				sign, err := k1util.Sign(p2pKey, msgHash[:])
@@ -304,7 +304,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the justification
-				justHash, err := hashProto(base.Justification[0])
+				justHash, err := hashProto(base.GetJustification()[0])
 				require.NoError(t, err)
 
 				justSign, err := k1util.Sign(p2pKey, justHash[:])
@@ -331,7 +331,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the base message
-				msgHash, err := hashProto(base.Msg)
+				msgHash, err := hashProto(base.GetMsg())
 				require.NoError(t, err)
 
 				sign, err := k1util.Sign(p2pKey, msgHash[:])
@@ -351,7 +351,7 @@ func TestComponent_handle(t *testing.T) {
 				}
 
 				// Sign the justification
-				justHash, err := hashProto(base.Justification[0])
+				justHash, err := hashProto(base.GetJustification()[0])
 				require.NoError(t, err)
 
 				justSign, err := k1util.Sign(p2pKey, justHash[:])
@@ -554,7 +554,7 @@ func signConsensusMsg(t *testing.T, msg *pbv1.ConsensusMsg, privKey *k1.PrivateK
 	}
 
 	// Sign the base message
-	msgHash, err := hashProto(msg.Msg)
+	msgHash, err := hashProto(msg.GetMsg())
 	require.NoError(t, err)
 
 	sign, err := k1util.Sign(privKey, msgHash[:])
@@ -574,7 +574,7 @@ func signConsensusMsg(t *testing.T, msg *pbv1.ConsensusMsg, privKey *k1.PrivateK
 	}
 
 	// Sign the justification
-	justHash, err := hashProto(msg.Justification[0])
+	justHash, err := hashProto(msg.GetJustification()[0])
 	require.NoError(t, err)
 
 	justSign, err := k1util.Sign(privKey, justHash[:])

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -114,7 +114,7 @@ func testComponent(t *testing.T, threshold, nodes int) {
 		}
 
 		sniffer := func(msgs *pbv1.SniffedConsensusInstance) {
-			sniffed <- len(msgs.Msgs)
+			sniffed <- len(msgs.GetMsgs())
 		}
 
 		gaterFunc := func(core.Duty) bool { return true }

--- a/core/consensus/component_test.go
+++ b/core/consensus/component_test.go
@@ -83,7 +83,7 @@ func testComponent(t *testing.T, threshold, nodes int) {
 	defer cancel()
 
 	// Create hosts and enrs (ony for threshold).
-	for i := 0; i < threshold; i++ {
+	for i := range threshold {
 		addr := testutil.AvailableAddr(t)
 		mAddr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", addr.IP, addr.Port))
 		require.NoError(t, err)
@@ -105,8 +105,8 @@ func testComponent(t *testing.T, threshold, nodes int) {
 	}
 
 	// Connect each host with its peers
-	for i := 0; i < threshold; i++ {
-		for j := 0; j < threshold; j++ {
+	for i := range threshold {
+		for j := range threshold {
 			if i == j {
 				continue
 			}
@@ -168,7 +168,7 @@ func testComponent(t *testing.T, threshold, nodes int) {
 
 	cancel()
 
-	for i := 0; i < threshold; i++ {
+	for range threshold {
 		require.NotZero(t, <-sniffed)
 	}
 }

--- a/core/consensus/msg.go
+++ b/core/consensus/msg.go
@@ -27,14 +27,14 @@ func newMsg(pbMsg *pbv1.QBFTMsg, justification []*pbv1.QBFTMsg, values map[[32]b
 		preparedValueHash [32]byte
 	)
 
-	if hash, ok := toHash32(pbMsg.ValueHash); ok {
+	if hash, ok := toHash32(pbMsg.GetValueHash()); ok {
 		valueHash = hash
 		if _, ok := values[valueHash]; !ok {
 			return msg{}, errors.New("value hash not found in values")
 		}
 	}
 
-	if hash, ok := toHash32(pbMsg.PreparedValueHash); ok {
+	if hash, ok := toHash32(pbMsg.GetPreparedValueHash()); ok {
 		preparedValueHash = hash
 		if _, ok := values[preparedValueHash]; !ok {
 			return msg{}, errors.New("prepared value hash not found in values")
@@ -73,19 +73,19 @@ type msg struct {
 }
 
 func (m msg) Type() qbft.MsgType {
-	return qbft.MsgType(m.msg.Type)
+	return qbft.MsgType(m.msg.GetType())
 }
 
 func (m msg) Instance() core.Duty {
-	return core.DutyFromProto(m.msg.Duty)
+	return core.DutyFromProto(m.msg.GetDuty())
 }
 
 func (m msg) Source() int64 {
-	return m.msg.PeerIdx
+	return m.msg.GetPeerIdx()
 }
 
 func (m msg) Round() int64 {
-	return m.msg.Round
+	return m.msg.GetRound()
 }
 
 func (m msg) Value() [32]byte {
@@ -93,7 +93,7 @@ func (m msg) Value() [32]byte {
 }
 
 func (m msg) PreparedRound() int64 {
-	return m.msg.PreparedRound
+	return m.msg.GetPreparedRound()
 }
 
 func (m msg) PreparedValue() [32]byte {
@@ -162,7 +162,7 @@ func verifyMsgSig(msg *pbv1.QBFTMsg, pubkey *k1.PublicKey) (bool, error) {
 		return false, err
 	}
 
-	recovered, err := k1util.Recover(hash[:], msg.Signature)
+	recovered, err := k1util.Recover(hash[:], msg.GetSignature())
 	if err != nil {
 		return false, errors.Wrap(err, "recover pubkey")
 	}

--- a/core/consensus/msg.go
+++ b/core/consensus/msg.go
@@ -152,7 +152,10 @@ func verifyMsgSig(msg *pbv1.QBFTMsg, pubkey *k1.PublicKey) (bool, error) {
 		return false, errors.New("empty signature")
 	}
 
-	clone := proto.Clone(msg).(*pbv1.QBFTMsg)
+	clone, ok := proto.Clone(msg).(*pbv1.QBFTMsg)
+	if !ok {
+		return false, errors.New("type assert qbft msg")
+	}
 	clone.Signature = nil
 	hash, err := hashProto(clone)
 	if err != nil {
@@ -169,7 +172,10 @@ func verifyMsgSig(msg *pbv1.QBFTMsg, pubkey *k1.PublicKey) (bool, error) {
 
 // signMsg returns a copy of the proto message with a populated signature signed by the provided private key.
 func signMsg(msg *pbv1.QBFTMsg, privkey *k1.PrivateKey) (*pbv1.QBFTMsg, error) {
-	clone := proto.Clone(msg).(*pbv1.QBFTMsg)
+	clone, ok := proto.Clone(msg).(*pbv1.QBFTMsg)
+	if !ok {
+		return nil, errors.New("type assert qbft msg")
+	}
 	clone.Signature = nil
 
 	hash, err := hashProto(clone)

--- a/core/consensus/roundtimer.go
+++ b/core/consensus/roundtimer.go
@@ -25,7 +25,7 @@ type timerFunc func(core.Duty) roundTimer
 // getTimerFunc returns a timer function based on the enabled features.
 func getTimerFunc() timerFunc {
 	if featureset.Enabled(featureset.EagerDoubleLinear) {
-		return func(duty core.Duty) roundTimer {
+		return func(core.Duty) roundTimer {
 			return newDoubleEagerLinearRoundTimer()
 		}
 	}

--- a/core/consensus/sniffed_internal_test.go
+++ b/core/consensus/sniffed_internal_test.go
@@ -7,9 +7,9 @@ import (
 	"compress/gzip"
 	"context"
 	"flag"
-	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -41,7 +41,7 @@ func TestSniffedFile(t *testing.T) {
 	)
 
 	for i, instance := range instances.Instances {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			if len(instance.Msgs) == 0 {
 				log.Error(ctx, "No messages in instance", nil, z.Int("i", i))
 				return

--- a/core/consensus/strategysim_internal_test.go
+++ b/core/consensus/strategysim_internal_test.go
@@ -69,7 +69,7 @@ func TestSimulatorOnce(t *testing.T) {
 		timeout:        simTimeout,
 	}, syncer)
 
-	require.Equal(t, 4, len(results))
+	require.Len(t, results, 4)
 	require.False(t, isUndecided(results))
 }
 

--- a/core/consensus/strategysim_internal_test.go
+++ b/core/consensus/strategysim_internal_test.go
@@ -181,7 +181,7 @@ func testRoundTimers(t *testing.T, timers []roundTimerFunc, itersPerConfig int) 
 		}
 	}
 
-	for i := 0; i < len(allConfigs); i++ {
+	for i := range len(allConfigs) {
 		allConfigs[i].index = i
 	}
 
@@ -451,7 +451,7 @@ func cancelAfter(cancel context.CancelFunc, n int) context.CancelFunc {
 }
 
 func gosched() {
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		time.Sleep(time.Microsecond)
 		runtime.Gosched()
 	}
@@ -757,7 +757,7 @@ func randomConfigs(names []string, peers int, n int, timer func(clockwork.Clock)
 	peerLatencies := randomPeerLatencies(peers, n, latencies, random)
 
 	var res []ssConfig
-	for i := 0; i < n; i++ {
+	for i := range n {
 		res = append(res, ssConfig{
 			names:          append([]string(nil), names...),
 			seed:           i,
@@ -774,9 +774,9 @@ func randomConfigs(names []string, peers int, n int, timer func(clockwork.Clock)
 
 func randomPeerLatencies(peers int, n int, selectFrom []time.Duration, random *rand.Rand) []map[int64]time.Duration {
 	var resp []map[int64]time.Duration
-	for i := 0; i < n; i++ {
+	for range n {
 		m := make(map[int64]time.Duration)
-		for i := 0; i < peers; i++ {
+		for i := range peers {
 			m[int64(i)] = selectFrom[random.Intn(len(selectFrom))]
 		}
 		resp = append(resp, m)
@@ -804,7 +804,7 @@ var (
 // proposalLatencyPercentiles.
 func normalStartLatencies(peers int, random *rand.Rand) map[int64]time.Duration {
 	resp := make(map[int64]time.Duration, peers)
-	for i := 0; i < peers; i++ {
+	for i := range peers {
 		resp[int64(i)] = normalDuration(proposalMean, proposalStdDev, random)
 	}
 
@@ -833,7 +833,7 @@ func disableRandomNodes(configs []ssConfig, n int) []ssConfig {
 	random := rand.New(rand.NewSource(0))
 	for _, config := range configs {
 		size := len(config.latencyPerPeer)
-		for i := 0; i < n; i++ {
+		for range n {
 			config.startByPeer[int64(random.Intn(size))] = disabled
 		}
 	}

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -61,7 +61,7 @@ func TestDeadliner(t *testing.T) {
 	clock.Advance(time.Duration(maxSlot) * time.Second)
 
 	var actualDuties []core.Duty
-	for i := 0; i < len(nonExpiredDuties); i++ {
+	for range len(nonExpiredDuties) {
 		actualDuties = append(actualDuties, <-deadliner.C())
 	}
 

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -65,7 +65,7 @@ func TestMemDB(t *testing.T) {
 
 	// Kick of some queries, it should return when the data is populated.
 	awaitResponse := make(chan *eth2p0.AttestationData)
-	for i := 0; i < queries; i++ {
+	for range queries {
 		go func() {
 			data, err := db.AwaitAttestation(ctx, slot, commIdx)
 			require.NoError(t, err)
@@ -110,7 +110,7 @@ func TestMemDB(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get and assert the attQuery responses.
-	for i := 0; i < queries; i++ {
+	for range queries {
 		actual := <-awaitResponse
 		require.Equal(t, attData.String(), actual.String())
 	}
@@ -160,7 +160,7 @@ func TestMemDBProposer(t *testing.T) {
 		block *eth2api.VersionedProposal
 	}
 	var awaitResponse [queries]chan response
-	for i := 0; i < queries; i++ {
+	for i := range queries {
 		awaitResponse[i] = make(chan response)
 		go func(slot int) {
 			block, err := db.AwaitProposal(ctx, slots[slot])
@@ -171,7 +171,7 @@ func TestMemDBProposer(t *testing.T) {
 
 	proposals := make([]*eth2api.VersionedProposal, queries)
 	pubkeysByIdx := make(map[eth2p0.ValidatorIndex]core.PubKey)
-	for i := 0; i < queries; i++ {
+	for i := range queries {
 		proposals[i] = &eth2api.VersionedProposal{
 			Version:   eth2spec.DataVersionBellatrix,
 			Bellatrix: testutil.RandomBellatrixBeaconBlock(),
@@ -182,7 +182,7 @@ func TestMemDBProposer(t *testing.T) {
 	}
 
 	// Store the Blocks
-	for i := 0; i < queries; i++ {
+	for i := range queries {
 		unsigned, err := core.NewVersionedProposal(proposals[i])
 		require.NoError(t, err)
 
@@ -194,7 +194,7 @@ func TestMemDBProposer(t *testing.T) {
 	}
 
 	// Get and assert the proQuery responses
-	for i := 0; i < queries; i++ {
+	for i := range queries {
 		actualData := <-awaitResponse[i]
 		require.Equal(t, proposals[i], actualData.block)
 	}
@@ -206,7 +206,7 @@ func TestMemDBAggregator(t *testing.T) {
 
 	const queries = 3
 
-	for i := 0; i < queries; i++ {
+	for range queries {
 		agg := testutil.RandomAttestation()
 		set := core.UnsignedDataSet{
 			testutil.RandomCorePubKey(t): core.NewAggregatedAttestation(agg),
@@ -232,7 +232,7 @@ func TestMemDBSyncContribution(t *testing.T) {
 
 		const queries = 3
 
-		for i := 0; i < queries; i++ {
+		for range queries {
 			contrib := testutil.RandomSyncCommitteeContribution()
 			set := core.UnsignedDataSet{
 				testutil.RandomCorePubKey(t): core.NewSyncContribution(contrib),

--- a/core/parsigdb/memory_internal_test.go
+++ b/core/parsigdb/memory_internal_test.go
@@ -86,7 +86,7 @@ func TestGetThresholdMatching(t *testing.T) {
 			for name, provider := range providers {
 				t.Run(name, func(t *testing.T) {
 					var datas []core.ParSignedData
-					for i := 0; i < len(test.input); i++ {
+					for i := range len(test.input) {
 						datas = append(datas, provider(i))
 					}
 
@@ -132,7 +132,7 @@ func TestMemDBThreshold(t *testing.T) {
 	att := testutil.RandomAttestation()
 
 	enqueueN := func() {
-		for i := 0; i < n; i++ {
+		for i := range n {
 			err := db.StoreExternal(context.Background(), core.NewAttesterDuty(123), core.ParSignedDataSet{
 				pubkey: core.NewPartialAttestation(att, i+1),
 			})

--- a/core/parsigex/memory_test.go
+++ b/core/parsigex/memory_test.go
@@ -27,7 +27,7 @@ func TestMemEx(t *testing.T) {
 	var received []tuple
 
 	var exes []core.ParSigEx
-	for i := 0; i < n; i++ {
+	for i := range n {
 		ex := memExFunc()
 		ex.Subscribe(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
 			require.NotEqual(t, i, set[pubkey].ShareIdx, "received from self")
@@ -42,7 +42,7 @@ func TestMemEx(t *testing.T) {
 		exes = append(exes, ex)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		set := make(core.ParSignedDataSet)
 		set[pubkey] = core.ParSignedData{
 			SignedData: nil,

--- a/core/parsigex/memory_test.go
+++ b/core/parsigex/memory_test.go
@@ -28,7 +28,6 @@ func TestMemEx(t *testing.T) {
 
 	var exes []core.ParSigEx
 	for i := 0; i < n; i++ {
-		i := i
 		ex := memExFunc()
 		ex.Subscribe(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
 			require.NotEqual(t, i, set[pubkey].ShareIdx, "received from self")

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -71,18 +71,18 @@ func (m *ParSigEx) handle(ctx context.Context, _ peer.ID, req proto.Message) (pr
 		return nil, false, errors.New("invalid request type")
 	}
 
-	if pb == nil || pb.Duty == nil || pb.DataSet == nil {
+	if pb == nil || pb.GetDuty() == nil || pb.GetDataSet() == nil {
 		return nil, false, errors.New("invalid parsigex msg fields", z.Any("msg", pb))
 	}
 
-	duty := core.DutyFromProto(pb.Duty)
+	duty := core.DutyFromProto(pb.GetDuty())
 	ctx = log.WithCtx(ctx, z.Any("duty", duty))
 
 	if !m.gaterFunc(duty) {
 		return nil, false, errors.New("invalid duty")
 	}
 
-	set, err := core.ParSignedDataSetFromProto(duty.Type, pb.DataSet)
+	set, err := core.ParSignedDataSetFromProto(duty.Type, pb.GetDataSet())
 	if err != nil {
 		return nil, false, errors.Wrap(err, "convert parsigex proto")
 	}

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -50,7 +50,7 @@ func TestParSigEx(t *testing.T) {
 	)
 
 	// create hosts
-	for i := 0; i < n; i++ {
+	for range n {
 		h := testutil.CreateHost(t, testutil.AvailableAddr(t))
 		info := peer.AddrInfo{
 			ID:    h.ID(),
@@ -62,8 +62,8 @@ func TestParSigEx(t *testing.T) {
 	}
 
 	// connect each host with its peers
-	for i := 0; i < n; i++ {
-		for k := 0; k < n; k++ {
+	for i := range n {
+		for k := range n {
 			if i == k {
 				continue
 			}
@@ -81,7 +81,7 @@ func TestParSigEx(t *testing.T) {
 	var wg sync.WaitGroup
 
 	// create ParSigEx components for each host
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(n - 1)
 		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, verifyFunc, gaterFunc)
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
@@ -95,7 +95,7 @@ func TestParSigEx(t *testing.T) {
 		parsigexs = append(parsigexs, sigex)
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		wg.Add(1)
 		go func(node int) {
 			defer wg.Done()

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -95,13 +95,20 @@ func TestParSigEx(t *testing.T) {
 		parsigexs = append(parsigexs, sigex)
 	}
 
+	errCh := make(chan error, n)
 	for i := range n {
 		wg.Add(1)
 		go func(node int) {
 			defer wg.Done()
 			// broadcast partially signed data
-			require.NoError(t, parsigexs[node].Broadcast(context.Background(), duty, data))
+			err := parsigexs[node].Broadcast(context.Background(), duty, data)
+			errCh <- err
 		}(i)
+	}
+
+	for range n {
+		err := <-errCh
+		require.NoError(t, err)
 	}
 
 	wg.Wait()

--- a/core/priority/calculate.go
+++ b/core/priority/calculate.go
@@ -31,7 +31,6 @@ func calculateResult(msgs []*pbv1.PriorityMsg, minRequired int) (*pbv1.PriorityR
 	proposalsByTopic := make(map[[32]byte][]*pbv1.PriorityTopicProposal)
 	for _, msg := range sortInput(msgs) {
 		for _, topic := range msg.Topics {
-			topic := topic // Copy iteration value since it is a pointer
 			topicHash, err := hashProto(topic.Topic)
 			if err != nil {
 				return nil, err
@@ -52,7 +51,6 @@ func calculateResult(msgs []*pbv1.PriorityMsg, minRequired int) (*pbv1.PriorityR
 		)
 		for _, proposal := range proposals {
 			for order, prio := range proposal.Priorities {
-				prio := prio // Copy iteration value since it is a pointer
 				priority, err := hashProto(prio)
 				if err != nil {
 					return nil, err
@@ -107,7 +105,6 @@ func orderTopicResults(values []*pbv1.PriorityTopicResult) ([]*pbv1.PriorityTopi
 
 	var tuples []tuple
 	for _, value := range values {
-		value := value // Copy iteration value since it is a pointer
 		hash, err := hashProto(value.Topic)
 		if err != nil {
 			return nil, err

--- a/core/priority/calculate.go
+++ b/core/priority/calculate.go
@@ -30,8 +30,8 @@ func calculateResult(msgs []*pbv1.PriorityMsg, minRequired int) (*pbv1.PriorityR
 	// Group all priority sets by topic
 	proposalsByTopic := make(map[[32]byte][]*pbv1.PriorityTopicProposal)
 	for _, msg := range sortInput(msgs) {
-		for _, topic := range msg.Topics {
-			topicHash, err := hashProto(topic.Topic)
+		for _, topic := range msg.GetTopics() {
+			topicHash, err := hashProto(topic.GetTopic())
 			if err != nil {
 				return nil, err
 			}
@@ -50,7 +50,7 @@ func calculateResult(msgs []*pbv1.PriorityMsg, minRequired int) (*pbv1.PriorityR
 			allPriorities [][32]byte
 		)
 		for _, proposal := range proposals {
-			for order, prio := range proposal.Priorities {
+			for order, prio := range proposal.GetPriorities() {
 				priority, err := hashProto(prio)
 				if err != nil {
 					return nil, err
@@ -70,7 +70,7 @@ func calculateResult(msgs []*pbv1.PriorityMsg, minRequired int) (*pbv1.PriorityR
 
 		// Extract scores with min required count.
 		minScore := (minRequired - 1) * countWeight
-		result := &pbv1.PriorityTopicResult{Topic: proposals[0].Topic}
+		result := &pbv1.PriorityTopicResult{Topic: proposals[0].GetTopic()}
 		for _, priority := range allPriorities {
 			score := scores[priority]
 			if score <= minScore {
@@ -105,7 +105,7 @@ func orderTopicResults(values []*pbv1.PriorityTopicResult) ([]*pbv1.PriorityTopi
 
 	var tuples []tuple
 	for _, value := range values {
-		hash, err := hashProto(value.Topic)
+		hash, err := hashProto(value.GetTopic())
 		if err != nil {
 			return nil, err
 		}
@@ -132,7 +132,7 @@ func orderTopicResults(values []*pbv1.PriorityTopicResult) ([]*pbv1.PriorityTopi
 func sortInput(msgs []*pbv1.PriorityMsg) []*pbv1.PriorityMsg {
 	resp := append([]*pbv1.PriorityMsg(nil), msgs...) // Copy to not mutate input param.
 	sort.Slice(resp, func(i, j int) bool {
-		return resp[i].PeerId < resp[j].PeerId
+		return resp[i].GetPeerId() < resp[j].GetPeerId()
 	})
 
 	return resp
@@ -155,27 +155,27 @@ func validateMsgs(msgs []*pbv1.PriorityMsg) error {
 	)
 	for _, msg := range msgs {
 		if duty == nil {
-			duty = msg.Duty
-		} else if !proto.Equal(duty, msg.Duty) {
+			duty = msg.GetDuty()
+		} else if !proto.Equal(duty, msg.GetDuty()) {
 			return errors.New("mismatching duties")
 		}
-		if dedupPeers(msg.PeerId) {
+		if dedupPeers(msg.GetPeerId()) {
 			return errors.New("duplicate peer")
 		}
 		dedupTopics := newDeduper[[32]byte]() // Peers may not provide duplicate topics.
-		for _, topic := range msg.Topics {
-			topicHash, err := hashProto(topic.Topic)
+		for _, topic := range msg.GetTopics() {
+			topicHash, err := hashProto(topic.GetTopic())
 			if err != nil {
 				return err
 			}
 			if dedupTopics(topicHash) {
 				return errors.New("duplicate topic")
-			} else if len(topic.Priorities) >= maxPriorities {
+			} else if len(topic.GetPriorities()) >= maxPriorities {
 				return errors.New("max priority reached")
 			}
 
 			dedupPriority := newDeduper[[32]byte]() // Topics may not include duplicates priority.
-			for _, priority := range topic.Priorities {
+			for _, priority := range topic.GetPriorities() {
 				prioHash, err := hashProto(priority)
 				if err != nil {
 					return err

--- a/core/priority/calculate_internal_test.go
+++ b/core/priority/calculate_internal_test.go
@@ -3,8 +3,8 @@
 package priority
 
 import (
-	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -167,7 +167,7 @@ func TestCalculateResults(t *testing.T) {
 							Topic: toAny("ignored"),
 						},
 					},
-					PeerId: fmt.Sprint(j),
+					PeerId: strconv.Itoa(j),
 					Duty:   &pbv1.Duty{Slot: test.Slot},
 				})
 			}

--- a/core/priority/calculate_internal_test.go
+++ b/core/priority/calculate_internal_test.go
@@ -179,27 +179,27 @@ func TestCalculateResults(t *testing.T) {
 
 			result, err := calculateResult(msgs, Q)
 			require.NoError(t, err)
-			require.Len(t, result.Topics, 2)
+			require.Len(t, result.GetTopics(), 2)
 
 			var topicResult *pbv1.PriorityTopicResult
-			for _, result := range result.Topics {
-				if proto.Equal(result.Topic, topic) {
+			for _, result := range result.GetTopics() {
+				if proto.Equal(result.GetTopic(), topic) {
 					topicResult = result
 				}
 			}
 			if len(test.Result) > 0 {
 				var actualResult []string
 				var actualScores []int64
-				for _, prio := range topicResult.Priorities {
-					actualResult = append(actualResult, fromAny(prio.Priority))
-					actualScores = append(actualScores, prio.Score)
+				for _, prio := range topicResult.GetPriorities() {
+					actualResult = append(actualResult, fromAny(prio.GetPriority()))
+					actualScores = append(actualScores, prio.GetScore())
 				}
 				require.Equal(t, test.Result, actualResult)
 				if len(test.Scores) != 0 {
 					require.Equal(t, test.Scores, actualScores)
 				}
 			} else {
-				require.Empty(t, result.Topics[0].Priorities)
+				require.Empty(t, result.GetTopics()[0].GetPriorities())
 			}
 		})
 	}
@@ -237,5 +237,5 @@ func fromAny(a *anypb.Any) string {
 		panic(err)
 	}
 
-	return string(pb.(*pbv1.ParSignedData).Data)
+	return string(pb.(*pbv1.ParSignedData).GetData())
 }

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -151,7 +151,10 @@ func (c *Component) Prioritise(ctx context.Context, duty core.Duty, proposals ..
 
 // signMsg returns a copy of the proto message with a populated signature signed by the provided private key.
 func signMsg(msg *pbv1.PriorityMsg, privkey *k1.PrivateKey) (*pbv1.PriorityMsg, error) {
-	clone := proto.Clone(msg).(*pbv1.PriorityMsg)
+	clone, ok := proto.Clone(msg).(*pbv1.PriorityMsg)
+	if !ok {
+		return nil, errors.New("type assert priority msg")
+	}
 	clone.Signature = nil
 
 	hash, err := hashProto(clone)
@@ -173,7 +176,10 @@ func verifyMsgSig(msg *pbv1.PriorityMsg, pubkey *k1.PublicKey) (bool, error) {
 		return false, errors.New("empty signature")
 	}
 
-	clone := proto.Clone(msg).(*pbv1.PriorityMsg)
+	clone, ok := proto.Clone(msg).(*pbv1.PriorityMsg)
+	if !ok {
+		return false, errors.New("type assert priority msg")
+	}
 	clone.Signature = nil
 	hash, err := hashProto(clone)
 	if err != nil {

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -96,7 +96,7 @@ func (c *Component) Start(ctx context.Context) {
 func (c *Component) Subscribe(fn func(context.Context, core.Duty, []TopicResult) error) {
 	c.prioritiser.Subscribe(func(ctx context.Context, duty core.Duty, result *pbv1.PriorityResult) error {
 		var results []TopicResult
-		for _, topic := range result.Topics {
+		for _, topic := range result.GetTopics() {
 			result, err := topicResultFromProto(topic)
 			if err != nil {
 				return err
@@ -141,7 +141,7 @@ func (c *Component) Prioritise(ctx context.Context, duty core.Duty, proposals ..
 
 	err = c.prioritiser.Prioritise(ctx, msg)
 	if ctx.Err() != nil {
-		return nil //nolint:nilerr // Context expiry is expected behaviour, return nil.
+		return nil
 	} else if err != nil {
 		return errors.Wrap(err, "prioritise", z.Any("duty", duty))
 	}
@@ -186,7 +186,7 @@ func verifyMsgSig(msg *pbv1.PriorityMsg, pubkey *k1.PublicKey) (bool, error) {
 		return false, err
 	}
 
-	actual, err := k1util.Recover(hash[:], msg.Signature)
+	actual, err := k1util.Recover(hash[:], msg.GetSignature())
 	if err != nil {
 		return false, errors.Wrap(err, "sig to pub")
 	}
@@ -211,11 +211,11 @@ func newMsgVerifier(peers []peer.ID) (func(msg *pbv1.PriorityMsg) error, error) 
 	}
 
 	return func(msg *pbv1.PriorityMsg) error {
-		if msg == nil || msg.Duty == nil {
+		if msg == nil || msg.GetDuty() == nil {
 			return errors.New("invalid priority msg proto fields", z.Any("msg", msg))
 		}
 
-		key, ok := keys[msg.PeerId]
+		key, ok := keys[msg.GetPeerId()]
 		if !ok {
 			return errors.New("unknown peer id")
 		}
@@ -261,7 +261,7 @@ func topicResultFromProto(p *pbv1.PriorityTopicResult) (TopicResult, error) {
 	}
 
 	topicVal := new(structpb.Value)
-	if err := p.Topic.UnmarshalTo(topicVal); err != nil {
+	if err := p.GetTopic().UnmarshalTo(topicVal); err != nil {
 		return TopicResult{}, errors.Wrap(err, "anypb topic")
 	}
 
@@ -271,9 +271,9 @@ func topicResultFromProto(p *pbv1.PriorityTopicResult) (TopicResult, error) {
 	}
 
 	var priorities []ScoredPriority
-	for _, scored := range p.Priorities {
+	for _, scored := range p.GetPriorities() {
 		prioVal := new(structpb.Value)
-		if err := scored.Priority.UnmarshalTo(prioVal); err != nil {
+		if err := scored.GetPriority().UnmarshalTo(prioVal); err != nil {
 			return TopicResult{}, errors.Wrap(err, "anypb priority")
 		}
 
@@ -284,7 +284,7 @@ func topicResultFromProto(p *pbv1.PriorityTopicResult) (TopicResult, error) {
 
 		priorities = append(priorities, ScoredPriority{
 			Priority: prio,
-			Score:    int(scored.Score),
+			Score:    int(scored.GetScore()),
 		})
 	}
 

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -68,14 +68,14 @@ func TestPrioritiser(t *testing.T) {
 			consensus, msgValidator, time.Hour, deadliner)
 
 		prio.Subscribe(func(_ context.Context, duty core.Duty, result *pbv1.PriorityResult) error {
-			require.Len(t, result.Topics, 1)
+			require.Len(t, result.GetTopics(), 1)
 
-			resTopic, err := result.Topics[0].Topic.UnmarshalNew()
+			resTopic, err := result.GetTopics()[0].GetTopic().UnmarshalNew()
 			require.NoError(t, err)
 
 			requireAnyDuty(t, duties, duty)
 			requireProtoEqual(t, topic, resTopic)
-			results <- result.Topics[0].Priorities
+			results <- result.GetTopics()[0].GetPriorities()
 
 			return nil
 		})
@@ -91,14 +91,13 @@ func TestPrioritiser(t *testing.T) {
 				errCh <- err
 			}()
 		}
-
 	}
 
 	for range n * len(duties) {
 		res := <-results
 		require.Len(t, res, 1)
-		require.EqualValues(t, n*1000, res[0].Score)
-		requireProtoEqual(t, prioToAny(0), res[0].Priority)
+		require.EqualValues(t, n*1000, res[0].GetScore())
+		requireProtoEqual(t, prioToAny(0), res[0].GetPriority())
 	}
 
 	cancel()
@@ -123,8 +122,8 @@ func (t *testConsensus) ProposePriority(ctx context.Context, duty core.Duty, res
 	defer t.mu.Unlock()
 
 	if t.proposed[duty.Slot] != nil {
-		prev := mustResultsToText(t.proposed[duty.Slot].Topics)
-		this := mustResultsToText(result.Topics)
+		prev := mustResultsToText(t.proposed[duty.Slot].GetTopics())
+		this := mustResultsToText(result.GetTopics())
 		require.Equal(t.t, prev, this)
 
 		return nil

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -41,7 +41,7 @@ func TestPrioritiser(t *testing.T) {
 	)
 
 	// Create libp2p tcp nodes.
-	for i := 0; i < n; i++ {
+	for range n {
 		tcpNode := testutil.CreateHost(t, testutil.AvailableAddr(t))
 		for _, other := range tcpNodes {
 			tcpNode.Peerstore().AddAddrs(other.ID(), other.Addrs(), peerstore.PermanentAddrTTL)
@@ -54,12 +54,12 @@ func TestPrioritiser(t *testing.T) {
 	}
 
 	// Create prioritisers
-	for i := 0; i < n; i++ {
+	for i := range n {
 		tcpNode := tcpNodes[i]
 
 		// Propose 0:[0], 1:[0,1], 2:[0,1,2] - expect [0]
 		var priorities []*anypb.Any
-		for j := 0; j <= i; j++ {
+		for j := range i + 1 {
 			priorities = append(priorities, prioToAny(j))
 		}
 
@@ -91,7 +91,7 @@ func TestPrioritiser(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < n*len(duties); i++ {
+	for range n * len(duties) {
 		res := <-results
 		require.Len(t, res, 1)
 		require.EqualValues(t, n*1000, res[0].Score)

--- a/core/proto.go
+++ b/core/proto.go
@@ -39,8 +39,8 @@ func DutyToProto(duty Duty) *pbv1.Duty {
 // DutyFromProto returns the duty from a protobuf.
 func DutyFromProto(duty *pbv1.Duty) Duty {
 	return Duty{
-		Slot: duty.Slot,
-		Type: DutyType(duty.Type),
+		Slot: duty.GetSlot(),
+		Type: DutyType(duty.GetType()),
 	}
 }
 
@@ -63,13 +63,13 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSigned
 	switch typ {
 	case DutyAttester:
 		var a Attestation
-		if err := unmarshal(data.Data, &a); err != nil {
+		if err := unmarshal(data.GetData(), &a); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal attestation")
 		}
 		signedData = a
 	case DutyProposer:
 		var b VersionedSignedProposal
-		if err := unmarshal(data.Data, &b); err != nil {
+		if err := unmarshal(data.GetData(), &b); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal proposal")
 		}
 		signedData = b
@@ -77,55 +77,55 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSigned
 		return ParSignedData{}, ErrDeprecatedDutyBuilderProposer
 	case DutyBuilderRegistration:
 		var r VersionedSignedValidatorRegistration
-		if err := unmarshal(data.Data, &r); err != nil {
+		if err := unmarshal(data.GetData(), &r); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal validator (builder) registration")
 		}
 		signedData = r
 	case DutyExit:
 		var e SignedVoluntaryExit
-		if err := unmarshal(data.Data, &e); err != nil {
+		if err := unmarshal(data.GetData(), &e); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal exit")
 		}
 		signedData = e
 	case DutyRandao:
 		var s SignedRandao
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal signed randao")
 		}
 		signedData = s
 	case DutySignature:
 		var s Signature
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal signature")
 		}
 		signedData = s
 	case DutyPrepareAggregator:
 		var s BeaconCommitteeSelection
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal beacon committee subscription")
 		}
 		signedData = s
 	case DutyAggregator:
 		var s SignedAggregateAndProof
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal signed aggregate and proof")
 		}
 		signedData = s
 	case DutySyncMessage:
 		var s SignedSyncMessage
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal signed sync message")
 		}
 		signedData = s
 	case DutyPrepareSyncContribution:
 		var s SyncCommitteeSelection
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal sync committee selection")
 		}
 		signedData = s
 	case DutySyncContribution:
 		var s SignedSyncContributionAndProof
-		if err := unmarshal(data.Data, &s); err != nil {
+		if err := unmarshal(data.GetData(), &s); err != nil {
 			return ParSignedData{}, errors.Wrap(err, "unmarshal sync contribution and proof")
 		}
 		signedData = s
@@ -135,7 +135,7 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSigned
 
 	return ParSignedData{
 		SignedData: signedData,
-		ShareIdx:   int(data.ShareIdx),
+		ShareIdx:   int(data.GetShareIdx()),
 	}, nil
 }
 
@@ -171,7 +171,7 @@ func ParSignedDataSetToProto(set ParSignedDataSet) (*pbv1.ParSignedDataSet, erro
 
 // ParSignedDataSetFromProto returns the set from a protobuf.
 func ParSignedDataSetFromProto(typ DutyType, set *pbv1.ParSignedDataSet) (ParSignedDataSet, error) {
-	if set == nil || len(set.Set) == 0 {
+	if set == nil || len(set.GetSet()) == 0 {
 		return nil, errors.New("invalid partial signed data set proto fields", z.Any("set", set))
 	}
 
@@ -179,7 +179,7 @@ func ParSignedDataSetFromProto(typ DutyType, set *pbv1.ParSignedDataSet) (ParSig
 		resp = make(ParSignedDataSet)
 		err  error
 	)
-	for pubkey, data := range set.Set {
+	for pubkey, data := range set.GetSet() {
 		resp[PubKey(pubkey)], err = ParSignedDataFromProto(typ, data)
 		if err != nil {
 			return nil, err
@@ -207,12 +207,12 @@ func UnsignedDataSetToProto(set UnsignedDataSet) (*pbv1.UnsignedDataSet, error) 
 
 // UnsignedDataSetFromProto returns the set from a protobuf.
 func UnsignedDataSetFromProto(typ DutyType, set *pbv1.UnsignedDataSet) (UnsignedDataSet, error) {
-	if set == nil || len(set.Set) == 0 {
+	if set == nil || len(set.GetSet()) == 0 {
 		return nil, errors.New("invalid unsigned data set fields", z.Any("set", set))
 	}
 
 	resp := make(UnsignedDataSet)
-	for pubkey, data := range set.Set {
+	for pubkey, data := range set.GetSet() {
 		var err error
 		resp[PubKey(pubkey)], err = unmarshalUnsignedData(typ, data)
 		if err != nil {

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -128,7 +128,6 @@ func (s *Scheduler) Run() error {
 // emitCoreSlot calls all slot subscriptions asynchronously with the provided slot.
 func (s *Scheduler) emitCoreSlot(ctx context.Context, slot core.Slot) {
 	for _, sub := range s.slotSubs {
-		sub := sub
 		go func(sub func(context.Context, core.Slot) error) {
 			err := sub(ctx, slot)
 			if err != nil {

--- a/core/scheduler/scheduler_internal_test.go
+++ b/core/scheduler/scheduler_internal_test.go
@@ -48,7 +48,7 @@ func setupScheduler(t *testing.T) (*Scheduler, validators) {
 			return nil, err
 		}
 
-		for idx := 0; idx < len(res); idx++ {
+		for idx := range len(res) {
 			res[idx].PubKey = testutil.RandomEth2PubKey(t)
 		}
 
@@ -61,7 +61,7 @@ func setupScheduler(t *testing.T) (*Scheduler, validators) {
 			return nil, err
 		}
 
-		for idx := 0; idx < len(res); idx++ {
+		for idx := range len(res) {
 			res[idx].PubKey = testutil.RandomEth2PubKey(t)
 		}
 
@@ -74,7 +74,7 @@ func setupScheduler(t *testing.T) (*Scheduler, validators) {
 			return nil, err
 		}
 
-		for idx := 0; idx < len(res); idx++ {
+		for idx := range len(res) {
 			res[idx].PubKey = testutil.RandomEth2PubKey(t)
 		}
 

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -145,7 +145,7 @@ func TestSchedulerWait(t *testing.T) {
 			sched := scheduler.NewForT(t, clock, dd.delay, nil, eth2Cl, false)
 			sched.Stop() // Just run wait functions, then quit.
 			require.NoError(t, sched.Run())
-			require.EqualValues(t, test.WaitSecs, clock.Since(t0).Seconds())
+			require.Equal(t, test.WaitSecs, int(clock.Since(t0).Seconds()))
 		})
 	}
 }

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -268,7 +268,7 @@ func TestSchedulerDuties(t *testing.T) {
 
 			// Add deadlines to results
 			deadlines := delayer.get()
-			for i := 0; i < len(results); i++ {
+			for i := range len(results) {
 				results[i].Time = deadlines[results[i].Duty].UTC().Format("04:05.000")
 			}
 			// Make result order deterministic

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -55,7 +55,7 @@ func TestSigAgg(t *testing.T) {
 			parsigs []core.ParSignedData
 			att     = testutil.RandomAttestation()
 		)
-		for i := 0; i < peers; i++ {
+		for range peers {
 			parsig := core.NewPartialAttestation(att, 0) // All partial sig with the same shareIdx (0)
 			parsigs = append(parsigs, parsig)
 		}

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -4,7 +4,6 @@ package core
 
 import (
 	"context"
-	"fmt"
 	"hash/fnv"
 	"strconv"
 	"strings"
@@ -27,7 +26,7 @@ func StartDutyTrace(ctx context.Context, duty Duty, spanName string, opts ...tra
 	copy(traceID[:], h.Sum(nil))
 
 	var outerSpan, innerSpan trace.Span
-	ctx, outerSpan = tracer.Start(tracer.RootedCtx(ctx, traceID), fmt.Sprintf("core/duty.%s", strings.Title(duty.Type.String())))
+	ctx, outerSpan = tracer.Start(tracer.RootedCtx(ctx, traceID), "core/duty."+strings.Title(duty.Type.String()))
 	ctx, innerSpan = tracer.Start(ctx, spanName, opts...)
 
 	slotStr := strconv.FormatUint(duty.Slot, 10)

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -82,9 +82,7 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 		return nil
 	}
 
-	var (
-		attRoot eth2p0.Root
-	)
+	var attRoot eth2p0.Root
 	if duty.Type == core.DutyAttester {
 		att, ok := data.(core.Attestation)
 		if !ok {

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -5,6 +5,7 @@ package tracker
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -429,7 +430,7 @@ func (a *InclusionChecker) Run(ctx context.Context) {
 }
 
 func (a *InclusionChecker) checkBlock(ctx context.Context, slot uint64) error {
-	atts, err := a.eth2Cl.BlockAttestations(ctx, fmt.Sprint(slot))
+	atts, err := a.eth2Cl.BlockAttestations(ctx, strconv.FormatUint(slot, 10))
 	if err != nil {
 		return err
 	} else if len(atts) == 0 {

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -153,7 +153,7 @@ func TestInclusion(t *testing.T) {
 }
 
 func addRandomBits(list bitfield.Bitlist) {
-	for i := 0; i < rand.Intn(4); i++ {
+	for range rand.Intn(4) {
 		list.SetBitAt(uint64(rand.Intn(int(list.Len()))), true)
 	}
 }

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -715,7 +715,6 @@ func (t *Tracker) DutyDBStored(duty core.Duty, set core.UnsignedDataSet, stepErr
 // ParSigDBStoredInternal implements core.Tracker interface.
 func (t *Tracker) ParSigDBStoredInternal(duty core.Duty, set core.ParSignedDataSet, stepErr error) {
 	for pubkey, parSig := range set {
-		parSig := parSig
 		select {
 		case <-t.quit:
 			return
@@ -733,7 +732,6 @@ func (t *Tracker) ParSigDBStoredInternal(duty core.Duty, set core.ParSignedDataS
 // ParSigExBroadcasted implements core.Tracker interface.
 func (t *Tracker) ParSigExBroadcasted(duty core.Duty, set core.ParSignedDataSet, stepErr error) {
 	for pubkey, parSig := range set {
-		parSig := parSig
 		select {
 		case <-t.quit:
 			return
@@ -751,7 +749,6 @@ func (t *Tracker) ParSigExBroadcasted(duty core.Duty, set core.ParSignedDataSet,
 // ParSigDBStoredExternal implements core.Tracker interface.
 func (t *Tracker) ParSigDBStoredExternal(duty core.Duty, set core.ParSignedDataSet, stepErr error) {
 	for pubkey, parSig := range set {
-		parSig := parSig
 		select {
 		case <-t.quit:
 			return

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -404,7 +404,7 @@ func TestTrackerParticipation(t *testing.T) {
 	// Assuming a DV with 4 nodes.
 	numPeers := 4
 	var peers []p2p.Peer
-	for i := 0; i < numPeers; i++ {
+	for i := range numPeers {
 		peers = append(peers, p2p.Peer{Index: i})
 	}
 
@@ -675,7 +675,7 @@ func setupData(t *testing.T, slots []int, numVals int) ([]testDutyData, []core.P
 
 	var pubkeys []core.PubKey
 	pubkeysByIdx := make(map[eth2p0.ValidatorIndex]core.PubKey)
-	for i := 0; i < numVals; i++ {
+	for i := range numVals {
 		pubkey := testutil.RandomCorePubKey(t)
 		pubkeysByIdx[eth2p0.ValidatorIndex(i)] = pubkey
 		pubkeys = append(pubkeys, pubkey)
@@ -688,7 +688,7 @@ func setupData(t *testing.T, slots []int, numVals int) ([]testDutyData, []core.P
 		defset := make(core.DutyDefinitionSet)
 		unsignedset := make(core.UnsignedDataSet)
 		parsignedset := make(core.ParSignedDataSet)
-		for i := 0; i < numVals; i++ {
+		for i := range numVals {
 			defset[pubkeysByIdx[eth2p0.ValidatorIndex(i)]] = core.NewAttesterDefinition(&eth2v1.AttesterDuty{
 				Slot:             eth2p0.Slot(slot),
 				ValidatorIndex:   eth2p0.ValidatorIndex(i),
@@ -1135,7 +1135,7 @@ func analyseParSigs(t *testing.T, dataGen func() core.SignedData) {
 
 	makeEvents := func(n int, pubkey string, data core.SignedData) {
 		offset := len(events)
-		for i := 0; i < n; i++ {
+		for i := range n {
 			data, err := data.SetSignature(testutil.RandomCoreSignature())
 			require.NoError(t, err)
 			events = append(events, event{
@@ -1175,7 +1175,7 @@ func TestDutyFailedMultipleEvents(t *testing.T) {
 	testErr := errors.New("test error")
 	var events []event
 	for step := fetcher; step < sentinel; step++ {
-		for i := 0; i < 5; i++ {
+		for range 5 {
 			events = append(events, event{step: step, duty: duty, stepErr: testErr})
 		}
 	}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -25,7 +25,7 @@ import (
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
 	eth2capella "github.com/attestantio/go-eth2-client/api/v1/capella"
-	deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
@@ -791,7 +791,7 @@ func createProposeBlockResponse(proposal *eth2api.VersionedProposal) (*proposeBl
 
 func submitProposal(p eth2client.ProposalSubmitter) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
-		denebBlock := new(deneb.SignedBlockContents)
+		denebBlock := new(eth2deneb.SignedBlockContents)
 		err := unmarshal(typ, body, denebBlock)
 		if err == nil {
 			block := &eth2api.VersionedSignedProposal{
@@ -863,7 +863,7 @@ func submitProposal(p eth2client.ProposalSubmitter) handlerFunc {
 func submitBlindedBlock(p eth2client.BlindedProposalSubmitter) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
 		// The blinded block maybe either bellatrix, capella or deneb.
-		denebBlock := new(deneb.SignedBlindedBeaconBlock)
+		denebBlock := new(eth2deneb.SignedBlindedBeaconBlock)
 		err := unmarshal(typ, body, denebBlock)
 		if err == nil {
 			block := &eth2api.VersionedSignedBlindedProposal{

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1144,6 +1144,7 @@ func writeError(ctx context.Context, w http.ResponseWriter, endpoint string, err
 		}
 	}
 
+	//nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 	if aerr.StatusCode/100 == 4 {
 		// 4xx status codes are client errors (not server), so log as debug only.
 		log.Debug(ctx, "Validator api 4xx response",

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -308,7 +308,7 @@ func wrap(endpoint string, handler handlerFunc) http.Handler {
 		} else {
 			writeError(ctx, w, endpoint, apiError{
 				StatusCode: http.StatusUnsupportedMediaType,
-				Message:    fmt.Sprintf("unsupported media type %s", contentHeader),
+				Message:    "unsupported media type " + contentHeader,
 			})
 
 			return
@@ -1234,7 +1234,7 @@ func uintParam(params map[string]string, name string) (uint64, error) {
 	if !ok {
 		return 0, apiError{
 			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintf("missing path parameter %s", name),
+			Message:    "missing path parameter " + name,
 		}
 	}
 
@@ -1255,7 +1255,7 @@ func uintQuery(query url.Values, name string) (uint64, error) {
 	if !query.Has(name) {
 		return 0, apiError{
 			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintf("missing query parameter %s", name),
+			Message:    "missing query parameter " + name,
 		}
 	}
 
@@ -1281,7 +1281,7 @@ func hexQueryFixed(query url.Values, name string, target []byte) error {
 	} else if !ok {
 		return apiError{
 			StatusCode: http.StatusBadRequest,
-			Message:    fmt.Sprintf("missing 0x-hex query parameter %s", name),
+			Message:    "missing 0x-hex query parameter " + name,
 		}
 	} else if len(resp) != len(target) {
 		return apiError{

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -67,11 +67,10 @@ func TestProxyShutdown(t *testing.T) {
 	proxy := httptest.NewServer(proxyHandler(ctx, addr(target.URL)))
 
 	// Make a request to the proxy server, this will block until the proxy is shutdown.
-	done := make(chan struct{})
+	errCh := make(chan error, 1)
 	go func() {
 		_, err := http.Get(proxy.URL)
-		require.NoError(t, err)
-		close(done)
+		errCh <- err
 	}()
 
 	// Wait for the target server is serving the request.
@@ -79,7 +78,8 @@ func TestProxyShutdown(t *testing.T) {
 	// Shutdown the proxy server.
 	cancel()
 	// Wait for the request to complete.
-	<-done
+	err := <-errCh
+	require.NoError(t, err)
 }
 
 func TestRouterIntegration(t *testing.T) {
@@ -887,7 +887,7 @@ func TestRouter(t *testing.T) {
 			}
 			resp, err := cl.Validators(ctx, opts)
 			require.NoError(t, err)
-			require.Len(t, resp.Data, 0)
+			require.Empty(t, resp.Data)
 		}
 
 		testRouter(t, handler, callback)
@@ -909,7 +909,7 @@ func TestRouter(t *testing.T) {
 			res := resp.Data
 
 			// Two validators are expected as the testutil.RandomBeaconState(t) returns two validators.
-			require.Equal(t, 2, len(res))
+			require.Len(t, res, 2)
 		}
 
 		testRouter(t, handler, callback)
@@ -929,7 +929,7 @@ func TestRouter(t *testing.T) {
 			}
 			resp, err := cl.AttesterDuties(ctx, opts)
 			require.NoError(t, err)
-			require.Len(t, resp.Data, 0)
+			require.Empty(t, resp.Data)
 		}
 
 		testRouter(t, handler, callback)
@@ -949,7 +949,7 @@ func TestRouter(t *testing.T) {
 			}
 			res, err := cl.SyncCommitteeDuties(ctx, opts)
 			require.NoError(t, err)
-			require.Len(t, res.Data, 0)
+			require.Empty(t, res.Data)
 		}
 
 		testRouter(t, handler, callback)
@@ -969,7 +969,7 @@ func TestRouter(t *testing.T) {
 			}
 			res, err := cl.ProposerDuties(ctx, opts)
 			require.NoError(t, err)
-			require.Len(t, res.Data, 0)
+			require.Empty(t, res.Data)
 		}
 
 		testRouter(t, handler, callback)

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -712,7 +712,7 @@ func TestRouter(t *testing.T) {
 			ProposerDutiesFunc: func(ctx context.Context, opts *eth2api.ProposerDutiesOpts) (*eth2api.Response[[]*eth2v1.ProposerDuty], error) {
 				// Returns ordered total number of duties for the epoch
 				var res []*eth2v1.ProposerDuty
-				for i := 0; i < total; i++ {
+				for i := range total {
 					res = append(res, &eth2v1.ProposerDuty{
 						ValidatorIndex: eth2p0.ValidatorIndex(i),
 						Slot:           eth2p0.Slot(int(opts.Epoch)*slotsPerEpoch + i),

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -622,7 +622,7 @@ func TestRouter(t *testing.T) {
 		server := httptest.NewServer(r)
 		defer server.Close()
 
-		endpointURL := fmt.Sprintf("%s/eth/v1/node/version", server.URL)
+		endpointURL := server.URL + "/eth/v1/node/version"
 
 		// node_version is a GET-only endpoint, we expect it to fail
 		resp, err := http.Post(
@@ -1899,7 +1899,7 @@ func (h testHandler) newBeaconHandler(t *testing.T) http.Handler {
 	})
 	mux.HandleFunc("/eth/v1/config/spec", func(w http.ResponseWriter, r *http.Request) {
 		res := map[string]any{
-			"SLOTS_PER_EPOCH": fmt.Sprint(slotsPerEpoch),
+			"SLOTS_PER_EPOCH": strconv.Itoa(slotsPerEpoch),
 		}
 		writeResponse(ctx, w, "", nest(res, "data"), nil)
 	})

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"runtime"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1202,7 +1203,7 @@ func (c Component) ProposerConfig(ctx context.Context) (*eth2exp.ProposerConfigR
 				Enabled:  c.builderEnabled(uint64(slot)),
 				GasLimit: gasLimit,
 				Overrides: map[string]string{
-					"timestamp":  fmt.Sprint(timestamp.Unix()),
+					"timestamp":  strconv.FormatInt(timestamp.Unix(), 10),
 					"public_key": string(pubkey),
 				},
 			},

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -896,7 +896,7 @@ func (c Component) ProposerDuties(ctx context.Context, opts *eth2api.ProposerDut
 	duties := eth2Resp.Data
 
 	// Replace root public keys with public shares
-	for i := 0; i < len(duties); i++ {
+	for i := range len(duties) {
 		if duties[i] == nil {
 			return nil, errors.New("proposer duty cannot be nil")
 		}
@@ -920,7 +920,7 @@ func (c Component) AttesterDuties(ctx context.Context, opts *eth2api.AttesterDut
 	duties := eth2Resp.Data
 
 	// Replace root public keys with public shares.
-	for i := 0; i < len(duties); i++ {
+	for i := range len(duties) {
 		if duties[i] == nil {
 			return nil, errors.New("attester duty cannot be nil")
 		}
@@ -944,7 +944,7 @@ func (c Component) SyncCommitteeDuties(ctx context.Context, opts *eth2api.SyncCo
 	duties := eth2Resp.Data
 
 	// Replace root public keys with public shares.
-	for i := 0; i < len(duties); i++ {
+	for i := range len(duties) {
 		if duties[i] == nil {
 			return nil, errors.New("sync committee duty cannot be nil")
 		}

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -1289,7 +1290,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 					Enabled:  true,
 					GasLimit: 30000000,
 					Overrides: map[string]string{
-						"timestamp":  fmt.Sprint(genesis.Add(slotDuration).Unix()),
+						"timestamp":  strconv.FormatInt(genesis.Add(slotDuration).Unix(), 10),
 						"public_key": string(pk),
 					},
 				},

--- a/dkg/bcast/client.go
+++ b/dkg/bcast/client.go
@@ -102,7 +102,7 @@ func (c *client) Broadcast(ctx context.Context, msgID string, msg proto.Message)
 		var found bool
 		for i, pID := range c.peers {
 			if resp.Input == pID {
-				sigs[i] = resp.Output.Signature
+				sigs[i] = resp.Output.GetSignature()
 				found = true
 
 				break

--- a/dkg/bcast/impl.go
+++ b/dkg/bcast/impl.go
@@ -76,8 +76,8 @@ func New(tcpNode host.Host, peers []peer.ID, secret *k1.PrivateKey) *Component {
 // hashAny is a function that hashes a any-wrapped protobuf message.
 func hashAny(anyPB *anypb.Any) ([]byte, error) {
 	h := sha256.New()
-	_, _ = h.Write([]byte(anyPB.TypeUrl))
-	_, _ = h.Write(anyPB.Value)
+	_, _ = h.Write([]byte(anyPB.GetTypeUrl()))
+	_, _ = h.Write(anyPB.GetValue())
 
 	return h.Sum(nil), nil
 }

--- a/dkg/bcast/impl_test.go
+++ b/dkg/bcast/impl_test.go
@@ -66,7 +66,6 @@ func TestBCast(t *testing.T) {
 
 	// Create broadcasters
 	for i := 0; i < n; i++ {
-		i := i
 		callback := func(_ context.Context, peerID peer.ID, msgID string, msg proto.Message) error {
 			results <- result{Source: peerID, MsgID: msgID, Msg: msg, Target: peers[i]}
 			return nil

--- a/dkg/bcast/impl_test.go
+++ b/dkg/bcast/impl_test.go
@@ -36,7 +36,7 @@ func TestBCast(t *testing.T) {
 	)
 
 	// Create secretes and libp2p nodes
-	for i := 0; i < n; i++ {
+	for range n {
 		secret, err := k1.GeneratePrivateKey()
 		require.NoError(t, err)
 		secrets = append(secrets, secret)
@@ -48,8 +48,8 @@ func TestBCast(t *testing.T) {
 	}
 
 	// Connect peers
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			tcpNodes[i].Peerstore().AddAddrs(tcpNodes[j].ID(), tcpNodes[j].Addrs(), peerstore.PermanentAddrTTL)
 		}
 	}
@@ -65,7 +65,7 @@ func TestBCast(t *testing.T) {
 	results := make(chan result, 1024)
 
 	// Create broadcasters
-	for i := 0; i < n; i++ {
+	for i := range n {
 		callback := func(_ context.Context, peerID peer.ID, msgID string, msg proto.Message) error {
 			results <- result{Source: peerID, MsgID: msgID, Msg: msg, Target: peers[i]}
 			return nil
@@ -93,7 +93,7 @@ func TestBCast(t *testing.T) {
 		t.Helper()
 
 		targets := make(map[peer.ID]struct{})
-		for i := 0; i < n-1; i++ {
+		for range n - 1 {
 			actual := <-results
 			require.Equal(t, expected.Source, actual.Source)
 			require.Equal(t, expected.MsgID, actual.MsgID)

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -182,12 +182,12 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.Wrap(err, "private key not matching definition file")
 	}
 
-	peerIds, err := def.PeerIDs()
+	peerIDs, err := def.PeerIDs()
 	if err != nil {
 		return errors.Wrap(err, "get peer IDs")
 	}
 
-	ex := newExchanger(tcpNode, nodeIdx.PeerIdx, peerIds, def.NumValidators, []sigType{
+	ex := newExchanger(tcpNode, nodeIdx.PeerIdx, peerIDs, def.NumValidators, []sigType{
 		sigLock,
 		sigDepositData,
 		sigValidatorRegistration,
@@ -203,7 +203,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		peerMap[p.ID] = nodeIdx
 	}
 
-	caster := bcast.New(tcpNode, peerIds, key)
+	caster := bcast.New(tcpNode, peerIDs, key)
 
 	// register bcast callbacks for frostp2p
 	tp, err := newFrostP2P(tcpNode, peerMap, caster, def.Threshold, def.NumValidators)
@@ -219,7 +219,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	// Improve UX of "context cancelled" errors when sync fails.
 	ctx = errors.WithCtxErr(ctx, "p2p connection failed, please retry DKG")
 
-	nextStepSync, stopSync, err := startSyncProtocol(ctx, tcpNode, key, def.DefinitionHash, peerIds, cancel, conf.TestConfig)
+	nextStepSync, stopSync, err := startSyncProtocol(ctx, tcpNode, key, def.DefinitionHash, peerIDs, cancel, conf.TestConfig)
 	if err != nil {
 		return err
 	}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -372,7 +372,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	log.Info(ctx, "Successfully completed DKG ceremony 🎉")
 
 	if dashboardURL != "" {
-		log.Info(ctx, fmt.Sprintf("You can find your newly-created cluster dashboard here: %s", dashboardURL))
+		log.Info(ctx, "You can find your newly-created cluster dashboard here: "+dashboardURL)
 	}
 
 	return nil

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -411,7 +411,6 @@ func setupP2P(ctx context.Context, key *k1.PrivateKey, conf Config, peers []p2p.
 	p2p.RegisterConnectionLogger(ctx, tcpNode, peerIDs)
 
 	for _, relay := range relays {
-		relay := relay
 		go p2p.NewRelayReserver(tcpNode, relay)(ctx)
 	}
 
@@ -664,8 +663,6 @@ func aggLockHashSig(data map[core.PubKey][]core.ParSignedData, shares map[core.P
 	)
 
 	for pk, psigs := range data {
-		pk := pk
-		psigs := psigs
 		for _, s := range psigs {
 			sig, err := tblsconv.SignatureFromBytes(s.Signature())
 			if err != nil {
@@ -836,9 +833,6 @@ func aggDepositData(data map[core.PubKey][]core.ParSignedData, shares []share,
 	var resp []eth2p0.DepositData
 
 	for pk, psigsData := range data {
-		pk := pk
-		psigsData := psigsData
-
 		msg, ok := msgs[pk]
 		if !ok {
 			return nil, errors.New("deposit message not found")
@@ -923,9 +917,6 @@ func aggValidatorRegistrations(
 	var resp []core.VersionedSignedValidatorRegistration
 
 	for pk, psigsData := range data {
-		pk := pk
-		psigsData := psigsData
-
 		msg, ok := msgs[pk]
 		if !ok {
 			return nil, errors.New("validator registration not found")
@@ -1039,7 +1030,6 @@ func createDistValidators(shares []share, depositDatas [][]eth2p0.DepositData, v
 		}
 
 		for _, dd := range depositDatasList {
-			dd := dd
 			newDepositData := cluster.DepositData{
 				PubKey:                dd.PublicKey[:],
 				WithdrawalCredentials: dd.WithdrawalCredentials,

--- a/dkg/dkg_internal_test.go
+++ b/dkg/dkg_internal_test.go
@@ -49,7 +49,7 @@ func TestInvalidSignatures(t *testing.T) {
 
 	getSigs := func(msg []byte) []core.ParSignedData {
 		var sigs []core.ParSignedData
-		for i := 0; i < n-1; i++ {
+		for i := range n - 1 {
 			sig, err := tbls.Sign(secretShares[i+1], msg)
 			require.NoError(t, err)
 
@@ -117,7 +117,7 @@ func TestValidSignatures(t *testing.T) {
 
 	getSigs := func(msg []byte) []core.ParSignedData {
 		var sigs []core.ParSignedData
-		for i := 0; i < n-1; i++ {
+		for i := range n - 1 {
 			pk := secretShares[i+1]
 			sig, err := tbls.Sign(pk, msg)
 			require.NoError(t, err)

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -185,7 +185,6 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 	// Run dkg for each node
 	var eg errgroup.Group
 	for i := 0; i < len(def.Operators); i++ {
-		i := i
 		conf := conf
 		conf.DataDir = path.Join(dir, fmt.Sprintf("node%d", i))
 		conf.P2P.TCPAddrs = []string{testutil.AvailableAddr(t).String()}

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -184,7 +184,7 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 
 	// Run dkg for each node
 	var eg errgroup.Group
-	for i := 0; i < len(def.Operators); i++ {
+	for i := range len(def.Operators) {
 		conf := conf
 		conf.DataDir = path.Join(dir, fmt.Sprintf("node%d", i))
 		conf.P2P.TCPAddrs = []string{testutil.AvailableAddr(t).String()}
@@ -213,7 +213,7 @@ func testDKG(t *testing.T, def cluster.Definition, dir string, p2pKeys []*k1.Pri
 	testutil.RequireNoError(t, err)
 
 	// check that the privkey lock file has been deleted in all nodes at the end of dkg
-	for i := 0; i < len(def.Operators); i++ {
+	for i := range len(def.Operators) {
 		lockPath := path.Join(dir, fmt.Sprintf("node%d", i), "charon-enr-private-key.lock")
 
 		_, openErr := os.Open(lockPath)
@@ -319,7 +319,7 @@ func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 		secretShares = make([][]tbls.PrivateKey, def.NumValidators)
 		locks        []cluster.Lock
 	)
-	for i := 0; i < len(def.Operators); i++ {
+	for i := range len(def.Operators) {
 		dataDir := path.Join(dir, fmt.Sprintf("node%d", i))
 		keyFiles, err := keystore.LoadFilesUnordered(path.Join(dataDir, "/validator_keys"))
 		require.NoError(t, err)
@@ -354,9 +354,9 @@ func verifyDKGResults(t *testing.T, def cluster.Definition, dir string) {
 	}
 
 	// 	Ensure keystores can generate valid tbls aggregate signature.
-	for i := 0; i < def.NumValidators; i++ {
+	for i := range def.NumValidators {
 		var sigs []tbls.Signature
-		for j := 0; j < len(def.Operators); j++ {
+		for j := range len(def.Operators) {
 			msg := []byte("data")
 			sig, err := tbls.Sign(secretShares[i][j], msg)
 			require.NoError(t, err)
@@ -618,7 +618,7 @@ func getConfigs(t *testing.T, def cluster.Definition, keys []*k1.PrivateKey, dir
 	tcpNodeCallback := testutil.NewTCPNodeCallback(t, dkgsync.Protocols()...)
 
 	var configs []dkg.Config
-	for i := 0; i < len(def.Operators); i++ {
+	for i := range len(def.Operators) {
 		conf := dkg.Config{
 			DataDir: path.Join(dir, fmt.Sprintf("node%d", i)),
 			P2P: p2p.Config{

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -58,7 +58,7 @@ type exchanger struct {
 
 func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int, sigTypes []sigType, timeout time.Duration) *exchanger {
 	// Partial signature roots not known yet, so skip verification in parsigex, rather verify before we aggregate.
-	noopVerifier := func(ctx context.Context, duty core.Duty, key core.PubKey, data core.ParSignedData) error {
+	noopVerifier := func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error {
 		return nil
 	}
 

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -29,15 +29,15 @@ func TestExchanger(t *testing.T) {
 
 	// Create pubkeys for each DV
 	pubkeys := make([]core.PubKey, dvs)
-	for i := 0; i < dvs; i++ {
+	for i := range dvs {
 		pubkeys[i] = testutil.RandomCorePubKey(t)
 	}
 
 	// Expected data is what is desired at the end of exchange
 	expectedData := make(map[core.PubKey][]core.ParSignedData)
-	for i := 0; i < dvs; i++ {
+	for i := range dvs {
 		set := make([]core.ParSignedData, nodes)
-		for j := 0; j < nodes; j++ {
+		for j := range nodes {
 			set[j] = core.NewPartialSignature(testutil.RandomCoreSignature(), j+1)
 		}
 		expectedData[pubkeys[i]] = set
@@ -68,7 +68,7 @@ func TestExchanger(t *testing.T) {
 	)
 
 	// Create hosts
-	for i := 0; i < nodes; i++ {
+	for range nodes {
 		h := testutil.CreateHost(t, testutil.AvailableAddr(t))
 		info := peer.AddrInfo{
 			ID:    h.ID(),
@@ -80,8 +80,8 @@ func TestExchanger(t *testing.T) {
 	}
 
 	// Connect each host with its peers
-	for i := 0; i < nodes; i++ {
-		for j := 0; j < nodes; j++ {
+	for i := range nodes {
+		for j := range nodes {
 			if i == j {
 				continue
 			}
@@ -89,7 +89,7 @@ func TestExchanger(t *testing.T) {
 		}
 	}
 
-	for i := 0; i < nodes; i++ {
+	for i := range nodes {
 		ex := newExchanger(hosts[i], i, peers, dvs, expectedSigTypes, 8*time.Second)
 		exchangers = append(exchangers, ex)
 	}
@@ -104,7 +104,7 @@ func TestExchanger(t *testing.T) {
 
 	// send multiple (supported) messages at the same time, showing that exchanger can exchange messages of various
 	// sigTypes concurrently
-	for i := 0; i < nodes; i++ {
+	for i := range nodes {
 		wg.Add(2)
 		go func(node int) {
 			defer wg.Done()
@@ -130,7 +130,7 @@ func TestExchanger(t *testing.T) {
 		}(i)
 	}
 
-	for i := 0; i < nodes; i++ {
+	for i := range nodes {
 		wg.Add(1)
 		go func(node int) {
 			defer wg.Done()

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -96,6 +96,7 @@ func TestExchanger(t *testing.T) {
 
 	type respStruct struct {
 		data    map[core.PubKey][]core.ParSignedData
+		err     error
 		sigType sigType
 	}
 
@@ -110,10 +111,10 @@ func TestExchanger(t *testing.T) {
 			defer wg.Done()
 
 			data, err := exchangers[node].exchange(ctx, sigDepositData, dataToBeSent[node])
-			require.NoError(t, err)
 
 			respChan <- respStruct{
 				data:    data,
+				err:     err,
 				sigType: sigDepositData,
 			}
 		}(i)
@@ -121,10 +122,10 @@ func TestExchanger(t *testing.T) {
 			defer wg.Done()
 
 			data, err := exchangers[node].exchange(ctx, sigValidatorRegistration, dataToBeSent[node])
-			require.NoError(t, err)
 
 			respChan <- respStruct{
 				data:    data,
+				err:     err,
 				sigType: sigValidatorRegistration,
 			}
 		}(i)
@@ -136,10 +137,10 @@ func TestExchanger(t *testing.T) {
 			defer wg.Done()
 
 			data, err := exchangers[node].exchange(ctx, sigLock, dataToBeSent[node])
-			require.NoError(t, err)
 
 			respChan <- respStruct{
 				data:    data,
+				err:     err,
 				sigType: sigLock,
 			}
 		}(i)
@@ -152,6 +153,7 @@ func TestExchanger(t *testing.T) {
 
 	actual := make(sigTypeStore)
 	for res := range respChan {
+		require.NoError(t, res.err)
 		actual[res.sigType] = res.data
 	}
 

--- a/dkg/frost.go
+++ b/dkg/frost.go
@@ -178,7 +178,6 @@ func getRound2Inputs(
 		if key.ValIdx != vIdx {
 			continue
 		}
-		cast := cast // Copy loop variable
 		castMap[key.SourceID] = &cast
 	}
 
@@ -187,7 +186,6 @@ func getRound2Inputs(
 		if key.ValIdx != vIdx {
 			continue
 		}
-		share := share // Copy loop variable
 		shareMap[key.SourceID] = &share
 	}
 

--- a/dkg/frost.go
+++ b/dkg/frost.go
@@ -95,7 +95,7 @@ func newFrostParticipants(numValidators, numNodes, threshold, shareIdx uint32, d
 	}
 
 	resp := make(map[uint32]*frost.DkgParticipant)
-	for vIdx := uint32(0); vIdx < numValidators; vIdx++ {
+	for vIdx := range numValidators {
 		p, err := frost.NewDkgParticipant(
 			shareIdx,
 			threshold,

--- a/dkg/frost_internal_test.go
+++ b/dkg/frost_internal_test.go
@@ -26,7 +26,7 @@ func TestFrostDKG(t *testing.T) {
 	tp := &frostMemTransport{nodes: nodes}
 
 	var eg errgroup.Group
-	for i := 0; i < nodes; i++ {
+	for i := range nodes {
 		eg.Go(func() error {
 			shares, err := runFrostParallel(ctx, tp, vals, nodes, nodes, uint32(i+1), "test context")
 			if err != nil {

--- a/dkg/frost_internal_test.go
+++ b/dkg/frost_internal_test.go
@@ -27,7 +27,6 @@ func TestFrostDKG(t *testing.T) {
 
 	var eg errgroup.Group
 	for i := 0; i < nodes; i++ {
-		i := i // Copy loop variable.
 		eg.Go(func() error {
 			shares, err := runFrostParallel(ctx, tp, vals, nodes, nodes, uint32(i+1), "test context")
 			if err != nil {

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -93,7 +93,7 @@ func newCheckMsg(messageID string) (bcast.CheckMessage, error) {
 		return nil, errors.New("frost message id unsupported", z.Str("message_id", messageID))
 	}
 
-	return func(ctx context.Context, peerID peer.ID, msgAny *anypb.Any) error {
+	return func(_ context.Context, _ peer.ID, msgAny *anypb.Any) error {
 		targetFn := func(messageID string) proto.Message {
 			switch messageID {
 			case round1CastID:

--- a/dkg/frostp2p.go
+++ b/dkg/frostp2p.go
@@ -143,18 +143,18 @@ func newBcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *p
 				return errors.New("invalid round 1 casts message")
 			}
 
-			for _, cast := range msg.Casts {
-				if int(cast.Key.SourceId) != peers[pID].ShareIdx {
+			for _, cast := range msg.GetCasts() {
+				if int(cast.GetKey().GetSourceId()) != peers[pID].ShareIdx {
 					return errors.New("invalid round 1 cast source ID")
-				} else if cast.Key.TargetId != 0 {
+				} else if cast.GetKey().GetTargetId() != 0 {
 					return errors.New("invalid round 1 cast target ID")
-				} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
+				} else if int(cast.GetKey().GetValIdx()) < 0 || int(cast.GetKey().GetValIdx()) >= numVals {
 					return errors.New("invalid round 1 cast validator index")
 				}
 
-				if len(cast.Commitments) != threshold {
+				if len(cast.GetCommitments()) != threshold {
 					return errors.New("invalid amount of commitments in round 1",
-						z.Int("received", len(cast.Commitments)),
+						z.Int("received", len(cast.GetCommitments())),
 						z.Int("expected", threshold),
 					)
 				}
@@ -176,12 +176,12 @@ func newBcastCallback(peers map[peer.ID]cluster.NodeIdx, round1CastsRecv chan *p
 				return errors.New("invalid round 2 casts message")
 			}
 
-			for _, cast := range msg.Casts {
-				if int(cast.Key.SourceId) != peers[pID].ShareIdx {
+			for _, cast := range msg.GetCasts() {
+				if int(cast.GetKey().GetSourceId()) != peers[pID].ShareIdx {
 					return errors.New("invalid round 2 cast source ID")
-				} else if cast.Key.TargetId != 0 {
+				} else if cast.GetKey().GetTargetId() != 0 {
 					return errors.New("invalid round 2 cast target ID")
-				} else if int(cast.Key.ValIdx) < 0 || int(cast.Key.ValIdx) >= numVals {
+				} else if int(cast.GetKey().GetValIdx()) < 0 || int(cast.GetKey().GetValIdx()) >= numVals {
 					return errors.New("invalid round 2 cast validator index")
 				}
 			}
@@ -211,12 +211,12 @@ func newP2PCallback(tcpNode host.Host, peers map[peer.ID]cluster.NodeIdx, round1
 			return nil, false, errors.New("invalid round 1 p2p message")
 		}
 
-		for _, share := range msg.Shares {
-			if int(share.Key.SourceId) != peers[pID].ShareIdx {
+		for _, share := range msg.GetShares() {
+			if int(share.GetKey().GetSourceId()) != peers[pID].ShareIdx {
 				return nil, false, errors.New("invalid round 1 p2p source ID")
-			} else if int(share.Key.TargetId) != peers[tcpNode.ID()].ShareIdx {
+			} else if int(share.GetKey().GetTargetId()) != peers[tcpNode.ID()].ShareIdx {
 				return nil, false, errors.New("invalid round 1 p2p target ID")
-			} else if int(share.Key.ValIdx) < 0 || int(share.Key.ValIdx) >= numVals {
+			} else if int(share.GetKey().GetValIdx()) < 0 || int(share.GetKey().GetValIdx()) >= numVals {
 				return nil, false, errors.New("invalid round 1 p2p validator index")
 			}
 		}
@@ -353,7 +353,7 @@ func makeRound1Response(casts []*pb.FrostRound1Casts, p2ps []*pb.FrostRound1P2P)
 		p2pMap  = make(map[msgKey]sharing.ShamirShare)
 	)
 	for _, msg := range casts {
-		for _, castPB := range msg.Casts {
+		for _, castPB := range msg.GetCasts() {
 			key, cast, err := round1CastFromProto(castPB)
 			if err != nil {
 				return nil, nil, err
@@ -364,7 +364,7 @@ func makeRound1Response(casts []*pb.FrostRound1Casts, p2ps []*pb.FrostRound1P2P)
 	}
 
 	for _, msg := range p2ps {
-		for _, sharePB := range msg.Shares {
+		for _, sharePB := range msg.GetShares() {
 			key, share, err := shamirShareFromProto(sharePB)
 			if err != nil {
 				return nil, nil, err
@@ -381,7 +381,7 @@ func makeRound1Response(casts []*pb.FrostRound1Casts, p2ps []*pb.FrostRound1P2P)
 func makeRound2Response(msgs []*pb.FrostRound2Casts) (map[msgKey]frost.Round2Bcast, error) {
 	castMap := make(map[msgKey]frost.Round2Bcast)
 	for _, msg := range msgs {
-		for _, castPB := range msg.Casts {
+		for _, castPB := range msg.GetCasts() {
 			key, cast, err := round2CastFromProto(castPB)
 			if err != nil {
 				return nil, err
@@ -406,14 +406,14 @@ func shamirShareFromProto(shamir *pb.FrostRound1ShamirShare) (msgKey, sharing.Sh
 		return msgKey{}, sharing.ShamirShare{}, errors.New("round 1 shamir share proto cannot be nil")
 	}
 
-	protoKey, err := keyFromProto(shamir.Key)
+	protoKey, err := keyFromProto(shamir.GetKey())
 	if err != nil {
 		return msgKey{}, sharing.ShamirShare{}, err
 	}
 
 	return protoKey, sharing.ShamirShare{
-		Id:    shamir.Id,
-		Value: shamir.Value,
+		Id:    shamir.GetId(),
+		Value: shamir.GetValue(),
 	}, nil
 }
 
@@ -436,17 +436,17 @@ func round1CastFromProto(cast *pb.FrostRound1Cast) (msgKey, frost.Round1Bcast, e
 		return msgKey{}, frost.Round1Bcast{}, errors.New("round 1 cast cannot be nil")
 	}
 
-	wi, err := curve.Scalar.SetBytes(cast.Wi)
+	wi, err := curve.Scalar.SetBytes(cast.GetWi())
 	if err != nil {
 		return msgKey{}, frost.Round1Bcast{}, errors.Wrap(err, "decode wi scalar")
 	}
-	ci, err := curve.Scalar.SetBytes(cast.Ci)
+	ci, err := curve.Scalar.SetBytes(cast.GetCi())
 	if err != nil {
 		return msgKey{}, frost.Round1Bcast{}, errors.Wrap(err, "decode c1 scalar")
 	}
 
 	var comms []curves.Point
-	for _, comm := range cast.Commitments {
+	for _, comm := range cast.GetCommitments() {
 		c, err := curve.Point.FromAffineCompressed(comm)
 		if err != nil {
 			return msgKey{}, frost.Round1Bcast{}, errors.Wrap(err, "decode commitment")
@@ -455,7 +455,7 @@ func round1CastFromProto(cast *pb.FrostRound1Cast) (msgKey, frost.Round1Bcast, e
 		comms = append(comms, c)
 	}
 
-	key, err := keyFromProto(cast.Key)
+	key, err := keyFromProto(cast.GetKey())
 	if err != nil {
 		return msgKey{}, frost.Round1Bcast{}, err
 	}
@@ -480,16 +480,16 @@ func round2CastFromProto(cast *pb.FrostRound2Cast) (msgKey, frost.Round2Bcast, e
 		return msgKey{}, frost.Round2Bcast{}, errors.New("round 2 cast cannot be nil")
 	}
 
-	verificationKey, err := curve.Point.FromAffineCompressed(cast.VerificationKey)
+	verificationKey, err := curve.Point.FromAffineCompressed(cast.GetVerificationKey())
 	if err != nil {
 		return msgKey{}, frost.Round2Bcast{}, errors.Wrap(err, "decode verification key scalar")
 	}
-	vkShare, err := curve.Point.FromAffineCompressed(cast.VkShare)
+	vkShare, err := curve.Point.FromAffineCompressed(cast.GetVkShare())
 	if err != nil {
 		return msgKey{}, frost.Round2Bcast{}, errors.Wrap(err, "decode c1 scalar")
 	}
 
-	key, err := keyFromProto(cast.Key)
+	key, err := keyFromProto(cast.GetKey())
 	if err != nil {
 		return msgKey{}, frost.Round2Bcast{}, err
 	}
@@ -514,9 +514,9 @@ func keyFromProto(key *pb.FrostMsgKey) (msgKey, error) {
 	}
 
 	return msgKey{
-		ValIdx:   key.ValIdx,
-		SourceID: key.SourceId,
-		TargetID: key.TargetId,
+		ValIdx:   key.GetValIdx(),
+		SourceID: key.GetSourceId(),
+		TargetID: key.GetTargetId(),
 	}, nil
 }
 

--- a/dkg/frostp2p_internal_test.go
+++ b/dkg/frostp2p_internal_test.go
@@ -255,8 +255,8 @@ func TestP2PCallback(t *testing.T) {
 			msg := pb.FrostRound1P2P{Shares: []*pb.FrostRound1ShamirShare{{Key: tt.key}}}
 
 			resp, respBool, err := callbackFunc(ctx, peers[0], &msg)
-			require.Equal(t, resp, nil)
-			require.Equal(t, respBool, false)
+			require.Nil(t, resp)
+			require.False(t, respBool)
 			require.Equal(t, err.Error(), tt.errorMsg)
 		})
 	}

--- a/dkg/frostp2p_internal_test.go
+++ b/dkg/frostp2p_internal_test.go
@@ -30,7 +30,7 @@ func TestBcastCallback(t *testing.T) {
 
 	// Create libp2p peers
 	peerMap := make(map[peer.ID]cluster.NodeIdx)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		secret, err := k1.GeneratePrivateKey()
 		require.NoError(t, err)
 
@@ -189,7 +189,7 @@ func TestP2PCallback(t *testing.T) {
 
 	// Create libp2p peers
 	peerMap := make(map[peer.ID]cluster.NodeIdx)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		secret, err := k1.GeneratePrivateKey()
 		require.NoError(t, err)
 

--- a/dkg/nodesigs_internal_test.go
+++ b/dkg/nodesigs_internal_test.go
@@ -41,7 +41,7 @@ func TestSigsExchange(t *testing.T) {
 	defer cancel()
 
 	// Create secretes and libp2p nodes
-	for i := 0; i < n; i++ {
+	for i := range n {
 		secret, err := k1.GeneratePrivateKey()
 		require.NoError(t, err)
 		secrets = append(secrets, secret)
@@ -60,13 +60,13 @@ func TestSigsExchange(t *testing.T) {
 	}
 
 	// Connect peers
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			tcpNodes[i].Peerstore().AddAddrs(tcpNodes[j].ID(), tcpNodes[j].Addrs(), peerstore.PermanentAddrTTL)
 		}
 	}
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		component := bcast.New(tcpNodes[i], peers, secrets[i])
 		nsigs = append(nsigs, newNodeSigBcast(
 			clusterPeers,
@@ -78,7 +78,7 @@ func TestSigsExchange(t *testing.T) {
 	results = make([][][]byte, n)
 
 	var eg errgroup.Group
-	for i := 0; i < n; i++ {
+	for i := range n {
 		eg.Go(func() error {
 			res, err := nsigs[i].exchange(
 				ctx,
@@ -116,7 +116,7 @@ func TestSigsCallbacks(t *testing.T) {
 	)
 
 	// Create secretes and libp2p nodes
-	for i := 0; i < n; i++ {
+	for i := range n {
 		secret, err := k1.GeneratePrivateKey()
 		require.NoError(t, err)
 		secrets = append(secrets, secret)
@@ -135,8 +135,8 @@ func TestSigsCallbacks(t *testing.T) {
 	}
 
 	// Connect peers
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			tcpNodes[i].Peerstore().AddAddrs(tcpNodes[j].ID(), tcpNodes[j].Addrs(), peerstore.PermanentAddrTTL)
 		}
 	}

--- a/dkg/nodesigs_internal_test.go
+++ b/dkg/nodesigs_internal_test.go
@@ -67,7 +67,6 @@ func TestSigsExchange(t *testing.T) {
 	}
 
 	for i := 0; i < n; i++ {
-		i := i
 		component := bcast.New(tcpNodes[i], peers, secrets[i])
 		nsigs = append(nsigs, newNodeSigBcast(
 			clusterPeers,
@@ -80,7 +79,6 @@ func TestSigsExchange(t *testing.T) {
 
 	var eg errgroup.Group
 	for i := 0; i < n; i++ {
-		i := i
 		eg.Go(func() error {
 			res, err := nsigs[i].exchange(
 				ctx,

--- a/dkg/sync/client.go
+++ b/dkg/sync/client.go
@@ -183,11 +183,11 @@ func (c *Client) sendMsgs(ctx context.Context, stream network.Stream) (relayBrok
 			return false, true, err
 		} else if shutdown {
 			return false, false, nil
-		} else if resp.Error != "" {
-			return false, false, errors.New("peer responded with error: " + resp.Error)
+		} else if resp.GetError() != "" {
+			return false, false, errors.New("peer responded with error: " + resp.GetError())
 		}
 
-		rtt := time.Since(resp.SyncTimestamp.AsTime())
+		rtt := time.Since(resp.GetSyncTimestamp().AsTime())
 		c.tcpNode.Peerstore().RecordLatency(c.peer, rtt)
 	}
 }

--- a/dkg/sync/server.go
+++ b/dkg/sync/server.go
@@ -268,7 +268,7 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 
 		// Prep response
 		resp := &pb.MsgSyncResponse{
-			SyncTimestamp: msg.Timestamp,
+			SyncTimestamp: msg.GetTimestamp(),
 		}
 
 		if err := s.validReq(pubkey, msg); err != nil {
@@ -279,7 +279,7 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 			log.Info(ctx, fmt.Sprintf("Connected to peer %d of %d", count, s.allCount))
 		}
 
-		if err := s.updateStep(pID, int(msg.Step)); err != nil {
+		if err := s.updateStep(pID, int(msg.GetStep())); err != nil {
 			return err
 		}
 
@@ -288,7 +288,7 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 			return err
 		}
 
-		if msg.Shutdown {
+		if msg.GetShutdown() {
 			s.setShutdown(pID)
 			return nil
 		}
@@ -298,16 +298,16 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 // validReq returns an error message and false if the request version or definition hash are invalid.
 // Else it returns true or an error.
 func (s *Server) validReq(pubkey crypto.PubKey, msg *pb.MsgSync) error {
-	msgVersion, err := version.Parse(msg.Version)
+	msgVersion, err := version.Parse(msg.GetVersion())
 	if err != nil {
 		return errors.Wrap(err, "parse peer version")
 	}
 
 	if version.Compare(msgVersion, s.version) != 0 {
-		return fmt.Errorf("mismatching charon version; expect=%s, got=%s", s.version, msg.Version) //nolint: wrapcheck,forbidigo // Use stdlib errors when sending over the wire.
+		return fmt.Errorf("mismatching charon version; expect=%s, got=%s", s.version, msg.GetVersion()) //nolint: wrapcheck,forbidigo // Use stdlib errors when sending over the wire.
 	}
 
-	ok, err := pubkey.Verify(s.defHash, msg.HashSignature)
+	ok, err := pubkey.Verify(s.defHash, msg.GetHashSignature())
 	if err != nil { // Note: libp2p verify does another hash of defHash.
 		return errors.Wrap(err, "error verifying definition hash signature")
 	} else if !ok {

--- a/dkg/sync/sync_test.go
+++ b/dkg/sync/sync_test.go
@@ -23,7 +23,7 @@ import (
 
 func TestSyncProtocol(t *testing.T) {
 	versions := make(map[int]version.SemVer)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		versions[i] = version.Version
 	}
 
@@ -74,7 +74,7 @@ func testCluster(t *testing.T, n int, versions map[int]version.SemVer, expectErr
 		clients  []*sync.Client
 		keys     []libp2pcrypto.PrivKey
 	)
-	for i := 0; i < n; i++ {
+	for i := range n {
 		tcpNode, key := newTCPNode(t, int64(i))
 		tcpNodes = append(tcpNodes, tcpNode)
 		keys = append(keys, key)
@@ -83,8 +83,8 @@ func testCluster(t *testing.T, n int, versions map[int]version.SemVer, expectErr
 		servers = append(servers, server)
 	}
 
-	for i := 0; i < n; i++ {
-		for j := 0; j < n; j++ {
+	for i := range n {
+		for j := range n {
 			if i == j {
 				continue
 			}
@@ -132,7 +132,7 @@ func testCluster(t *testing.T, n int, versions map[int]version.SemVer, expectErr
 		return
 	}
 
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		assertAllAtStep(ctx, t, servers, i)
 
 		for _, client := range clients {

--- a/eth2util/deposit/deposit.go
+++ b/eth2util/deposit/deposit.go
@@ -268,7 +268,7 @@ func DedupAmounts(amounts []eth2p0.Gwei) []eth2p0.Gwei {
 func WriteClusterDepositDataFiles(depositDatas [][]eth2p0.DepositData, network string, clusterDir string, numNodes int) error {
 	// The loop across partial amounts (shall be unique)
 	for _, dd := range depositDatas {
-		for n := 0; n < numNodes; n++ {
+		for n := range numNodes {
 			nodeDir := path.Join(clusterDir, fmt.Sprintf("node%d", n))
 			if err := WriteDepositDataFile(dd, network, nodeDir); err != nil {
 				return err

--- a/eth2util/deposit/deposit.go
+++ b/eth2util/deposit/deposit.go
@@ -105,12 +105,12 @@ func MarshalDepositData(depositDatas []eth2p0.DepositData, network string) ([]by
 		}
 
 		ddList = append(ddList, depositDataJSON{
-			PubKey:                fmt.Sprintf("%x", depositData.PublicKey),
-			WithdrawalCredentials: fmt.Sprintf("%x", depositData.WithdrawalCredentials),
+			PubKey:                hex.EncodeToString(depositData.PublicKey[:]),
+			WithdrawalCredentials: hex.EncodeToString(depositData.WithdrawalCredentials),
 			Amount:                uint64(depositData.Amount),
-			Signature:             fmt.Sprintf("%x", depositData.Signature),
-			DepositMessageRoot:    fmt.Sprintf("%x", msgRoot),
-			DepositDataRoot:       fmt.Sprintf("%x", dataRoot),
+			Signature:             hex.EncodeToString(depositData.Signature[:]),
+			DepositMessageRoot:    hex.EncodeToString(msgRoot[:]),
+			DepositDataRoot:       hex.EncodeToString(dataRoot[:]),
 			ForkVersion:           strings.TrimPrefix(forkVersion, "0x"),
 			NetworkName:           network,
 			DepositCliVersion:     depositCliVersion,

--- a/eth2util/deposit/deposit_test.go
+++ b/eth2util/deposit/deposit_test.go
@@ -186,7 +186,7 @@ func TestWriteClusterDepositDataFiles(t *testing.T) {
 	const numNodes = 4
 	dir := t.TempDir()
 
-	for n := 0; n < numNodes; n++ {
+	for n := range numNodes {
 		err := os.MkdirAll(path.Join(dir, fmt.Sprintf("node%d", n)), 0o755)
 		require.NoError(t, err)
 	}
@@ -202,7 +202,7 @@ func TestWriteClusterDepositDataFiles(t *testing.T) {
 		expected, err := deposit.MarshalDepositData(depositDatas[i], eth2util.Goerli.Name)
 		require.NoError(t, err)
 
-		for n := 0; n < numNodes; n++ {
+		for n := range numNodes {
 			nodeDir := path.Join(dir, fmt.Sprintf("node%d", n))
 			filepath := deposit.GetDepositFilePath(nodeDir, depositDatas[i][0].Amount)
 			actual, err := os.ReadFile(filepath)
@@ -234,7 +234,7 @@ func mustGenerateDepositDatas(t *testing.T, amount eth2p0.Gwei) []eth2p0.Deposit
 		network = eth2util.Goerli.Name
 	)
 
-	for i := 0; i < len(privKeys); i++ {
+	for i := range len(privKeys) {
 		sk, pk := GetKeys(t, privKeys[i])
 
 		msg, err := deposit.NewMessage(pk, withdrawalAddrs[i], amount)

--- a/eth2util/eip712/eip712_test.go
+++ b/eth2util/eip712/eip712_test.go
@@ -3,7 +3,7 @@
 package eip712_test
 
 import (
-	"fmt"
+	"encoding/hex"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -34,5 +34,5 @@ func TestCreatorHash(t *testing.T) {
 
 	resp, err := eip712.HashTypedData(data)
 	require.NoError(t, err)
-	require.Equal(t, "7c8fe012e2f872ca7ec870164184f57b921166f80565ff74af7bee5796f973e4", fmt.Sprintf("%x", resp))
+	require.Equal(t, "7c8fe012e2f872ca7ec870164184f57b921166f80565ff74af7bee5796f973e4", hex.EncodeToString(resp))
 }

--- a/eth2util/enr/enr.go
+++ b/eth2util/enr/enr.go
@@ -242,7 +242,7 @@ func toBigEndian(i int) []byte {
 // fromBigEndian returns the integer encoded as big endian byte slice.
 func fromBigEndian(b []byte) int {
 	var x uint64
-	for i := 0; i < len(b); i++ {
+	for i := range len(b) {
 		x = x<<8 | uint64(b[i])
 	}
 

--- a/eth2util/enr/enr_internal_test.go
+++ b/eth2util/enr/enr_internal_test.go
@@ -15,7 +15,7 @@ import (
 
 func TestBackwardsENR(t *testing.T) {
 	random := rand.New(rand.NewSource(time.Now().Unix()))
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		k, err := ecdsa.GenerateKey(k1.S256(), random)
 		require.NoError(t, err)
 

--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -110,6 +110,7 @@ func postKeys(ctx context.Context, addr, authToken string, reqBody keymanagerReq
 	}
 	_ = resp.Body.Close()
 
+	//nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 	if resp.StatusCode/100 != 2 {
 		return errors.New("failed posting keys", z.Int("status", resp.StatusCode), z.Str("body", string(data)))
 	}

--- a/eth2util/keymanager/keymanager.go
+++ b/eth2util/keymanager/keymanager.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -98,7 +97,7 @@ func postKeys(ctx context.Context, addr, authToken string, reqBody keymanagerReq
 		return errors.Wrap(err, "new post request", z.Str("url", addr))
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", authToken))
+	req.Header.Set("Authorization", "Bearer "+authToken)
 
 	resp, err := new(http.Client).Do(req)
 	if err != nil {

--- a/eth2util/keymanager/keymanager_test.go
+++ b/eth2util/keymanager/keymanager_test.go
@@ -31,7 +31,7 @@ func TestImportKeystores(t *testing.T) {
 		secrets    []tbls.PrivateKey
 	)
 
-	for i := 0; i < numSecrets; i++ {
+	for range numSecrets {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(t, err)
 		secrets = append(secrets, secret)
@@ -71,7 +71,7 @@ func TestImportKeystores(t *testing.T) {
 			require.Equal(t, len(req.Keystores), len(req.Passwords))
 			require.Equal(t, len(req.Keystores), numSecrets)
 
-			for i := 0; i < numSecrets; i++ {
+			for i := range numSecrets {
 				var ks noopKeystore
 				require.NoError(t, json.Unmarshal([]byte(req.Keystores[i]), &ks))
 				secret, err := decrypt(t, ks, req.Passwords[i])

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -85,7 +85,7 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 
 	fork, join, cancel := forkjoin.New(
 		context.Background(),
-		func(ctx context.Context, d data) (any, error) {
+		func(_ context.Context, d data) (any, error) {
 			filename := path.Join(dir, fmt.Sprintf(filenameFmt, d.index))
 
 			password, err := randomHex32()

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -257,11 +257,11 @@ func KeysharesToValidatorPubkey(cl *manifestpb.Cluster, shares []tbls.PrivateKey
 	}
 
 	// this is sadly a O(n^2) search
-	for _, validator := range cl.Validators {
-		valHex := fmt.Sprintf("0x%x", validator.PublicKey)
+	for _, validator := range cl.GetValidators() {
+		valHex := fmt.Sprintf("0x%x", validator.GetPublicKey())
 
 		valPubShares := make(map[tbls.PublicKey]struct{})
-		for _, valShare := range validator.PubShares {
+		for _, valShare := range validator.GetPubShares() {
 			valPubShares[tbls.PublicKey(valShare)] = struct{}{}
 		}
 
@@ -285,7 +285,7 @@ func KeysharesToValidatorPubkey(cl *manifestpb.Cluster, shares []tbls.PrivateKey
 		}
 	}
 
-	if len(ret) != len(cl.Validators) {
+	if len(ret) != len(cl.GetValidators()) {
 		return nil, errors.New("amount of key shares don't match amount of validator public keys")
 	}
 

--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -120,8 +120,6 @@ func storeKeysInternal(secrets []tbls.PrivateKey, dir string, filenameFmt string
 	defer cancel()
 
 	for i, secret := range secrets {
-		i := i
-		secret := secret
 		d := data{
 			index:  i,
 			secret: secret,

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -4,6 +4,7 @@ package keystore_test
 
 import (
 	"bytes"
+	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"os"
@@ -201,7 +202,7 @@ func TestLoadScrypt(t *testing.T) {
 
 	require.Len(t, keyfiles, 1)
 
-	require.Equal(t, "10b16fc552aa607fa1399027f7b86ab789077e470b5653b338693dc2dde02468", fmt.Sprintf("%x", keyfiles[0].PrivateKey))
+	require.Equal(t, "10b16fc552aa607fa1399027f7b86ab789077e470b5653b338693dc2dde02468", hex.EncodeToString(keyfiles[0].PrivateKey[:]))
 }
 
 func TestSequencedKeys(t *testing.T) {

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -28,7 +28,7 @@ func TestStoreLoad(t *testing.T) {
 	dir := t.TempDir()
 
 	var secrets []tbls.PrivateKey
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(t, err)
 
@@ -61,7 +61,7 @@ func TestStoreLoadNonCharonNames(t *testing.T) {
 
 	expect := make(map[tbls.PrivateKey]bool)
 	var secrets []tbls.PrivateKey
-	for i := 0; i < len(filenames); i++ {
+	for range len(filenames) {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(t, err)
 
@@ -73,7 +73,7 @@ func TestStoreLoadNonCharonNames(t *testing.T) {
 	require.NoError(t, err)
 
 	// rename according to filenames slice
-	for idx := 0; idx < len(filenames); idx++ {
+	for idx := range len(filenames) {
 		oldPath := filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.json", idx))
 		newPath := filepath.Join(dir, fmt.Sprintf("%s.json", filenames[idx]))
 		require.NoError(t, os.Rename(oldPath, newPath))
@@ -97,7 +97,7 @@ func TestStoreLoadKeysAll(t *testing.T) {
 	dir := t.TempDir()
 
 	var secrets []tbls.PrivateKey
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(t, err)
 
@@ -120,7 +120,7 @@ func TestStoreLoadKeysAllNonSequentialIdx(t *testing.T) {
 	dir := t.TempDir()
 
 	var secrets []tbls.PrivateKey
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(t, err)
 
@@ -161,7 +161,7 @@ func TestStoreLoadSequentialNonCharonNames(t *testing.T) {
 
 	var secrets []tbls.PrivateKey
 
-	for i := 0; i < len(filenames); i++ {
+	for range len(filenames) {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(t, err)
 
@@ -172,7 +172,7 @@ func TestStoreLoadSequentialNonCharonNames(t *testing.T) {
 	require.NoError(t, err)
 
 	// rename according to filenames slice
-	for idx := 0; idx < len(filenames); idx++ {
+	for idx := range len(filenames) {
 		oldPath := filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.json", idx))
 		newPath := filepath.Join(dir, fmt.Sprintf("%s.json", filenames[idx]))
 		require.NoError(t, os.Rename(oldPath, newPath))
@@ -320,7 +320,7 @@ func TestKeyshareToValidatorPubkey(t *testing.T) {
 
 	cl := &manifestpb.Cluster{}
 
-	for valIdx := 0; valIdx < valAmt; valIdx++ {
+	for valIdx := range valAmt {
 		valPubk, err := tblsconv.PubkeyFromCore(testutil.RandomCorePubKey(t))
 		require.NoError(t, err)
 
@@ -329,7 +329,7 @@ func TestKeyshareToValidatorPubkey(t *testing.T) {
 		}
 
 		randomShareSelected := false
-		for shareIdx := 0; shareIdx < sharesAmt; shareIdx++ {
+		for range sharesAmt {
 			sharePriv, err := tbls.GenerateSecretKey()
 			require.NoError(t, err)
 

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -345,8 +345,8 @@ func TestKeyshareToValidatorPubkey(t *testing.T) {
 			validator.PubShares = append(validator.PubShares, sharePub[:])
 		}
 
-		rand.Shuffle(len(validator.PubShares), func(i, j int) {
-			validator.PubShares[i], validator.PubShares[j] = validator.PubShares[j], validator.PubShares[i]
+		rand.Shuffle(len(validator.GetPubShares()), func(i, j int) {
+			validator.PubShares[i], validator.PubShares[j] = validator.GetPubShares()[j], validator.GetPubShares()[i]
 		})
 
 		cl.Validators = append(cl.Validators, validator)
@@ -361,8 +361,8 @@ func TestKeyshareToValidatorPubkey(t *testing.T) {
 		valFound := false
 		sharePrivKeyFound := false
 
-		for _, val := range cl.Validators {
-			if string(valPubKey) == fmt.Sprintf("0x%x", val.PublicKey) {
+		for _, val := range cl.GetValidators() {
+			if string(valPubKey) == fmt.Sprintf("0x%x", val.GetPublicKey()) {
 				valFound = true
 				break
 			}

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -76,11 +76,11 @@ func TestStoreLoadNonCharonNames(t *testing.T) {
 	// rename according to filenames slice
 	for idx := range len(filenames) {
 		oldPath := filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.json", idx))
-		newPath := filepath.Join(dir, fmt.Sprintf("%s.json", filenames[idx]))
+		newPath := filepath.Join(dir, filenames[idx]+".json")
 		require.NoError(t, os.Rename(oldPath, newPath))
 
 		oldPath = filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.txt", idx))
-		newPath = filepath.Join(dir, fmt.Sprintf("%s.txt", filenames[idx]))
+		newPath = filepath.Join(dir, filenames[idx]+".txt")
 		require.NoError(t, os.Rename(oldPath, newPath))
 	}
 
@@ -175,11 +175,11 @@ func TestStoreLoadSequentialNonCharonNames(t *testing.T) {
 	// rename according to filenames slice
 	for idx := range len(filenames) {
 		oldPath := filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.json", idx))
-		newPath := filepath.Join(dir, fmt.Sprintf("%s.json", filenames[idx]))
+		newPath := filepath.Join(dir, filenames[idx]+".json")
 		require.NoError(t, os.Rename(oldPath, newPath))
 
 		oldPath = filepath.Join(dir, fmt.Sprintf("keystore-insecure-%d.txt", idx))
-		newPath = filepath.Join(dir, fmt.Sprintf("%s.txt", filenames[idx]))
+		newPath = filepath.Join(dir, filenames[idx]+".txt")
 		require.NoError(t, os.Rename(oldPath, newPath))
 	}
 

--- a/eth2util/keystore/load.go
+++ b/eth2util/keystore/load.go
@@ -81,7 +81,7 @@ func LoadFilesUnordered(dir string) (KeyFiles, error) {
 		return nil, errors.New("no keys found")
 	}
 
-	workFunc := func(ctx context.Context, filename string) (KeyFile, error) {
+	workFunc := func(_ context.Context, filename string) (KeyFile, error) {
 		b, err := os.ReadFile(filename)
 		if err != nil {
 			return KeyFile{}, errors.Wrap(err, "read file", z.Str("filename", filename))

--- a/eth2util/rlp/rlp_test.go
+++ b/eth2util/rlp/rlp_test.go
@@ -57,7 +57,7 @@ func FuzzEncodeBytesList(f *testing.F) {
 	d := merge(prefix, data)
 
 	// Add a few different lengths of byte slices
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		f.Add(i, d, d, d, d, d, d, d, d, d, d)
 	}
 

--- a/eth2util/rlp/rlp_test.go
+++ b/eth2util/rlp/rlp_test.go
@@ -5,6 +5,7 @@ package rlp_test
 import (
 	"crypto/rand"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -102,7 +103,7 @@ func TestBytesList(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			encoded := rlp.EncodeBytesList(test.input)
 			if len(test.output) == 0 {
 				require.Empty(t, encoded)
@@ -162,7 +163,7 @@ func TestBytes(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			encoded := rlp.EncodeBytes(test.input)
 			if len(test.output) == 0 {
 				require.Empty(t, encoded)

--- a/eth2util/rlp/rlp_test.go
+++ b/eth2util/rlp/rlp_test.go
@@ -4,7 +4,6 @@ package rlp_test
 
 import (
 	"crypto/rand"
-	"fmt"
 	"strconv"
 	"testing"
 
@@ -184,7 +183,7 @@ func TestBytes(t *testing.T) {
 
 func TestLengths(t *testing.T) {
 	for _, length := range []int{0, 1, 55, 56, 1023, 1024} {
-		t.Run(fmt.Sprint(length), func(t *testing.T) {
+		t.Run(strconv.Itoa(length), func(t *testing.T) {
 			buf := make([]byte, length)
 			_, err := rand.Read(buf)
 			require.NoError(t, err)

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"testing"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -58,8 +57,8 @@ func TestVerifyRegistrationReference(t *testing.T) {
 
 	sigEth2 := eth2p0.BLSSignature(sig)
 	require.Equal(t,
-		fmt.Sprintf("%x", registration.Signature),
-		fmt.Sprintf("%x", sigEth2),
+		hex.EncodeToString(registration.Signature[:]),
+		hex.EncodeToString(sigEth2[:]),
 	)
 
 	pubkey, err := tbls.SecretToPublicKey(secretShare)

--- a/eth2util/signing/signing_test.go
+++ b/eth2util/signing/signing_test.go
@@ -104,7 +104,7 @@ func TestConstantApplicationBuilder(t *testing.T) {
 		0xfa, 0xf7, 0x1b, 0x89, 0xce, 0x5c, 0x5c, 0x38,
 	}
 
-	for i := 0; i < len(forkSchedule); i++ {
+	for i := range len(forkSchedule) {
 		domain := getDomain(t, i)
 		require.Equal(t, expect, domain, "domain for fork schedule %d", i)
 	}

--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -153,7 +153,7 @@ func queryRelayAddrs(ctx context.Context, relayURL string, backoff func(), lockH
 		if err != nil {
 			log.Warn(ctx, "Failure querying relay addresses (will try again)", err)
 			continue
-		} else if resp.StatusCode/100 != 2 {
+		} else if resp.StatusCode/100 != 2 { //nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 			log.Warn(ctx, "Non-200 response querying relay addresses (will try again)", nil, z.Int("status_code", resp.StatusCode))
 			continue
 		}

--- a/p2p/gater_test.go
+++ b/p2p/gater_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/libp2p/go-libp2p"
@@ -28,7 +29,7 @@ func TestInterceptSecured(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			c, err := p2p.NewConnGater([]peer.ID{test.config}, nil)
 			require.NoError(t, err)
 

--- a/p2p/ping.go
+++ b/p2p/ping.go
@@ -34,7 +34,7 @@ type TestPingConfig struct {
 // and collects metrics.
 func NewPingService(h host.Host, peers []peer.ID, conf TestPingConfig) lifecycle.HookFuncCtx {
 	if conf.Disable {
-		return func(ctx context.Context) {}
+		return func(context.Context) {}
 	}
 
 	maxBackoff := time.Second * 30 // Sweet spot between not spamming, but snappy recovery.

--- a/p2p/receive_test.go
+++ b/p2p/receive_test.go
@@ -41,7 +41,7 @@ func TestSendReceive(t *testing.T) {
 			duty, ok := req.(*pbv1.Duty)
 			require.True(t, ok)
 
-			if duty.Slot%2 == 0 {
+			if duty.GetSlot()%2 == 0 {
 				return duty, true, nil
 			} else {
 				return nil, false, nil
@@ -60,7 +60,7 @@ func TestSendReceive(t *testing.T) {
 		slot := uint64(100)
 		resp, err := sendReceive(slot)
 		require.NoError(t, err)
-		require.Equal(t, slot, resp.Slot)
+		require.Equal(t, slot, resp.GetSlot())
 	})
 
 	t.Run("empty response", func(t *testing.T) {

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -233,7 +233,7 @@ func SetFuzzerDefaultsUnsafe() {
 	defaultWriterFunc = func(s network.Stream) pbio.Writer {
 		return fuzzReaderWriter{w: pbio.NewDelimitedWriter(s)}
 	}
-	defaultReaderFunc = func(s network.Stream) pbio.Reader {
+	defaultReaderFunc = func(network.Stream) pbio.Reader {
 		return fuzzReaderWriter{}
 	}
 }

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -98,7 +98,11 @@ type Sender struct {
 func (s *Sender) addResult(ctx context.Context, peerID peer.ID, err error) {
 	state := &peerState{}
 	if val, ok := s.states.Load(peerID); ok {
-		state = val.(*peerState)
+		state, ok = val.(*peerState)
+		if !ok {
+			log.Warn(ctx, "Type assertion peer state failing", err, z.Str("peer", PeerName(peerID)))
+			return
+		}
 	}
 
 	state.buffer.add(err)

--- a/p2p/sender_internal_test.go
+++ b/p2p/sender_internal_test.go
@@ -81,7 +81,7 @@ func TestAddResult(t *testing.T) {
 
 	wg.Add(concurrencyFactor)
 
-	for i := 0; i < concurrencyFactor; i++ {
+	for range concurrencyFactor {
 		go func() {
 			sender.addResult(ctx, "test", nil)
 			wg.Done()

--- a/p2p/sender_internal_test.go
+++ b/p2p/sender_internal_test.go
@@ -102,7 +102,7 @@ func TestSenderRetry(t *testing.T) {
 
 	h = new(testHost)
 	err = sender.SendAsync(ctx, h, "", "", nil)
-	require.Nil(t, err)
+	require.NoError(t, err)
 	require.Eventually(t, func() bool {
 		return h.Count() == 2
 	}, time.Second, time.Millisecond)

--- a/p2p/sender_internal_test.go
+++ b/p2p/sender_internal_test.go
@@ -32,7 +32,8 @@ func TestSenderAddResult(t *testing.T) {
 		t.Helper()
 		state := &peerState{}
 		if val, ok := sender.states.Load(peerID); ok {
-			state = val.(*peerState)
+			state, ok = val.(*peerState)
+			require.True(t, ok)
 		}
 		require.Equal(t, expect, state.failing.Load())
 	}

--- a/tbls/herumi.go
+++ b/tbls/herumi.go
@@ -185,8 +185,6 @@ func (Herumi) RecoverSecret(shares map[int]PrivateKey, _, _ uint) (PrivateKey, e
 	)
 
 	for idx, key := range shares {
-		// do a local copy, we're dealing with references here
-		key := key
 		var kpk bls.SecretKey
 		if err := kpk.Deserialize(key[:]); err != nil {
 			return PrivateKey{}, errors.Wrap(
@@ -248,8 +246,6 @@ func (Herumi) ThresholdAggregate(partialSignaturesByIndex map[int]Signature) (Si
 	)
 
 	for idx, rawSignature := range partialSignaturesByIndex {
-		// do a local copy, we're dealing with references here
-		rawSignature := rawSignature
 		var signature bls.Sign
 		if err := signature.Deserialize(rawSignature[:]); err != nil {
 			return Signature{}, errors.Wrap(

--- a/tbls/herumi.go
+++ b/tbls/herumi.go
@@ -3,7 +3,6 @@
 package tbls
 
 import (
-	"fmt"
 	"io"
 	"strconv"
 	"sync"
@@ -108,7 +107,7 @@ func (Herumi) ThresholdSplitInsecure(t *testing.T, secret PrivateKey, total uint
 	for i := 1; i <= int(total); i++ {
 		var blsID bls.ID
 
-		err := blsID.SetDecString(fmt.Sprintf("%d", i))
+		err := blsID.SetDecString(strconv.Itoa(i))
 		if err != nil {
 			return nil, errors.Wrap(
 				err,
@@ -154,7 +153,7 @@ func (Herumi) ThresholdSplit(secret PrivateKey, total uint, threshold uint) (map
 	for i := 1; i <= int(total); i++ {
 		var blsID bls.ID
 
-		err := blsID.SetDecString(fmt.Sprintf("%d", i))
+		err := blsID.SetDecString(strconv.Itoa(i))
 		if err != nil {
 			return nil, errors.Wrap(
 				err,

--- a/tbls/herumi.go
+++ b/tbls/herumi.go
@@ -338,7 +338,7 @@ func (Herumi) VerifyAggregate(publicShares []PublicKey, signature Signature, dat
 // provided random number generator. This is useful for testing.
 func generateInsecureSecret(t *testing.T, random io.Reader) (bls.SecretKey, error) {
 	t.Helper()
-	for i := 0; i < 100; i++ {
+	for range 100 {
 		b := make([]byte, 32)
 		_, err := random.Read(b)
 		require.NoError(t, err)

--- a/tbls/tbls_test.go
+++ b/tbls/tbls_test.go
@@ -8,7 +8,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/obolnetwork/charon/tbls"
@@ -32,99 +31,99 @@ func (ts *TestSuite) SetupTest() {
 
 func (ts *TestSuite) Test_GenerateSecretKey() {
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 }
 
 func (ts *TestSuite) Test_SecretToPublicKey() {
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 
 	pubk, err := tbls.SecretToPublicKey(secret)
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), pubk)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(pubk)
 }
 
 func (ts *TestSuite) Test_ThresholdSplit() {
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 
 	shares, err := tbls.ThresholdSplit(secret, 5, 3)
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), shares)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(shares)
 }
 
 func (ts *TestSuite) Test_RecoverSecret() {
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 
 	shares, err := tbls.ThresholdSplit(secret, 5, 3)
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
 	recovered, err := tbls.RecoverSecret(shares, 5, 3)
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
-	require.ElementsMatch(ts.T(), secret, recovered)
+	ts.Require().ElementsMatch(secret, recovered)
 }
 
 func (ts *TestSuite) Test_ThresholdAggregate() {
 	data := []byte("hello obol!")
 
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 
 	totalOGSig, err := tbls.Sign(secret, data)
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
 	shares, err := tbls.ThresholdSplit(secret, 5, 3)
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
 	signatures := map[int]tbls.Signature{}
 
 	for idx, key := range shares {
 		signature, err := tbls.Sign(key, data)
-		require.NoError(ts.T(), err)
+		ts.Require().NoError(err)
 		signatures[idx] = signature
 	}
 
 	totalSig, err := tbls.ThresholdAggregate(signatures)
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
-	require.Equal(ts.T(), totalOGSig, totalSig)
+	ts.Require().Equal(totalOGSig, totalSig)
 }
 
 func (ts *TestSuite) Test_Verify() {
 	data := []byte("hello obol!")
 
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 
 	signature, err := tbls.Sign(secret, data)
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), signature)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(signature)
 
 	pubkey, err := tbls.SecretToPublicKey(secret)
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), pubkey)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(pubkey)
 
-	require.NoError(ts.T(), tbls.Verify(pubkey, data, signature))
+	ts.Require().NoError(tbls.Verify(pubkey, data, signature))
 }
 
 func (ts *TestSuite) Test_Sign() {
 	data := []byte("hello obol!")
 
 	secret, err := tbls.GenerateSecretKey()
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), secret)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(secret)
 
 	signature, err := tbls.Sign(secret, data)
-	require.NoError(ts.T(), err)
-	require.NotEmpty(ts.T(), signature)
+	ts.Require().NoError(err)
+	ts.Require().NotEmpty(signature)
 }
 
 func (ts *TestSuite) Test_VerifyAggregate() {
@@ -139,11 +138,11 @@ func (ts *TestSuite) Test_VerifyAggregate() {
 
 	for range 10 {
 		secret, err := tbls.GenerateSecretKey()
-		require.NoError(ts.T(), err)
-		require.NotEmpty(ts.T(), secret)
+		ts.Require().NoError(err)
+		ts.Require().NotEmpty(secret)
 
 		pubkey, err := tbls.SecretToPublicKey(secret)
-		require.NoError(ts.T(), err)
+		ts.Require().NoError(err)
 
 		keys = append(keys, key{
 			pub:  pubkey,
@@ -156,15 +155,15 @@ func (ts *TestSuite) Test_VerifyAggregate() {
 
 	for _, key := range keys {
 		s, err := tbls.Sign(key.priv, data)
-		require.NoError(ts.T(), err)
+		ts.Require().NoError(err)
 		signs = append(signs, s)
 		pshares = append(pshares, key.pub)
 	}
 
 	sig, err := tbls.Aggregate(signs)
-	require.NoError(ts.T(), err)
+	ts.Require().NoError(err)
 
-	require.NoError(ts.T(), tbls.VerifyAggregate(pshares, sig, data))
+	ts.Require().NoError(tbls.VerifyAggregate(pshares, sig, data))
 }
 
 func runSuite(t *testing.T, i tbls.Implementation) {

--- a/tbls/tbls_test.go
+++ b/tbls/tbls_test.go
@@ -137,7 +137,7 @@ func (ts *TestSuite) Test_VerifyAggregate() {
 
 	var keys []key
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		secret, err := tbls.GenerateSecretKey()
 		require.NoError(ts.T(), err)
 		require.NotEmpty(ts.T(), secret)
@@ -187,7 +187,7 @@ func runBenchmark(b *testing.B, impl tbls.Implementation) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		// NOTE: we can't run suite.Run() here because testify doesn't allow us to pass testing.B in place of
 		// testing.T.
 		// So we're manually listing all the interface's methods here.

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -25,8 +25,8 @@ package beaconmock
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
@@ -95,7 +95,7 @@ func defaultHTTPMock() Mock {
 			{
 				Endpoint: "/eth/v1/beacon/genesis",
 				Key:      "genesis_time",
-				Value:    fmt.Sprint(genesis.Unix()),
+				Value:    strconv.FormatInt(genesis.Unix(), 10),
 			},
 		},
 		IsActiveFunc: func() bool { return true },

--- a/testutil/beaconmock/beaconmock_fuzz.go
+++ b/testutil/beaconmock/beaconmock_fuzz.go
@@ -94,7 +94,7 @@ func WithBeaconMockFuzzer() Option {
 			return duties, nil
 		}
 
-		mock.ProposerDutiesFunc = func(_ context.Context, epoch eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+		mock.ProposerDutiesFunc = func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
 			var duties []*eth2v1.ProposerDuty
 			fuzz.New().Fuzz(&duties)
 
@@ -115,7 +115,7 @@ func WithBeaconMockFuzzer() Option {
 			return block, nil
 		}
 
-		mock.AggregateAttestationFunc = func(ctx context.Context, slot eth2p0.Slot, attestationDataRoot eth2p0.Root) (*eth2p0.Attestation, error) {
+		mock.AggregateAttestationFunc = func(context.Context, eth2p0.Slot, eth2p0.Root) (*eth2p0.Attestation, error) {
 			var att *eth2p0.Attestation
 			fuzz.New().Fuzz(&att)
 

--- a/testutil/beaconmock/headproducer.go
+++ b/testutil/beaconmock/headproducer.go
@@ -204,7 +204,7 @@ func (p *headProducer) handleGetBlockRoot(w http.ResponseWriter, r *http.Request
 		w.WriteHeader(http.StatusBadRequest)
 		resp, err := json.Marshal(errorMsgJSON{
 			Code:    500,
-			Message: fmt.Sprintf("Invalid block ID: %s", blockID),
+			Message: "Invalid block ID: " + blockID,
 		})
 		if err != nil {
 			panic(err) // This should never happen and this is test code sorry ;)

--- a/testutil/beaconmock/headproducer_internal_test.go
+++ b/testutil/beaconmock/headproducer_internal_test.go
@@ -4,7 +4,6 @@ package beaconmock
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -60,7 +59,7 @@ func TestHeadProducer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			rawURL := fmt.Sprintf("eth/v1/events?topics=%s", strings.Join(test.topics, "&topics="))
+			rawURL := "eth/v1/events?topics=" + strings.Join(test.topics, "&topics=")
 			endpoint := testutil.MustParseURL(t, rawURL)
 			addr := base.ResolveReference(endpoint).String()
 

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -139,7 +139,7 @@ var ValidatorSetA = ValidatorSet{
 // WithValidatorSet configures the mock with the provided validator set.
 func WithValidatorSet(set ValidatorSet) Option {
 	return func(mock *Mock) {
-		mock.ValidatorsByPubKeyFunc = func(ctx context.Context, stateID string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
+		mock.ValidatorsByPubKeyFunc = func(ctx context.Context, _ string, pubkeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 			resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
 			if len(pubkeys) == 0 {
 				for idx, val := range set {
@@ -499,7 +499,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		HTTPMock:     httpMock,
 		httpServer:   httpServer,
 		headProducer: headProducer,
-		ProposalFunc: func(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+		ProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
 			var block *eth2api.VersionedProposal
 			if opts.BuilderBoostFactor == nil || *opts.BuilderBoostFactor == 0 {
 				block = &eth2api.VersionedProposal{
@@ -526,7 +526,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 
 			return block, nil
 		},
-		SignedBeaconBlockFunc: func(_ context.Context, blockID string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+		SignedBeaconBlockFunc: func(context.Context, string) (*eth2spec.VersionedSignedBeaconBlock, error) {
 			return testutil.RandomCapellaVersionedSignedBeaconBlock(), nil // Note the slot is probably wrong.
 		},
 		ProposerDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
@@ -535,16 +535,16 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		AttesterDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error) {
 			return []*eth2v1.AttesterDuty{}, nil
 		},
-		BlockAttestationsFunc: func(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
+		BlockAttestationsFunc: func(context.Context, string) ([]*eth2p0.Attestation, error) {
 			return []*eth2p0.Attestation{}, nil
 		},
-		NodePeerCountFunc: func(ctx context.Context) (int, error) {
+		NodePeerCountFunc: func(context.Context) (int, error) {
 			return 80, nil
 		},
 		AttestationDataFunc: func(ctx context.Context, slot eth2p0.Slot, index eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error) {
 			return attStore.NewAttestationData(ctx, slot, index)
 		},
-		AggregateAttestationFunc: func(ctx context.Context, slot eth2p0.Slot, root eth2p0.Root) (*eth2p0.Attestation, error) {
+		AggregateAttestationFunc: func(_ context.Context, _ eth2p0.Slot, root eth2p0.Root) (*eth2p0.Attestation, error) {
 			attData, err := attStore.AttestationDataByRoot(root)
 			if err != nil {
 				return nil, err
@@ -555,7 +555,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 				Data:            attData,
 			}, nil
 		},
-		CachedValidatorsFunc: func(_ context.Context) (eth2wrap.ActiveValidators, eth2wrap.CompleteValidators, error) {
+		CachedValidatorsFunc: func(context.Context) (eth2wrap.ActiveValidators, eth2wrap.CompleteValidators, error) {
 			return nil, nil, nil
 		},
 		ValidatorsFunc: func(context.Context, *eth2api.ValidatorsOpts) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
@@ -590,7 +590,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		SubmitValidatorRegistrationsFunc: func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error {
 			return nil
 		},
-		AggregateBeaconCommitteeSelectionsFunc: func(ctx context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
+		AggregateBeaconCommitteeSelectionsFunc: func(_ context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
 			return selections, nil
 		},
 		SubmitAggregateAttestationsFunc: func(context.Context, []*eth2p0.SignedAggregateAndProof) error {
@@ -605,7 +605,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		SyncCommitteeDutiesFunc: func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.SyncCommitteeDuty, error) {
 			return []*eth2v1.SyncCommitteeDuty{}, nil
 		},
-		AggregateSyncCommitteeSelectionsFunc: func(ctx context.Context, selections []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error) {
+		AggregateSyncCommitteeSelectionsFunc: func(_ context.Context, selections []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error) {
 			return selections, nil
 		},
 		SubmitSyncCommitteeMessagesFunc: func(context.Context, []*altair.SyncCommitteeMessage) error {
@@ -614,7 +614,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		SubmitSyncCommitteeSubscriptionsFunc: func(context.Context, []*eth2v1.SyncCommitteeSubscription) error {
 			return nil
 		},
-		SyncCommitteeContributionFunc: func(ctx context.Context, slot eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
+		SyncCommitteeContributionFunc: func(_ context.Context, slot eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
 			aggBits := bitfield.NewBitvector128()
 			aggBits.SetBitAt(uint64(slot%128), true)
 
@@ -637,7 +637,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 
 			return eth2Resp.Data, nil
 		},
-		ProposerConfigFunc: func(ctx context.Context) (*eth2exp.ProposerConfigResponse, error) {
+		ProposerConfigFunc: func(context.Context) (*eth2exp.ProposerConfigResponse, error) {
 			return nil, nil
 		},
 	}

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -244,7 +245,7 @@ func WithGenesisTime(t0 time.Time) Option {
 		mock.overrides = append(mock.overrides, staticOverride{
 			Endpoint: "/eth/v1/beacon/genesis",
 			Key:      "genesis_time",
-			Value:    fmt.Sprint(t0.Unix()),
+			Value:    strconv.FormatInt(t0.Unix(), 10),
 		})
 	}
 }
@@ -266,7 +267,7 @@ func WithSlotDuration(duration time.Duration) Option {
 		mock.overrides = append(mock.overrides, staticOverride{
 			Endpoint: "/eth/v1/config/spec",
 			Key:      "SECONDS_PER_SLOT",
-			Value:    fmt.Sprint(int(duration.Seconds())),
+			Value:    strconv.Itoa(int(duration.Seconds())),
 		})
 	}
 }
@@ -277,7 +278,7 @@ func WithSlotsPerEpoch(slotsPerEpoch int) Option {
 		mock.overrides = append(mock.overrides, staticOverride{
 			Endpoint: "/eth/v1/config/spec",
 			Key:      "SLOTS_PER_EPOCH",
-			Value:    fmt.Sprint(slotsPerEpoch),
+			Value:    strconv.Itoa(slotsPerEpoch),
 		})
 	}
 }
@@ -456,7 +457,7 @@ func WithDeterministicSyncCommDuties(n, k int) Option {
 		mock.overrides = append(mock.overrides, staticOverride{
 			Endpoint: "/eth/v1/config/spec",
 			Key:      "EPOCHS_PER_SYNC_COMMITTEE_PERIOD",
-			Value:    fmt.Sprint(n),
+			Value:    strconv.Itoa(n),
 		})
 	}
 }
@@ -467,7 +468,7 @@ func WithSyncCommitteeSize(size int) Option {
 		mock.overrides = append(mock.overrides, staticOverride{
 			Endpoint: "/eth/v1/config/spec",
 			Key:      "SYNC_COMMITTEE_SIZE",
-			Value:    fmt.Sprint(size),
+			Value:    strconv.Itoa(size),
 		})
 	}
 }
@@ -478,7 +479,7 @@ func WithSyncCommitteeSubnetCount(count int) Option {
 		mock.overrides = append(mock.overrides, staticOverride{
 			Endpoint: "/eth/v1/config/spec",
 			Key:      "SYNC_COMMITTEE_SUBNET_COUNT",
-			Value:    fmt.Sprint(count),
+			Value:    strconv.Itoa(count),
 		})
 	}
 }

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -118,9 +118,6 @@ func newHTTPServer(addr string, optionalHandlers map[string]http.HandlerFunc, ov
 
 	// Configure above endpoints.
 	for path, handler := range endpoints {
-		// Copy iteration variables.
-		path := path
-		handler := handler
 		r.Handle(path, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := log.WithTopic(r.Context(), "bmock")
 			ctx = log.WithCtx(ctx, z.Str("path", path))

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -60,30 +60,30 @@ func newHTTPServer(addr string, optionalHandlers map[string]http.HandlerFunc, ov
 	shutdown := make(chan struct{})
 
 	endpoints := map[string]http.HandlerFunc{
-		"/up": func(w http.ResponseWriter, r *http.Request) {
+		"/up": func(http.ResponseWriter, *http.Request) {
 			// Can be used to test if server is up.
 		},
-		"/eth/v1/validator/sync_committee_subscriptions": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/validator/sync_committee_subscriptions": func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 		},
-		"/eth/v1/validator/aggregate_attestation": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/validator/aggregate_attestation": func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusBadRequest)
 			_, _ = w.Write([]byte(`{"code": 403,"message": "Beacon node was not assigned to aggregate on that subnet."}`))
 		},
-		"/eth/v1/validator/beacon_committee_subscriptions": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/validator/beacon_committee_subscriptions": func(http.ResponseWriter, *http.Request) {
 		},
-		"/eth/v1/node/version": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/node/version": func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"data": {"version": "charon/static_beacon_mock"}}`))
 		},
-		"/eth/v1/node/syncing": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/node/syncing": func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"data": {"head_slot": "1","sync_distance": "0","is_syncing": false}}`))
 		},
-		"/eth/v1/beacon/headers/head": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/beacon/headers/head": func(w http.ResponseWriter, _ *http.Request) {
 			_, _ = w.Write([]byte(`{"data": {"header": {"message": {"slot": "1"}}}}`))
 		},
-		"/eth/v1/validator/prepare_beacon_proposer": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/validator/prepare_beacon_proposer": func(http.ResponseWriter, *http.Request) {
 		},
-		"/eth/v1/events": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v1/events": func(_ http.ResponseWriter, r *http.Request) {
 			select {
 			case <-shutdown:
 			case <-r.Context().Done():

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -89,7 +89,7 @@ func newHTTPServer(addr string, optionalHandlers map[string]http.HandlerFunc, ov
 			case <-r.Context().Done():
 			}
 		},
-		"/eth/v2/beacon/blocks/{block_id}": func(w http.ResponseWriter, r *http.Request) {
+		"/eth/v2/beacon/blocks/{block_id}": func(w http.ResponseWriter, _ *http.Request) {
 			type signedBlockResponseJSON struct {
 				Version *eth2spec.DataVersion        `json:"version"`
 				Data    *bellatrix.SignedBeaconBlock `json:"data"`
@@ -206,7 +206,12 @@ func newHTTPMock(optionalHandlers map[string]http.HandlerFunc, overrides ...stat
 		return nil, nil, errors.Wrap(err, "new http client")
 	}
 
-	return cl.(HTTPMock), srv, nil
+	httpMock, ok := cl.(HTTPMock)
+	if !ok {
+		return nil, nil, errors.New("type assert http mock")
+	}
+
+	return httpMock, srv, nil
 }
 
 // overrideResponse overrides the key in the raw response. If key is empty, it overrides the whole response.

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -88,7 +88,7 @@ func newAutoCmd() *cobra.Command {
 		Use:   "auto",
 		Short: "Convenience function that runs `compose define && compose lock && compose run`",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			err := compose.Auto(cmd.Context(), conf)
 			if err != nil {
 				log.Error(cmd.Context(), "auto command fatal error", err)
@@ -112,7 +112,7 @@ func newBuildLocalCmd() *cobra.Command {
 		Use:   "build-local",
 		Short: "Builds the obolnetwork/charon:local docker container from the local source code. Note this requires the CHARON_REPO env var.",
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return compose.BuildLocal(cmd.Context())
 		},
 	}

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -11,6 +11,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -127,9 +128,9 @@ func Define(ctx context.Context, dir string, conf Config) (TmplData, error) {
 
 		n := TmplNode{EnvVars: []kv{
 			{"name", "compose"},
-			{"num_validators", fmt.Sprint(conf.NumValidators)},
+			{"num_validators", strconv.Itoa(conf.NumValidators)},
 			{"operator_enrs", strings.Join(enrs, ",")},
-			{"threshold", fmt.Sprint(conf.Threshold)},
+			{"threshold", strconv.Itoa(conf.Threshold)},
 			{"withdrawal_addresses", zeroAddress},
 			{"fee-recipient_addresses", zeroAddress},
 			{"dkg_algorithm", "frost"},

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -307,7 +307,7 @@ var keyGenFunc = func() (*k1.PrivateKey, error) {
 // newP2PKeys returns a slice of newly generated secp256k1 private keys.
 func newP2PKeys(n int) ([]*k1.PrivateKey, error) {
 	var resp []*k1.PrivateKey
-	for i := 0; i < n; i++ {
+	for range n {
 		key, err := keyGenFunc()
 		if err != nil {
 			return nil, errors.Wrap(err, "new key")

--- a/testutil/compose/fuzz/fuzz_test.go
+++ b/testutil/compose/fuzz/fuzz_test.go
@@ -5,7 +5,6 @@ package fuzz_test
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"path"
 	"testing"
@@ -77,7 +76,7 @@ func TestFuzzers(t *testing.T) {
 			}
 
 			if *logDir != "" {
-				autoConfig.LogFile = path.Join(*logDir, fmt.Sprintf("%s.log", test.name))
+				autoConfig.LogFile = path.Join(*logDir, test.name+".log")
 			}
 
 			err = compose.Auto(context.Background(), autoConfig)

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
@@ -34,12 +35,12 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 		// Only single node to call charon create cluster generate keys
 		n := TmplNode{EnvVars: []kv{
 			{"name", fmt.Sprintf("compose-%d-%d", conf.NumNodes, conf.NumValidators)},
-			{"threshold", fmt.Sprint(conf.Threshold)},
-			{"nodes", fmt.Sprint(conf.NumNodes)},
+			{"threshold", strconv.Itoa(conf.Threshold)},
+			{"nodes", strconv.Itoa(conf.NumNodes)},
 			{"cluster-dir", "/compose"},
 			{"split-existing-keys", fmt.Sprintf(`"%v"`, conf.SplitKeysDir != "")},
 			{"split-keys-dir", splitKeysDir},
-			{"num-validators", fmt.Sprint(conf.NumValidators)},
+			{"num-validators", strconv.Itoa(conf.NumValidators)},
 			{"insecure-keys", fmt.Sprintf(`"%v"`, conf.InsecureKeys)},
 			{"withdrawal-addresses", zeroAddress},
 			{"fee-recipient-addresses", zeroAddress},

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -55,7 +55,7 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 	case KeyGenDKG:
 
 		var nodes []TmplNode
-		for i := 0; i < conf.NumNodes; i++ {
+		for i := range conf.NumNodes {
 			n := TmplNode{
 				EnvVars:    newNodeEnvs(i, conf, ""),
 				Entrypoint: "sh",

--- a/testutil/compose/run.go
+++ b/testutil/compose/run.go
@@ -23,7 +23,7 @@ func Run(ctx context.Context, dir string, conf Config) (TmplData, error) {
 		nodes []TmplNode
 		vcs   []TmplVC
 	)
-	for i := 0; i < conf.NumNodes; i++ {
+	for i := range conf.NumNodes {
 		typ := conf.VCs[i%len(conf.VCs)]
 		vc, err := getVC(typ, i, conf.NumValidators, conf.InsecureKeys, conf.BuilderAPI)
 		if err != nil {
@@ -101,7 +101,7 @@ func getVC(typ VCType, nodeIdx int, numVals int, insecure, builderAPI bool) (Tmp
 	resp := vcByType[typ]
 	if typ == VCTeku {
 		var keys []string
-		for i := 0; i < numVals; i++ {
+		for i := range numVals {
 			if insecure {
 				keys = append(keys, fmt.Sprintf("/compose/node%d/validator_keys/keystore-insecure-%d.json:/compose/node%d/validator_keys/keystore-insecure-%d.txt", nodeIdx, i, nodeIdx, i))
 			} else {

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -121,7 +121,7 @@ func TestSmoke(t *testing.T) {
 			Name: "1_of_4_down",
 			RunTmplFunc: func(data *compose.TmplData) {
 				node0 := data.Nodes[0]
-				for i := 0; i < len(node0.EnvVars); i++ {
+				for i := range len(node0.EnvVars) {
 					if strings.HasPrefix(node0.EnvVars[i].Key, "p2p") {
 						data.Nodes[0].EnvVars[i].Key = node0.EnvVars[i].Key + "-unset" // Zero p2p flags to it cannot communicate
 					}
@@ -136,7 +136,7 @@ func TestSmoke(t *testing.T) {
 			},
 			RunTmplFunc: func(data *compose.TmplData) {
 				node0 := data.Nodes[0]
-				for i := 0; i < len(node0.EnvVars); i++ {
+				for i := range len(node0.EnvVars) {
 					if strings.HasPrefix(node0.EnvVars[i].Key, "p2p") {
 						data.Nodes[0].EnvVars[i].Key = node0.EnvVars[i].Key + "-unset" // Zero p2p flags to it cannot communicate
 					}

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -5,7 +5,6 @@ package smoke_test
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -202,7 +201,7 @@ func TestSmoke(t *testing.T) {
 			}
 
 			if *logDir != "" {
-				autoConfig.LogFile = path.Join(*logDir, fmt.Sprintf("%s.log", test.Name))
+				autoConfig.LogFile = path.Join(*logDir, test.Name+".log")
 			}
 
 			err = compose.Auto(context.Background(), autoConfig)

--- a/testutil/compose/smoke/smoke_test.go
+++ b/testutil/compose/smoke/smoke_test.go
@@ -171,7 +171,6 @@ func TestSmoke(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test // Copy iterator for async usage
 		t.Run(test.Name, func(t *testing.T) {
 			dir, err := os.MkdirTemp("", "")
 			require.NoError(t, err)

--- a/testutil/error.go
+++ b/testutil/error.go
@@ -51,7 +51,7 @@ func RequireProtosEqual[P proto.Message](t *testing.T, a, b []P) {
 			"expected: %s\nactual: %v", len(a), len(b))
 	}
 
-	for i := 0; i < len(a); i++ {
+	for i := range len(a) {
 		RequireProtoEqual(t, a[i], b[i])
 	}
 }

--- a/testutil/fuzz.go
+++ b/testutil/fuzz.go
@@ -84,7 +84,7 @@ func NewEth2Fuzzer(t *testing.T, seed int64) *fuzz.Fuzzer {
 			func(e *altair.SyncAggregate, c fuzz.Continue) {
 				c.FuzzNoCustom(e)
 				bits := bitfield.NewBitvector512()
-				for i := 0; i < 64; i++ {
+				for i := range 64 {
 					bits.SetBitAt(uint64(i), true)
 				}
 				e.SyncCommitteeBits = bits
@@ -92,7 +92,7 @@ func NewEth2Fuzzer(t *testing.T, seed int64) *fuzz.Fuzzer {
 			func(e *altair.SyncCommitteeContribution, c fuzz.Continue) {
 				c.FuzzNoCustom(e)
 				bits := bitfield.NewBitvector128()
-				for i := 0; i < 16; i++ {
+				for i := range 16 {
 					bits.SetBitAt(uint64(i), true)
 				}
 				e.AggregationBits = bits

--- a/testutil/fuzz.go
+++ b/testutil/fuzz.go
@@ -77,7 +77,7 @@ func NewEth2Fuzzer(t *testing.T, seed int64) *fuzz.Fuzzer {
 				e.BlockHash = blockHash[:]
 			},
 			// Just zero BeaconBlockBody.Deposits to pass validation.
-			func(e *[]*eth2p0.Deposit, c fuzz.Continue) {
+			func(e *[]*eth2p0.Deposit, _ fuzz.Continue) {
 				*e = []*eth2p0.Deposit{}
 			},
 			// SyncAggregate.SyncCommitteeBits must have 64 bits

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -256,9 +256,9 @@ func tplDataFromPRs(prs []pullRequest, gitRange string, issueData func(int) (str
 			return -1
 		} else if a.Number > b.Number {
 			return 1
-		} else {
-			return 0
 		}
+
+		return 0
 	})
 
 	cats := make(map[string]tplCategory)
@@ -401,12 +401,12 @@ func prFromLog(l log) (pullRequest, bool) {
 		return pullRequest{}, false
 	} else if strings.Contains(ticket, "none") {
 		return pr, true
-	} else {
-		pr.Issue, ok = getNumber(ticket)
-		if !ok {
-			fmt.Printf("Failed parsing issue number from ticket (%v): %s \n", l.Commit, ticket)
-			return pullRequest{}, false
-		}
+	}
+
+	pr.Issue, ok = getNumber(ticket)
+	if !ok {
+		fmt.Printf("Failed parsing issue number from ticket (%v): %s \n", l.Commit, ticket)
+		return pullRequest{}, false
 	}
 
 	return pr, true

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -301,7 +301,7 @@ func tplDataFromPRs(prs []pullRequest, gitRange string, issueData func(int) (str
 		Tag:        tag,
 		Date:       time.Now().Format("2006-01-02"),
 		RangeText:  gitRange,
-		RangeLink:  fmt.Sprintf("https://github.com/obolnetwork/charon/compare/%s", gitRange),
+		RangeLink:  "https://github.com/obolnetwork/charon/compare/" + gitRange,
 		Categories: catSlice,
 		ExtraPRs:   noIssuePRs,
 	}, nil

--- a/testutil/genchangelog/main_internal_test.go
+++ b/testutil/genchangelog/main_internal_test.go
@@ -5,6 +5,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -73,7 +74,7 @@ func TestPRFromLog(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			actual, ok := prFromLog(test.in)
 			if test.out.Title == "" {
 				require.False(t, ok)

--- a/testutil/helpers.go
+++ b/testutil/helpers.go
@@ -14,10 +14,10 @@ import (
 )
 
 // BuilderFalse is a core.BuilderEnabled function that always returns false.
-var BuilderFalse = func(slot uint64) bool { return false }
+var BuilderFalse = func(slot uint64) bool { return false } //nolint:revive // keep slot variable name for clarity
 
 // BuilderTrue is a core.BuilderEnabled function that always returns true.
-var BuilderTrue = func(slot uint64) bool { return true }
+var BuilderTrue = func(slot uint64) bool { return true } //nolint:revive // keep slot variable name for clarity
 
 // NewTCPNodeCallback returns a callback that can be used to connect a TCP node to all other TCP nodes.
 func NewTCPNodeCallback(t *testing.T, protocols ...protocol.ID) func(host host.Host) {

--- a/testutil/integration/infosync_test.go
+++ b/testutil/integration/infosync_test.go
@@ -44,7 +44,7 @@ func TestInfoSync(t *testing.T) {
 	tcpNodeCallback := testutil.NewTCPNodeCallback(t, priority.Protocols()...)
 
 	var eg errgroup.Group
-	for i := 0; i < n; i++ {
+	for i := range n {
 		conf := app.Config{
 			Log:              log.DefaultConfig(),
 			Feature:          featureset.DefaultConfig(),

--- a/testutil/integration/infosync_test.go
+++ b/testutil/integration/infosync_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -122,7 +123,7 @@ func (a *priorityAsserter) Callback(t *testing.T, i int) func(ctx context.Contex
 			}
 		}
 
-		a.callbacks.Store(fmt.Sprint(i), true)
+		a.callbacks.Store(strconv.Itoa(i), true)
 
 		return nil
 	}

--- a/testutil/integration/infosync_test.go
+++ b/testutil/integration/infosync_test.go
@@ -45,7 +45,6 @@ func TestInfoSync(t *testing.T) {
 
 	var eg errgroup.Group
 	for i := 0; i < n; i++ {
-		i := i // Copy iteration variable
 		conf := app.Config{
 			Log:              log.DefaultConfig(),
 			Feature:          featureset.DefaultConfig(),

--- a/testutil/integration/nightly_dkg_test.go
+++ b/testutil/integration/nightly_dkg_test.go
@@ -298,7 +298,6 @@ func TestDKGWithHighValidatorsAmt(t *testing.T) {
 	dir := t.TempDir()
 
 	for idx := 0; idx < numNodes; idx++ {
-		idx := idx
 		eg.Go(func() error {
 			conf := dkgConf
 			conf.DataDir = path.Join(dir, fmt.Sprintf("node%d", idx))

--- a/testutil/integration/nightly_dkg_test.go
+++ b/testutil/integration/nightly_dkg_test.go
@@ -124,7 +124,7 @@ func TestLongWaitDKG(t *testing.T) {
 
 		if currIdx == numNodes-1 {
 			// Notify all nodes that everyone has started.
-			for i := 0; i < numNodes; i++ {
+			for range numNodes {
 				allNodesStarted <- struct{}{}
 			}
 
@@ -133,7 +133,7 @@ func TestLongWaitDKG(t *testing.T) {
 
 		// Notify already running nodes that a new window has started.
 		// Note that currIdx+1 nodes are running by now.
-		for i := 0; i <= currIdx; i++ {
+		for range currIdx + 1 {
 			newWindowStarted <- struct{}{}
 		}
 
@@ -297,7 +297,7 @@ func TestDKGWithHighValidatorsAmt(t *testing.T) {
 
 	dir := t.TempDir()
 
-	for idx := 0; idx < numNodes; idx++ {
+	for idx := range numNodes {
 		eg.Go(func() error {
 			conf := dkgConf
 			conf.DataDir = path.Join(dir, fmt.Sprintf("node%d", idx))

--- a/testutil/integration/ping_test.go
+++ b/testutil/integration/ping_test.go
@@ -94,7 +94,6 @@ func pingCluster(t *testing.T, test pingTest) {
 	var eg errgroup.Group
 
 	for i := 0; i < n; i++ {
-		i := i
 		conf := app.Config{
 			Log:              log.DefaultConfig(),
 			Feature:          featureset.DefaultConfig(),

--- a/testutil/integration/ping_test.go
+++ b/testutil/integration/ping_test.go
@@ -93,7 +93,7 @@ func pingCluster(t *testing.T, test pingTest) {
 
 	var eg errgroup.Group
 
-	for i := 0; i < n; i++ {
+	for i := range n {
 		conf := app.Config{
 			Log:              log.DefaultConfig(),
 			Feature:          featureset.DefaultConfig(),

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -139,7 +139,7 @@ func TestSimnetDuties(t *testing.T) {
 			args.VoluntaryExit = test.exit
 
 			if test.vcType == vcTeku {
-				for i := 0; i < args.N; i++ {
+				for i := range args.N {
 					args = startTeku(t, args, i)
 				}
 			} else if test.vcType == vcVmock {
@@ -201,7 +201,7 @@ func newSimnetArgs(t *testing.T) simnetArgs {
 	secrets := secretShares[0]
 
 	var vapiAddrs []string
-	for i := 0; i < n; i++ {
+	for range n {
 		vapiAddrs = append(vapiAddrs, testutil.AvailableAddr(t).String())
 	}
 
@@ -297,7 +297,7 @@ func testSimnet(t *testing.T, args simnetArgs, expect *simnetExpect) {
 		eg      errgroup.Group
 		results = make(chan simResult)
 	)
-	for i := 0; i < args.N; i++ {
+	for i := range args.N {
 		peerIdx := i
 		conf := app.Config{
 			Log:              log.DefaultConfig(),

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -390,6 +390,7 @@ func testSimnet(t *testing.T, args simnetArgs, expect *simnetExpect) {
 				cancel()
 				close(routineResCh)
 				close(errCh)
+
 				return
 			}
 		}

--- a/testutil/obolapimock/obolapi_exit.go
+++ b/testutil/obolapimock/obolapi_exit.go
@@ -134,7 +134,6 @@ func (ts *testServer) HandlePartialExit(writer http.ResponseWriter, request *htt
 	}
 
 	for _, exit := range data.PartialExits {
-		exit := exit
 		var validatorFound bool
 		var partialPubkey []byte
 

--- a/testutil/promrated/promrated/main.go
+++ b/testutil/promrated/promrated/main.go
@@ -28,7 +28,7 @@ func newRootCmd(runFunc func(context.Context, promrated.Config) error) *cobra.Co
 		Short: "Starts a promrated server",
 		Long:  `Starts a promrated server that polls rated and makes metrics available to prometheus`,
 		Args:  cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
 			return runFunc(cmd.Context(), config)
 		},
 	}

--- a/testutil/promrated/rated.go
+++ b/testutil/promrated/rated.go
@@ -106,7 +106,7 @@ func queryRatedAPI(ctx context.Context, url *url.URL, ratedAuth string, network 
 			backoff()
 
 			continue
-		} else if res.StatusCode/100 != 2 {
+		} else if res.StatusCode/100 != 2 { //nolint:usestdlibvars // we should not replace 100 with http.StatusContinue, it makes it less readable
 			incRatedErrors(res.StatusCode)
 
 			return nil, errors.New("not ok http response", z.Str("body", string(body)))

--- a/testutil/promrated/rated.go
+++ b/testutil/promrated/rated.go
@@ -89,7 +89,7 @@ func queryRatedAPI(ctx context.Context, url *url.URL, ratedAuth string, network 
 			return nil, errors.Wrap(err, "new rated request")
 		}
 
-		req.Header.Add("Authorization", fmt.Sprintf("Bearer %s", ratedAuth))
+		req.Header.Add("Authorization", "Bearer "+ratedAuth)
 		req.Header.Add("X-Rated-Network", clusterNetwork)
 		res, err := client.Do(req)
 		if err != nil {

--- a/testutil/promrated/rated.go
+++ b/testutil/promrated/rated.go
@@ -83,7 +83,7 @@ func queryRatedAPI(ctx context.Context, url *url.URL, ratedAuth string, network 
 	client := new(http.Client)
 	backoff := expbackoff.New(ctx)
 
-	for r := 0; r <= maxRetries; r++ {
+	for r := range maxRetries + 1 {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "new rated request")

--- a/testutil/promrated/rated_internal_test.go
+++ b/testutil/promrated/rated_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/testutil"
@@ -27,7 +26,7 @@ func TestGetNetworkStatistics(t *testing.T) {
 	defer ts.Close()
 
 	vals, err := getNetworkStatistics(context.Background(), ts.URL, "auth", "goerli")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	testutil.RequireGoldenJSON(t, vals)
 }
 
@@ -42,7 +41,7 @@ func TestGetNodeOperatorStatistics(t *testing.T) {
 	defer ts.Close()
 
 	vals, err := getNodeOperatorStatistics(context.Background(), ts.URL, "auth", "Lido", "goerli")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	testutil.RequireGoldenJSON(t, vals)
 }
 

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -109,7 +109,7 @@ func RandomValidatorSet(t *testing.T, vals int) map[eth2p0.ValidatorIndex]*eth2v
 	t.Helper()
 
 	resp := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
-	for i := 0; i < vals; i++ {
+	for range vals {
 		val := RandomValidator(t)
 		resp[val.Index] = val
 	}
@@ -706,7 +706,7 @@ func RandomSyncCommittee(t *testing.T) *altair.SyncCommittee {
 	t.Helper()
 
 	var pubkeys []eth2p0.BLSPubKey
-	for i := 0; i < 512; i++ {
+	for range 512 {
 		pubkeys = append(pubkeys, RandomEth2PubKey(t))
 	}
 
@@ -1071,7 +1071,7 @@ func RandomArray32Seed(r *rand.Rand) [32]byte {
 func RandomBitList(length int) bitfield.Bitlist {
 	size := 256
 	resp := bitfield.NewBitlist(uint64(size))
-	for i := 0; i < length; i++ {
+	for range length {
 		resp.SetBitAt(uint64(rand.Intn(size)), true)
 	}
 
@@ -1272,7 +1272,7 @@ func RandomDepositMsg(t *testing.T) eth2p0.DepositMessage {
 type constReader byte
 
 func (c constReader) Read(buf []byte) (int, error) {
-	for i := 0; i < len(buf); i++ {
+	for i := range len(buf) {
 		buf[i] = byte(c)
 	}
 

--- a/testutil/validatormock/component.go
+++ b/testutil/validatormock/component.go
@@ -201,7 +201,7 @@ func (m *Component) scheduleSlot(ctx context.Context, slot metaSlot) error {
 func (m *Component) manageEpochState(ctx context.Context, epoch metaEpoch) error {
 	// Delete attesters and sync committee members for all epochs in epochWindow in past including the current epoch.
 	e := epoch
-	for i := 0; i < epochWindow; i++ {
+	for range epochWindow {
 		// Delete attesters.
 		m.deleteAttesters(e)
 
@@ -212,7 +212,7 @@ func (m *Component) manageEpochState(ctx context.Context, epoch metaEpoch) error
 	}
 
 	// Start attesters for this up to lookAhead epoch if not present (idempotent).
-	for i := 0; i < epochWindow; i++ {
+	for range epochWindow {
 		if err := m.startAttesters(epoch); err != nil {
 			return err
 		}

--- a/testutil/validatormock/meta.go
+++ b/testutil/validatormock/meta.go
@@ -108,7 +108,7 @@ func (e metaEpoch) Slots() []metaSlot {
 func (e metaEpoch) SlotsForLookAhead(totalEpochs uint64) []metaSlot {
 	slot := e.FirstSlot()
 	var resp []metaSlot
-	for i := uint64(0); i < totalEpochs*e.meta.SlotsPerEpoch; i++ {
+	for range totalEpochs * e.meta.SlotsPerEpoch {
 		resp = append(resp, slot)
 		slot = slot.Next()
 	}
@@ -119,7 +119,7 @@ func (e metaEpoch) SlotsForLookAhead(totalEpochs uint64) []metaSlot {
 // SlotsForLookBack returns the slots in past epochs equal to totalEpochs including the current epoch.
 func (e metaEpoch) SlotsForLookBack(totalEpochs uint64) []metaSlot {
 	epoch := e
-	for i := uint64(0); i < totalEpochs; i++ {
+	for range totalEpochs {
 		epoch = epoch.Prev()
 	}
 
@@ -127,7 +127,7 @@ func (e metaEpoch) SlotsForLookBack(totalEpochs uint64) []metaSlot {
 	total := totalEpochs * e.meta.SlotsPerEpoch
 
 	var resp []metaSlot
-	for i := uint64(0); i < total; i++ {
+	for range total {
 		resp = append(resp, slot)
 		slot = slot.Next()
 	}

--- a/testutil/validatormock/propose_test.go
+++ b/testutil/validatormock/propose_test.go
@@ -4,10 +4,10 @@ package validatormock_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -41,7 +41,7 @@ func TestAttest(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		t.Run(fmt.Sprint(test.DutyFactor), func(t *testing.T) {
+		t.Run(strconv.Itoa(test.DutyFactor), func(t *testing.T) {
 			ctx := context.Background()
 			clock := clockwork.NewFakeClockAt(time.Date(2022, 0o3, 20, 0o1, 0, 0, 0, time.UTC))
 

--- a/testutil/verifypr/verify_internal_test.go
+++ b/testutil/verifypr/verify_internal_test.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -66,7 +66,7 @@ func TestTitle(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			err := verifyTitle(test.Title)
 			if test.Error == "" {
 				if err == nil {
@@ -163,7 +163,7 @@ func TestBody(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		t.Run(fmt.Sprint(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			err := verifyBody(test.Body)
 			if test.Error == "" {
 				if err == nil {


### PR DESCRIPTION
golangci-lint was on older version that did not support go1.22 yet, which causes false alarms.

---

This update introduced a lot of new, deprecated and modified linters. There are a lot of changes in the files and I would advise for easier review to go over the commits, as I've tried to keep them concise, so there are only changes from one linter or if many, the changes are little. Most eye catching changes in the files are:

- `testifylint`: we had quite a lot of assertions inside of go routines, this is a bit of a red flag, because as observed in [this small example](https://go.dev/play/p/WoBGMiKQDEk), a failed assertion might or might not be caught
- The `golangci-lint` used in pre-commit was a default `golangci-lint` from [here](https://github.com/golangci/golangci-lint), using its default config, which made the linter pass locally all the time. This is something I've observed multiple times ([dating back to my very first PR](https://github.com/ObolNetwork/charon/pull/2850#issuecomment-1927408052) :)). Now the pre-commit hook is running the locally installed `golangci-lint` tool and it checks if the version is the same as the one in the pipelines.
- Added `max-same-issues=0` and `max-issues-per-linter=0` so there is no limit on what we see in the output. Previously the default of 3 was used, so if there were hundreds of errors with one linter, it would have displayed only 3, which made it quite a hassle to fix.
- Bump the `golangci-lint` action's version to v6. It now points where exactly the issue is, which is great!

category: fixbuild
ticket: #3179 
