### PR TITLE
*: pin lighthouse version in compose tests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,12 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "docker"
+  directories:
+    - "/"
+    - "/testutil/promrated/"
+    - "/testutil/compose/static/vouch/"
+    - "/testutil/compose/static/lodestar/"
+    - "/testutil/compose/static/lighthouse/"
+  schedule:
+    interval: "daily"

--- a/testutil/compose/static/lighthouse/Dockerfile
+++ b/testutil/compose/static/lighthouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM sigp/lighthouse:latest-${TARGETARCH}-unstable-dev
+FROM sigp/lighthouse:v5.2.1
 
 ENV YQ_VERSION=v4.42.1
 

--- a/testutil/compose/static/lighthouse/run.sh
+++ b/testutil/compose/static/lighthouse/run.sh
@@ -16,7 +16,6 @@ for f in /compose/"${NODE}"/validator_keys/keystore-*.json; do
   echo "Importing key ${f}"
   cat "$(echo "${f}" | sed 's/json/txt/')" | lighthouse account validator import \
     --testnet-dir "/tmp/testnet" \
-    --stdin-inputs \
     --keystore "${f}"
 done
 


### PR DESCRIPTION
- Pin lighthouse version in Dockerfile for compose tests.
- Remove stdin flag (doesn't exist in new version).
- Add Docker images checks for dependabot.

category: bug
ticket: none
