### PR TITLE
*: flag refactors

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -115,7 +115,7 @@ func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
 	flags.IntVar(&config.NumDVs, "num-validators", 0, "The number of distributed validators needed in the cluster.")
 	flags.BoolVar(&config.SplitKeys, "split-existing-keys", false, "Split an existing validator's private key into a set of distributed validator private key shares. Does not re-create deposit data for this key.")
 	flags.StringVar(&config.SplitKeysDir, "split-keys-dir", "", "Directory containing keys to split. Expects keys in keystore-*.json and passwords in keystore-*.txt. Requires --split-existing-keys.")
-	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech", "The URL to publish the lock file to.")
+	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech/v1", "The URL to publish the lock file to.")
 	flags.BoolVar(&config.Publish, "publish", false, "Publish lock file to obol-api.")
 	flags.StringVar(&config.testnetConfig.Name, "testnet-name", "", "Name of the custom test network.")
 	flags.StringVar(&config.testnetConfig.GenesisForkVersionHex, "testnet-fork-version", "", "Genesis fork version of the custom test network (in hex).")

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -65,7 +65,7 @@ func bindDataDirFlag(flags *pflag.FlagSet, dataDir *string) {
 }
 
 func bindPublishFlags(flags *pflag.FlagSet, config *dkg.Config) {
-	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech", "The URL to publish the cluster to.")
+	flags.StringVar(&config.PublishAddr, "publish-address", "https://api.obol.tech/v1", "The URL to publish the cluster to.")
 	flags.DurationVar(&config.PublishTimeout, "publish-timeout", 30*time.Second, "Timeout for publishing a cluster, consider increasing if the cluster contains more than 200 validators.")
 	flags.BoolVar(&config.Publish, "publish", false, "Publish the created cluster to a remote API.")
 }

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -115,7 +115,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 
 		switch flag {
 		case publishAddress:
-			cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech", maybeRequired("The URL of the remote API."))
+			cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech/v1", maybeRequired("The URL of the remote API."))
 		case beaconNodeEndpoints:
 			cmd.Flags().StringSliceVar(&config.BeaconNodeEndpoints, beaconNodeEndpoints.String(), nil, maybeRequired("Comma separated list of one or more beacon node endpoint URLs."))
 		case privateKeyPath:

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -137,7 +137,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		case publishTimeout:
 			cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 30*time.Second, "Timeout for publishing a signed exit to the publish-address API.")
 		case validatorIndex:
-			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-pubkey is also provided, validator liveliness won't be checked on the beacon chain.")
+			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-public-key is also provided, validator liveliness won't be checked on the beacon chain.")
 		}
 
 		if f.required {

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -137,7 +137,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		case publishTimeout:
 			cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 30*time.Second, "Timeout for publishing a signed exit to the publish-address API.")
 		case validatorIndex:
-			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-public-key is also provided, validator liveliness won't be checked on the beacon chain.")
+			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-public-key is also provided, validator existence won't be checked on the beacon chain.")
 		}
 
 		if f.required {

--- a/cmd/exit_broadcast_internal_test.go
+++ b/cmd/exit_broadcast_internal_test.go
@@ -269,7 +269,7 @@ func Test_runBcastFullExitCmd_Config(t *testing.T) {
 
 			oapiURL := badStr
 			if !test.badOAPIURL {
-				oapiURL = "https://api.obol.tech"
+				oapiURL = "https://api.obol.tech/v1"
 			}
 
 			valAddr := badStr

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -351,7 +351,7 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 
 			oapiURL := badStr
 			if !test.badOAPIURL {
-				oapiURL = "https://api.obol.tech"
+				oapiURL = "https://api.obol.tech/v1"
 			}
 
 			valAddr := badStr

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -105,7 +105,7 @@ const (
 	// measurement tests
 	testVerdictGood testVerdict = "Good"
 	testVerdictAvg  testVerdict = "Avg"
-	testVerdictBad  testVerdict = "Bad"
+	testVerdictPoor testVerdict = "Poor"
 
 	// failed tests
 	testVerdictFail testVerdict = "Fail"
@@ -274,7 +274,7 @@ func calculateScore(results []testResult) categoryScore {
 	avg := 0
 	for _, t := range results {
 		switch t.Verdict {
-		case testVerdictBad:
+		case testVerdictPoor:
 			return categoryScoreC
 		case testVerdictGood:
 			avg++

--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -35,12 +35,12 @@ type testBeaconConfig struct {
 type testCaseBeacon func(context.Context, *testBeaconConfig, string) testResult
 
 const (
-	thresholdBeaconMeasureAvg = 40 * time.Millisecond
-	thresholdBeaconMeasureBad = 100 * time.Millisecond
-	thresholdBeaconLoadAvg    = 40 * time.Millisecond
-	thresholdBeaconLoadBad    = 100 * time.Millisecond
-	thresholdBeaconPeersAvg   = 50
-	thresholdBeaconPeersBad   = 20
+	thresholdBeaconMeasureAvg  = 40 * time.Millisecond
+	thresholdBeaconMeasurePoor = 100 * time.Millisecond
+	thresholdBeaconLoadAvg     = 40 * time.Millisecond
+	thresholdBeaconLoadPoor    = 100 * time.Millisecond
+	thresholdBeaconPeersAvg    = 50
+	thresholdBeaconPeersPoor   = 20
 )
 
 func newTestBeaconCmd(runFunc func(context.Context, io.Writer, testBeaconConfig) error) *cobra.Command {
@@ -278,8 +278,8 @@ func beaconPingMeasureTest(ctx context.Context, _ *testBeaconConfig, target stri
 		return failedTestResult(testRes, err)
 	}
 
-	if rtt > thresholdBeaconMeasureBad {
-		testRes.Verdict = testVerdictBad
+	if rtt > thresholdBeaconMeasurePoor {
+		testRes.Verdict = testVerdictPoor
 	} else if rtt > thresholdBeaconMeasureAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -345,8 +345,8 @@ func beaconPingLoadTest(ctx context.Context, conf *testBeaconConfig, target stri
 			highestRTT = rtt
 		}
 	}
-	if highestRTT > thresholdBeaconLoadBad {
-		testRes.Verdict = testVerdictBad
+	if highestRTT > thresholdBeaconLoadPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if highestRTT > thresholdBeaconLoadAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -441,8 +441,8 @@ func beaconPeerCountTest(ctx context.Context, _ *testBeaconConfig, target string
 
 	testRes.Measurement = strconv.Itoa(respUnmarshaled.Meta.Count)
 
-	if respUnmarshaled.Meta.Count < thresholdBeaconPeersBad {
-		testRes.Verdict = testVerdictBad
+	if respUnmarshaled.Meta.Count < thresholdBeaconPeersPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if respUnmarshaled.Meta.Count < thresholdBeaconPeersAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -26,8 +26,8 @@ type testMEVConfig struct {
 type testCaseMEV func(context.Context, *testMEVConfig, string) testResult
 
 const (
-	thresholdMEVMeasureAvg = 40 * time.Millisecond
-	thresholdMEVMeasureBad = 100 * time.Millisecond
+	thresholdMEVMeasureAvg  = 40 * time.Millisecond
+	thresholdMEVMeasurePoor = 100 * time.Millisecond
 )
 
 func newTestMEVCmd(runFunc func(context.Context, io.Writer, testMEVConfig) error) *cobra.Command {
@@ -250,8 +250,8 @@ func mevPingMeasureTest(ctx context.Context, _ *testMEVConfig, target string) te
 		return failedTestResult(testRes, errors.New("status code %v", z.Int("status_code", resp.StatusCode)))
 	}
 
-	if firstByte > thresholdMEVMeasureBad {
-		testRes.Verdict = testVerdictBad
+	if firstByte > thresholdMEVMeasurePoor {
+		testRes.Verdict = testVerdictPoor
 	} else if firstByte > thresholdMEVMeasureAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -53,12 +53,12 @@ type (
 )
 
 const (
-	thresholdPeersMeasureAvg = 50 * time.Millisecond
-	thresholdPeersMeasureBad = 240 * time.Millisecond
-	thresholdPeersLoadAvg    = 50 * time.Millisecond
-	thresholdPeersLoadBad    = 240 * time.Millisecond
-	thresholdRelayMeasureAvg = 50 * time.Millisecond
-	thresholdRelayMeasureBad = 240 * time.Millisecond
+	thresholdPeersMeasureAvg  = 50 * time.Millisecond
+	thresholdPeersMeasurePoor = 240 * time.Millisecond
+	thresholdPeersLoadAvg     = 50 * time.Millisecond
+	thresholdPeersLoadPoor    = 240 * time.Millisecond
+	thresholdRelayMeasureAvg  = 50 * time.Millisecond
+	thresholdRelayMeasurePoor = 240 * time.Millisecond
 )
 
 func newTestPeersCmd(runFunc func(context.Context, io.Writer, testPeersConfig) error) *cobra.Command {
@@ -605,8 +605,8 @@ func peerPingMeasureTest(ctx context.Context, _ *testPeersConfig, tcpNode host.H
 		return failedTestResult(testRes, result.Error)
 	}
 
-	if result.RTT > thresholdPeersMeasureBad {
-		testRes.Verdict = testVerdictBad
+	if result.RTT > thresholdPeersMeasurePoor {
+		testRes.Verdict = testVerdictPoor
 	} else if result.RTT > thresholdPeersMeasureAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -652,8 +652,8 @@ func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.H
 			highestRTT = val.RTT
 		}
 	}
-	if highestRTT > thresholdPeersLoadBad {
-		testRes.Verdict = testVerdictBad
+	if highestRTT > thresholdPeersLoadPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if highestRTT > thresholdPeersLoadAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -788,8 +788,8 @@ func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string
 		return failedTestResult(testRes, errors.New("status code %v", z.Int("status_code", resp.StatusCode)))
 	}
 
-	if firstByte > thresholdRelayMeasureBad {
-		testRes.Verdict = testVerdictBad
+	if firstByte > thresholdRelayMeasurePoor {
+		testRes.Verdict = testVerdictPoor
 	} else if firstByte > thresholdRelayMeasureAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -121,7 +121,7 @@ func TestPeersTest(t *testing.T) {
 					OutputToml: "",
 					Quiet:      true,
 					TestCases:  nil,
-					Timeout:    200 * time.Millisecond,
+					Timeout:    time.Second,
 				},
 				ENRs: []string{
 					"enr:-HW4QBHlcyD3fYWUMADiOv4OxODaL5wJG0a7P7d_ltu4VZe1MibZ1N-twFaoaq0BoCtXcY71etxLJGeEZT5p3XCO6GOAgmlkgnY0iXNlY3AyNTZrMaEDI2HRUlVBag__njkOWEEQRLlC9ylIVCrIXOuNBSlrx6o",
@@ -188,7 +188,7 @@ func TestPeersTest(t *testing.T) {
 					OutputToml: "",
 					Quiet:      false,
 					TestCases:  []string{"ping"},
-					Timeout:    200 * time.Millisecond,
+					Timeout:    time.Second,
 				},
 				ENRs: []string{
 					"enr:-HW4QBHlcyD3fYWUMADiOv4OxODaL5wJG0a7P7d_ltu4VZe1MibZ1N-twFaoaq0BoCtXcY71etxLJGeEZT5p3XCO6GOAgmlkgnY0iXNlY3AyNTZrMaEDI2HRUlVBag__njkOWEEQRLlC9ylIVCrIXOuNBSlrx6o",

--- a/cmd/testperformance.go
+++ b/cmd/testperformance.go
@@ -34,19 +34,19 @@ type testPerformanceConfig struct {
 }
 
 const (
-	diskWriteLoops               = 5
-	diskWriteMBsAvg              = 1000
-	diskWriteMBsBad              = 500
-	availableMemoryMBsAvg        = 4000
-	availableMemoryMBsBad        = 2000
-	totalMemoryMBsAvg            = 8000
-	totalMemoryMBsBad            = 4000
-	internetLatencyAvg           = 20 * time.Millisecond
-	internetLatencyBad           = 50 * time.Millisecond
-	internetDownloadSpeedMbpsAvg = 50
-	internetDownloadSpeedMbpsBad = 15
-	internetUploadSpeedMbpsAvg   = 50
-	internetUploadSpeedMbpsBad   = 15
+	diskWriteLoops                = 5
+	diskWriteMBsAvg               = 1000
+	diskWriteMBsPoor              = 500
+	availableMemoryMBsAvg         = 4000
+	availableMemoryMBsPoor        = 2000
+	totalMemoryMBsAvg             = 8000
+	totalMemoryMBsPoor            = 4000
+	internetLatencyAvg            = 20 * time.Millisecond
+	internetLatencyPoor           = 50 * time.Millisecond
+	internetDownloadSpeedMbpsAvg  = 50
+	internetDownloadSpeedMbpsPoor = 15
+	internetUploadSpeedMbpsAvg    = 50
+	internetUploadSpeedMbpsPoor   = 15
 )
 
 func newTestPerformanceCmd(runFunc func(context.Context, io.Writer, testPerformanceConfig) error) *cobra.Command {
@@ -227,8 +227,8 @@ func performanceDiskWriteTest(ctx context.Context, conf *testPerformanceConfig) 
 
 	diskWriteFinal := diskWriteTotal / diskWriteLoops
 
-	if diskWriteFinal < diskWriteMBsBad {
-		testRes.Verdict = testVerdictBad
+	if diskWriteFinal < diskWriteMBsPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if diskWriteFinal < diskWriteMBsAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -388,8 +388,8 @@ func performanceAvailableMemoryTest(ctx context.Context, _ *testPerformanceConfi
 
 	availableMemoryMB := availableMemory / 1024 / 1024
 
-	if availableMemoryMB < availableMemoryMBsBad {
-		testRes.Verdict = testVerdictBad
+	if availableMemoryMB < availableMemoryMBsPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if availableMemoryMB < availableMemoryMBsAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -466,8 +466,8 @@ func performanceTotalMemoryTest(ctx context.Context, _ *testPerformanceConfig) t
 
 	totalMemoryMB := totalMemory / 1024 / 1024
 
-	if totalMemoryMB < totalMemoryMBsBad {
-		testRes.Verdict = testVerdictBad
+	if totalMemoryMB < totalMemoryMBsPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if totalMemoryMB < totalMemoryMBsAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -537,8 +537,8 @@ func performanceInternetLatencyTest(ctx context.Context, conf *testPerformanceCo
 	}
 	latency := server.Latency
 
-	if latency > internetLatencyBad {
-		testRes.Verdict = testVerdictBad
+	if latency > internetLatencyPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if latency > internetLatencyAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -569,8 +569,8 @@ func performanceInternetDownloadSpeedTest(ctx context.Context, conf *testPerform
 	}
 	downloadSpeed := server.DLSpeed.Mbps()
 
-	if downloadSpeed < internetDownloadSpeedMbpsBad {
-		testRes.Verdict = testVerdictBad
+	if downloadSpeed < internetDownloadSpeedMbpsPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if downloadSpeed < internetDownloadSpeedMbpsAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -601,8 +601,8 @@ func performanceInternetUploadSpeedTest(ctx context.Context, conf *testPerforman
 	}
 	uploadSpeed := server.ULSpeed.Mbps()
 
-	if uploadSpeed < internetUploadSpeedMbpsBad {
-		testRes.Verdict = testVerdictBad
+	if uploadSpeed < internetUploadSpeedMbpsPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if uploadSpeed < internetUploadSpeedMbpsAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {

--- a/cmd/testperformance_internal_test.go
+++ b/cmd/testperformance_internal_test.go
@@ -41,10 +41,10 @@ func TestPerformanceTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					"local": {
-						{Name: "diskWrite", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "availableMemory", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "totalMemory", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "internetLatency", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "diskWrite", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "availableMemory", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "totalMemory", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "internetLatency", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
 				},
 				Score:        categoryScoreC,
@@ -88,10 +88,10 @@ func TestPerformanceTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					"local": {
-						{Name: "diskWrite", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "availableMemory", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "totalMemory", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "internetLatency", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "diskWrite", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "availableMemory", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "totalMemory", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "internetLatency", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
 				},
 				Score:        categoryScoreC,
@@ -130,7 +130,7 @@ func TestPerformanceTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					"local": {
-						{Name: "diskWrite", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "diskWrite", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
 				},
 				Score:        categoryScoreC,
@@ -152,10 +152,10 @@ func TestPerformanceTest(t *testing.T) {
 			expected: testCategoryResult{
 				Targets: map[string][]testResult{
 					"local": {
-						{Name: "diskWrite", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "availableMemory", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "totalMemory", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
-						{Name: "internetLatency", Verdict: testVerdictBad, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "diskWrite", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "availableMemory", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "totalMemory", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
+						{Name: "internetLatency", Verdict: testVerdictPoor, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
 				},
 				Score:        categoryScoreC,

--- a/cmd/testvalidator.go
+++ b/cmd/testvalidator.go
@@ -26,10 +26,10 @@ type testValidatorConfig struct {
 }
 
 const (
-	thresholdValidatorMeasureAvg = 50 * time.Millisecond
-	thresholdValidatorMeasureBad = 240 * time.Millisecond
-	thresholdValidatorLoadAvg    = 50 * time.Millisecond
-	thresholdValidatorLoadBad    = 240 * time.Millisecond
+	thresholdValidatorMeasureAvg  = 50 * time.Millisecond
+	thresholdValidatorMeasurePoor = 240 * time.Millisecond
+	thresholdValidatorLoadAvg     = 50 * time.Millisecond
+	thresholdValidatorLoadPoor    = 240 * time.Millisecond
 )
 
 func newTestValidatorCmd(runFunc func(context.Context, io.Writer, testValidatorConfig) error) *cobra.Command {
@@ -194,8 +194,8 @@ func validatorPingMeasureTest(ctx context.Context, conf *testValidatorConfig) te
 	defer conn.Close()
 	rtt := time.Since(before)
 
-	if rtt > thresholdValidatorMeasureBad {
-		testRes.Verdict = testVerdictBad
+	if rtt > thresholdValidatorMeasurePoor {
+		testRes.Verdict = testVerdictPoor
 	} else if rtt > thresholdValidatorMeasureAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {
@@ -264,8 +264,8 @@ func validatorPingLoadTest(ctx context.Context, conf *testValidatorConfig) testR
 			highestRTT = rtt
 		}
 	}
-	if highestRTT > thresholdValidatorLoadBad {
-		testRes.Verdict = testVerdictBad
+	if highestRTT > thresholdValidatorLoadPoor {
+		testRes.Verdict = testVerdictPoor
 	} else if highestRTT > thresholdValidatorLoadAvg {
 		testRes.Verdict = testVerdictAvg
 	} else {

--- a/testutil/compose/static/vouch/Dockerfile
+++ b/testutil/compose/static/vouch/Dockerfile
@@ -1,4 +1,4 @@
-FROM wealdtech/ethdo:1.30.0 as ethdo
+FROM wealdtech/ethdo:1.35.2 as ethdo
 
 FROM attestant/vouch:1.8.2
 


### PR DESCRIPTION
- Change Obol's API default URL in flags to include `/v1`
- validator-pubkey to validator-public-key in flag description
- Rename test command measurement from Bad to Poor
- Increase test peer unit tests timeout
- bump ethdo version in compose tests to 1.35.2

category: misc
ticket: none
