### PR TITLE
cmd: add file to homedir for fio in main-v1.1

### DIFF
--- a/cmd/testperformance.go
+++ b/cmd/testperformance.go
@@ -221,7 +221,7 @@ func fioCommand(ctx context.Context, filename string, blocksize int, operation s
 	//nolint:gosec
 	cmd, err := exec.CommandContext(ctx, "fio",
 		"--name=fioTest",
-		fmt.Sprintf("--filename=%v", filename),
+		fmt.Sprintf("--filename=%v/fiotest", filename),
 		fmt.Sprintf("--size=%vMb", diskOpsMBsTotal/diskOpsNumOfJobs),
 		fmt.Sprintf("--blocksize=%vk", blocksize),
 		fmt.Sprintf("--numjobs=%v", diskOpsNumOfJobs),


### PR DESCRIPTION
Add file for test and do not use a dir (the homedir in the default scenario).

category: bug
ticket: none
