### PR TITLE
testutil/promrated: fixing promrated network overview stats

### DIFF
--- a/testutil/promrated/rated.go
+++ b/testutil/promrated/rated.go
@@ -35,7 +35,7 @@ func getNetworkStatistics(ctx context.Context, ratedEndpoint string, ratedAuth s
 		return networkEffectivenessData{}, errors.Wrap(err, "parse rated endpoint")
 	}
 
-	url.Path = "/v0/eth/network/stats"
+	url.Path = "/v0/eth/network/overview"
 
 	body, err := queryRatedAPI(ctx, url, ratedAuth, network)
 	if err != nil {

--- a/testutil/promrated/rated_internal_test.go
+++ b/testutil/promrated/rated_internal_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestGetNetworkStatistics(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, "/v0/eth/network/stats", r.URL.Path)
+		require.Equal(t, "/v0/eth/network/overview", r.URL.Path)
 
 		require.Equal(t, "Bearer auth", r.Header.Get("Authorization"))
 		require.Equal(t, "prater", r.Header.Get("X-Rated-Network"))


### PR DESCRIPTION
Rated api seemed to change the url for this endpoint 👍🏼 

category: misc
ticket: #3233