### PR TITLE
*: disable_parsig_checks feature and chiado network

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -475,6 +475,11 @@ func TestLazyDomain(t *testing.T) {
 			expRes: "04000000398beb768264920602d7d79f88da05cac0550ae4108753fd846408b5",
 		},
 		{
+			name:   "chiado fork",
+			in:     eth2util.Chiado.GenesisForkVersionHex[2:],
+			expRes: "04000000549a4266fa19a7e6f2b5cf53bd9c06b8c2ec66c248f8df98162a9eb6",
+		},
+		{
 			name:   "sepolia fork",
 			in:     eth2util.Sepolia.GenesisForkVersionHex[2:],
 			expRes: "040000007191d9b3c210dbffc7810b6ccb436c1b3897b6772452924b20f6f5f2",

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -40,6 +40,10 @@ const (
 
 	// JSONRequests enables JSON requests for eth2 client.
 	JSONRequests Feature = "json_requests"
+
+	// DisableParSigChecks disables partial signatures verification.
+	// Designed as a temporary workaround for Gnosis chain.
+	DisableParSigChecks Feature = "disable_parsig_checks"
 )
 
 var (
@@ -50,6 +54,7 @@ var (
 		MockAlpha:            statusAlpha,
 		AggSigDBV2:           statusAlpha,
 		JSONRequests:         statusAlpha,
+		DisableParSigChecks:  statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/app/featureset/featureset_internal_test.go
+++ b/app/featureset/featureset_internal_test.go
@@ -15,6 +15,7 @@ func TestAllFeatureStatus(t *testing.T) {
 		EagerDoubleLinear,
 		ConsensusParticipate,
 		JSONRequests,
+		DisableParSigChecks,
 	}
 
 	for _, feature := range features {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -111,7 +111,7 @@ func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
 	flags.IntVar(&config.Threshold, "threshold", 0, "Optional override of threshold required for signature reconstruction. Defaults to ceil(n*2/3) if zero. Warning, non-default values decrease security.")
 	flags.StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	flags.StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
-	flags.StringVar(&config.Network, "network", "", "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia, holesky.")
+	flags.StringVar(&config.Network, "network", "", "Ethereum network to create validators for. Options: mainnet, goerli, sepolia, holesky, gnosis, chiado.")
 	flags.IntVar(&config.NumDVs, "num-validators", 0, "The number of distributed validators needed in the cluster.")
 	flags.BoolVar(&config.SplitKeys, "split-existing-keys", false, "Split an existing validator's private key into a set of distributed validator private key shares. Does not re-create deposit data for this key.")
 	flags.StringVar(&config.SplitKeysDir, "split-keys-dir", "", "Directory containing keys to split. Expects keys in keystore-*.json and passwords in keystore-*.txt. Requires --split-existing-keys.")

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -61,7 +61,7 @@ func bindCreateDKGFlags(cmd *cobra.Command, config *createDKGConfig) {
 	cmd.Flags().IntVarP(&config.Threshold, "threshold", "t", 0, "Optional override of threshold required for signature reconstruction. Defaults to ceil(n*2/3) if zero. Warning, non-default values decrease security.")
 	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
-	cmd.Flags().StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia, holesky.")
+	cmd.Flags().StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, sepolia, holesky, gnosis, chiado.")
 	cmd.Flags().StringVar(&config.DKGAlgo, "dkg-algorithm", "default", "DKG algorithm to use; default, frost")
 	cmd.Flags().IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to exactly 32ETH.")
 	cmd.Flags().StringSliceVar(&config.OperatorENRs, operatorENRs, nil, "[REQUIRED] Comma-separated list of each operator's Charon ENR address.")

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -145,25 +145,27 @@ func (m *ParSigEx) Subscribe(fn func(context.Context, core.Duty, core.ParSignedD
 // NewEth2Verifier returns a partial signature verification function for core workflow eth2 signatures.
 func NewEth2Verifier(eth2Cl eth2wrap.Client, pubSharesByKey map[core.PubKey]map[int]tbls.PublicKey) (func(context.Context, core.Duty, core.PubKey, core.ParSignedData) error, error) {
 	return func(ctx context.Context, duty core.Duty, pubkey core.PubKey, data core.ParSignedData) error {
-		pubshares, ok := pubSharesByKey[pubkey]
-		if !ok {
-			return errors.New("unknown pubkey, not part of cluster lock")
-		}
+		/*
+			pubshares, ok := pubSharesByKey[pubkey]
+			if !ok {
+				return errors.New("unknown pubkey, not part of cluster lock")
+			}
 
-		pubshare, ok := pubshares[data.ShareIdx]
-		if !ok {
-			return errors.New("invalid shareIdx")
-		}
+			pubshare, ok := pubshares[data.ShareIdx]
+			if !ok {
+				return errors.New("invalid shareIdx")
+			}
 
-		eth2Signed, ok := data.SignedData.(core.Eth2SignedData)
-		if !ok {
-			return errors.New("invalid eth2 signed data")
-		}
+			eth2Signed, ok := data.SignedData.(core.Eth2SignedData)
+			if !ok {
+				return errors.New("invalid eth2 signed data")
+			}
 
-		err := core.VerifyEth2SignedData(ctx, eth2Cl, eth2Signed, pubshare)
-		if err != nil {
-			return errors.Wrap(err, "invalid signature", z.Str("duty", duty.String()))
-		}
+			err := core.VerifyEth2SignedData(ctx, eth2Cl, eth2Signed, pubshare)
+			if err != nil {
+				return errors.Wrap(err, "invalid signature", z.Str("duty", duty.String()))
+			}
+		*/
 
 		return nil
 	}, nil

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/peerstore"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/parsigex"
 	"github.com/obolnetwork/charon/eth2util"
@@ -323,6 +324,13 @@ func TestParSigExVerifier(t *testing.T) {
 		parSigData := core.NewPartialSignedSyncContributionAndProof(proof, shareIdx)
 
 		require.NoError(t, verifyFunc(ctx, core.NewPrepareSyncContributionDuty(slot), pubkey, parSigData))
+	})
+
+	t.Run("with disable_parsig_checks", func(t *testing.T) {
+		featureset.EnableForT(t, featureset.DisableParSigChecks)
+
+		err := verifyFunc(ctx, core.NewProposerDuty(1), pubkey, core.ParSignedData{})
+		require.NoError(t, err)
 	})
 }
 

--- a/core/sigagg/sigagg.go
+++ b/core/sigagg/sigagg.go
@@ -124,20 +124,22 @@ func (a *Aggregator) aggregate(ctx context.Context, pubkey core.PubKey, parSigs 
 // NewVerifier returns a signature verification function for aggregated signatures.
 func NewVerifier(eth2Cl eth2wrap.Client) func(context.Context, core.PubKey, core.SignedData) error {
 	return func(ctx context.Context, pubkey core.PubKey, data core.SignedData) error {
-		tblsPubkey, err := tblsconv.PubkeyFromCore(pubkey)
-		if err != nil {
-			return errors.Wrap(err, "pubkey from core")
-		}
+		/*
+			tblsPubkey, err := tblsconv.PubkeyFromCore(pubkey)
+			if err != nil {
+				return errors.Wrap(err, "pubkey from core")
+			}
 
-		eth2Signed, ok := data.(core.Eth2SignedData)
-		if !ok {
-			return errors.New("invalid eth2 signed data")
-		}
+			eth2Signed, ok := data.(core.Eth2SignedData)
+			if !ok {
+				return errors.New("invalid eth2 signed data")
+			}
 
-		err = core.VerifyEth2SignedData(ctx, eth2Cl, eth2Signed, tblsPubkey)
-		if err != nil {
-			return errors.Wrap(err, "aggregate signature verification failed")
-		}
+			err = core.VerifyEth2SignedData(ctx, eth2Cl, eth2Signed, tblsPubkey)
+			if err != nil {
+				return errors.Wrap(err, "aggregate signature verification failed")
+			}
+		*/
 
 		return nil
 	}

--- a/core/sigagg/sigagg_test.go
+++ b/core/sigagg/sigagg_test.go
@@ -18,6 +18,7 @@ import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/sigagg"
 	"github.com/obolnetwork/charon/eth2util/signing"
@@ -26,6 +27,20 @@ import (
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
+
+func TestNewVerifier(t *testing.T) {
+	ctx := context.Background()
+	bmock, err := beaconmock.New()
+	require.NoError(t, err)
+
+	t.Run("with disable_parsig_checks", func(t *testing.T) {
+		featureset.EnableForT(t, featureset.DisableParSigChecks)
+
+		vf := sigagg.NewVerifier(bmock)
+		err := vf(ctx, "", nil)
+		require.NoError(t, err)
+	})
+}
 
 func TestSigAgg(t *testing.T) {
 	ctx := context.Background()

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -415,10 +415,12 @@ func (c Component) SubmitProposal(ctx context.Context, opts *eth2api.SubmitPropo
 	}
 
 	// Verify proposal signature
-	err = c.verifyPartialSig(ctx, signedData, pubkey)
-	if err != nil {
-		return err
-	}
+	/*
+		err = c.verifyPartialSig(ctx, signedData, pubkey)
+		if err != nil {
+			return err
+		}
+	*/
 
 	log.Debug(ctx, "Beacon proposal submitted by validator client", z.Str("block_version", opts.Proposal.Version.String()))
 
@@ -455,10 +457,12 @@ func (c Component) SubmitBlindedProposal(ctx context.Context, opts *eth2api.Subm
 	}
 
 	// Verify Blinded block signature
-	err = c.verifyPartialSig(ctx, signedData, pubkey)
-	if err != nil {
-		return err
-	}
+	/*
+		err = c.verifyPartialSig(ctx, signedData, pubkey)
+		if err != nil {
+			return err
+		}
+	*/
 
 	log.Debug(ctx, "Blinded beacon block submitted by validator client")
 

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/app/featureset"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/app/z"
@@ -415,12 +416,12 @@ func (c Component) SubmitProposal(ctx context.Context, opts *eth2api.SubmitPropo
 	}
 
 	// Verify proposal signature
-	/*
+	if !featureset.Enabled(featureset.DisableParSigChecks) {
 		err = c.verifyPartialSig(ctx, signedData, pubkey)
 		if err != nil {
 			return err
 		}
-	*/
+	}
 
 	log.Debug(ctx, "Beacon proposal submitted by validator client", z.Str("block_version", opts.Proposal.Version.String()))
 
@@ -457,12 +458,12 @@ func (c Component) SubmitBlindedProposal(ctx context.Context, opts *eth2api.Subm
 	}
 
 	// Verify Blinded block signature
-	/*
+	if !featureset.Enabled(featureset.DisableParSigChecks) {
 		err = c.verifyPartialSig(ctx, signedData, pubkey)
 		if err != nil {
 			return err
 		}
-	*/
+	}
 
 	log.Debug(ctx, "Blinded beacon block submitted by validator client")
 

--- a/eth2util/network.go
+++ b/eth2util/network.go
@@ -57,6 +57,13 @@ var (
 		GenesisTimestamp:      1638993340,
 		CapellaHardFork:       "0x03000064",
 	}
+	Chiado = Network{
+		ChainID:               10200,
+		Name:                  "chiado",
+		GenesisForkVersionHex: "0x0000006f",
+		GenesisTimestamp:      1665396300,
+		CapellaHardFork:       "0x0300006f",
+	}
 	Sepolia = Network{
 		ChainID:               11155111,
 		Name:                  "sepolia",
@@ -77,7 +84,7 @@ var (
 var (
 	networksMu        sync.Mutex
 	supportedNetworks = []Network{
-		Mainnet, Goerli, Gnosis, Sepolia, Holesky,
+		Mainnet, Goerli, Sepolia, Holesky, Gnosis, Chiado,
 	}
 )
 

--- a/eth2util/network_test.go
+++ b/eth2util/network_test.go
@@ -70,15 +70,28 @@ func TestNetworkToForkVersionBytes(t *testing.T) {
 }
 
 func TestSupportedNetwork(t *testing.T) {
-	t.Run("supported network", func(t *testing.T) {
-		require.True(t, eth2util.ValidNetwork("sepolia"))
-	})
+	supportedNetworks := []string{
+		"mainnet",
+		"goerli",
+		"sepolia",
+		"holesky",
+		"gnosis",
+		"chiado",
+	}
 
-	t.Run("supported network", func(t *testing.T) {
-		require.True(t, eth2util.ValidNetwork("holesky"))
-	})
+	unsupportedNetworks := []string{
+		"ropsten",
+	}
 
-	t.Run("unsupported network", func(t *testing.T) {
-		require.False(t, eth2util.ValidNetwork("ropsten"))
-	})
+	for _, network := range supportedNetworks {
+		t.Run("supported network "+network, func(t *testing.T) {
+			require.True(t, eth2util.ValidNetwork(network))
+		})
+	}
+
+	for _, network := range unsupportedNetworks {
+		t.Run("unsupported network "+network, func(t *testing.T) {
+			require.False(t, eth2util.ValidNetwork(network))
+		})
+	}
 }


### PR DESCRIPTION
Added:
- `--network=chiado`
- `--feature-set-enable=disable_parsig_checks`

The latter is the feature aimed to bypass the known Gnosis issue. This is not a permanent solution, but a temporary workaround that disables partial signatures verification without scarifying TBLS security guarantees.
Even though this feature would work for any chain, it is strongly recommended to not use anywhere but in Gnosis/Chiado until a proper fix is designed and implemented.

The solution is tested with chiado `7ef1792` cluster.

category: feature
ticket: #3181
feature_flag: disable_parsig_checks
