### PR TITLE
cmd: hardening threshold parameter checks

### DIFF
--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"encoding/json"
+	"math"
 	"os"
 	"path"
 
@@ -181,14 +182,15 @@ func validateWithdrawalAddrs(addrs []string, network string) error {
 
 // validateDKGConfig returns an error if any of the provided config parameter is invalid.
 func validateDKGConfig(threshold, numOperators int, network string, depositAmounts []int) error {
-	// Don't allow cluster size to be less than 4.
+	// Don't allow cluster size to be less than 3.
 	if numOperators < minNodes {
-		return errors.New("insufficient operator ENRs", z.Int("count", numOperators), z.Int("min", minNodes))
+		return errors.New("number of operators is below minimum", z.Int("operators", numOperators), z.Int("min", minNodes))
 	}
 
 	// Ensure threshold setting is sound
+	minThreshold := int(math.Ceil(float64(numOperators*2) / 3))
 	if threshold < minThreshold {
-		return errors.New("threshold cannot be smaller than 2", z.Int("threshold", threshold))
+		return errors.New("threshold cannot be smaller than BFT quorum", z.Int("threshold", threshold), z.Int("min", minThreshold))
 	}
 	if threshold > numOperators {
 		return errors.New("threshold cannot be greater than length of operators",

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -94,11 +94,11 @@ func TestCreateDkgInvalid(t *testing.T) {
 		},
 		{
 			conf:   createDKGConfig{OperatorENRs: []string{""}},
-			errMsg: "insufficient operator ENRs",
+			errMsg: "number of operators is below minimum",
 		},
 		{
 			conf:   createDKGConfig{},
-			errMsg: "insufficient operator ENRs",
+			errMsg: "number of operators is below minimum",
 		},
 	}
 
@@ -124,7 +124,7 @@ func TestRequireOperatorENRFlag(t *testing.T) {
 		{
 			name: "operator ENRs less than threshold",
 			args: []string{"dkg", "--operator-enrs=enr:-JG4QG472ZVvl8ySSnUK9uNVDrP_hjkUrUqIxUC75aayzmDVQedXkjbqc7QKyOOS71VmlqnYzri_taV8ZesFYaoQSIOGAYHtv1WsgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKwwq_CAld6oVKOrixE-JzMtvvNgb9yyI-_rwq4NFtajIN0Y3CCDhqDdWRwgg4u", "--fee-recipient-addresses=0xa6430105220d0b29688b734b8ea0f3ca9936e846", "--withdrawal-addresses=0xa6430105220d0b29688b734b8ea0f3ca9936e846"},
-			err:  "insufficient operator ENRs",
+			err:  "number of operators is below minimum",
 		},
 	}
 
@@ -195,14 +195,14 @@ func TestValidateDKGConfig(t *testing.T) {
 		threshold := 1
 		numOperators := 3
 		err := validateDKGConfig(threshold, numOperators, "", nil)
-		require.ErrorContains(t, err, "threshold cannot be smaller than 2")
+		require.ErrorContains(t, err, "threshold cannot be smaller than BFT quorum")
 	})
 
 	t.Run("insufficient ENRs", func(t *testing.T) {
 		threshold := 2
 		numOperators := 2
 		err := validateDKGConfig(threshold, numOperators, "", nil)
-		require.ErrorContains(t, err, "insufficient operator ENRs")
+		require.ErrorContains(t, err, "number of operators is below minimum")
 	})
 
 	t.Run("invalid network", func(t *testing.T) {


### PR DESCRIPTION
Ensure the threshold parameter given as input to the `create dkg` and `create cluster` commands is sound.

category: bug
ticket: #3241 
