### PR TITLE
cmd: unified create validation

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -324,6 +324,16 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 		return errors.New("missing --nodes flag")
 	}
 
+	if conf.Threshold > conf.NumNodes {
+		return errors.New("threshold cannot be greater than number of nodes",
+			z.Int("threshold", conf.Threshold), z.Int("nodes", conf.NumNodes))
+	}
+
+	// Don't allow cluster size to be less than 3.
+	if conf.NumNodes < minNodes {
+		return errors.New("number of nodes is below minimum", z.Int("nodes", conf.NumNodes), z.Int("min", minNodes))
+	}
+
 	// Check for valid network configuration.
 	if err := validateNetworkConfig(conf); err != nil {
 		return errors.Wrap(err, "get network config")

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -39,6 +39,10 @@ func TestCreateCluster(t *testing.T) {
 	def, err := loadDefinition(context.Background(), defPath)
 	require.NoError(t, err)
 
+	defPathTwoNodes := "../cluster/examples/cluster-definition-001.json"
+	defTwoNodes, err := loadDefinition(context.Background(), defPathTwoNodes)
+	require.NoError(t, err)
+
 	tests := []struct {
 		Name            string
 		Config          clusterConfig
@@ -218,7 +222,7 @@ func TestCreateCluster(t *testing.T) {
 			Config: clusterConfig{
 				Name:      "test_cluster",
 				NumNodes:  3,
-				Threshold: 4,
+				Threshold: 3,
 				NumDVs:    5,
 				Network:   "goerli",
 			},
@@ -230,6 +234,34 @@ func TestCreateCluster(t *testing.T) {
 
 				return config
 			},
+		},
+		{
+			Name: "test with threshold larger than number of nodes",
+			Config: clusterConfig{
+				Name:      "test_cluster",
+				NumNodes:  3,
+				Threshold: 4,
+				NumDVs:    5,
+				Network:   "goerli",
+			},
+			expectedErr: "threshold cannot be greater than number of nodes",
+		},
+		{
+			Name: "test with number of nodes below minimum",
+			Config: clusterConfig{
+				Name:      "test_cluster",
+				NumNodes:  2,
+				Threshold: 2,
+				NumDVs:    1,
+				Network:   "goerli",
+			},
+			defFileProvider: func() []byte {
+				data, err := json.Marshal(defTwoNodes)
+				require.NoError(t, err)
+
+				return data
+			},
+			expectedErr: "number of nodes is below minimum",
 		},
 		{
 			Name: "custom testnet flags",

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -186,9 +186,9 @@ func validateDKGConfig(threshold, numOperators int, network string, depositAmoun
 			z.Int("threshold", threshold), z.Int("operators", numOperators))
 	}
 
-	// Don't allow cluster size to be less than 4.
+	// Don't allow cluster size to be less than 3.
 	if numOperators < minNodes {
-		return errors.New("insufficient operator ENRs", z.Int("count", numOperators), z.Int("min", minNodes))
+		return errors.New("number of operators is below minimum", z.Int("operators", numOperators), z.Int("min", minNodes))
 	}
 
 	if !eth2util.ValidNetwork(network) {

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -90,11 +90,11 @@ func TestCreateDkgInvalid(t *testing.T) {
 		},
 		{
 			conf:   createDKGConfig{OperatorENRs: []string{""}},
-			errMsg: "insufficient operator ENRs",
+			errMsg: "number of operators is below minimum",
 		},
 		{
 			conf:   createDKGConfig{},
-			errMsg: "insufficient operator ENRs",
+			errMsg: "number of operators is below minimum",
 		},
 	}
 
@@ -120,7 +120,7 @@ func TestRequireOperatorENRFlag(t *testing.T) {
 		{
 			name: "operator ENRs less than threshold",
 			args: []string{"dkg", "--operator-enrs=enr:-JG4QG472ZVvl8ySSnUK9uNVDrP_hjkUrUqIxUC75aayzmDVQedXkjbqc7QKyOOS71VmlqnYzri_taV8ZesFYaoQSIOGAYHtv1WsgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQKwwq_CAld6oVKOrixE-JzMtvvNgb9yyI-_rwq4NFtajIN0Y3CCDhqDdWRwgg4u", "--fee-recipient-addresses=0xa6430105220d0b29688b734b8ea0f3ca9936e846", "--withdrawal-addresses=0xa6430105220d0b29688b734b8ea0f3ca9936e846"},
-			err:  "insufficient operator ENRs",
+			err:  "number of operators is below minimum",
 		},
 	}
 
@@ -186,11 +186,11 @@ func TestValidateDKGConfig(t *testing.T) {
 		require.ErrorContains(t, err, "threshold cannot be greater than length of operators")
 	})
 
-	t.Run("insufficient ENRs", func(t *testing.T) {
+	t.Run("number of operators is below minimum", func(t *testing.T) {
 		threshold := 1
 		numOperators := 2
 		err := validateDKGConfig(threshold, numOperators, "", nil)
-		require.ErrorContains(t, err, "insufficient operator ENRs")
+		require.ErrorContains(t, err, "number of operators is below minimum")
 	})
 
 	t.Run("invalid network", func(t *testing.T) {


### PR DESCRIPTION
Unified `create cluster` and `create dkg` commands validation:
* The minimum number of nodes (operators) is 3.
* The threshold cannot be greater than the number of nodes (operators).

category: refactor
ticket: none