### PR TITLE
cmd: refactor exits

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -22,7 +22,7 @@ type exitConfig struct {
 	ValidatorPubkey       string
 	ValidatorIndex        uint64
 	ValidatorIndexPresent bool
-	ExpertMode            bool
+	SkipBeaconNodeCheck   bool
 	PrivateKeyPath        string
 	ValidatorKeysDir      string
 	LockFilePath          string

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -60,7 +60,7 @@ func newSubmitPartialExitCmd(runFunc func(context.Context, exitConfig) error) *c
 		valIdxPresent := cmd.Flags().Lookup(validatorIndex.String()).Changed
 		valPubkPresent := cmd.Flags().Lookup(validatorPubkey.String()).Changed
 
-		if valIdxPresent && !valIdxPresent {
+		if !valPubkPresent && !valIdxPresent {
 			//nolint:revive // we use our own version of the errors package.
 			return errors.New(fmt.Sprintf("either %s or %s must be specified at least.", validatorIndex.String(), validatorPubkey.String()))
 		}
@@ -115,14 +115,12 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "cannot create eth2 client for specified beacon node")
 	}
 
-	logFields := []z.Field{}
 	if config.ValidatorIndexPresent {
-		logFields = append(logFields, z.U64("validator_index", config.ValidatorIndex))
+		ctx = log.WithCtx(ctx, z.U64("validator_index", config.ValidatorIndex))
 	}
 	if config.ValidatorPubkey != "" {
-		logFields = append(logFields, z.Str("validator_pubkey", config.ValidatorPubkey))
+		ctx = log.WithCtx(ctx, z.Str("validator_pubkey", config.ValidatorPubkey))
 	}
-	ctx = log.WithCtx(ctx, logFields...)
 
 	if config.SkipBeaconNodeCheck {
 		log.Info(ctx, "Both public key and index are specified, beacon node won't be checked for validator existence/liveness")

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -61,6 +61,7 @@ func newSubmitPartialExitCmd(runFunc func(context.Context, exitConfig) error) *c
 		valPubkPresent := cmd.Flags().Lookup(validatorPubkey.String()).Changed
 
 		if valIdxPresent && !valIdxPresent {
+			//nolint:revive // we use our own version of the errors package.
 			return errors.New(fmt.Sprintf("either %s or %s must be specified at least.", validatorIndex.String(), validatorPubkey.String()))
 		}
 
@@ -169,6 +170,7 @@ func fetchValidatorBLSPubKey(ctx context.Context, config exitConfig, eth2Cl eth2
 		if err != nil {
 			return eth2p0.BLSPubKey{}, errors.Wrap(err, "cannot convert validator pubkey to bytes")
 		}
+
 		return valEth2, nil
 	}
 
@@ -213,7 +215,7 @@ func fetchValidatorIndex(ctx context.Context, config exitConfig, eth2Cl eth2wrap
 
 	for _, val := range rawValData.Data {
 		if val.Validator.PublicKey == valEth2 {
-			return eth2p0.ValidatorIndex(val.Index), nil
+			return val.Index, nil
 		}
 	}
 

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -92,7 +92,7 @@ func Test_runSubmitPartialExit(t *testing.T) {
 		)
 	})
 
-	t.Run("main flow with expert mode with bad pubkey", func(t *testing.T) {
+	t.Run("main flow with skipBeaconNodeCheck mode with bad pubkey", func(t *testing.T) {
 		runSubmitPartialExitFlowTest(
 			t,
 			true,
@@ -103,7 +103,7 @@ func Test_runSubmitPartialExit(t *testing.T) {
 		)
 	})
 
-	t.Run("main flow with expert mode with pubkey not found in cluster lock", func(t *testing.T) {
+	t.Run("main flow with skipBeaconNodeCheck mode with pubkey not found in cluster lock", func(t *testing.T) {
 		runSubmitPartialExitFlowTest(
 			t,
 			true,
@@ -120,14 +120,14 @@ func Test_runSubmitPartialExit(t *testing.T) {
 	t.Run("main flow with validator index", func(t *testing.T) {
 		runSubmitPartialExitFlowTest(t, true, false, "", 0, "")
 	})
-	t.Run("main flow with expert mode", func(t *testing.T) {
+	t.Run("main flow with skipBeaconNodeCheck mode", func(t *testing.T) {
 		runSubmitPartialExitFlowTest(t, true, true, "", 0, "")
 	})
 
 	t.Run("config", Test_runSubmitPartialExit_Config)
 }
 
-func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, expertMode bool, valPubkey string, valIndex uint64, errString string) {
+func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, skipBeaconNodeCheck bool, valPubkey string, valIndex uint64, errString string) {
 	t.Helper()
 	t.Parallel()
 	ctx := context.Background()
@@ -215,11 +215,11 @@ func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, expertMode bool,
 		pubkey = valPubkey
 	}
 
-	if expertMode {
+	if skipBeaconNodeCheck {
 		config.ValidatorIndex = index
 		config.ValidatorIndexPresent = true
 		config.ValidatorPubkey = pubkey
-		config.ExpertMode = true
+		config.SkipBeaconNodeCheck = true
 	} else {
 		if useValIdx {
 			config.ValidatorIndex = index


### PR DESCRIPTION
Refactor exits logic. There is no change in the logic anywhere. The main differences are:
- fetching the validator index and validator pub key are in separate functions, which makes it more readable what is the flow
- `ExpertMode` is renamed to `SkipBeaconNodeCheck` as this is essentially what it does

If others agree, I'm in favour of completely removing the `SkipBeaconNodeCheck` config, as it is unnecessary.

category: refactor
ticket: none
