### PR TITLE
testutil: update docker-compose command to docker compose

### DIFF
--- a/p2p/bootnode.go
+++ b/p2p/bootnode.go
@@ -122,7 +122,7 @@ func resolveRelay(ctx context.Context, rawURL, lockHashHex string, callback func
 // queryRelayAddrs returns the relay multiaddrs via a http GET query to the url.
 //
 // This supports resolving relay addrs from known http URLs which is handy
-// when relays are deployed in docker-compose or kubernetes
+// when relays are deployed in docker compose or kubernetes
 //
 // It retries until the context is cancelled.
 func queryRelayAddrs(ctx context.Context, relayURL string, backoff func(), lockHashHex string) ([]ma.Multiaddr, error) {

--- a/testutil/compose/README.md
+++ b/testutil/compose/README.md
@@ -1,6 +1,6 @@
 # Charon Compose
 
-> Run, test, and debug a developer-focussed insecure local charon cluster using docker-compose
+> Run, test, and debug a developer-focussed insecure local charon cluster using docker compose
 
 Compose is a tool that generates `docker-compose.yml` files such that different charon clusters can be created and run.
 
@@ -16,7 +16,7 @@ The `compose` command also includes some convenience functions.
 - `compose clean`: Cleans the compose directory of existing files.
 - `compose auto`: Runs `compose define && compose lock && compose run`.
 
-Note that compose automatically runs `docker-compose up` at the end of each command. This can be disabled via `--up=false`.
+Note that compose automatically runs `docker compose up` at the end of each command. This can be disabled via `--up=false`.
 
 The `compose new` step configures the target cluster and key generation process. See `compose new --help` for supported flags.
 

--- a/testutil/compose/alert.go
+++ b/testutil/compose/alert.go
@@ -33,7 +33,7 @@ func startAlertCollector(ctx context.Context, dir string) chan string {
 		// Time required to wait for prometheus container to start.
 		time.Sleep(time.Second * 10)
 		for ; ctx.Err() == nil; time.Sleep(iterSleep) { // Sleep for iterSleep before next iteration.
-			cmd := exec.CommandContext(ctx, "docker-compose", "exec", "-T", "curl", "curl", "-s", "http://prometheus:9090/api/v1/rules?type=alert")
+			cmd := exec.CommandContext(ctx, "docker", "compose", "exec", "-T", "curl", "curl", "-s", "http://prometheus:9090/api/v1/rules?type=alert")
 			cmd.Dir = dir
 			out, err := cmd.CombinedOutput()
 			if ctx.Err() != nil {

--- a/testutil/compose/auto.go
+++ b/testutil/compose/auto.go
@@ -28,7 +28,7 @@ type AutoConfig struct {
 	RunTmplFunc func(*TmplData)
 	// DefineTmplFunc allows arbitrary overrides if the define step template.
 	DefineTmplFunc func(*TmplData)
-	// LogFile enables writing (appending) docker-compose output to this file path instead of stdout.
+	// LogFile enables writing (appending) docker compose output to this file path instead of stdout.
 	LogFile string
 }
 
@@ -106,7 +106,7 @@ func Auto(ctx context.Context, conf AutoConfig) error {
 
 	_, _ = w.Write([]byte("===== run step: docker compose up --no-start --build =====\n"))
 
-	// Build and create docker-compose services before executing docker compose up.
+	// Build and create docker compose services before executing docker compose up.
 	if err = execBuildAndCreate(ctx, conf.Dir); err != nil {
 		return err
 	}
@@ -204,7 +204,7 @@ func execDown(ctx context.Context, dir string) error {
 // execUp executes `docker compose up` and it writes docker compose logs to the given out io.Writer.
 func execUp(ctx context.Context, dir string, out io.Writer) error {
 	// Build first so containers start at the same time below.
-	log.Info(ctx, "Executing docker-compose build")
+	log.Info(ctx, "Executing docker compose build")
 	cmd := exec.CommandContext(ctx, "docker", "compose", "build", "--parallel")
 	cmd.Dir = dir
 	if out, err := cmd.CombinedOutput(); err != nil {
@@ -226,7 +226,7 @@ func execUp(ctx context.Context, dir string, out io.Writer) error {
 			err = ctx.Err()
 		}
 
-		return errors.Wrap(err, "exec docker-compose up")
+		return errors.Wrap(err, "exec docker compose up")
 	}
 
 	return nil

--- a/testutil/compose/compose/main.go
+++ b/testutil/compose/compose/main.go
@@ -1,7 +1,7 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
 // Command compose provides a tool to run, test, debug local charon clusters
-// using docker-compose.
+// using docker compose.
 //
 //	It consists of multiple steps:
 //	 - compose new: Creates a new config.json that defines what will be composed.
@@ -34,7 +34,7 @@ func main() {
 func newRootCmd() *cobra.Command {
 	root := &cobra.Command{
 		Use:   "compose",
-		Short: "Charon Compose - Run, test, and debug a developer-focussed insecure local charon cluster using docker-compose",
+		Short: "Charon Compose - Run, test, and debug a developer-focussed insecure local charon cluster using docker compose",
 	}
 
 	root.AddCommand(newNewCmd())

--- a/testutil/compose/define.go
+++ b/testutil/compose/define.go
@@ -145,7 +145,7 @@ func Define(ctx context.Context, dir string, conf Config) (TmplData, error) {
 			Nodes:          []TmplNode{n},
 		}
 	} else {
-		// Other keygens only need a noop docker-compose, since charon-compose.yml
+		// Other keygens only need a noop docker compose, since charon-compose.yml
 		// is used directly in their compose lock.
 
 		data = TmplData{
@@ -169,7 +169,7 @@ func Define(ctx context.Context, dir string, conf Config) (TmplData, error) {
 	}
 
 	log.Info(ctx, "Creating docker-compose.yml")
-	log.Info(ctx, "Create cluster definition: docker-compose up")
+	log.Info(ctx, "Create cluster definition: docker compose up")
 
 	if err := WriteDockerCompose(dir, data); err != nil {
 		return TmplData{}, err

--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -70,7 +70,7 @@ services:
 
   {{if .Alerting}}
   curl:
-    # Can be used to curl services; e.g. docker-compose exec curl curl http://prometheus:9090/api/v1/rules\?type\=alert
+    # Can be used to curl services; e.g. docker compose exec curl curl http://prometheus:9090/api/v1/rules\?type\=alert
     image: curlimages/curl:latest
     command: sleep 1d
     networks: [compose]

--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-node-base: &node-base
   image: obolnetwork/charon:{{.CharonImageTag}}
   {{if .CharonEntrypoint }}entrypoint: {{.CharonEntrypoint}}

--- a/testutil/compose/lock.go
+++ b/testutil/compose/lock.go
@@ -77,7 +77,7 @@ func Lock(ctx context.Context, dir string, conf Config) (TmplData, error) {
 	}
 
 	log.Info(ctx, "Creating docker-compose.yml")
-	log.Info(ctx, "Create keys and cluster lock with: docker-compose up")
+	log.Info(ctx, "Create keys and cluster lock with: docker compose up")
 
 	conf.Step = stepLocked
 	if err := WriteConfig(dir, conf); err != nil {

--- a/testutil/compose/template.go
+++ b/testutil/compose/template.go
@@ -85,7 +85,7 @@ func WriteDockerCompose(dir string, data TmplData) error {
 
 	err = os.WriteFile(path.Join(dir, "docker-compose.yml"), buf.Bytes(), 0o755) //nolint:gosec
 	if err != nil {
-		return errors.Wrap(err, "write docker-compose")
+		return errors.Wrap(err, "write docker-compose.yml")
 	}
 
 	return nil

--- a/testutil/compose/testdata/TestDockerCompose_define_create_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_create_yml.golden
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-node-base: &node-base
   image: obolnetwork/charon:latest
   entrypoint: echo

--- a/testutil/compose/testdata/TestDockerCompose_define_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_define_dkg_yml.golden
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-node-base: &node-base
   image: obolnetwork/charon:latest
   command: [create,dkg]

--- a/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_create_yml.golden
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-node-base: &node-base
   image: obolnetwork/charon:latest
   command: [create,cluster]

--- a/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_lock_dkg_yml.golden
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-node-base: &node-base
   image: obolnetwork/charon:latest
   command: not used

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -211,7 +211,7 @@ services:
       - .:/compose
   
   curl:
-    # Can be used to curl services; e.g. docker-compose exec curl curl http://prometheus:9090/api/v1/rules\?type\=alert
+    # Can be used to curl services; e.g. docker compose exec curl curl http://prometheus:9090/api/v1/rules\?type\=alert
     image: curlimages/curl:latest
     command: sleep 1d
     networks: [compose]

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -1,5 +1,3 @@
-version: "3.8"
-
 x-node-base: &node-base
   image: obolnetwork/charon:latest
   command: run


### PR DESCRIPTION
Compose tests were failing because of `docker-compose` command hasn't been changed to `docker compose` on some places and the version on top wasn't removed.

category: test
ticket: none

