### PR TITLE
*: enable gnosis hotfix automatically

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -171,6 +171,14 @@ func Run(ctx context.Context, conf Config) (err error) {
 		network = "unknown"
 	}
 
+	// For Gnosis/Chiado we automatically enable GnosisBlockHotfix feature.
+	if network == eth2util.Chiado.Name || network == eth2util.Gnosis.Name {
+		// Even though we alter the feature flag post Init() call,
+		// this shall be safe for the GnosisBlockHotfix feature flag.
+		// We don't expect any serialization to happen in between.
+		featureset.EnableGnosisBlockHotfixIfNotDisabled(ctx, conf.Feature)
+	}
+
 	p2pKey := conf.TestConfig.P2PKey
 	if p2pKey == nil {
 		var err error

--- a/app/featureset/config.go
+++ b/app/featureset/config.go
@@ -85,7 +85,7 @@ func Init(ctx context.Context, config Config) error {
 
 // EnableGnosisBlockHotfixIfNotDisabled enables GnosisBlockHotfix if it was not disabled by the user.
 // This is still a temporary workaround for the gnosis chain.
-// When go-eth2-client is fully supporting custom specs, this function has be removed with GnosisBlockHotfix feature.
+// When go-eth2-client is fully supporting custom specs, this function has to be removed with GnosisBlockHotfix feature.
 func EnableGnosisBlockHotfixIfNotDisabled(ctx context.Context, config Config) {
 	initMu.Lock()
 	defer initMu.Unlock()

--- a/app/featureset/config.go
+++ b/app/featureset/config.go
@@ -83,6 +83,29 @@ func Init(ctx context.Context, config Config) error {
 	return nil
 }
 
+// EnableGnosisBlockHotfixIfNotDisabled enables GnosisBlockHotfix if it was not disabled by the user.
+// This is still a temporary workaround for the gnosis chain.
+// When go-eth2-client is fully supporting custom specs, this function has be removed with GnosisBlockHotfix feature.
+func EnableGnosisBlockHotfixIfNotDisabled(ctx context.Context, config Config) {
+	initMu.Lock()
+	defer initMu.Unlock()
+
+	disabled := false
+
+	for _, f := range config.Disabled {
+		if strings.EqualFold(string(GnosisBlockHotfix), f) {
+			disabled = true
+			break
+		}
+	}
+
+	if disabled {
+		log.Warn(ctx, "Feature gnosis_block_hotfix is required by gnosis/chiado, but explicitly disabled", nil)
+	} else {
+		state[GnosisBlockHotfix] = enable
+	}
+}
+
 // EnableForT enables a feature for testing.
 func EnableForT(t *testing.T, feature Feature) {
 	t.Helper()

--- a/app/featureset/config_test.go
+++ b/app/featureset/config_test.go
@@ -46,3 +46,26 @@ func TestEnableForT(t *testing.T) {
 	featureset.DisableForT(t, testFeature)
 	require.False(t, featureset.Enabled(testFeature))
 }
+
+func TestEnableGnosisBlockHotfixIfNotDisabled(t *testing.T) {
+	ctx := context.Background()
+	config := featureset.DefaultConfig()
+
+	t.Run("not disabled explicitly", func(t *testing.T) {
+		err := featureset.Init(ctx, config)
+		require.NoError(t, err)
+
+		featureset.EnableGnosisBlockHotfixIfNotDisabled(ctx, config)
+		require.True(t, featureset.Enabled(featureset.GnosisBlockHotfix))
+	})
+
+	t.Run("disabled explicitly", func(t *testing.T) {
+		config.Disabled = append(config.Disabled, string(featureset.GnosisBlockHotfix))
+
+		err := featureset.Init(ctx, config)
+		require.NoError(t, err)
+
+		featureset.EnableGnosisBlockHotfixIfNotDisabled(ctx, config)
+		require.False(t, featureset.Enabled(featureset.GnosisBlockHotfix))
+	})
+}

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -41,6 +41,9 @@ const (
 	// JSONRequests enables JSON requests for eth2 client.
 	JSONRequests Feature = "json_requests"
 
+	// GnosisBlockHotfix enables Gnosis/Chiado SSZ fix.
+	// The feature gets automatically enabled when the current network is gnosis|chiado,
+	// unless the user disabled this feature explicitly.
 	GnosisBlockHotfix Feature = "gnosis_block_hotfix"
 )
 

--- a/app/featureset/featureset_internal_test.go
+++ b/app/featureset/featureset_internal_test.go
@@ -15,6 +15,7 @@ func TestAllFeatureStatus(t *testing.T) {
 		EagerDoubleLinear,
 		ConsensusParticipate,
 		JSONRequests,
+		GnosisBlockHotfix,
 	}
 
 	for _, feature := range features {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -111,7 +111,7 @@ func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
 	flags.IntVar(&config.Threshold, "threshold", 0, "Optional override of threshold required for signature reconstruction. Defaults to ceil(n*2/3) if zero. Warning, non-default values decrease security.")
 	flags.StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	flags.StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
-	flags.StringVar(&config.Network, "network", "", "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia, holesky.")
+	flags.StringVar(&config.Network, "network", "", "Ethereum network to create validators for. Options: mainnet, goerli, sepolia, holesky, gnosis, chiado.")
 	flags.IntVar(&config.NumDVs, "num-validators", 0, "The number of distributed validators needed in the cluster.")
 	flags.BoolVar(&config.SplitKeys, "split-existing-keys", false, "Split an existing validator's private key into a set of distributed validator private key shares. Does not re-create deposit data for this key.")
 	flags.StringVar(&config.SplitKeysDir, "split-keys-dir", "", "Directory containing keys to split. Expects keys in keystore-*.json and passwords in keystore-*.txt. Requires --split-existing-keys.")

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -61,7 +61,7 @@ func bindCreateDKGFlags(cmd *cobra.Command, config *createDKGConfig) {
 	cmd.Flags().IntVarP(&config.Threshold, "threshold", "t", 0, "Optional override of threshold required for signature reconstruction. Defaults to ceil(n*2/3) if zero. Warning, non-default values decrease security.")
 	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
-	cmd.Flags().StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, gnosis, sepolia, holesky.")
+	cmd.Flags().StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, sepolia, holesky, gnosis, chiado.")
 	cmd.Flags().StringVar(&config.DKGAlgo, "dkg-algorithm", "default", "DKG algorithm to use; default, frost")
 	cmd.Flags().IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to exactly 32ETH.")
 	cmd.Flags().StringSliceVar(&config.OperatorENRs, operatorENRs, nil, "[REQUIRED] Comma-separated list of each operator's Charon ENR address.")

--- a/eth2util/network.go
+++ b/eth2util/network.go
@@ -57,6 +57,13 @@ var (
 		GenesisTimestamp:      1638993340,
 		CapellaHardFork:       "0x03000064",
 	}
+	Chiado = Network{
+		ChainID:               10200,
+		Name:                  "chiado",
+		GenesisForkVersionHex: "0x0000006f",
+		GenesisTimestamp:      1665396300,
+		CapellaHardFork:       "0x0300006f",
+	}
 	Sepolia = Network{
 		ChainID:               11155111,
 		Name:                  "sepolia",
@@ -77,7 +84,7 @@ var (
 var (
 	networksMu        sync.Mutex
 	supportedNetworks = []Network{
-		Mainnet, Goerli, Gnosis, Sepolia, Holesky,
+		Mainnet, Goerli, Gnosis, Chiado, Sepolia, Holesky,
 	}
 )
 

--- a/eth2util/network_test.go
+++ b/eth2util/network_test.go
@@ -69,16 +69,29 @@ func TestNetworkToForkVersionBytes(t *testing.T) {
 	require.ErrorContains(t, err, "invalid network name")
 }
 
-func TestSupportedNetwork(t *testing.T) {
-	t.Run("supported network", func(t *testing.T) {
-		require.True(t, eth2util.ValidNetwork("sepolia"))
-	})
+func TestValidNetwork(t *testing.T) {
+	supportedNetworks := []string{
+		"mainnet",
+		"goerli",
+		"sepolia",
+		"holesky",
+		"gnosis",
+		"chiado",
+	}
 
-	t.Run("supported network", func(t *testing.T) {
-		require.True(t, eth2util.ValidNetwork("holesky"))
-	})
+	unsupportedNetworks := []string{
+		"ropsten",
+	}
 
-	t.Run("unsupported network", func(t *testing.T) {
-		require.False(t, eth2util.ValidNetwork("ropsten"))
-	})
+	for _, network := range supportedNetworks {
+		t.Run("supported network "+network, func(t *testing.T) {
+			require.True(t, eth2util.ValidNetwork(network))
+		})
+	}
+
+	for _, network := range unsupportedNetworks {
+		t.Run("unsupported network "+network, func(t *testing.T) {
+			require.False(t, eth2util.ValidNetwork(network))
+		})
+	}
 }


### PR DESCRIPTION
* Added `chiado` network spec in addition to the existing `gnosis`.
* Feature `gnosis_block_hotfix` is enabled automatically when gnosis | chiado network is detected.
* When the user explicitly disables `gnosis_block_hotfix` feature, the app just yields warning during startup:

```
Feature gnosis_block_hotfix is required by gnosis/chiado, but explicitly disabled
```

category: feature
ticket: none
feature_flag: gnosis_block_hotfix
