### PR TITLE
workflows: bump govulncheck to v1.1.3

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -13,5 +13,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/actions/setup-go
-      - run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.0
+      - run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.3
       - run: govulncheck -show=traces -test ./...


### PR DESCRIPTION
govulncheck is failing currently in the pipeline, this is an attempt to fix it by simply bumping its version...

category: misc
ticket: none
