### PR TITLE
*: fix flaky testpeers test

### DIFF
--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -156,8 +156,8 @@ func testAllBeacons(ctx context.Context, queuedTestCases []testCaseName, allTest
 
 	doneReading := make(chan bool)
 	go func() {
-		for singlePeerRes := range singleBeaconResCh {
-			maps.Copy(allBeaconsRes, singlePeerRes)
+		for singleBeaconRes := range singleBeaconResCh {
+			maps.Copy(allBeaconsRes, singleBeaconRes)
 		}
 		doneReading <- true
 	}()

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -137,8 +137,8 @@ func testAllMEVs(ctx context.Context, queuedTestCases []testCaseName, allTestCas
 
 	doneReading := make(chan bool)
 	go func() {
-		for singlePeerRes := range singleMEVResCh {
-			maps.Copy(allMEVsRes, singlePeerRes)
+		for singleMEVRes := range singleMEVResCh {
+			maps.Copy(allMEVsRes, singleMEVRes)
 		}
 		doneReading <- true
 	}()

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -499,6 +499,7 @@ func runPeerTest(ctx context.Context, queuedTestCases []testCaseName, allTestCas
 	for _, t := range queuedTestCases {
 		select {
 		case <-ctx.Done():
+			testResCh <- failedTestResult(testResult{Name: t.name}, errTimeoutInterrupted)
 			return
 		default:
 			testResCh <- allTestCases[t](ctx, &conf, tcpNode, target)


### PR DESCRIPTION
- fix test peers on timeout, sometimes it went in the case where the current context is done, but the result of the currently running test wasn't sent to the channel
- fix wrongly named variables

category: test
ticket: none
