### PR TITLE
*: add --all for exit sign command

### DIFF
--- a/app/obolapi/exit.go
+++ b/app/obolapi/exit.go
@@ -62,9 +62,9 @@ func fullExitURL(valPubkey, lockHash string, shareIndex uint64) string {
 	).Replace(fullExitTmpl)
 }
 
-// PostPartialExit POSTs the set of msg's to the Obol API, for a given lock hash.
+// PostPartialExits POSTs the set of msg's to the Obol API, for a given lock hash.
 // It respects the timeout specified in the Client instance.
-func (c Client) PostPartialExit(ctx context.Context, lockHash []byte, shareIndex uint64, identityKey *k1.PrivateKey, exitBlobs ...ExitBlob) error {
+func (c Client) PostPartialExits(ctx context.Context, lockHash []byte, shareIndex uint64, identityKey *k1.PrivateKey, exitBlobs ...ExitBlob) error {
 	lockHashStr := "0x" + hex.EncodeToString(lockHash)
 
 	path := partialExitURL(lockHashStr)

--- a/app/obolapi/exit_test.go
+++ b/app/obolapi/exit_test.go
@@ -97,7 +97,7 @@ func TestAPIFlow(t *testing.T) {
 
 		// send all the partial exits
 		for idx, exit := range exits {
-			require.NoError(t, cl.PostPartialExit(ctx, lock.LockHash, uint64(idx+1), identityKeys[idx], exit), "share index: %d", idx+1)
+			require.NoError(t, cl.PostPartialExits(ctx, lock.LockHash, uint64(idx+1), identityKeys[idx], exit), "share index: %d", idx+1)
 		}
 
 		for idx := range exits {
@@ -188,7 +188,7 @@ func TestAPIFlowMissingSig(t *testing.T) {
 
 		// send all the partial exits
 		for idx, exit := range exits {
-			require.NoError(t, cl.PostPartialExit(ctx, lock.LockHash, uint64(idx+1), identityKeys[idx], exit), "share index: %d", idx+1)
+			require.NoError(t, cl.PostPartialExits(ctx, lock.LockHash, uint64(idx+1), identityKeys[idx], exit), "share index: %d", idx+1)
 		}
 
 		for idx := range exits {

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -34,6 +34,7 @@ type exitConfig struct {
 	BeaconNodeTimeout     time.Duration
 	ExitFromFilePath      string
 	Log                   log.Config
+	All                   bool
 }
 
 func newExitCmd(cmds ...*cobra.Command) *cobra.Command {
@@ -63,6 +64,7 @@ const (
 	fetchedExitPath
 	publishTimeout
 	validatorIndex
+	all
 )
 
 func (ef exitFlag) String() string {
@@ -91,6 +93,8 @@ func (ef exitFlag) String() string {
 		return "publish-timeout"
 	case validatorIndex:
 		return "validator-index"
+	case all:
+		return "all"
 	default:
 		return "unknown"
 	}
@@ -113,6 +117,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 			return s
 		}
 
+		//nolint:exhaustive // `all` is not yet implemented
 		switch flag {
 		case publishAddress:
 			cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech/v1", maybeRequired("The URL of the remote API."))
@@ -138,6 +143,9 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 			cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 30*time.Second, "Timeout for publishing a signed exit to the publish-address API.")
 		case validatorIndex:
 			cmd.Flags().Uint64Var(&config.ValidatorIndex, validatorIndex.String(), 0, "Validator index of the validator to exit, the associated public key must be present in the cluster lock manifest. If --validator-public-key is also provided, validator existence won't be checked on the beacon chain.")
+			// TODO: enable after all functionalities for --all are ready
+			// case all:
+			// 	cmd.Flags().BoolVar(&config.All, all.String(), false, "Exit all currently active validators in the cluster.")
 		}
 
 		if f.required {

--- a/cmd/exit_sign_internal_test.go
+++ b/cmd/exit_sign_internal_test.go
@@ -66,7 +66,8 @@ func Test_runSubmitPartialExit(t *testing.T) {
 			false,
 			"test",
 			0,
-			"cannot convert validator pubkey to bytes",
+			"cannot convert core pubkey to eth2 pubkey",
+			false,
 		)
 	})
 
@@ -78,6 +79,7 @@ func Test_runSubmitPartialExit(t *testing.T) {
 			testutil.RandomEth2PubKey(t).String(),
 			0,
 			"validator not present in cluster lock",
+			false,
 		)
 	})
 
@@ -89,6 +91,7 @@ func Test_runSubmitPartialExit(t *testing.T) {
 			"",
 			9999,
 			"validator index not found in beacon node response",
+			false,
 		)
 	})
 
@@ -99,7 +102,8 @@ func Test_runSubmitPartialExit(t *testing.T) {
 			true,
 			"test",
 			9999,
-			"cannot convert validator pubkey to bytes",
+			"cannot convert core pubkey to eth2 pubkey",
+			false,
 		)
 	})
 
@@ -111,23 +115,27 @@ func Test_runSubmitPartialExit(t *testing.T) {
 			testutil.RandomEth2PubKey(t).String(),
 			9999,
 			"validator not present in cluster lock",
+			false,
 		)
 	})
 
 	t.Run("main flow with pubkey", func(t *testing.T) {
-		runSubmitPartialExitFlowTest(t, false, false, "", 0, "")
+		runSubmitPartialExitFlowTest(t, false, false, "", 0, "", false)
 	})
 	t.Run("main flow with validator index", func(t *testing.T) {
-		runSubmitPartialExitFlowTest(t, true, false, "", 0, "")
+		runSubmitPartialExitFlowTest(t, true, false, "", 0, "", false)
 	})
 	t.Run("main flow with skipBeaconNodeCheck mode", func(t *testing.T) {
-		runSubmitPartialExitFlowTest(t, true, true, "", 0, "")
+		runSubmitPartialExitFlowTest(t, true, true, "", 0, "", false)
+	})
+	t.Run("main flow with all mode", func(t *testing.T) {
+		runSubmitPartialExitFlowTest(t, false, false, "", 0, "", true)
 	})
 
 	t.Run("config", Test_runSubmitPartialExit_Config)
 }
 
-func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, skipBeaconNodeCheck bool, valPubkey string, valIndex uint64, errString string) {
+func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, skipBeaconNodeCheck bool, valPubkey string, valIndex uint64, errString string, all bool) {
 	t.Helper()
 	t.Parallel()
 	ctx := context.Background()
@@ -202,6 +210,7 @@ func runSubmitPartialExitFlowTest(t *testing.T, useValIdx bool, skipBeaconNodeCh
 		ExitEpoch:           194048,
 		BeaconNodeTimeout:   30 * time.Second,
 		PublishTimeout:      10 * time.Second,
+		All:                 all,
 	}
 
 	index := uint64(0)
@@ -279,7 +288,7 @@ func Test_runSubmitPartialExit_Config(t *testing.T) {
 		{
 			name:             "Bad validator address",
 			badValidatorAddr: true,
-			errData:          "cannot convert validator pubkey to bytes",
+			errData:          "cannot convert core pubkey to eth2 pubkey",
 		},
 	}
 


### PR DESCRIPTION
Add `--all` command for signing partial exits. This PR is one of a couple incoming PRs that will be for the `--all` functionality. Mind that the CLI flag is not enabled until all of them are implemented and merged.

category: feature
ticket: #3243 
