### PR TITLE
*: allow deposits greater than 32eth

### DIFF
--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -131,7 +131,7 @@ type Definition struct {
 	// Note that this was added in v1.1.0, so may be empty for older versions.
 	Timestamp string `config_hash:"3" definition_hash:"3" json:"timestamp" ssz:"ByteList[32]"`
 
-	// NumValidators is the number of DVs (n*32ETH) to be created in the cluster lock file.
+	// NumValidators is the number of DVs to be created in the cluster lock file.
 	NumValidators int `config_hash:"4" definition_hash:"4" json:"num_validators" ssz:"uint64"`
 
 	// Threshold required for signature reconstruction. Defaults to safe value for number of nodes/peers.
@@ -152,7 +152,7 @@ type Definition struct {
 	// ValidatorAddresses define addresses of each validator.
 	ValidatorAddresses []ValidatorAddresses `config_hash:"10" definition_hash:"10" json:"validators" ssz:"CompositeList[65536]"`
 
-	// DepositAmounts specifies partial deposit amounts that sum up to 32ETH.
+	// DepositAmounts specifies partial deposit amounts that sum up to [32ETH..2048ETH].
 	DepositAmounts []eth2p0.Gwei `config_hash:"11" definition_hash:"11" json:"deposit_amounts" ssz:"uint64[256]"`
 
 	// ConfigHash uniquely identifies a cluster definition excluding operator ENRs and signatures.

--- a/cluster/deposit.go
+++ b/cluster/deposit.go
@@ -11,7 +11,7 @@ type DepositData struct {
 	// WithdrawalCredentials included in the deposit.
 	WithdrawalCredentials []byte `json:"withdrawal_credentials" lock_hash:"1" ssz:"Bytes32"`
 
-	// Amount is the amount in Gwei to be deposited [1ETH..32ETH].
+	// Amount is the amount in Gwei to be deposited [1ETH..2048ETH].
 	Amount int `json:"amount" lock_hash:"2" ssz:"uint64"`
 
 	// Signature is the BLS signature of the deposit message (above three fields).

--- a/cluster/distvalidator.go
+++ b/cluster/distvalidator.go
@@ -14,7 +14,7 @@ import (
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
-// DistValidator is a distributed validator (1x32ETH) managed by the cluster.
+// DistValidator is a distributed validator managed by the cluster.
 type DistValidator struct {
 	// PubKey is the distributed validator group public key.
 	PubKey []byte `json:"distributed_public_key" lock_hash:"0" ssz:"Bytes48"`

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -22,7 +22,7 @@ type Lock struct {
 	// Definition is embedded and extended by Lock.
 	Definition `json:"cluster_definition" lock_hash:"0" ssz:"Composite"`
 
-	// Validators are the distributed validators (n*32ETH) managed by the cluster.
+	// Validators are the distributed validators managed by the cluster.
 	Validators []DistValidator `json:"distributed_validators" lock_hash:"1" ssz:"Composite[65536]"`
 
 	// LockHash uniquely identifies a cluster lock.

--- a/cmd/addvalidators.go
+++ b/cmd/addvalidators.go
@@ -244,7 +244,7 @@ func writeDepositDatas(ctx context.Context, clusterDir string, numOps int, secre
 
 	var depositDatas []eth2p0.DepositData
 	for i, val := range vals {
-		depositMsg, err := deposit.NewMessage(eth2p0.BLSPubKey(val.GetPublicKey()), val.GetWithdrawalAddress(), deposit.MaxDepositAmount)
+		depositMsg, err := deposit.NewMessage(eth2p0.BLSPubKey(val.GetPublicKey()), val.GetWithdrawalAddress(), deposit.DefaultDepositAmount)
 		if err != nil {
 			return errors.Wrap(err, "new deposit message")
 		}

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -123,7 +123,7 @@ func bindClusterFlags(flags *pflag.FlagSet, config *clusterConfig) {
 	flags.StringVar(&config.testnetConfig.GenesisForkVersionHex, "testnet-fork-version", "", "Genesis fork version of the custom test network (in hex).")
 	flags.Uint64Var(&config.testnetConfig.ChainID, "testnet-chain-id", 0, "Chain ID of the custom test network.")
 	flags.Int64Var(&config.testnetConfig.GenesisTimestamp, "testnet-genesis-timestamp", 0, "Genesis timestamp of the custom test network.")
-	flags.IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to exactly 32ETH.")
+	flags.IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to at least 32ETH.")
 }
 
 func bindInsecureFlags(flags *pflag.FlagSet, insecureKeys *bool) {
@@ -196,7 +196,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 
 	if len(depositAmounts) == 0 {
 		// If partial deposit amounts were not specified, default to single amount of 32ETH.
-		depositAmounts = []eth2p0.Gwei{deposit.MaxDepositAmount}
+		depositAmounts = []eth2p0.Gwei{deposit.DefaultDepositAmount}
 	}
 
 	if len(secrets) == 0 {

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -366,7 +366,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 		vals := make(map[string]struct{})
 		amounts := deposit.DedupAmounts(deposit.EthsToGweis(conf.DepositAmounts))
 		if len(amounts) == 0 {
-			amounts = []eth2p0.Gwei{deposit.MaxDepositAmount}
+			amounts = []eth2p0.Gwei{deposit.DefaultDepositAmount}
 		}
 		for _, val := range lock.Validators {
 			vals[val.PublicKeyHex()] = struct{}{}

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -58,13 +58,13 @@ func bindCreateDKGFlags(cmd *cobra.Command, config *createDKGConfig) {
 
 	cmd.Flags().StringVar(&config.Name, "name", "", "Optional cosmetic cluster name")
 	cmd.Flags().StringVar(&config.OutputDir, "output-dir", ".charon", "The folder to write the output cluster-definition.json file to.")
-	cmd.Flags().IntVar(&config.NumValidators, "num-validators", 1, "The number of distributed validators the cluster will manage (32ETH staked for each).")
+	cmd.Flags().IntVar(&config.NumValidators, "num-validators", 1, "The number of distributed validators the cluster will manage (32ETH+ staked for each).")
 	cmd.Flags().IntVarP(&config.Threshold, "threshold", "t", 0, "Optional override of threshold required for signature reconstruction. Defaults to ceil(n*2/3) if zero. Warning, non-default values decrease security.")
 	cmd.Flags().StringSliceVar(&config.FeeRecipientAddrs, "fee-recipient-addresses", nil, "Comma separated list of Ethereum addresses of the fee recipient for each validator. Either provide a single fee recipient address or fee recipient addresses for each validator.")
 	cmd.Flags().StringSliceVar(&config.WithdrawalAddrs, "withdrawal-addresses", nil, "Comma separated list of Ethereum addresses to receive the returned stake and accrued rewards for each validator. Either provide a single withdrawal address or withdrawal addresses for each validator.")
 	cmd.Flags().StringVar(&config.Network, "network", defaultNetwork, "Ethereum network to create validators for. Options: mainnet, goerli, sepolia, holesky, gnosis, chiado.")
 	cmd.Flags().StringVar(&config.DKGAlgo, "dkg-algorithm", "default", "DKG algorithm to use; default, frost")
-	cmd.Flags().IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to exactly 32ETH.")
+	cmd.Flags().IntSliceVar(&config.DepositAmounts, "deposit-amounts", nil, "List of partial deposit amounts (integers) in ETH. Values must sum up to at least 32ETH.")
 	cmd.Flags().StringSliceVar(&config.OperatorENRs, operatorENRs, nil, "[REQUIRED] Comma-separated list of each operator's Charon ENR address.")
 
 	mustMarkFlagRequired(cmd, operatorENRs)

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -214,6 +214,6 @@ func TestValidateDKGConfig(t *testing.T) {
 
 	t.Run("wrong deposit amounts sum", func(t *testing.T) {
 		err := validateDKGConfig(3, 4, "goerli", []int{8, 16})
-		require.ErrorContains(t, err, "sum of partial deposit amounts must sum up to 32ETH")
+		require.ErrorContains(t, err, "sum of partial deposit amounts must be at least 32ETH")
 	})
 }

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -246,7 +246,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	// Sign, exchange and aggregate Deposit Data
 	depositAmounts := def.DepositAmounts
 	if len(depositAmounts) == 0 {
-		depositAmounts = []eth2p0.Gwei{deposit.MaxDepositAmount}
+		depositAmounts = []eth2p0.Gwei{deposit.DefaultDepositAmount}
 	} else {
 		depositAmounts = deposit.DedupAmounts(depositAmounts)
 	}

--- a/dkg/dkg_internal_test.go
+++ b/dkg/dkg_internal_test.go
@@ -137,7 +137,7 @@ func TestValidSignatures(t *testing.T) {
 	withdrawalAddr := testutil.RandomETHAddress()
 	network := eth2util.Goerli.Name
 
-	msg, err := deposit.NewMessage(eth2Pubkey, withdrawalAddr, deposit.MaxDepositAmount)
+	msg, err := deposit.NewMessage(eth2Pubkey, withdrawalAddr, deposit.DefaultDepositAmount)
 	require.NoError(t, err)
 	sigRoot, err := deposit.GetMessageSigningRoot(msg, network)
 	require.NoError(t, err)

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -385,7 +385,7 @@ func verifyDistValidators(t *testing.T, lock cluster.Lock, def cluster.Definitio
 		// Assert Deposit Data
 		depositAmounts := deposit.DedupAmounts(def.DepositAmounts)
 		if len(depositAmounts) == 0 {
-			depositAmounts = []eth2p0.Gwei{deposit.MaxDepositAmount}
+			depositAmounts = []eth2p0.Gwei{deposit.DefaultDepositAmount}
 		}
 		require.Len(t, val.PartialDepositData, len(depositAmounts))
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -31,7 +31,7 @@ The schema of the `cluster-definition.json` is defined as:
   "uuid": "1234-abcdef-1234-abcdef",            // Random unique identifier.
   "version": "v1.3.0",                          // Schema version
   "timestamp": "2022-01-01T12:00:00+00:00",     // Creation timestamp
-  "num_validators": 100,                        // Number of distributed validators (n*32ETH staked) to be created in cluster.lock
+  "num_validators": 100,                        // Number of distributed validators to be created in cluster.lock
   "threshold": 3,                               // Threshold required for signature reconstruction
   "validators": [                               // Metadata related to each validator to be created
     {
@@ -41,7 +41,7 @@ The schema of the `cluster-definition.json` is defined as:
   ],
   "dkg_algorithm": "foo_dkg_v1" ,               // DKG algorithm for key generation
   "fork_version": "0x00112233",                 // Chain/network identifier
-  "deposit_amounts": [                          // Partial deposit amounts in gwei (must sum up to 32ETH)
+  "deposit_amounts": [                          // Partial deposit amounts in gwei (must sum up to at least 32ETH)
     "16000000000",
     "16000000000"
   ],
@@ -63,7 +63,7 @@ The `cluster-lock.json` has the following schema:
 ```json
 {
   "cluster_definition": {...},                              // Cluster definition json, identical schema to above,
-  "distributed_validators": [                               // Length equal to num_validators (n*32ETH staked).
+  "distributed_validators": [                               // Length equal to num_validators.
     {
       "distributed_public_key":  "0x123..abfc",             // DV root pubkey
       "public_shares": ["0x123..abfc", "0x123..abfc"],      // The public share of each operator (length of num_operators)
@@ -71,7 +71,7 @@ The `cluster-lock.json` has the following schema:
       "builder_registration": {...}                         // Pre-generated signed builder registration for the validator
     }
   ],
-  "deposit_amounts": [                                      // Partial deposit amounts in gwei (must sum up to 32ETH)
+  "deposit_amounts": [                                      // Partial deposit amounts in gwei (must sum up to at least 32ETH)
     "16000000000",
     "16000000000"
   ],
@@ -89,7 +89,7 @@ on how an individual `distributed_validator` looks like.
 The following is the historical change log of the cluster config:
 - `v1.8.0` **default**:
   - Added the `deposit_amounts` list to cluster lock which contains partial deposit amounts in gwei.
-  - When not specified, the single value of 32ETH will be used. All partial amounts must sum up to 32ETH.
+  - When not specified, the single value of 32ETH will be used. All partial amounts must sum up to at least 32ETH.
   - `distributed_validator` structure replaced `deposit_data` with `partial_deposit_data` respectively.
 - `v1.7.0`:
   - Added the `builder_registration` structure to `distributed_validators` list in cluster lock.

--- a/testutil/compose/config.go
+++ b/testutil/compose/config.go
@@ -73,7 +73,7 @@ type Config struct {
 	// Threshold required for signature reconstruction. Defaults to safe value for number of nodes/peers.
 	Threshold int `json:"threshold"`
 
-	// NumValidators is the number of DVs (n*32ETH) to be created in the cluster lock file.
+	// NumValidators is the number of DVs to be created in the cluster lock file.
 	NumValidators int `json:"num_validators"`
 
 	// ImageTag defines the charon docker image tag: obolnetwork/charon:{ImageTag}.


### PR DESCRIPTION
Currently the maximum allowed deposit is 32 ETH both in `create cluster` and in `create dkg`. We want to allow deposits larger than 32 ETH per validator. The maximum is to be set to 2048 ETH.

category: feature
ticket: #3278