### PR TITLE
cmd: fix test peers out of range

### DIFF
--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -474,8 +474,10 @@ func testSinglePeer(ctx context.Context, queuedTestCases []testCaseName, allTest
 		var testName string
 		select {
 		case <-ctx.Done():
-			testName = queuedTestCases[testCounter].name
-			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			if testCounter < len(queuedTestCases) {
+				testName = queuedTestCases[testCounter].name
+				allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			}
 			finished = true
 		case result, ok := <-singleTestResCh:
 			if !ok {


### PR DESCRIPTION
After #3267 was merged, on `ctx.Done()` we push the latest unfinished test. This causes out of range in the outer function in some ocassions.

category: bug
ticket: none
