### PR TITLE
*: disable intrange linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -151,6 +151,7 @@ linters:
   enable-all: true
   disable:
     # Keep disabled
+    - intrange
     - containedctx
     - contextcheck
     - cyclop


### PR DESCRIPTION
Go v1.23 allows to range over int slices without calling `len` first.

Since it's a low-importance change, we can disable intrange linter to avoid being blocked by it during pre-commit.

category: misc
ticket: none