### PR TITLE
cmd: broadcast all exits

### DIFF
--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -33,6 +33,7 @@ type exitConfig struct {
 	PlaintextOutput       bool
 	BeaconNodeTimeout     time.Duration
 	ExitFromFilePath      string
+	ExitFromFileDir       string
 	Log                   log.Config
 	All                   bool
 }
@@ -60,6 +61,7 @@ const (
 	validatorPubkey
 	exitEpoch
 	exitFromFile
+	exitFromDir
 	beaconNodeTimeout
 	fetchedExitPath
 	publishTimeout
@@ -85,6 +87,8 @@ func (ef exitFlag) String() string {
 		return "exit-epoch"
 	case exitFromFile:
 		return "exit-from-file"
+	case exitFromDir:
+		return "exit-from-dir"
 	case beaconNodeTimeout:
 		return "beacon-node-timeout"
 	case fetchedExitPath:
@@ -135,6 +139,8 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 162304, maybeRequired("Exit epoch at which the validator will exit, must be the same across all the partial exits."))
 		case exitFromFile:
 			cmd.Flags().StringVar(&config.ExitFromFilePath, exitFromFile.String(), "", maybeRequired("Retrieves a signed exit message from a pre-prepared file instead of --publish-address."))
+		case exitFromDir:
+			cmd.Flags().StringVar(&config.ExitFromFileDir, exitFromDir.String(), "", maybeRequired("Retrieves a signed exit messages from a pre-prepared files in a directory instead of --publish-address."))
 		case beaconNodeTimeout:
 			cmd.Flags().DurationVar(&config.BeaconNodeTimeout, beaconNodeTimeout.String(), 30*time.Second, maybeRequired("Timeout for beacon node HTTP calls."))
 		case fetchedExitPath:

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -115,7 +115,6 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 	}
 
 	fullExits := make(map[core.PubKey]eth2p0.SignedVoluntaryExit)
-	// multiple
 	if config.All {
 		if config.ExitFromFileDir != "" {
 			entries, err := os.ReadDir(config.ExitFromFileDir)

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -139,7 +139,10 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 		} else {
 			for _, validator := range cl.GetValidators() {
 				validatorPubKeyHex := fmt.Sprintf("0x%x", validator.GetPublicKey())
-				exit, err := fetchFullExit(ctx, "", config, cl, identityKey, validatorPubKeyHex)
+
+				valCtx := log.WithCtx(ctx, z.Str("validator", validatorPubKeyHex))
+
+				exit, err := fetchFullExit(valCtx, "", config, cl, identityKey, validatorPubKeyHex)
 				if err != nil {
 					return errors.Wrap(err, "fetch full exit for all from public key")
 				}

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -236,7 +236,10 @@ func broadcastExitsToBeacon(ctx context.Context, eth2Cl eth2wrap.Client, exits m
 		if err := tbls.Verify(pubkey, exitRoot[:], signature); err != nil {
 			return errors.Wrap(err, "exit message signature not verified")
 		}
+	}
 
+	for validator, fullExit := range exits {
+		valCtx := log.WithCtx(ctx, z.Str("validator", validator.String()))
 		if err := eth2Cl.SubmitVoluntaryExit(valCtx, &fullExit); err != nil {
 			return errors.Wrap(err, "could not submit voluntary exit")
 		}

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -125,7 +124,7 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 				if !strings.HasPrefix(entry.Name(), "exit-") {
 					continue
 				}
-				exit, err := fetchFullExit(ctx, path.Join(config.ExitFromFileDir+"/"+entry.Name()), config, cl, identityKey, "")
+				exit, err := fetchFullExit(ctx, filepath.Join(config.ExitFromFileDir, entry.Name()), config, cl, identityKey, "")
 				if err != nil {
 					return errors.Wrap(err, "fetch full exit for all from dir")
 				}

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -125,7 +126,7 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 				if !strings.HasPrefix(entry.Name(), "exit-") {
 					continue
 				}
-				exit, err := fetchFullExit(ctx, config.ExitFromFileDir+"/"+entry.Name(), config, cl, identityKey, "")
+				exit, err := fetchFullExit(ctx, path.Join(config.ExitFromFileDir+"/"+entry.Name()), config, cl, identityKey, "")
 				if err != nil {
 					return errors.Wrap(err, "fetch full exit for all from dir")
 				}


### PR DESCRIPTION
Second part of adding the `--all` flag for exits.

This PR is for the `charon exit broadcast` command. Additionally, a flag `exitFromDir` is introduced so point to a directory with exit files.

category: feature
ticket: #3243 
