### PR TITLE
app: generic consensus debugger

### DIFF
--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -46,7 +46,7 @@ var (
 // It serves prometheus metrics, pprof profiling and the runtime enr.
 func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, debugAddr string,
 	tcpNode host.Host, eth2Cl eth2wrap.Client,
-	peerIDs []peer.ID, registry *prometheus.Registry, qbftDebug http.Handler,
+	peerIDs []peer.ID, registry *prometheus.Registry, consensusDebugger http.Handler,
 	pubkeys []core.PubKey, seenPubkeys <-chan core.PubKey, vapiCalls <-chan struct{},
 	numValidators int,
 ) {
@@ -93,8 +93,8 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, d
 	if debugAddr != "" {
 		debugMux := http.NewServeMux()
 
-		// Serve sniffed qbft instances messages in gzipped protobuf format.
-		debugMux.Handle("/debug/qbft", qbftDebug)
+		// Serve sniffed consensus instances messages in gzipped protobuf format.
+		debugMux.Handle("/debug/consensus", consensusDebugger)
 
 		// Copied from net/http/pprof/pprof.go
 		debugMux.HandleFunc("/debug/pprof/", pprof.Index)

--- a/core/consensus/debugger_internal_test.go
+++ b/core/consensus/debugger_internal_test.go
@@ -1,6 +1,6 @@
 // Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
-package app
+package consensus
 
 import (
 	"compress/gzip"
@@ -17,10 +17,10 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 )
 
-func TestQBFTDebugger(t *testing.T) {
+func TestDebugger(t *testing.T) {
 	var (
 		instances []*pbv1.SniffedConsensusInstance
-		debug     = new(qbftDebugger)
+		debug     = new(debugger)
 	)
 
 	for range 10 {
@@ -28,9 +28,10 @@ func TestQBFTDebugger(t *testing.T) {
 			Msgs: []*pbv1.SniffedConsensusMsg{
 				{
 					Timestamp: timestamppb.Now(),
+					// Eventually the ConsensusMsg will be replaced by a more generic message type.
 					Msg: &pbv1.ConsensusMsg{
-						Msg:           randomQBFTMessage(),
-						Justification: []*pbv1.QBFTMsg{randomQBFTMessage(), randomQBFTMessage()},
+						Msg:           randomQBFTMsg(),
+						Justification: []*pbv1.QBFTMsg{randomQBFTMsg(), randomQBFTMsg()},
 					},
 				},
 			},
@@ -58,7 +59,7 @@ func TestQBFTDebugger(t *testing.T) {
 	require.True(t, proto.Equal(&pbv1.SniffedConsensusInstances{Instances: instances}, resp))
 }
 
-func randomQBFTMessage() *pbv1.QBFTMsg {
+func randomQBFTMsg() *pbv1.QBFTMsg {
 	return &pbv1.QBFTMsg{
 		Type:          rand.Int63(),
 		Duty:          &pbv1.Duty{Slot: rand.Uint64()},


### PR DESCRIPTION
Towards larger consensus abstraction work: reworked QBFT messages debugger to be the generic consensus messages debugger (except for wire representation). This is to eliminate QBFT specific leaked from the consensus/qbft packages.

Breaking change: the debug endpoint `/debug/qbft` has been changed to `/debug/consensus` (and the received file name is changed from `qbft_messages.pb.gz` to `consensus_messages.pb.gz`).
We are not aware of any systems or users actively using or relying on that endpoint in production.

category: refactor
ticket: #3299 
