### PR TITLE
cmd: print consensus protocols

### DIFF
--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -184,7 +184,6 @@ func TestValidateWithdrawalAddr(t *testing.T) {
 }
 
 func TestValidateDKGConfig(t *testing.T) {
-
 	t.Run("insufficient ENRs", func(t *testing.T) {
 		numOperators := 2
 		err := validateDKGConfig(numOperators, "", nil)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/obolnetwork/charon/app/version"
+	"github.com/obolnetwork/charon/core/consensus"
 )
 
 type versionConfig struct {
@@ -36,7 +37,7 @@ func newVersionCmd(runFunc func(io.Writer, versionConfig)) *cobra.Command {
 }
 
 func bindVersionFlags(flags *pflag.FlagSet, config *versionConfig) {
-	flags.BoolVar(&config.Verbose, "verbose", false, "Includes detailed module version info")
+	flags.BoolVar(&config.Verbose, "verbose", false, "Includes detailed module version info and supported protocols")
 }
 
 func runVersionCmd(out io.Writer, config versionConfig) {
@@ -61,5 +62,11 @@ func runVersionCmd(out io.Writer, config versionConfig) {
 			dep = dep.Replace
 		}
 		_, _ = fmt.Fprintf(out, "\t%v %v\n", dep.Path, dep.Version)
+	}
+
+	_, _ = fmt.Fprint(out, "Consensus protocols:\n")
+
+	for _, protocol := range consensus.Protocols() {
+		_, _ = fmt.Fprintf(out, "\t%v\n", protocol)
 	}
 }

--- a/cmd/version_internal_test.go
+++ b/cmd/version_internal_test.go
@@ -1,0 +1,49 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/version"
+	"github.com/obolnetwork/charon/core/consensus"
+)
+
+func TestRunVersionCmd(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		runVersionCmd(&buf, versionConfig{Verbose: false})
+
+		str := buf.String()
+		require.Contains(t, str, "git_commit_hash")
+		require.Contains(t, str, "git_commit_time")
+		require.NotContains(t, str, "Package:")
+		require.NotContains(t, str, "/n")
+
+		parts := strings.Split(str, " ")
+		require.Len(t, parts, 2)
+
+		semver, err := version.Parse(parts[0])
+		require.NoError(t, err)
+		require.Equal(t, version.Version, semver)
+	})
+
+	t.Run("verbose", func(t *testing.T) {
+		var buf bytes.Buffer
+
+		runVersionCmd(&buf, versionConfig{Verbose: true})
+
+		str := buf.String()
+		require.Contains(t, str, "git_commit_hash")
+		require.Contains(t, str, "git_commit_time")
+		require.Contains(t, str, "Package:")
+		require.Contains(t, str, "Dependencies:")
+		require.Contains(t, str, "Consensus protocols:")
+		require.Contains(t, str, consensus.Protocols()[0])
+	})
+}


### PR DESCRIPTION
Changed `charon version --verbose` to print available consensus protocols in the order defined by the implementation.
Added internal tests.

category: feature
ticket: #3305