### PR TITLE
github: use minor go versions in pipelines

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -6,4 +6,4 @@ runs:
     - name: Setup go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.23.1'
+        go-version: '1.23'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.23.1"
+  go: "1.23"
 linters-settings:
   cyclop:
     max-complexity: 15


### PR DESCRIPTION
Instead of having to bump golang version on each patch release, use latest patch. That's what we already do in `go.mod`.

category: misc
ticket: none
