### PR TITLE
github: bump only patch versions for bls-wth-go-binary library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  ignore:
+  - dependency-name: "github.com/herumi/bls-eth-go-binary"
+    update-types: ["version-update:semver-major","version-update:semver-minor"]
 - package-ecosystem: "docker"
   directories:
     - "/"


### PR DESCRIPTION
Bump only patch versions for `bls-wth-go-binary`. Hope this works as intended...

category: misc
ticket: none
