### PR TITLE
docs: fix typos in documentation files

### DIFF
--- a/docs/dkg.md
+++ b/docs/dkg.md
@@ -36,7 +36,7 @@ This cluster-definition file is created with the help of the [Distributed Valida
   - The list of participants in the cluster specified by Ethereum address(/ENS)
   - The threshold of fault tolerance required (if not choosing the safe default)
   - The network (fork_version/chainId) that this cluster will validate on
-- These key pieces of information form the basis of the cluster configuration. These fields (and some technical fields like DKG algorithm to use) are serialised and merklised to produce the manifests `cluster_definition_hash`. This merkle root will be used to confirm that their is no ambiguity or deviation between manifests when they are provided to charon nodes.
+- These key pieces of information form the basis of the cluster configuration. These fields (and some technical fields like DKG algorithm to use) are serialised and merklised to produce the manifests `cluster_definition_hash`. This merkle root will be used to confirm that there is no ambiguity or deviation between manifests when they are provided to charon nodes.
 - Once the leader is satisfied with the configuration they publish it to the launchpad's data availability layer for the other participants to access. (For early development the launchpad will use a centralised backend db to store the cluster configuration. Near production, solutions like IPFS or arweave may be more suitable for the long term decentralisation of the launchpad.)
 - The leader will then share the URL to this ceremony with their intended participants.
 - Anyone that clicks the ceremony url, or inputs the `config_hash` when prompted on the landing page will be brought to the ceremony status page. (After completing all disclaimers and advisories)

--- a/docs/goguidelines.md
+++ b/docs/goguidelines.md
@@ -1,6 +1,6 @@
 # Charon Go Guidelines
 
-This page contains guidelines, principals and best practices relating to how we write go code.
+This page contains guidelines, principles and best practices relating to how we write go code.
 As an open source project, we need to aim for high code quality, consistency and canonical go.
 
 ## Required Knowledge

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -78,7 +78,7 @@ charon/             # project root
     - `version`: Print charon version
   - Defines and parses [viper](https://github.com/spf13/viper) configuration parameters for required by each command.
 - `cluster/`: Cluster config definition and files formats
-  - `cluster-definition.json` defines the intended cluster including confutation including operators.
+  - `cluster-definition.json` defines the intended cluster including configuration including operators.
   - `cluster-lock.json` extends cluster definition adding distributed validator public keys and public shares.
 - `dkg/`: Distributed Key Generation command
   - Runs the dkg command that takes a cluster definition as input and generates a cluster lock file and private shares as output.


### PR DESCRIPTION
This pull request fixes several typographical errors found in the documentation files, specifically in the following:

- `dkg.md`
- `goguidelines.md`
- `structure.md`

category: docs
ticket: none
