### PR TITLE
cmd: add cluster lock and cluster definition to test peers

### DIFF
--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -320,7 +320,7 @@ func TestPeersTestFlags(t *testing.T) {
 		{
 			name:        "no enrs flag",
 			args:        []string{"peers"},
-			expectedErr: "required flag(s) \"enrs\" not set",
+			expectedErr: "--enrs, --cluster-lock-file-path or --cluster-definition-file-path must be specified.",
 		},
 		{
 			name:        "no output toml on quiet",


### PR DESCRIPTION
Sometimes users find it easier to test with already created `cluster-definition.json` or `cluster-lock.json` files. It saves copying and pasting ENRs and potentially making a mistake.

category: feature
ticket: none

