### PR TITLE
docs: typo in README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,7 @@ This page acts as an index for the charon (pronounced 'kharon') markdown documen
 - [Architecture](architecture.md): Overview of charon cluster and node architecture
 - [Project Structure](structure.md): Project folder structure
 - [Branching and Release Model](branching.md): Git branching and release model
-- [Go Guidelines](goguidelines.md): Guidelines and principals relating to go development
+- [Go Guidelines](goguidelines.md): Guidelines and principles relating to go development
 - [Contributing](contributing.md): How to contribute to charon; githooks, PR templates, etc.
 - [Distributed Key Generation](dkg.md): How charon can create distributed validator key shares remotely from a cluster-definition file.
 - [Consensus](consensus.md): How charon handles various consensus protocols.


### PR DESCRIPTION
<img width="695" alt="Снимок экрана 2024-11-11 в 19 08 00" src="https://github.com/user-attachments/assets/79884417-fc3d-46f4-a0d4-834b58b898da">

In the "Go Guidelines" section, the word "principals" corrected to "**principles**" (the correct spelling).

category: docs
ticket: none