### PR TITLE
cmd: test command UX

### DIFF
--- a/cmd/ascii.go
+++ b/cmd/ascii.go
@@ -39,7 +39,7 @@ func validatorASCII() []string {
 
 func mevASCII() []string {
 	return []string{
-		"__  __ ________      __                                         ",
+		" __  __ ________      __                                        ",
 		"|  \\/  |  ____\\ \\    / /                                        ",
 		"| \\  / | |__   \\ \\  / /                                         ",
 		"| |\\/| |  __|   \\ \\/ /                                          ",

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -48,6 +48,7 @@ func New() *cobra.Command {
 		newCombineCmd(newCombineFunc),
 		newAlphaCmd(
 			newTestCmd(
+				newTestAllCmd(runTestAll),
 				newTestPeersCmd(runTestPeers),
 				newTestBeaconCmd(runTestBeacon),
 				newTestValidatorCmd(runTestValidator),

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -276,6 +276,26 @@ func writeResultToWriter(res testCategoryResult, w io.Writer) error {
 	return nil
 }
 
+func evaluateHighestRTTScore(testResCh chan time.Duration, testRes testResult, avg time.Duration, poor time.Duration) testResult {
+	highestRTT := time.Duration(0)
+	for rtt := range testResCh {
+		if rtt > highestRTT {
+			highestRTT = rtt
+		}
+	}
+
+	if highestRTT == 0 || highestRTT > poor {
+		testRes.Verdict = testVerdictPoor
+	} else if highestRTT > avg {
+		testRes.Verdict = testVerdictAvg
+	} else {
+		testRes.Verdict = testVerdictGood
+	}
+	testRes.Measurement = Duration{highestRTT}.String()
+
+	return testRes
+}
+
 func calculateScore(results []testResult) categoryScore {
 	// TODO(kalo): calculate score more elaborately (potentially use weights)
 	avg := 0

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/signal"
+	"slices"
 	"sort"
 	"strings"
 	"syscall"
@@ -229,12 +230,14 @@ func writeResultToWriter(res testCategoryResult, w io.Writer) error {
 	lines = append(lines, "")
 	lines = append(lines, fmt.Sprintf("%-64s%s", "TEST NAME", "RESULT"))
 	suggestions := []string{}
-	for target, testResults := range res.Targets {
-		if target != "" && len(testResults) > 0 {
+	targets := maps.Keys(res.Targets)
+	slices.Sort(targets)
+	for _, target := range targets {
+		if target != "" && len(res.Targets[target]) > 0 {
 			lines = append(lines, "")
 			lines = append(lines, target)
 		}
-		for _, singleTestRes := range testResults {
+		for _, singleTestRes := range res.Targets[target] {
 			testOutput := ""
 			testOutput += fmt.Sprintf("%-64s", singleTestRes.Name)
 			if singleTestRes.Measurement != "" {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/pelletier/go-toml/v2"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 	"golang.org/x/exp/maps"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -64,6 +65,13 @@ func bindTestFlags(cmd *cobra.Command, config *testConfig) {
 	cmd.Flags().StringSliceVar(&config.TestCases, "test-cases", nil, fmt.Sprintf("List of comma separated names of tests to be exeucted. Available tests are: %v", listTestCases(cmd)))
 	cmd.Flags().DurationVar(&config.Timeout, "timeout", time.Hour, "Execution timeout for all tests.")
 	cmd.Flags().BoolVar(&config.Quiet, "quiet", false, "Do not print test results to stdout.")
+}
+
+func bindTestLogFlags(flags *pflag.FlagSet, config *log.Config) {
+	flags.StringVar(&config.Format, "log-format", "console", "Log format; console, logfmt or json")
+	flags.StringVar(&config.Level, "log-level", "info", "Log level; debug, info, warn or error")
+	flags.StringVar(&config.Color, "log-color", "auto", "Log color; auto, force, disable.")
+	flags.StringVar(&config.LogOutputPath, "log-output-path", "", "Path in which to write on-disk logs.")
 }
 
 func listTestCases(cmd *cobra.Command) []string {

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -289,7 +289,7 @@ func writeResultToWriter(res testCategoryResult, w io.Writer) error {
 	return nil
 }
 
-func evaluateHighestRTTScore(testResCh chan time.Duration, testRes testResult, avg time.Duration, poor time.Duration) testResult {
+func evaluateHighestRTTScores(testResCh chan time.Duration, testRes testResult, avg time.Duration, poor time.Duration) testResult {
 	highestRTT := time.Duration(0)
 	for rtt := range testResCh {
 		if rtt > highestRTT {
@@ -297,14 +297,18 @@ func evaluateHighestRTTScore(testResCh chan time.Duration, testRes testResult, a
 		}
 	}
 
-	if highestRTT == 0 || highestRTT > poor {
+	return evaluateRTT(highestRTT, testRes, avg, poor)
+}
+
+func evaluateRTT(rtt time.Duration, testRes testResult, avg time.Duration, poor time.Duration) testResult {
+	if rtt == 0 || rtt > poor {
 		testRes.Verdict = testVerdictPoor
-	} else if highestRTT > avg {
+	} else if rtt > avg {
 		testRes.Verdict = testVerdictAvg
 	} else {
 		testRes.Verdict = testVerdictGood
 	}
-	testRes.Measurement = Duration{highestRTT}.String()
+	testRes.Measurement = Duration{rtt}.String()
 
 	return testRes
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -35,6 +35,7 @@ const (
 	validatorTestCategory   = "validator"
 	mevTestCategory         = "mev"
 	performanceTestCategory = "performance"
+	allTestCategory         = "all"
 )
 
 type testConfig struct {
@@ -77,6 +78,16 @@ func listTestCases(cmd *cobra.Command) []string {
 		testCaseNames = maps.Keys(supportedMEVTestCases())
 	case performanceTestCategory:
 		testCaseNames = maps.Keys(supportedPerformanceTestCases())
+	case allTestCategory:
+		testCaseNames = slices.Concat(
+			maps.Keys(supportedPeerTestCases()),
+			maps.Keys(supportedSelfTestCases()),
+			maps.Keys(supportedRelayTestCases()),
+			maps.Keys(supportedBeaconTestCases()),
+			maps.Keys(supportedValidatorTestCases()),
+			maps.Keys(supportedMEVTestCases()),
+			maps.Keys(supportedPerformanceTestCases()),
+		)
 	default:
 		log.Warn(cmd.Context(), "Unknown command for listing test cases", nil, z.Str("name", cmd.Name()))
 	}

--- a/cmd/testall.go
+++ b/cmd/testall.go
@@ -1,0 +1,97 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"context"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/obolnetwork/charon/app/errors"
+)
+
+type testAllConfig struct {
+	testConfig
+	Peers       testPeersConfig
+	Beacon      testBeaconConfig
+	Validator   testValidatorConfig
+	MEV         testMEVConfig
+	Performance testPerformanceConfig
+}
+
+func newTestAllCmd(runFunc func(context.Context, io.Writer, testAllConfig) error) *cobra.Command {
+	var config testAllConfig
+
+	cmd := &cobra.Command{
+		Use:   "all",
+		Short: "Run tests towards peer nodes, beacon nodes, validator client, MEV relays, own hardware and internet connectivity.",
+		Long:  `Run tests towards peer nodes, beacon nodes, validator client, MEV relays, own hardware and internet connectivity. Verify that Charon can efficiently do its duties on the tested setup.`,
+		Args:  cobra.NoArgs,
+		PreRunE: func(cmd *cobra.Command, _ []string) error {
+			return mustOutputToFileOnQuiet(cmd)
+		},
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runFunc(cmd.Context(), cmd.OutOrStdout(), config)
+		},
+	}
+
+	bindTestFlags(cmd, &config.testConfig)
+
+	bindTestPeersFlags(cmd, &config.Peers, "peers-")
+	bindTestBeaconFlags(cmd, &config.Beacon, "beacon-")
+	bindTestValidatorFlags(cmd, &config.Validator, "validator-")
+	bindTestMEVFlags(cmd, &config.MEV, "mev-")
+	bindTestPerformanceFlags(cmd, &config.Performance, "performance-")
+
+	bindP2PFlags(cmd, &config.Peers.P2P)
+	bindDataDirFlag(cmd.Flags(), &config.Peers.DataDir)
+	bindTestLogFlags(cmd.Flags(), &config.Peers.Log)
+
+	wrapPreRunE(cmd, func(cmd *cobra.Command, _ []string) error {
+		testCasesPresent := cmd.Flags().Lookup("test-cases").Changed
+
+		if testCasesPresent {
+			//nolint:revive // we use our own version of the errors package
+			return errors.New("test-cases cannot be specified when explicitly running all test cases.")
+		}
+
+		return nil
+	})
+
+	return cmd
+}
+
+func runTestAll(ctx context.Context, w io.Writer, cfg testAllConfig) (err error) {
+	cfg.Beacon.testConfig = cfg.testConfig
+	err = runTestBeacon(ctx, w, cfg.Beacon)
+	if err != nil {
+		return err
+	}
+
+	cfg.Validator.testConfig = cfg.testConfig
+	err = runTestValidator(ctx, w, cfg.Validator)
+	if err != nil {
+		return err
+	}
+
+	cfg.MEV.testConfig = cfg.testConfig
+	err = runTestMEV(ctx, w, cfg.MEV)
+	if err != nil {
+		return err
+	}
+
+	cfg.Performance.testConfig = cfg.testConfig
+	err = runTestPerformance(ctx, w, cfg.Performance)
+	if err != nil {
+		return err
+	}
+
+	cfg.Peers.testConfig = cfg.testConfig
+	err = runTestPeers(ctx, w, cfg.Peers)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -377,14 +377,7 @@ func beaconPingMeasureTest(ctx context.Context, _ *testBeaconConfig, target stri
 		return failedTestResult(testRes, err)
 	}
 
-	if rtt > thresholdBeaconMeasurePoor {
-		testRes.Verdict = testVerdictPoor
-	} else if rtt > thresholdBeaconMeasureAvg {
-		testRes.Verdict = testVerdictAvg
-	} else {
-		testRes.Verdict = testVerdictGood
-	}
-	testRes.Measurement = Duration{rtt}.String()
+	testRes = evaluateRTT(rtt, testRes, thresholdBeaconMeasureAvg, thresholdBeaconMeasurePoor)
 
 	return testRes
 }
@@ -438,7 +431,7 @@ func beaconPingLoadTest(ctx context.Context, conf *testBeaconConfig, target stri
 	close(testResCh)
 	log.Info(ctx, "Ping load tests finished", z.Any("target", target))
 
-	testRes = evaluateHighestRTTScore(testResCh, testRes, thresholdBeaconLoadAvg, thresholdBeaconLoadPoor)
+	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdBeaconLoadAvg, thresholdBeaconLoadPoor)
 
 	return testRes
 }

--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -177,20 +177,18 @@ func newTestBeaconCmd(runFunc func(context.Context, io.Writer, testBeaconConfig)
 	}
 
 	bindTestFlags(cmd, &config.testConfig)
-	bindTestBeaconFlags(cmd, &config)
+	bindTestBeaconFlags(cmd, &config, "")
 
 	return cmd
 }
 
-func bindTestBeaconFlags(cmd *cobra.Command, config *testBeaconConfig) {
-	const endpoints = "endpoints"
-	cmd.Flags().StringSliceVar(&config.Endpoints, endpoints, nil, "[REQUIRED] Comma separated list of one or more beacon node endpoint URLs.")
-	mustMarkFlagRequired(cmd, endpoints)
-	cmd.Flags().BoolVar(&config.LoadTest, "load-test", false, "Enable load test, not advisable when testing towards external beacon nodes.")
-	cmd.Flags().DurationVar(&config.LoadTestDuration, "load-test-duration", 5*time.Second, "Time to keep running the load tests in seconds. For each second a new continuous ping instance is spawned.")
-	cmd.Flags().StringVar(&config.SimulationFileDir, "simulation-file-dir", "./", "JSON directory to which simulation file results will be written.")
-	cmd.Flags().IntVar(&config.SimulationDuration, "simulation-duration-in-slots", slotsInEpoch, "Time to keep running the simulation in slots.")
-	cmd.Flags().BoolVar(&config.SimulationVerbose, "simulation-verbose", false, "Show results for each request and each validator.")
+func bindTestBeaconFlags(cmd *cobra.Command, config *testBeaconConfig, flagsPrefix string) {
+	cmd.Flags().StringSliceVar(&config.Endpoints, flagsPrefix+"endpoints", nil, "[REQUIRED] Comma separated list of one or more beacon node endpoint URLs.")
+	cmd.Flags().BoolVar(&config.LoadTest, flagsPrefix+"load-test", false, "Enable load test, not advisable when testing towards external beacon nodes.")
+	cmd.Flags().DurationVar(&config.LoadTestDuration, flagsPrefix+"load-test-duration", 5*time.Second, "Time to keep running the load tests in seconds. For each second a new continuous ping instance is spawned.")
+	cmd.Flags().IntVar(&config.SimulationDuration, flagsPrefix+"simulation-duration-in-slots", slotsInEpoch, "Time to keep running the simulation in slots.")
+	cmd.Flags().BoolVar(&config.SimulationVerbose, flagsPrefix+"simulation-verbose", false, "Show results for each request and each validator.")
+	mustMarkFlagRequired(cmd, flagsPrefix+"endpoints")
 }
 
 func supportedBeaconTestCases() map[testCaseName]testCaseBeacon {

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -253,14 +253,7 @@ func mevPingMeasureTest(ctx context.Context, _ *testMEVConfig, target string) te
 		return failedTestResult(testRes, err)
 	}
 
-	if rtt > thresholdMEVMeasurePoor {
-		testRes.Verdict = testVerdictPoor
-	} else if rtt > thresholdMEVMeasureAvg {
-		testRes.Verdict = testVerdictAvg
-	} else {
-		testRes.Verdict = testVerdictGood
-	}
-	testRes.Measurement = Duration{rtt}.String()
+	testRes = evaluateRTT(rtt, testRes, thresholdMEVMeasureAvg, thresholdMEVMeasurePoor)
 
 	return testRes
 }

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
 )
 
 type testMEVConfig struct {
@@ -35,8 +36,8 @@ func newTestMEVCmd(runFunc func(context.Context, io.Writer, testMEVConfig) error
 
 	cmd := &cobra.Command{
 		Use:   "mev",
-		Short: "Run multiple tests towards mev nodes",
-		Long:  `Run multiple tests towards mev nodes. Verify that Charon can efficiently interact with MEV Node(s).`,
+		Short: "Run multiple tests towards MEV relays",
+		Long:  `Run multiple tests towards MEV relays. Verify that Charon can efficiently interact with MEV relay(s).`,
 		Args:  cobra.NoArgs,
 		PreRunE: func(cmd *cobra.Command, _ []string) error {
 			return mustOutputToFileOnQuiet(cmd)

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -66,6 +66,8 @@ func supportedMEVTestCases() map[testCaseName]testCaseMEV {
 }
 
 func runTestMEV(ctx context.Context, w io.Writer, cfg testMEVConfig) (err error) {
+	log.Info(ctx, "Starting MEV relays test")
+
 	testCases := supportedMEVTestCases()
 	queuedTests := filterTests(maps.Keys(testCases), cfg.testConfig)
 	if len(queuedTests) == 0 {

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -124,6 +124,8 @@ func runTestMEV(ctx context.Context, w io.Writer, cfg testMEVConfig) (err error)
 	return nil
 }
 
+// mev relays tests
+
 func testAllMEVs(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseMEV, conf testMEVConfig, allMEVsResCh chan map[string][]testResult) {
 	defer close(allMEVsResCh)
 	// run tests for all mev nodes
@@ -188,27 +190,6 @@ func testSingleMEV(ctx context.Context, queuedTestCases []testCaseName, allTestC
 	return nil
 }
 
-// Shorten the hash of the MEV relay endpoint
-// Example: https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
-// to https://0xac6e...37ae@boost-relay.flashbots.net
-func formatMEVRelayName(urlString string) string {
-	splitScheme := strings.Split(urlString, "://")
-	if len(splitScheme) == 1 {
-		return urlString
-	}
-	hashSplit := strings.Split(splitScheme[1], "@")
-	if len(hashSplit) == 1 {
-		return urlString
-	}
-	hash := hashSplit[0]
-	if !strings.HasPrefix(hash, "0x") || len(hash) < 18 {
-		return urlString
-	}
-	hashShort := hash[:6] + "..." + hash[len(hash)-4:]
-
-	return splitScheme[0] + "://" + hashShort + "@" + hashSplit[1]
-}
-
 func runMEVTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseMEV, cfg testMEVConfig, target string, ch chan testResult) {
 	defer close(ch)
 	for _, t := range queuedTestCases {
@@ -256,4 +237,27 @@ func mevPingMeasureTest(ctx context.Context, _ *testMEVConfig, target string) te
 	testRes = evaluateRTT(rtt, testRes, thresholdMEVMeasureAvg, thresholdMEVMeasurePoor)
 
 	return testRes
+}
+
+// helper functions
+
+// Shorten the hash of the MEV relay endpoint
+// Example: https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
+// to https://0xac6e...37ae@boost-relay.flashbots.net
+func formatMEVRelayName(urlString string) string {
+	splitScheme := strings.Split(urlString, "://")
+	if len(splitScheme) == 1 {
+		return urlString
+	}
+	hashSplit := strings.Split(splitScheme[1], "@")
+	if len(hashSplit) == 1 {
+		return urlString
+	}
+	hash := hashSplit[0]
+	if !strings.HasPrefix(hash, "0x") || len(hash) < 18 {
+		return urlString
+	}
+	hashShort := hash[:6] + "..." + hash[len(hash)-4:]
+
+	return splitScheme[0] + "://" + hashShort + "@" + hashSplit[1]
 }

--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -48,13 +48,13 @@ func newTestMEVCmd(runFunc func(context.Context, io.Writer, testMEVConfig) error
 	}
 
 	bindTestFlags(cmd, &config.testConfig)
-	bindTestMEVFlags(cmd, &config)
+	bindTestMEVFlags(cmd, &config, "")
 
 	return cmd
 }
 
-func bindTestMEVFlags(cmd *cobra.Command, config *testMEVConfig) {
-	const endpoints = "endpoints"
+func bindTestMEVFlags(cmd *cobra.Command, config *testMEVConfig, flagsPrefix string) {
+	endpoints := flagsPrefix + "endpoints"
 	cmd.Flags().StringSliceVar(&config.Endpoints, endpoints, nil, "[REQUIRED] Comma separated list of one or more MEV relay endpoint URLs.")
 	mustMarkFlagRequired(cmd, endpoints)
 }

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -25,7 +25,6 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/protocol/ping"
 	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
 	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
@@ -122,13 +121,6 @@ func bindTestPeersFlags(cmd *cobra.Command, config *testPeersConfig, flagsPrefix
 	cmd.Flags().DurationVar(&config.DirectConnectionTimeout, flagsPrefix+"direct-connection-timeout", 2*time.Minute, "Time to keep trying to establish direct connection to peer.")
 	cmd.Flags().StringVar(&config.ClusterLockFilePath, flagsPrefix+"cluster-lock-file-path", "", "Path to cluster lock file, used to fetch peers' ENR addresses.")
 	cmd.Flags().StringVar(&config.ClusterDefinitionFilePath, flagsPrefix+"cluster-definition-file-path", "", "Path to cluster definition file, used to fetch peers' ENR addresses.")
-}
-
-func bindTestLogFlags(flags *pflag.FlagSet, config *log.Config) {
-	flags.StringVar(&config.Format, "log-format", "console", "Log format; console, logfmt or json")
-	flags.StringVar(&config.Level, "log-level", "info", "Log level; debug, info, warn or error")
-	flags.StringVar(&config.Color, "log-color", "auto", "Log color; auto, force, disable.")
-	flags.StringVar(&config.LogOutputPath, "log-output-path", "", "Path in which to write on-disk logs.")
 }
 
 func supportedPeerTestCases() map[testCaseName]testCasePeer {

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -83,7 +83,7 @@ func newTestPeersCmd(runFunc func(context.Context, io.Writer, testPeersConfig) e
 	}
 
 	bindTestFlags(cmd, &config.testConfig)
-	bindTestPeersFlags(cmd, &config)
+	bindTestPeersFlags(cmd, &config, "")
 	bindP2PFlags(cmd, &config.P2P)
 	bindDataDirFlag(cmd.Flags(), &config.DataDir)
 	bindTestLogFlags(cmd.Flags(), &config.Log)
@@ -116,14 +116,13 @@ func newTestPeersCmd(runFunc func(context.Context, io.Writer, testPeersConfig) e
 	return cmd
 }
 
-func bindTestPeersFlags(cmd *cobra.Command, config *testPeersConfig) {
-	const enrs = "enrs"
-	cmd.Flags().StringSliceVar(&config.ENRs, enrs, nil, "Comma-separated list of each peer ENR address.")
-	cmd.Flags().DurationVar(&config.KeepAlive, "keep-alive", 30*time.Minute, "Time to keep TCP node alive after test completion, so connection is open for other peers to test on their end.")
-	cmd.Flags().DurationVar(&config.LoadTestDuration, "load-test-duration", 30*time.Second, "Time to keep running the load tests in seconds. For each second a new continuous ping instance is spawned.")
-	cmd.Flags().DurationVar(&config.DirectConnectionTimeout, "direct-connection-timeout", 2*time.Minute, "Time to keep trying to establish direct connection to peer.")
-	cmd.Flags().StringVar(&config.ClusterLockFilePath, "cluster-lock-file-path", "", "Path to cluster lock file, used to fetch peers' ENR addresses.")
-	cmd.Flags().StringVar(&config.ClusterDefinitionFilePath, "cluster-definition-file-path", "", "Path to cluster definition file, used to fetch peers' ENR addresses.")
+func bindTestPeersFlags(cmd *cobra.Command, config *testPeersConfig, flagsPrefix string) {
+	cmd.Flags().StringSliceVar(&config.ENRs, flagsPrefix+"enrs", nil, "[REQUIRED] Comma-separated list of each peer ENR address.")
+	cmd.Flags().DurationVar(&config.KeepAlive, flagsPrefix+"keep-alive", 30*time.Minute, "Time to keep TCP node alive after test completion, so connection is open for other peers to test on their end.")
+	cmd.Flags().DurationVar(&config.LoadTestDuration, flagsPrefix+"load-test-duration", 30*time.Second, "Time to keep running the load tests in seconds. For each second a new continuous ping instance is spawned.")
+	cmd.Flags().DurationVar(&config.DirectConnectionTimeout, flagsPrefix+"direct-connection-timeout", 2*time.Minute, "Time to keep trying to establish direct connection to peer.")
+	cmd.Flags().StringVar(&config.ClusterLockFilePath, flagsPrefix+"cluster-lock-file-path", "", "Path to cluster lock file, used to fetch peers' ENR addresses.")
+	cmd.Flags().StringVar(&config.ClusterDefinitionFilePath, flagsPrefix+"cluster-definition-file-path", "", "Path to cluster definition file, used to fetch peers' ENR addresses.")
 }
 
 func bindTestLogFlags(flags *pflag.FlagSet, config *log.Config) {

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -145,6 +145,521 @@ func supportedSelfTestCases() map[testCaseName]testCasePeerSelf {
 	}
 }
 
+func runTestPeers(ctx context.Context, w io.Writer, conf testPeersConfig) error {
+	log.Info(ctx, "Starting charon peers and relays test")
+
+	relayTestCases := supportedRelayTestCases()
+	queuedTestsRelay := filterTests(maps.Keys(relayTestCases), conf.testConfig)
+	sortTests(queuedTestsRelay)
+
+	peerTestCases := supportedPeerTestCases()
+	queuedTestsPeer := filterTests(maps.Keys(peerTestCases), conf.testConfig)
+	sortTests(queuedTestsPeer)
+
+	selfTestCases := supportedSelfTestCases()
+	queuedTestsSelf := filterTests(maps.Keys(selfTestCases), conf.testConfig)
+	sortTests(queuedTestsSelf)
+
+	if len(queuedTestsPeer) == 0 && len(queuedTestsSelf) == 0 {
+		return errors.New("test case not supported")
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, conf.Timeout)
+	defer cancel()
+
+	testResultsChan := make(chan map[string][]testResult)
+	testResults := make(map[string][]testResult)
+
+	tcpNode, shutdown, err := startTCPNode(ctx, conf)
+	if err != nil {
+		return err
+	}
+	defer shutdown()
+
+	group, _ := errgroup.WithContext(timeoutCtx)
+	doneReading := make(chan bool)
+
+	startTime := time.Now()
+	group.Go(func() error {
+		return testAllRelays(timeoutCtx, queuedTestsRelay, relayTestCases, conf, testResultsChan)
+	})
+	group.Go(func() error {
+		return testAllPeers(timeoutCtx, queuedTestsPeer, peerTestCases, conf, tcpNode, testResultsChan)
+	})
+	group.Go(func() error {
+		return testSelf(timeoutCtx, queuedTestsSelf, selfTestCases, conf, testResultsChan)
+	})
+
+	go func() {
+		for result := range testResultsChan {
+			maps.Copy(testResults, result)
+		}
+		doneReading <- true
+	}()
+
+	err = group.Wait()
+	execTime := Duration{time.Since(startTime)}
+	if err != nil {
+		return errors.Wrap(err, "peers test errgroup")
+	}
+	close(testResultsChan)
+	<-doneReading
+
+	// use lowest score as score of all
+	var score categoryScore
+	for _, t := range testResults {
+		targetScore := calculateScore(t)
+		if score == "" || score < targetScore {
+			score = targetScore
+		}
+	}
+
+	res := testCategoryResult{
+		CategoryName:  peersTestCategory,
+		Targets:       testResults,
+		ExecutionTime: execTime,
+		Score:         score,
+	}
+
+	if !conf.Quiet {
+		err = writeResultToWriter(res, w)
+		if err != nil {
+			return err
+		}
+	}
+
+	if conf.OutputToml != "" {
+		err = writeResultToFile(res, conf.OutputToml)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info(ctx, "Keeping TCP node alive for peers until keep-alive time is reached...")
+	blockAndWait(ctx, conf.KeepAlive)
+
+	return nil
+}
+
+// charon peers tests
+
+func testAllPeers(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, allPeersResCh chan map[string][]testResult) error {
+	// run tests for all peer nodes
+	allPeersRes := make(map[string][]testResult)
+	singlePeerResCh := make(chan map[string][]testResult)
+	group, _ := errgroup.WithContext(ctx)
+
+	enrs, err := fetchENRs(conf)
+	if err != nil {
+		return err
+	}
+	for _, enr := range enrs {
+		currENR := enr // TODO: can be removed after go1.22 version bump
+		group.Go(func() error {
+			return testSinglePeer(ctx, queuedTestCases, allTestCases, conf, tcpNode, currENR, singlePeerResCh)
+		})
+	}
+
+	doneReading := make(chan bool)
+	go func() {
+		for singlePeerRes := range singlePeerResCh {
+			maps.Copy(allPeersRes, singlePeerRes)
+		}
+		doneReading <- true
+	}()
+
+	err = group.Wait()
+	if err != nil {
+		return errors.Wrap(err, "peers test errgroup")
+	}
+	close(singlePeerResCh)
+	<-doneReading
+
+	allPeersResCh <- allPeersRes
+
+	return nil
+}
+
+func testSinglePeer(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target string, allTestResCh chan map[string][]testResult) error {
+	singleTestResCh := make(chan testResult)
+	allTestRes := []testResult{}
+	enrTarget, err := enr.Parse(target)
+	if err != nil {
+		return err
+	}
+	peerTarget, err := p2p.NewPeerFromENR(enrTarget, 0)
+	if err != nil {
+		return err
+	}
+
+	formatENR := target[:13] + "..." + target[len(target)-4:] // enr:- + first 8 chars + ... + last 4 chars
+	nameENR := fmt.Sprintf("peer %v %v", peerTarget.Name, formatENR)
+
+	if len(queuedTestCases) == 0 {
+		allTestResCh <- map[string][]testResult{nameENR: allTestRes}
+		return nil
+	}
+
+	// run all peers tests for a peer, pushing each completed test to the channel until all are complete or timeout occurs
+	go runPeerTest(ctx, queuedTestCases, allTestCases, conf, tcpNode, peerTarget, singleTestResCh)
+	testCounter := 0
+	finished := false
+	for !finished {
+		var testName string
+		select {
+		case <-ctx.Done():
+			if testCounter < len(queuedTestCases) {
+				testName = queuedTestCases[testCounter].name
+				allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			}
+			finished = true
+		case result, ok := <-singleTestResCh:
+			if !ok {
+				finished = true
+				continue
+			}
+			testName = queuedTestCases[testCounter].name
+			testCounter++
+			result.Name = testName
+			allTestRes = append(allTestRes, result)
+		}
+	}
+
+	allTestResCh <- map[string][]testResult{nameENR: allTestRes}
+
+	return nil
+}
+
+func runPeerTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target p2p.Peer, testResCh chan testResult) {
+	defer close(testResCh)
+	for _, t := range queuedTestCases {
+		select {
+		case <-ctx.Done():
+			testResCh <- failedTestResult(testResult{Name: t.name}, errTimeoutInterrupted)
+			return
+		default:
+			testResCh <- allTestCases[t](ctx, &conf, tcpNode, target)
+		}
+	}
+}
+
+func peerPingTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
+	testRes := testResult{Name: "Ping"}
+
+	ticker := time.NewTicker(1)
+	defer ticker.Stop()
+
+	for ; true; <-ticker.C {
+		select {
+		case <-ctx.Done():
+			return failedTestResult(testRes, errTimeoutInterrupted)
+		default:
+			ticker.Reset(3 * time.Second)
+			result, err := pingPeerOnce(ctx, tcpNode, peer)
+			if err != nil {
+				return failedTestResult(testRes, err)
+			}
+
+			if result.Error != nil {
+				switch {
+				case errors.Is(result.Error, context.DeadlineExceeded):
+					return failedTestResult(testRes, errTimeoutInterrupted)
+				case p2p.IsRelayError(result.Error):
+					return failedTestResult(testRes, result.Error)
+				default:
+					log.Warn(ctx, "Ping to peer failed, retrying in 3 sec...", nil, z.Str("peer_name", peer.Name))
+					continue
+				}
+			}
+
+			testRes.Verdict = testVerdictOk
+
+			return testRes
+		}
+	}
+
+	testRes.Verdict = testVerdictFail
+	testRes.Error = errNoTicker
+
+	return testRes
+}
+
+func peerPingMeasureTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
+	testRes := testResult{Name: "PingMeasure"}
+
+	result, err := pingPeerOnce(ctx, tcpNode, peer)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	if result.Error != nil {
+		return failedTestResult(testRes, result.Error)
+	}
+
+	if result.RTT > thresholdPeersMeasurePoor {
+		testRes.Verdict = testVerdictPoor
+	} else if result.RTT > thresholdPeersMeasureAvg {
+		testRes.Verdict = testVerdictAvg
+	} else {
+		testRes.Verdict = testVerdictGood
+	}
+	testRes.Measurement = Duration{result.RTT}.String()
+
+	return testRes
+}
+
+func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
+	log.Info(ctx, "Running ping load tests...",
+		z.Any("duration", conf.LoadTestDuration),
+		z.Any("target", peer.Name),
+	)
+	testRes := testResult{Name: "PingLoad"}
+
+	testResCh := make(chan time.Duration, math.MaxInt16)
+	pingCtx, cancel := context.WithTimeout(ctx, conf.LoadTestDuration)
+	defer cancel()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var wg sync.WaitGroup
+	for pingCtx.Err() == nil {
+		select {
+		case <-ticker.C:
+			wg.Add(1)
+			go func() {
+				pingPeerContinuously(pingCtx, tcpNode, peer, testResCh)
+				wg.Done()
+			}()
+		case <-pingCtx.Done():
+		}
+	}
+	wg.Wait()
+	close(testResCh)
+	log.Info(ctx, "Ping load tests finished", z.Any("target", peer.Name))
+
+	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdPeersLoadAvg, thresholdPeersLoadPoor)
+
+	return testRes
+}
+
+func peerDirectConnTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, p2pPeer p2p.Peer) testResult {
+	testRes := testResult{Name: "DirectConn"}
+
+	log.Info(ctx, "Trying to establish direct connection...",
+		z.Any("timeout", conf.DirectConnectionTimeout),
+		z.Any("target", p2pPeer.Name))
+
+	var err error
+	for range int(conf.DirectConnectionTimeout.Seconds()) {
+		err = tcpNode.Connect(network.WithForceDirectDial(ctx, "relay_to_direct"), peer.AddrInfo{ID: p2pPeer.ID})
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	log.Info(ctx, "Direct connection established", z.Any("target", p2pPeer.Name))
+
+	conns := tcpNode.Network().ConnsToPeer(p2pPeer.ID)
+	if len(conns) < 2 {
+		return failedTestResult(testRes, errors.New("expected 2 connections to peer (relay and direct)", z.Int("connections", len(conns))))
+	}
+
+	testRes.Verdict = testVerdictOk
+
+	return testRes
+}
+
+// self tests
+
+func testSelf(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, allTestResCh chan map[string][]testResult) error {
+	singleTestResCh := make(chan testResult)
+	allTestRes := []testResult{}
+	if len(queuedTestCases) == 0 {
+		allTestResCh <- map[string][]testResult{"self": allTestRes}
+		return nil
+	}
+	go runSelfTest(ctx, queuedTestCases, allTestCases, conf, singleTestResCh)
+
+	testCounter := 0
+	finished := false
+	for !finished {
+		var testName string
+		select {
+		case <-ctx.Done():
+			testName = queuedTestCases[testCounter].name
+			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			finished = true
+		case result, ok := <-singleTestResCh:
+			if !ok {
+				finished = true
+				continue
+			}
+			testName = queuedTestCases[testCounter].name
+			testCounter++
+			result.Name = testName
+			allTestRes = append(allTestRes, result)
+		}
+	}
+
+	allTestResCh <- map[string][]testResult{"self": allTestRes}
+
+	return nil
+}
+
+func runSelfTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, ch chan testResult) {
+	defer close(ch)
+	for _, t := range queuedTestCases {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			ch <- allTestCases[t](ctx, &conf)
+		}
+	}
+}
+
+func libp2pTCPPortOpenTest(ctx context.Context, cfg *testPeersConfig) testResult {
+	testRes := testResult{Name: "Libp2pTCPPortOpen"}
+
+	group, _ := errgroup.WithContext(ctx)
+
+	for _, addr := range cfg.P2P.TCPAddrs {
+		group.Go(func() error { return dialLibp2pTCPIP(ctx, addr) })
+	}
+
+	err := group.Wait()
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+
+	testRes.Verdict = testVerdictOk
+
+	return testRes
+}
+
+// charon relays tests
+
+func testAllRelays(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, allRelaysResCh chan map[string][]testResult) error {
+	// run tests for all relays
+	allRelayRes := make(map[string][]testResult)
+	singleRelayResCh := make(chan map[string][]testResult)
+	group, _ := errgroup.WithContext(ctx)
+
+	for _, relay := range conf.P2P.Relays {
+		group.Go(func() error {
+			return testSingleRelay(ctx, queuedTestCases, allTestCases, conf, relay, singleRelayResCh)
+		})
+	}
+
+	doneReading := make(chan bool)
+	go func() {
+		for singleRelayRes := range singleRelayResCh {
+			maps.Copy(allRelayRes, singleRelayRes)
+		}
+		doneReading <- true
+	}()
+
+	err := group.Wait()
+	if err != nil {
+		return errors.Wrap(err, "relays test errgroup")
+	}
+	close(singleRelayResCh)
+	<-doneReading
+
+	allRelaysResCh <- allRelayRes
+
+	return nil
+}
+
+func testSingleRelay(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, allTestResCh chan map[string][]testResult) error {
+	singleTestResCh := make(chan testResult)
+	allTestRes := []testResult{}
+	relayName := fmt.Sprintf("relay %v", target)
+	if len(queuedTestCases) == 0 {
+		allTestResCh <- map[string][]testResult{relayName: allTestRes}
+		return nil
+	}
+
+	// run all relay tests for a relay, pushing each completed test to the channel until all are complete or timeout occurs
+	go runRelayTest(ctx, queuedTestCases, allTestCases, conf, target, singleTestResCh)
+	testCounter := 0
+	finished := false
+	for !finished {
+		var testName string
+		select {
+		case <-ctx.Done():
+			testName = queuedTestCases[testCounter].name
+			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			finished = true
+		case result, ok := <-singleTestResCh:
+			if !ok {
+				finished = true
+				continue
+			}
+			testName = queuedTestCases[testCounter].name
+			testCounter++
+			result.Name = testName
+			allTestRes = append(allTestRes, result)
+		}
+	}
+
+	allTestResCh <- map[string][]testResult{relayName: allTestRes}
+
+	return nil
+}
+
+func runRelayTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, testResCh chan testResult) {
+	defer close(testResCh)
+	for _, t := range queuedTestCases {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			testResCh <- allTestCases[t](ctx, &conf, target)
+		}
+	}
+}
+
+func relayPingTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
+	testRes := testResult{Name: "PingRelay"}
+
+	client := http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 399 {
+		return failedTestResult(testRes, errors.New(httpStatusError(resp.StatusCode)))
+	}
+
+	testRes.Verdict = testVerdictOk
+
+	return testRes
+}
+
+func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
+	testRes := testResult{Name: "PingMeasureRelay"}
+
+	rtt, err := requestRTT(ctx, target, http.MethodGet, nil, 200)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+
+	testRes = evaluateRTT(rtt, testRes, thresholdRelayMeasureAvg, thresholdRelayMeasurePoor)
+
+	return testRes
+}
+
+// helper functions
+
 func fetchPeersFromDefinition(path string) ([]string, error) {
 	f, err := os.ReadFile(path)
 	if err != nil {
@@ -334,428 +849,6 @@ func pingPeerContinuously(ctx context.Context, tcpNode host.Host, peer p2p.Peer,
 	}
 }
 
-func runTestPeers(ctx context.Context, w io.Writer, conf testPeersConfig) error {
-	log.Info(ctx, "Starting charon peers and relays test")
-
-	relayTestCases := supportedRelayTestCases()
-	queuedTestsRelay := filterTests(maps.Keys(relayTestCases), conf.testConfig)
-	sortTests(queuedTestsRelay)
-
-	peerTestCases := supportedPeerTestCases()
-	queuedTestsPeer := filterTests(maps.Keys(peerTestCases), conf.testConfig)
-	sortTests(queuedTestsPeer)
-
-	selfTestCases := supportedSelfTestCases()
-	queuedTestsSelf := filterTests(maps.Keys(selfTestCases), conf.testConfig)
-	sortTests(queuedTestsSelf)
-
-	if len(queuedTestsPeer) == 0 && len(queuedTestsSelf) == 0 {
-		return errors.New("test case not supported")
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, conf.Timeout)
-	defer cancel()
-
-	testResultsChan := make(chan map[string][]testResult)
-	testResults := make(map[string][]testResult)
-
-	tcpNode, shutdown, err := startTCPNode(ctx, conf)
-	if err != nil {
-		return err
-	}
-	defer shutdown()
-
-	group, _ := errgroup.WithContext(timeoutCtx)
-	doneReading := make(chan bool)
-
-	startTime := time.Now()
-	group.Go(func() error {
-		return testAllRelays(timeoutCtx, queuedTestsRelay, relayTestCases, conf, testResultsChan)
-	})
-	group.Go(func() error {
-		return testAllPeers(timeoutCtx, queuedTestsPeer, peerTestCases, conf, tcpNode, testResultsChan)
-	})
-	group.Go(func() error {
-		return testSelf(timeoutCtx, queuedTestsSelf, selfTestCases, conf, testResultsChan)
-	})
-
-	go func() {
-		for result := range testResultsChan {
-			maps.Copy(testResults, result)
-		}
-		doneReading <- true
-	}()
-
-	err = group.Wait()
-	execTime := Duration{time.Since(startTime)}
-	if err != nil {
-		return errors.Wrap(err, "peers test errgroup")
-	}
-	close(testResultsChan)
-	<-doneReading
-
-	// use lowest score as score of all
-	var score categoryScore
-	for _, t := range testResults {
-		targetScore := calculateScore(t)
-		if score == "" || score < targetScore {
-			score = targetScore
-		}
-	}
-
-	res := testCategoryResult{
-		CategoryName:  peersTestCategory,
-		Targets:       testResults,
-		ExecutionTime: execTime,
-		Score:         score,
-	}
-
-	if !conf.Quiet {
-		err = writeResultToWriter(res, w)
-		if err != nil {
-			return err
-		}
-	}
-
-	if conf.OutputToml != "" {
-		err = writeResultToFile(res, conf.OutputToml)
-		if err != nil {
-			return err
-		}
-	}
-
-	log.Info(ctx, "Keeping TCP node alive for peers until keep-alive time is reached...")
-	blockAndWait(ctx, conf.KeepAlive)
-
-	return nil
-}
-
-func testAllRelays(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, allRelaysResCh chan map[string][]testResult) error {
-	// run tests for all relays
-	allRelayRes := make(map[string][]testResult)
-	singleRelayResCh := make(chan map[string][]testResult)
-	group, _ := errgroup.WithContext(ctx)
-
-	for _, relay := range conf.P2P.Relays {
-		group.Go(func() error {
-			return testSingleRelay(ctx, queuedTestCases, allTestCases, conf, relay, singleRelayResCh)
-		})
-	}
-
-	doneReading := make(chan bool)
-	go func() {
-		for singleRelayRes := range singleRelayResCh {
-			maps.Copy(allRelayRes, singleRelayRes)
-		}
-		doneReading <- true
-	}()
-
-	err := group.Wait()
-	if err != nil {
-		return errors.Wrap(err, "relays test errgroup")
-	}
-	close(singleRelayResCh)
-	<-doneReading
-
-	allRelaysResCh <- allRelayRes
-
-	return nil
-}
-
-func testSingleRelay(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, allTestResCh chan map[string][]testResult) error {
-	singleTestResCh := make(chan testResult)
-	allTestRes := []testResult{}
-	relayName := fmt.Sprintf("relay %v", target)
-	if len(queuedTestCases) == 0 {
-		allTestResCh <- map[string][]testResult{relayName: allTestRes}
-		return nil
-	}
-
-	// run all relay tests for a relay, pushing each completed test to the channel until all are complete or timeout occurs
-	go runRelayTest(ctx, queuedTestCases, allTestCases, conf, target, singleTestResCh)
-	testCounter := 0
-	finished := false
-	for !finished {
-		var testName string
-		select {
-		case <-ctx.Done():
-			testName = queuedTestCases[testCounter].name
-			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
-			finished = true
-		case result, ok := <-singleTestResCh:
-			if !ok {
-				finished = true
-				continue
-			}
-			testName = queuedTestCases[testCounter].name
-			testCounter++
-			result.Name = testName
-			allTestRes = append(allTestRes, result)
-		}
-	}
-
-	allTestResCh <- map[string][]testResult{relayName: allTestRes}
-
-	return nil
-}
-
-func runRelayTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, testResCh chan testResult) {
-	defer close(testResCh)
-	for _, t := range queuedTestCases {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			testResCh <- allTestCases[t](ctx, &conf, target)
-		}
-	}
-}
-
-func testAllPeers(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, allPeersResCh chan map[string][]testResult) error {
-	// run tests for all peer nodes
-	allPeersRes := make(map[string][]testResult)
-	singlePeerResCh := make(chan map[string][]testResult)
-	group, _ := errgroup.WithContext(ctx)
-
-	enrs, err := fetchENRs(conf)
-	if err != nil {
-		return err
-	}
-	for _, enr := range enrs {
-		currENR := enr // TODO: can be removed after go1.22 version bump
-		group.Go(func() error {
-			return testSinglePeer(ctx, queuedTestCases, allTestCases, conf, tcpNode, currENR, singlePeerResCh)
-		})
-	}
-
-	doneReading := make(chan bool)
-	go func() {
-		for singlePeerRes := range singlePeerResCh {
-			maps.Copy(allPeersRes, singlePeerRes)
-		}
-		doneReading <- true
-	}()
-
-	err = group.Wait()
-	if err != nil {
-		return errors.Wrap(err, "peers test errgroup")
-	}
-	close(singlePeerResCh)
-	<-doneReading
-
-	allPeersResCh <- allPeersRes
-
-	return nil
-}
-
-func testSinglePeer(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target string, allTestResCh chan map[string][]testResult) error {
-	singleTestResCh := make(chan testResult)
-	allTestRes := []testResult{}
-	enrTarget, err := enr.Parse(target)
-	if err != nil {
-		return err
-	}
-	peerTarget, err := p2p.NewPeerFromENR(enrTarget, 0)
-	if err != nil {
-		return err
-	}
-
-	formatENR := target[:13] + "..." + target[len(target)-4:] // enr:- + first 8 chars + ... + last 4 chars
-	nameENR := fmt.Sprintf("peer %v %v", peerTarget.Name, formatENR)
-
-	if len(queuedTestCases) == 0 {
-		allTestResCh <- map[string][]testResult{nameENR: allTestRes}
-		return nil
-	}
-
-	// run all peers tests for a peer, pushing each completed test to the channel until all are complete or timeout occurs
-	go runPeerTest(ctx, queuedTestCases, allTestCases, conf, tcpNode, peerTarget, singleTestResCh)
-	testCounter := 0
-	finished := false
-	for !finished {
-		var testName string
-		select {
-		case <-ctx.Done():
-			if testCounter < len(queuedTestCases) {
-				testName = queuedTestCases[testCounter].name
-				allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
-			}
-			finished = true
-		case result, ok := <-singleTestResCh:
-			if !ok {
-				finished = true
-				continue
-			}
-			testName = queuedTestCases[testCounter].name
-			testCounter++
-			result.Name = testName
-			allTestRes = append(allTestRes, result)
-		}
-	}
-
-	allTestResCh <- map[string][]testResult{nameENR: allTestRes}
-
-	return nil
-}
-
-func runPeerTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target p2p.Peer, testResCh chan testResult) {
-	defer close(testResCh)
-	for _, t := range queuedTestCases {
-		select {
-		case <-ctx.Done():
-			testResCh <- failedTestResult(testResult{Name: t.name}, errTimeoutInterrupted)
-			return
-		default:
-			testResCh <- allTestCases[t](ctx, &conf, tcpNode, target)
-		}
-	}
-}
-
-func testSelf(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, allTestResCh chan map[string][]testResult) error {
-	singleTestResCh := make(chan testResult)
-	allTestRes := []testResult{}
-	if len(queuedTestCases) == 0 {
-		allTestResCh <- map[string][]testResult{"self": allTestRes}
-		return nil
-	}
-	go runSelfTest(ctx, queuedTestCases, allTestCases, conf, singleTestResCh)
-
-	testCounter := 0
-	finished := false
-	for !finished {
-		var testName string
-		select {
-		case <-ctx.Done():
-			testName = queuedTestCases[testCounter].name
-			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
-			finished = true
-		case result, ok := <-singleTestResCh:
-			if !ok {
-				finished = true
-				continue
-			}
-			testName = queuedTestCases[testCounter].name
-			testCounter++
-			result.Name = testName
-			allTestRes = append(allTestRes, result)
-		}
-	}
-
-	allTestResCh <- map[string][]testResult{"self": allTestRes}
-
-	return nil
-}
-
-func runSelfTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, ch chan testResult) {
-	defer close(ch)
-	for _, t := range queuedTestCases {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			ch <- allTestCases[t](ctx, &conf)
-		}
-	}
-}
-
-func peerPingTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
-	testRes := testResult{Name: "Ping"}
-
-	ticker := time.NewTicker(1)
-	defer ticker.Stop()
-
-	for ; true; <-ticker.C {
-		select {
-		case <-ctx.Done():
-			return failedTestResult(testRes, errTimeoutInterrupted)
-		default:
-			ticker.Reset(3 * time.Second)
-			result, err := pingPeerOnce(ctx, tcpNode, peer)
-			if err != nil {
-				return failedTestResult(testRes, err)
-			}
-
-			if result.Error != nil {
-				switch {
-				case errors.Is(result.Error, context.DeadlineExceeded):
-					return failedTestResult(testRes, errTimeoutInterrupted)
-				case p2p.IsRelayError(result.Error):
-					return failedTestResult(testRes, result.Error)
-				default:
-					log.Warn(ctx, "Ping to peer failed, retrying in 3 sec...", nil, z.Str("peer_name", peer.Name))
-					continue
-				}
-			}
-
-			testRes.Verdict = testVerdictOk
-
-			return testRes
-		}
-	}
-
-	testRes.Verdict = testVerdictFail
-	testRes.Error = errNoTicker
-
-	return testRes
-}
-
-func peerPingMeasureTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
-	testRes := testResult{Name: "PingMeasure"}
-
-	result, err := pingPeerOnce(ctx, tcpNode, peer)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	if result.Error != nil {
-		return failedTestResult(testRes, result.Error)
-	}
-
-	if result.RTT > thresholdPeersMeasurePoor {
-		testRes.Verdict = testVerdictPoor
-	} else if result.RTT > thresholdPeersMeasureAvg {
-		testRes.Verdict = testVerdictAvg
-	} else {
-		testRes.Verdict = testVerdictGood
-	}
-	testRes.Measurement = Duration{result.RTT}.String()
-
-	return testRes
-}
-
-func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
-	log.Info(ctx, "Running ping load tests...",
-		z.Any("duration", conf.LoadTestDuration),
-		z.Any("target", peer.Name),
-	)
-	testRes := testResult{Name: "PingLoad"}
-
-	testResCh := make(chan time.Duration, math.MaxInt16)
-	pingCtx, cancel := context.WithTimeout(ctx, conf.LoadTestDuration)
-	defer cancel()
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	var wg sync.WaitGroup
-	for pingCtx.Err() == nil {
-		select {
-		case <-ticker.C:
-			wg.Add(1)
-			go func() {
-				pingPeerContinuously(pingCtx, tcpNode, peer, testResCh)
-				wg.Done()
-			}()
-		case <-pingCtx.Done():
-		}
-	}
-	wg.Wait()
-	close(testResCh)
-	log.Info(ctx, "Ping load tests finished", z.Any("target", peer.Name))
-
-	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdPeersLoadAvg, thresholdPeersLoadPoor)
-
-	return testRes
-}
-
 func dialLibp2pTCPIP(ctx context.Context, address string) error {
 	d := net.Dialer{Timeout: time.Second}
 	conn, err := d.DialContext(ctx, "tcp", address)
@@ -778,89 +871,4 @@ func dialLibp2pTCPIP(ctx context.Context, address string) error {
 	}
 
 	return nil
-}
-
-func peerDirectConnTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, p2pPeer p2p.Peer) testResult {
-	testRes := testResult{Name: "DirectConn"}
-
-	log.Info(ctx, "Trying to establish direct connection...",
-		z.Any("timeout", conf.DirectConnectionTimeout),
-		z.Any("target", p2pPeer.Name))
-
-	var err error
-	for range int(conf.DirectConnectionTimeout.Seconds()) {
-		err = tcpNode.Connect(network.WithForceDirectDial(ctx, "relay_to_direct"), peer.AddrInfo{ID: p2pPeer.ID})
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	log.Info(ctx, "Direct connection established", z.Any("target", p2pPeer.Name))
-
-	conns := tcpNode.Network().ConnsToPeer(p2pPeer.ID)
-	if len(conns) < 2 {
-		return failedTestResult(testRes, errors.New("expected 2 connections to peer (relay and direct)", z.Int("connections", len(conns))))
-	}
-
-	testRes.Verdict = testVerdictOk
-
-	return testRes
-}
-
-func libp2pTCPPortOpenTest(ctx context.Context, cfg *testPeersConfig) testResult {
-	testRes := testResult{Name: "Libp2pTCPPortOpen"}
-
-	group, _ := errgroup.WithContext(ctx)
-
-	for _, addr := range cfg.P2P.TCPAddrs {
-		group.Go(func() error { return dialLibp2pTCPIP(ctx, addr) })
-	}
-
-	err := group.Wait()
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-
-	testRes.Verdict = testVerdictOk
-
-	return testRes
-}
-
-func relayPingTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
-	testRes := testResult{Name: "PingRelay"}
-
-	client := http.Client{}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 399 {
-		return failedTestResult(testRes, errors.New(httpStatusError(resp.StatusCode)))
-	}
-
-	testRes.Verdict = testVerdictOk
-
-	return testRes
-}
-
-func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
-	testRes := testResult{Name: "PingMeasureRelay"}
-
-	rtt, err := requestRTT(ctx, target, http.MethodGet, nil, 200)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-
-	testRes = evaluateRTT(rtt, testRes, thresholdRelayMeasureAvg, thresholdRelayMeasurePoor)
-
-	return testRes
 }

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -759,7 +759,7 @@ func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.H
 	close(testResCh)
 	log.Info(ctx, "Ping load tests finished", z.Any("target", peer.Name))
 
-	testRes = evaluateHighestRTTScore(testResCh, testRes, thresholdPeersLoadAvg, thresholdPeersLoadPoor)
+	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdPeersLoadAvg, thresholdPeersLoadPoor)
 
 	return testRes
 }
@@ -868,14 +868,7 @@ func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string
 		return failedTestResult(testRes, err)
 	}
 
-	if rtt > thresholdRelayMeasurePoor {
-		testRes.Verdict = testVerdictPoor
-	} else if rtt > thresholdRelayMeasureAvg {
-		testRes.Verdict = testVerdictAvg
-	} else {
-		testRes.Verdict = testVerdictGood
-	}
-	testRes.Measurement = Duration{rtt}.String()
+	testRes = evaluateRTT(rtt, testRes, thresholdRelayMeasureAvg, thresholdRelayMeasurePoor)
 
 	return testRes
 }

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -568,7 +568,8 @@ func testSinglePeer(ctx context.Context, queuedTestCases []testCaseName, allTest
 		return err
 	}
 
-	nameENR := fmt.Sprintf("peer %v %v", peerTarget.Name, target)
+	formatENR := target[:13] + "..." + target[len(target)-4:] // enr:- + first 8 chars + ... + last 4 chars
+	nameENR := fmt.Sprintf("peer %v %v", peerTarget.Name, formatENR)
 
 	if len(queuedTestCases) == 0 {
 		allTestResCh <- map[string][]testResult{nameENR: allTestRes}

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -78,19 +78,19 @@ func TestPeersTest(t *testing.T) {
 						{Name: "pingRelay", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingMeasureRelay", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
-					"peer inexpensive-farm enr:-HW4QBHlcyD3fYWUMADiOv4OxODaL5wJG0a7P7d_ltu4VZe1MibZ1N-twFaoaq0BoCtXcY71etxLJGeEZT5p3XCO6GOAgmlkgnY0iXNlY3AyNTZrMaEDI2HRUlVBag__njkOWEEQRLlC9ylIVCrIXOuNBSlrx6o": {
+					"peer inexpensive-farm enr:-HW4QBHlc...rx6o": {
 						{Name: "ping", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingMeasure", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingLoad", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "directConn", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
-					"peer anxious-pencil enr:-HW4QDwUF804f4WhUjwcp4JJ-PrRH0glQZv8s2cVHlBRPJ3SYcYO-dvJGsKhztffrski5eujJkl8oAc983MZy6-PqF2AgmlkgnY0iXNlY3AyNTZrMaECPEPryjkmUBnQFyjmMw9rl7DVtKL0243nN5iepqsvKDw": {
+					"peer anxious-pencil enr:-HW4QDwUF...vKDw": {
 						{Name: "ping", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingMeasure", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingLoad", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "directConn", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
-					"peer important-pen enr:-HW4QPSBgUTag8oZs3zIsgWzlBUrSgT8pgZmFJa7HWwKXUcRLlISa68OJtp-JTzhUXsJ2vSGwKGACn0OTatWdJATxn-AgmlkgnY0iXNlY3AyNTZrMaECA3R_ffXLXCLJsfEwf6xeoAFgWnDIOdq8kS0Yqkhwbr0": {
+					"peer important-pen enr:-HW4QPSBg...wbr0": {
 						{Name: "ping", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingMeasure", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingLoad", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
@@ -144,13 +144,13 @@ func TestPeersTest(t *testing.T) {
 						{Name: "pingRelay", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingMeasureRelay", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
-					"peer inexpensive-farm enr:-HW4QBHlcyD3fYWUMADiOv4OxODaL5wJG0a7P7d_ltu4VZe1MibZ1N-twFaoaq0BoCtXcY71etxLJGeEZT5p3XCO6GOAgmlkgnY0iXNlY3AyNTZrMaEDI2HRUlVBag__njkOWEEQRLlC9ylIVCrIXOuNBSlrx6o": {
+					"peer inexpensive-farm enr:-HW4QBHlc...rx6o": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
-					"peer anxious-pencil enr:-HW4QDwUF804f4WhUjwcp4JJ-PrRH0glQZv8s2cVHlBRPJ3SYcYO-dvJGsKhztffrski5eujJkl8oAc983MZy6-PqF2AgmlkgnY0iXNlY3AyNTZrMaECPEPryjkmUBnQFyjmMw9rl7DVtKL0243nN5iepqsvKDw": {
+					"peer anxious-pencil enr:-HW4QDwUF...vKDw": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
-					"peer important-pen enr:-HW4QPSBgUTag8oZs3zIsgWzlBUrSgT8pgZmFJa7HWwKXUcRLlISa68OJtp-JTzhUXsJ2vSGwKGACn0OTatWdJATxn-AgmlkgnY0iXNlY3AyNTZrMaECA3R_ffXLXCLJsfEwf6xeoAFgWnDIOdq8kS0Yqkhwbr0": {
+					"peer important-pen enr:-HW4QPSBg...wbr0": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
 				},
@@ -204,13 +204,13 @@ func TestPeersTest(t *testing.T) {
 			expected: testCategoryResult{
 				CategoryName: peersTestCategory,
 				Targets: map[string][]testResult{
-					"peer inexpensive-farm enr:-HW4QBHlcyD3fYWUMADiOv4OxODaL5wJG0a7P7d_ltu4VZe1MibZ1N-twFaoaq0BoCtXcY71etxLJGeEZT5p3XCO6GOAgmlkgnY0iXNlY3AyNTZrMaEDI2HRUlVBag__njkOWEEQRLlC9ylIVCrIXOuNBSlrx6o": {
+					"peer inexpensive-farm enr:-HW4QBHlc...rx6o": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
-					"peer anxious-pencil enr:-HW4QDwUF804f4WhUjwcp4JJ-PrRH0glQZv8s2cVHlBRPJ3SYcYO-dvJGsKhztffrski5eujJkl8oAc983MZy6-PqF2AgmlkgnY0iXNlY3AyNTZrMaECPEPryjkmUBnQFyjmMw9rl7DVtKL0243nN5iepqsvKDw": {
+					"peer anxious-pencil enr:-HW4QDwUF...vKDw": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
-					"peer important-pen enr:-HW4QPSBgUTag8oZs3zIsgWzlBUrSgT8pgZmFJa7HWwKXUcRLlISa68OJtp-JTzhUXsJ2vSGwKGACn0OTatWdJATxn-AgmlkgnY0iXNlY3AyNTZrMaECA3R_ffXLXCLJsfEwf6xeoAFgWnDIOdq8kS0Yqkhwbr0": {
+					"peer important-pen enr:-HW4QPSBg...wbr0": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
 				},
@@ -247,13 +247,13 @@ func TestPeersTest(t *testing.T) {
 						{Name: "pingRelay", Verdict: testVerdictOk, Measurement: "", Suggestion: "", Error: testResultError{}},
 						{Name: "pingMeasureRelay", Verdict: testVerdictGood, Measurement: "", Suggestion: "", Error: testResultError{}},
 					},
-					"peer inexpensive-farm enr:-HW4QBHlcyD3fYWUMADiOv4OxODaL5wJG0a7P7d_ltu4VZe1MibZ1N-twFaoaq0BoCtXcY71etxLJGeEZT5p3XCO6GOAgmlkgnY0iXNlY3AyNTZrMaEDI2HRUlVBag__njkOWEEQRLlC9ylIVCrIXOuNBSlrx6o": {
+					"peer inexpensive-farm enr:-HW4QBHlc...rx6o": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
-					"peer anxious-pencil enr:-HW4QDwUF804f4WhUjwcp4JJ-PrRH0glQZv8s2cVHlBRPJ3SYcYO-dvJGsKhztffrski5eujJkl8oAc983MZy6-PqF2AgmlkgnY0iXNlY3AyNTZrMaECPEPryjkmUBnQFyjmMw9rl7DVtKL0243nN5iepqsvKDw": {
+					"peer anxious-pencil enr:-HW4QDwUF...vKDw": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
-					"peer important-pen enr:-HW4QPSBgUTag8oZs3zIsgWzlBUrSgT8pgZmFJa7HWwKXUcRLlISa68OJtp-JTzhUXsJ2vSGwKGACn0OTatWdJATxn-AgmlkgnY0iXNlY3AyNTZrMaECA3R_ffXLXCLJsfEwf6xeoAFgWnDIOdq8kS0Yqkhwbr0": {
+					"peer important-pen enr:-HW4QPSBg...wbr0": {
 						{Name: "ping", Verdict: testVerdictFail, Measurement: "", Suggestion: "", Error: errTimeoutInterrupted},
 					},
 				},

--- a/cmd/testperformance.go
+++ b/cmd/testperformance.go
@@ -92,16 +92,16 @@ func newTestPerformanceCmd(runFunc func(context.Context, io.Writer, testPerforma
 	}
 
 	bindTestFlags(cmd, &config.testConfig)
-	bindTestPerformanceFlags(cmd, &config)
+	bindTestPerformanceFlags(cmd, &config, "")
 
 	return cmd
 }
 
-func bindTestPerformanceFlags(cmd *cobra.Command, config *testPerformanceConfig) {
-	cmd.Flags().StringVar(&config.DiskIOTestFileDir, "disk-io-test-file-dir", "", "Directory at which disk performance will be measured. If none specified, current user's home directory will be used.")
-	cmd.Flags().IntVar(&config.DiskIOBlockSizeKb, "disk-io-block-size-kb", 4096, "The block size in kilobytes used for I/O units. Same value applies for both reads and writes.")
-	cmd.Flags().StringSliceVar(&config.InternetTestServersOnly, "internet-test-servers-only", []string{}, "List of specific server names to be included for the internet tests, the best performing one is chosen. If not provided, closest and best performing servers are chosen automatically.")
-	cmd.Flags().StringSliceVar(&config.InternetTestServersExclude, "internet-test-servers-exclude", []string{}, "List of server names to be excluded from the tests. To be specified only if you experience issues with a server that is wrongly considered best performing.")
+func bindTestPerformanceFlags(cmd *cobra.Command, config *testPerformanceConfig, flagsPrefix string) {
+	cmd.Flags().StringVar(&config.DiskIOTestFileDir, flagsPrefix+"disk-io-test-file-dir", "", "Directory at which disk performance will be measured. If none specified, current user's home directory will be used.")
+	cmd.Flags().IntVar(&config.DiskIOBlockSizeKb, flagsPrefix+"disk-io-block-size-kb", 4096, "The block size in kilobytes used for I/O units. Same value applies for both reads and writes.")
+	cmd.Flags().StringSliceVar(&config.InternetTestServersOnly, flagsPrefix+"internet-test-servers-only", []string{}, "List of specific server names to be included for the internet tests, the best performing one is chosen. If not provided, closest and best performing servers are chosen automatically.")
+	cmd.Flags().StringSliceVar(&config.InternetTestServersExclude, flagsPrefix+"internet-test-servers-exclude", []string{}, "List of server names to be excluded from the tests. To be specified only if you experience issues with a server that is wrongly considered best performing.")
 }
 
 func supportedPerformanceTestCases() map[testCaseName]func(context.Context, *testPerformanceConfig) testResult {

--- a/cmd/testperformance.go
+++ b/cmd/testperformance.go
@@ -119,6 +119,8 @@ func supportedPerformanceTestCases() map[testCaseName]func(context.Context, *tes
 }
 
 func runTestPerformance(ctx context.Context, w io.Writer, cfg testPerformanceConfig) (err error) {
+	log.Info(ctx, "Starting machine performance and network connectivity test")
+
 	testCases := supportedPerformanceTestCases()
 	queuedTests := filterTests(maps.Keys(testCases), cfg.testConfig)
 	if len(queuedTests) == 0 {

--- a/cmd/testvalidator.go
+++ b/cmd/testvalidator.go
@@ -196,14 +196,7 @@ func validatorPingMeasureTest(ctx context.Context, conf *testValidatorConfig) te
 	defer conn.Close()
 	rtt := time.Since(before)
 
-	if rtt > thresholdValidatorMeasurePoor {
-		testRes.Verdict = testVerdictPoor
-	} else if rtt > thresholdValidatorMeasureAvg {
-		testRes.Verdict = testVerdictAvg
-	} else {
-		testRes.Verdict = testVerdictGood
-	}
-	testRes.Measurement = Duration{rtt}.String()
+	testRes = evaluateRTT(rtt, testRes, thresholdValidatorMeasureAvg, thresholdValidatorMeasurePoor)
 
 	return testRes
 }
@@ -260,7 +253,7 @@ func validatorPingLoadTest(ctx context.Context, conf *testValidatorConfig) testR
 	close(testResCh)
 	log.Info(ctx, "Ping load tests finished", z.Any("target", conf.APIAddress))
 
-	testRes = evaluateHighestRTTScore(testResCh, testRes, thresholdValidatorLoadAvg, thresholdValidatorLoadPoor)
+	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdValidatorLoadAvg, thresholdValidatorLoadPoor)
 
 	return testRes
 }

--- a/cmd/testvalidator.go
+++ b/cmd/testvalidator.go
@@ -49,14 +49,14 @@ func newTestValidatorCmd(runFunc func(context.Context, io.Writer, testValidatorC
 	}
 
 	bindTestFlags(cmd, &config.testConfig)
-	bindTestValidatorFlags(cmd, &config)
+	bindTestValidatorFlags(cmd, &config, "")
 
 	return cmd
 }
 
-func bindTestValidatorFlags(cmd *cobra.Command, config *testValidatorConfig) {
-	cmd.Flags().StringVar(&config.APIAddress, "validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API.")
-	cmd.Flags().DurationVar(&config.LoadTestDuration, "load-test-duration", 5*time.Second, "Time to keep running the load tests in seconds. For each second a new continuous ping instance is spawned.")
+func bindTestValidatorFlags(cmd *cobra.Command, config *testValidatorConfig, flagsPrefix string) {
+	cmd.Flags().StringVar(&config.APIAddress, flagsPrefix+"validator-api-address", "127.0.0.1:3600", "Listening address (ip and port) for validator-facing traffic proxying the beacon-node API.")
+	cmd.Flags().DurationVar(&config.LoadTestDuration, flagsPrefix+"load-test-duration", 5*time.Second, "Time to keep running the load tests in seconds. For each second a new continuous ping instance is spawned.")
 }
 
 func supportedValidatorTestCases() map[testCaseName]func(context.Context, *testValidatorConfig) testResult {


### PR DESCRIPTION
Multiple changes to improve UX of the test command:
1. Add `charon test all` that runs all 5 test commands
2. Shorten the ENRs and MEV relays URLs hashes when outputting results
3. Sort the targets of the tests (so that it's easier to follow consecutive re-ran tests)

Also do some refactoring of the functions.

category: feature
ticket: none
