### PR TITLE
cmd: group and move functions in test command

### DIFF
--- a/cmd/testmev.go
+++ b/cmd/testmev.go
@@ -124,6 +124,8 @@ func runTestMEV(ctx context.Context, w io.Writer, cfg testMEVConfig) (err error)
 	return nil
 }
 
+// mev relays tests
+
 func testAllMEVs(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseMEV, conf testMEVConfig, allMEVsResCh chan map[string][]testResult) {
 	defer close(allMEVsResCh)
 	// run tests for all mev nodes
@@ -188,27 +190,6 @@ func testSingleMEV(ctx context.Context, queuedTestCases []testCaseName, allTestC
 	return nil
 }
 
-// Shorten the hash of the MEV relay endpoint
-// Example: https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
-// to https://0xac6e...37ae@boost-relay.flashbots.net
-func formatMEVRelayName(urlString string) string {
-	splitScheme := strings.Split(urlString, "://")
-	if len(splitScheme) == 1 {
-		return urlString
-	}
-	hashSplit := strings.Split(splitScheme[1], "@")
-	if len(hashSplit) == 1 {
-		return urlString
-	}
-	hash := hashSplit[0]
-	if !strings.HasPrefix(hash, "0x") || len(hash) < 18 {
-		return urlString
-	}
-	hashShort := hash[:6] + "..." + hash[len(hash)-4:]
-
-	return splitScheme[0] + "://" + hashShort + "@" + hashSplit[1]
-}
-
 func runMEVTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseMEV, cfg testMEVConfig, target string, ch chan testResult) {
 	defer close(ch)
 	for _, t := range queuedTestCases {
@@ -256,4 +237,27 @@ func mevPingMeasureTest(ctx context.Context, _ *testMEVConfig, target string) te
 	testRes = evaluateRTT(rtt, testRes, thresholdMEVMeasureAvg, thresholdMEVMeasurePoor)
 
 	return testRes
+}
+
+// helper functions
+
+// Shorten the hash of the MEV relay endpoint
+// Example: https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
+// to https://0xac6e...37ae@boost-relay.flashbots.net
+func formatMEVRelayName(urlString string) string {
+	splitScheme := strings.Split(urlString, "://")
+	if len(splitScheme) == 1 {
+		return urlString
+	}
+	hashSplit := strings.Split(splitScheme[1], "@")
+	if len(hashSplit) == 1 {
+		return urlString
+	}
+	hash := hashSplit[0]
+	if !strings.HasPrefix(hash, "0x") || len(hash) < 18 {
+		return urlString
+	}
+	hashShort := hash[:6] + "..." + hash[len(hash)-4:]
+
+	return splitScheme[0] + "://" + hashShort + "@" + hashSplit[1]
 }

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -145,6 +145,521 @@ func supportedSelfTestCases() map[testCaseName]testCasePeerSelf {
 	}
 }
 
+func runTestPeers(ctx context.Context, w io.Writer, conf testPeersConfig) error {
+	log.Info(ctx, "Starting charon peers and relays test")
+
+	relayTestCases := supportedRelayTestCases()
+	queuedTestsRelay := filterTests(maps.Keys(relayTestCases), conf.testConfig)
+	sortTests(queuedTestsRelay)
+
+	peerTestCases := supportedPeerTestCases()
+	queuedTestsPeer := filterTests(maps.Keys(peerTestCases), conf.testConfig)
+	sortTests(queuedTestsPeer)
+
+	selfTestCases := supportedSelfTestCases()
+	queuedTestsSelf := filterTests(maps.Keys(selfTestCases), conf.testConfig)
+	sortTests(queuedTestsSelf)
+
+	if len(queuedTestsPeer) == 0 && len(queuedTestsSelf) == 0 {
+		return errors.New("test case not supported")
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, conf.Timeout)
+	defer cancel()
+
+	testResultsChan := make(chan map[string][]testResult)
+	testResults := make(map[string][]testResult)
+
+	tcpNode, shutdown, err := startTCPNode(ctx, conf)
+	if err != nil {
+		return err
+	}
+	defer shutdown()
+
+	group, _ := errgroup.WithContext(timeoutCtx)
+	doneReading := make(chan bool)
+
+	startTime := time.Now()
+	group.Go(func() error {
+		return testAllRelays(timeoutCtx, queuedTestsRelay, relayTestCases, conf, testResultsChan)
+	})
+	group.Go(func() error {
+		return testAllPeers(timeoutCtx, queuedTestsPeer, peerTestCases, conf, tcpNode, testResultsChan)
+	})
+	group.Go(func() error {
+		return testSelf(timeoutCtx, queuedTestsSelf, selfTestCases, conf, testResultsChan)
+	})
+
+	go func() {
+		for result := range testResultsChan {
+			maps.Copy(testResults, result)
+		}
+		doneReading <- true
+	}()
+
+	err = group.Wait()
+	execTime := Duration{time.Since(startTime)}
+	if err != nil {
+		return errors.Wrap(err, "peers test errgroup")
+	}
+	close(testResultsChan)
+	<-doneReading
+
+	// use lowest score as score of all
+	var score categoryScore
+	for _, t := range testResults {
+		targetScore := calculateScore(t)
+		if score == "" || score < targetScore {
+			score = targetScore
+		}
+	}
+
+	res := testCategoryResult{
+		CategoryName:  peersTestCategory,
+		Targets:       testResults,
+		ExecutionTime: execTime,
+		Score:         score,
+	}
+
+	if !conf.Quiet {
+		err = writeResultToWriter(res, w)
+		if err != nil {
+			return err
+		}
+	}
+
+	if conf.OutputToml != "" {
+		err = writeResultToFile(res, conf.OutputToml)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Info(ctx, "Keeping TCP node alive for peers until keep-alive time is reached...")
+	blockAndWait(ctx, conf.KeepAlive)
+
+	return nil
+}
+
+// charon peers tests
+
+func testAllPeers(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, allPeersResCh chan map[string][]testResult) error {
+	// run tests for all peer nodes
+	allPeersRes := make(map[string][]testResult)
+	singlePeerResCh := make(chan map[string][]testResult)
+	group, _ := errgroup.WithContext(ctx)
+
+	enrs, err := fetchENRs(conf)
+	if err != nil {
+		return err
+	}
+	for _, enr := range enrs {
+		currENR := enr // TODO: can be removed after go1.22 version bump
+		group.Go(func() error {
+			return testSinglePeer(ctx, queuedTestCases, allTestCases, conf, tcpNode, currENR, singlePeerResCh)
+		})
+	}
+
+	doneReading := make(chan bool)
+	go func() {
+		for singlePeerRes := range singlePeerResCh {
+			maps.Copy(allPeersRes, singlePeerRes)
+		}
+		doneReading <- true
+	}()
+
+	err = group.Wait()
+	if err != nil {
+		return errors.Wrap(err, "peers test errgroup")
+	}
+	close(singlePeerResCh)
+	<-doneReading
+
+	allPeersResCh <- allPeersRes
+
+	return nil
+}
+
+func testSinglePeer(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target string, allTestResCh chan map[string][]testResult) error {
+	singleTestResCh := make(chan testResult)
+	allTestRes := []testResult{}
+	enrTarget, err := enr.Parse(target)
+	if err != nil {
+		return err
+	}
+	peerTarget, err := p2p.NewPeerFromENR(enrTarget, 0)
+	if err != nil {
+		return err
+	}
+
+	formatENR := target[:13] + "..." + target[len(target)-4:] // enr:- + first 8 chars + ... + last 4 chars
+	nameENR := fmt.Sprintf("peer %v %v", peerTarget.Name, formatENR)
+
+	if len(queuedTestCases) == 0 {
+		allTestResCh <- map[string][]testResult{nameENR: allTestRes}
+		return nil
+	}
+
+	// run all peers tests for a peer, pushing each completed test to the channel until all are complete or timeout occurs
+	go runPeerTest(ctx, queuedTestCases, allTestCases, conf, tcpNode, peerTarget, singleTestResCh)
+	testCounter := 0
+	finished := false
+	for !finished {
+		var testName string
+		select {
+		case <-ctx.Done():
+			if testCounter < len(queuedTestCases) {
+				testName = queuedTestCases[testCounter].name
+				allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			}
+			finished = true
+		case result, ok := <-singleTestResCh:
+			if !ok {
+				finished = true
+				continue
+			}
+			testName = queuedTestCases[testCounter].name
+			testCounter++
+			result.Name = testName
+			allTestRes = append(allTestRes, result)
+		}
+	}
+
+	allTestResCh <- map[string][]testResult{nameENR: allTestRes}
+
+	return nil
+}
+
+func runPeerTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target p2p.Peer, testResCh chan testResult) {
+	defer close(testResCh)
+	for _, t := range queuedTestCases {
+		select {
+		case <-ctx.Done():
+			testResCh <- failedTestResult(testResult{Name: t.name}, errTimeoutInterrupted)
+			return
+		default:
+			testResCh <- allTestCases[t](ctx, &conf, tcpNode, target)
+		}
+	}
+}
+
+func peerPingTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
+	testRes := testResult{Name: "Ping"}
+
+	ticker := time.NewTicker(1)
+	defer ticker.Stop()
+
+	for ; true; <-ticker.C {
+		select {
+		case <-ctx.Done():
+			return failedTestResult(testRes, errTimeoutInterrupted)
+		default:
+			ticker.Reset(3 * time.Second)
+			result, err := pingPeerOnce(ctx, tcpNode, peer)
+			if err != nil {
+				return failedTestResult(testRes, err)
+			}
+
+			if result.Error != nil {
+				switch {
+				case errors.Is(result.Error, context.DeadlineExceeded):
+					return failedTestResult(testRes, errTimeoutInterrupted)
+				case p2p.IsRelayError(result.Error):
+					return failedTestResult(testRes, result.Error)
+				default:
+					log.Warn(ctx, "Ping to peer failed, retrying in 3 sec...", nil, z.Str("peer_name", peer.Name))
+					continue
+				}
+			}
+
+			testRes.Verdict = testVerdictOk
+
+			return testRes
+		}
+	}
+
+	testRes.Verdict = testVerdictFail
+	testRes.Error = errNoTicker
+
+	return testRes
+}
+
+func peerPingMeasureTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
+	testRes := testResult{Name: "PingMeasure"}
+
+	result, err := pingPeerOnce(ctx, tcpNode, peer)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	if result.Error != nil {
+		return failedTestResult(testRes, result.Error)
+	}
+
+	if result.RTT > thresholdPeersMeasurePoor {
+		testRes.Verdict = testVerdictPoor
+	} else if result.RTT > thresholdPeersMeasureAvg {
+		testRes.Verdict = testVerdictAvg
+	} else {
+		testRes.Verdict = testVerdictGood
+	}
+	testRes.Measurement = Duration{result.RTT}.String()
+
+	return testRes
+}
+
+func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
+	log.Info(ctx, "Running ping load tests...",
+		z.Any("duration", conf.LoadTestDuration),
+		z.Any("target", peer.Name),
+	)
+	testRes := testResult{Name: "PingLoad"}
+
+	testResCh := make(chan time.Duration, math.MaxInt16)
+	pingCtx, cancel := context.WithTimeout(ctx, conf.LoadTestDuration)
+	defer cancel()
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+
+	var wg sync.WaitGroup
+	for pingCtx.Err() == nil {
+		select {
+		case <-ticker.C:
+			wg.Add(1)
+			go func() {
+				pingPeerContinuously(pingCtx, tcpNode, peer, testResCh)
+				wg.Done()
+			}()
+		case <-pingCtx.Done():
+		}
+	}
+	wg.Wait()
+	close(testResCh)
+	log.Info(ctx, "Ping load tests finished", z.Any("target", peer.Name))
+
+	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdPeersLoadAvg, thresholdPeersLoadPoor)
+
+	return testRes
+}
+
+func peerDirectConnTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, p2pPeer p2p.Peer) testResult {
+	testRes := testResult{Name: "DirectConn"}
+
+	log.Info(ctx, "Trying to establish direct connection...",
+		z.Any("timeout", conf.DirectConnectionTimeout),
+		z.Any("target", p2pPeer.Name))
+
+	var err error
+	for range int(conf.DirectConnectionTimeout.Seconds()) {
+		err = tcpNode.Connect(network.WithForceDirectDial(ctx, "relay_to_direct"), peer.AddrInfo{ID: p2pPeer.ID})
+		if err == nil {
+			break
+		}
+		time.Sleep(time.Second)
+	}
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	log.Info(ctx, "Direct connection established", z.Any("target", p2pPeer.Name))
+
+	conns := tcpNode.Network().ConnsToPeer(p2pPeer.ID)
+	if len(conns) < 2 {
+		return failedTestResult(testRes, errors.New("expected 2 connections to peer (relay and direct)", z.Int("connections", len(conns))))
+	}
+
+	testRes.Verdict = testVerdictOk
+
+	return testRes
+}
+
+// self tests
+
+func testSelf(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, allTestResCh chan map[string][]testResult) error {
+	singleTestResCh := make(chan testResult)
+	allTestRes := []testResult{}
+	if len(queuedTestCases) == 0 {
+		allTestResCh <- map[string][]testResult{"self": allTestRes}
+		return nil
+	}
+	go runSelfTest(ctx, queuedTestCases, allTestCases, conf, singleTestResCh)
+
+	testCounter := 0
+	finished := false
+	for !finished {
+		var testName string
+		select {
+		case <-ctx.Done():
+			testName = queuedTestCases[testCounter].name
+			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			finished = true
+		case result, ok := <-singleTestResCh:
+			if !ok {
+				finished = true
+				continue
+			}
+			testName = queuedTestCases[testCounter].name
+			testCounter++
+			result.Name = testName
+			allTestRes = append(allTestRes, result)
+		}
+	}
+
+	allTestResCh <- map[string][]testResult{"self": allTestRes}
+
+	return nil
+}
+
+func runSelfTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, ch chan testResult) {
+	defer close(ch)
+	for _, t := range queuedTestCases {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			ch <- allTestCases[t](ctx, &conf)
+		}
+	}
+}
+
+func libp2pTCPPortOpenTest(ctx context.Context, cfg *testPeersConfig) testResult {
+	testRes := testResult{Name: "Libp2pTCPPortOpen"}
+
+	group, _ := errgroup.WithContext(ctx)
+
+	for _, addr := range cfg.P2P.TCPAddrs {
+		group.Go(func() error { return dialLibp2pTCPIP(ctx, addr) })
+	}
+
+	err := group.Wait()
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+
+	testRes.Verdict = testVerdictOk
+
+	return testRes
+}
+
+// charon relays tests
+
+func testAllRelays(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, allRelaysResCh chan map[string][]testResult) error {
+	// run tests for all relays
+	allRelayRes := make(map[string][]testResult)
+	singleRelayResCh := make(chan map[string][]testResult)
+	group, _ := errgroup.WithContext(ctx)
+
+	for _, relay := range conf.P2P.Relays {
+		group.Go(func() error {
+			return testSingleRelay(ctx, queuedTestCases, allTestCases, conf, relay, singleRelayResCh)
+		})
+	}
+
+	doneReading := make(chan bool)
+	go func() {
+		for singleRelayRes := range singleRelayResCh {
+			maps.Copy(allRelayRes, singleRelayRes)
+		}
+		doneReading <- true
+	}()
+
+	err := group.Wait()
+	if err != nil {
+		return errors.Wrap(err, "relays test errgroup")
+	}
+	close(singleRelayResCh)
+	<-doneReading
+
+	allRelaysResCh <- allRelayRes
+
+	return nil
+}
+
+func testSingleRelay(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, allTestResCh chan map[string][]testResult) error {
+	singleTestResCh := make(chan testResult)
+	allTestRes := []testResult{}
+	relayName := fmt.Sprintf("relay %v", target)
+	if len(queuedTestCases) == 0 {
+		allTestResCh <- map[string][]testResult{relayName: allTestRes}
+		return nil
+	}
+
+	// run all relay tests for a relay, pushing each completed test to the channel until all are complete or timeout occurs
+	go runRelayTest(ctx, queuedTestCases, allTestCases, conf, target, singleTestResCh)
+	testCounter := 0
+	finished := false
+	for !finished {
+		var testName string
+		select {
+		case <-ctx.Done():
+			testName = queuedTestCases[testCounter].name
+			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
+			finished = true
+		case result, ok := <-singleTestResCh:
+			if !ok {
+				finished = true
+				continue
+			}
+			testName = queuedTestCases[testCounter].name
+			testCounter++
+			result.Name = testName
+			allTestRes = append(allTestRes, result)
+		}
+	}
+
+	allTestResCh <- map[string][]testResult{relayName: allTestRes}
+
+	return nil
+}
+
+func runRelayTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, testResCh chan testResult) {
+	defer close(testResCh)
+	for _, t := range queuedTestCases {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			testResCh <- allTestCases[t](ctx, &conf, target)
+		}
+	}
+}
+
+func relayPingTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
+	testRes := testResult{Name: "PingRelay"}
+
+	client := http.Client{}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode > 399 {
+		return failedTestResult(testRes, errors.New(httpStatusError(resp.StatusCode)))
+	}
+
+	testRes.Verdict = testVerdictOk
+
+	return testRes
+}
+
+func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
+	testRes := testResult{Name: "PingMeasureRelay"}
+
+	rtt, err := requestRTT(ctx, target, http.MethodGet, nil, 200)
+	if err != nil {
+		return failedTestResult(testRes, err)
+	}
+
+	testRes = evaluateRTT(rtt, testRes, thresholdRelayMeasureAvg, thresholdRelayMeasurePoor)
+
+	return testRes
+}
+
+// helper functions
+
 func fetchPeersFromDefinition(path string) ([]string, error) {
 	f, err := os.ReadFile(path)
 	if err != nil {
@@ -334,428 +849,6 @@ func pingPeerContinuously(ctx context.Context, tcpNode host.Host, peer p2p.Peer,
 	}
 }
 
-func runTestPeers(ctx context.Context, w io.Writer, conf testPeersConfig) error {
-	log.Info(ctx, "Starting charon peers and relays test")
-
-	relayTestCases := supportedRelayTestCases()
-	queuedTestsRelay := filterTests(maps.Keys(relayTestCases), conf.testConfig)
-	sortTests(queuedTestsRelay)
-
-	peerTestCases := supportedPeerTestCases()
-	queuedTestsPeer := filterTests(maps.Keys(peerTestCases), conf.testConfig)
-	sortTests(queuedTestsPeer)
-
-	selfTestCases := supportedSelfTestCases()
-	queuedTestsSelf := filterTests(maps.Keys(selfTestCases), conf.testConfig)
-	sortTests(queuedTestsSelf)
-
-	if len(queuedTestsPeer) == 0 && len(queuedTestsSelf) == 0 {
-		return errors.New("test case not supported")
-	}
-
-	timeoutCtx, cancel := context.WithTimeout(ctx, conf.Timeout)
-	defer cancel()
-
-	testResultsChan := make(chan map[string][]testResult)
-	testResults := make(map[string][]testResult)
-
-	tcpNode, shutdown, err := startTCPNode(ctx, conf)
-	if err != nil {
-		return err
-	}
-	defer shutdown()
-
-	group, _ := errgroup.WithContext(timeoutCtx)
-	doneReading := make(chan bool)
-
-	startTime := time.Now()
-	group.Go(func() error {
-		return testAllRelays(timeoutCtx, queuedTestsRelay, relayTestCases, conf, testResultsChan)
-	})
-	group.Go(func() error {
-		return testAllPeers(timeoutCtx, queuedTestsPeer, peerTestCases, conf, tcpNode, testResultsChan)
-	})
-	group.Go(func() error {
-		return testSelf(timeoutCtx, queuedTestsSelf, selfTestCases, conf, testResultsChan)
-	})
-
-	go func() {
-		for result := range testResultsChan {
-			maps.Copy(testResults, result)
-		}
-		doneReading <- true
-	}()
-
-	err = group.Wait()
-	execTime := Duration{time.Since(startTime)}
-	if err != nil {
-		return errors.Wrap(err, "peers test errgroup")
-	}
-	close(testResultsChan)
-	<-doneReading
-
-	// use lowest score as score of all
-	var score categoryScore
-	for _, t := range testResults {
-		targetScore := calculateScore(t)
-		if score == "" || score < targetScore {
-			score = targetScore
-		}
-	}
-
-	res := testCategoryResult{
-		CategoryName:  peersTestCategory,
-		Targets:       testResults,
-		ExecutionTime: execTime,
-		Score:         score,
-	}
-
-	if !conf.Quiet {
-		err = writeResultToWriter(res, w)
-		if err != nil {
-			return err
-		}
-	}
-
-	if conf.OutputToml != "" {
-		err = writeResultToFile(res, conf.OutputToml)
-		if err != nil {
-			return err
-		}
-	}
-
-	log.Info(ctx, "Keeping TCP node alive for peers until keep-alive time is reached...")
-	blockAndWait(ctx, conf.KeepAlive)
-
-	return nil
-}
-
-func testAllRelays(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, allRelaysResCh chan map[string][]testResult) error {
-	// run tests for all relays
-	allRelayRes := make(map[string][]testResult)
-	singleRelayResCh := make(chan map[string][]testResult)
-	group, _ := errgroup.WithContext(ctx)
-
-	for _, relay := range conf.P2P.Relays {
-		group.Go(func() error {
-			return testSingleRelay(ctx, queuedTestCases, allTestCases, conf, relay, singleRelayResCh)
-		})
-	}
-
-	doneReading := make(chan bool)
-	go func() {
-		for singleRelayRes := range singleRelayResCh {
-			maps.Copy(allRelayRes, singleRelayRes)
-		}
-		doneReading <- true
-	}()
-
-	err := group.Wait()
-	if err != nil {
-		return errors.Wrap(err, "relays test errgroup")
-	}
-	close(singleRelayResCh)
-	<-doneReading
-
-	allRelaysResCh <- allRelayRes
-
-	return nil
-}
-
-func testSingleRelay(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, allTestResCh chan map[string][]testResult) error {
-	singleTestResCh := make(chan testResult)
-	allTestRes := []testResult{}
-	relayName := fmt.Sprintf("relay %v", target)
-	if len(queuedTestCases) == 0 {
-		allTestResCh <- map[string][]testResult{relayName: allTestRes}
-		return nil
-	}
-
-	// run all relay tests for a relay, pushing each completed test to the channel until all are complete or timeout occurs
-	go runRelayTest(ctx, queuedTestCases, allTestCases, conf, target, singleTestResCh)
-	testCounter := 0
-	finished := false
-	for !finished {
-		var testName string
-		select {
-		case <-ctx.Done():
-			testName = queuedTestCases[testCounter].name
-			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
-			finished = true
-		case result, ok := <-singleTestResCh:
-			if !ok {
-				finished = true
-				continue
-			}
-			testName = queuedTestCases[testCounter].name
-			testCounter++
-			result.Name = testName
-			allTestRes = append(allTestRes, result)
-		}
-	}
-
-	allTestResCh <- map[string][]testResult{relayName: allTestRes}
-
-	return nil
-}
-
-func runRelayTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCaseRelay, conf testPeersConfig, target string, testResCh chan testResult) {
-	defer close(testResCh)
-	for _, t := range queuedTestCases {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			testResCh <- allTestCases[t](ctx, &conf, target)
-		}
-	}
-}
-
-func testAllPeers(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, allPeersResCh chan map[string][]testResult) error {
-	// run tests for all peer nodes
-	allPeersRes := make(map[string][]testResult)
-	singlePeerResCh := make(chan map[string][]testResult)
-	group, _ := errgroup.WithContext(ctx)
-
-	enrs, err := fetchENRs(conf)
-	if err != nil {
-		return err
-	}
-	for _, enr := range enrs {
-		currENR := enr // TODO: can be removed after go1.22 version bump
-		group.Go(func() error {
-			return testSinglePeer(ctx, queuedTestCases, allTestCases, conf, tcpNode, currENR, singlePeerResCh)
-		})
-	}
-
-	doneReading := make(chan bool)
-	go func() {
-		for singlePeerRes := range singlePeerResCh {
-			maps.Copy(allPeersRes, singlePeerRes)
-		}
-		doneReading <- true
-	}()
-
-	err = group.Wait()
-	if err != nil {
-		return errors.Wrap(err, "peers test errgroup")
-	}
-	close(singlePeerResCh)
-	<-doneReading
-
-	allPeersResCh <- allPeersRes
-
-	return nil
-}
-
-func testSinglePeer(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target string, allTestResCh chan map[string][]testResult) error {
-	singleTestResCh := make(chan testResult)
-	allTestRes := []testResult{}
-	enrTarget, err := enr.Parse(target)
-	if err != nil {
-		return err
-	}
-	peerTarget, err := p2p.NewPeerFromENR(enrTarget, 0)
-	if err != nil {
-		return err
-	}
-
-	formatENR := target[:13] + "..." + target[len(target)-4:] // enr:- + first 8 chars + ... + last 4 chars
-	nameENR := fmt.Sprintf("peer %v %v", peerTarget.Name, formatENR)
-
-	if len(queuedTestCases) == 0 {
-		allTestResCh <- map[string][]testResult{nameENR: allTestRes}
-		return nil
-	}
-
-	// run all peers tests for a peer, pushing each completed test to the channel until all are complete or timeout occurs
-	go runPeerTest(ctx, queuedTestCases, allTestCases, conf, tcpNode, peerTarget, singleTestResCh)
-	testCounter := 0
-	finished := false
-	for !finished {
-		var testName string
-		select {
-		case <-ctx.Done():
-			if testCounter < len(queuedTestCases) {
-				testName = queuedTestCases[testCounter].name
-				allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
-			}
-			finished = true
-		case result, ok := <-singleTestResCh:
-			if !ok {
-				finished = true
-				continue
-			}
-			testName = queuedTestCases[testCounter].name
-			testCounter++
-			result.Name = testName
-			allTestRes = append(allTestRes, result)
-		}
-	}
-
-	allTestResCh <- map[string][]testResult{nameENR: allTestRes}
-
-	return nil
-}
-
-func runPeerTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeer, conf testPeersConfig, tcpNode host.Host, target p2p.Peer, testResCh chan testResult) {
-	defer close(testResCh)
-	for _, t := range queuedTestCases {
-		select {
-		case <-ctx.Done():
-			testResCh <- failedTestResult(testResult{Name: t.name}, errTimeoutInterrupted)
-			return
-		default:
-			testResCh <- allTestCases[t](ctx, &conf, tcpNode, target)
-		}
-	}
-}
-
-func testSelf(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, allTestResCh chan map[string][]testResult) error {
-	singleTestResCh := make(chan testResult)
-	allTestRes := []testResult{}
-	if len(queuedTestCases) == 0 {
-		allTestResCh <- map[string][]testResult{"self": allTestRes}
-		return nil
-	}
-	go runSelfTest(ctx, queuedTestCases, allTestCases, conf, singleTestResCh)
-
-	testCounter := 0
-	finished := false
-	for !finished {
-		var testName string
-		select {
-		case <-ctx.Done():
-			testName = queuedTestCases[testCounter].name
-			allTestRes = append(allTestRes, testResult{Name: testName, Verdict: testVerdictFail, Error: errTimeoutInterrupted})
-			finished = true
-		case result, ok := <-singleTestResCh:
-			if !ok {
-				finished = true
-				continue
-			}
-			testName = queuedTestCases[testCounter].name
-			testCounter++
-			result.Name = testName
-			allTestRes = append(allTestRes, result)
-		}
-	}
-
-	allTestResCh <- map[string][]testResult{"self": allTestRes}
-
-	return nil
-}
-
-func runSelfTest(ctx context.Context, queuedTestCases []testCaseName, allTestCases map[testCaseName]testCasePeerSelf, conf testPeersConfig, ch chan testResult) {
-	defer close(ch)
-	for _, t := range queuedTestCases {
-		select {
-		case <-ctx.Done():
-			return
-		default:
-			ch <- allTestCases[t](ctx, &conf)
-		}
-	}
-}
-
-func peerPingTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
-	testRes := testResult{Name: "Ping"}
-
-	ticker := time.NewTicker(1)
-	defer ticker.Stop()
-
-	for ; true; <-ticker.C {
-		select {
-		case <-ctx.Done():
-			return failedTestResult(testRes, errTimeoutInterrupted)
-		default:
-			ticker.Reset(3 * time.Second)
-			result, err := pingPeerOnce(ctx, tcpNode, peer)
-			if err != nil {
-				return failedTestResult(testRes, err)
-			}
-
-			if result.Error != nil {
-				switch {
-				case errors.Is(result.Error, context.DeadlineExceeded):
-					return failedTestResult(testRes, errTimeoutInterrupted)
-				case p2p.IsRelayError(result.Error):
-					return failedTestResult(testRes, result.Error)
-				default:
-					log.Warn(ctx, "Ping to peer failed, retrying in 3 sec...", nil, z.Str("peer_name", peer.Name))
-					continue
-				}
-			}
-
-			testRes.Verdict = testVerdictOk
-
-			return testRes
-		}
-	}
-
-	testRes.Verdict = testVerdictFail
-	testRes.Error = errNoTicker
-
-	return testRes
-}
-
-func peerPingMeasureTest(ctx context.Context, _ *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
-	testRes := testResult{Name: "PingMeasure"}
-
-	result, err := pingPeerOnce(ctx, tcpNode, peer)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	if result.Error != nil {
-		return failedTestResult(testRes, result.Error)
-	}
-
-	if result.RTT > thresholdPeersMeasurePoor {
-		testRes.Verdict = testVerdictPoor
-	} else if result.RTT > thresholdPeersMeasureAvg {
-		testRes.Verdict = testVerdictAvg
-	} else {
-		testRes.Verdict = testVerdictGood
-	}
-	testRes.Measurement = Duration{result.RTT}.String()
-
-	return testRes
-}
-
-func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, peer p2p.Peer) testResult {
-	log.Info(ctx, "Running ping load tests...",
-		z.Any("duration", conf.LoadTestDuration),
-		z.Any("target", peer.Name),
-	)
-	testRes := testResult{Name: "PingLoad"}
-
-	testResCh := make(chan time.Duration, math.MaxInt16)
-	pingCtx, cancel := context.WithTimeout(ctx, conf.LoadTestDuration)
-	defer cancel()
-	ticker := time.NewTicker(time.Second)
-	defer ticker.Stop()
-
-	var wg sync.WaitGroup
-	for pingCtx.Err() == nil {
-		select {
-		case <-ticker.C:
-			wg.Add(1)
-			go func() {
-				pingPeerContinuously(pingCtx, tcpNode, peer, testResCh)
-				wg.Done()
-			}()
-		case <-pingCtx.Done():
-		}
-	}
-	wg.Wait()
-	close(testResCh)
-	log.Info(ctx, "Ping load tests finished", z.Any("target", peer.Name))
-
-	testRes = evaluateHighestRTTScores(testResCh, testRes, thresholdPeersLoadAvg, thresholdPeersLoadPoor)
-
-	return testRes
-}
-
 func dialLibp2pTCPIP(ctx context.Context, address string) error {
 	d := net.Dialer{Timeout: time.Second}
 	conn, err := d.DialContext(ctx, "tcp", address)
@@ -778,89 +871,4 @@ func dialLibp2pTCPIP(ctx context.Context, address string) error {
 	}
 
 	return nil
-}
-
-func peerDirectConnTest(ctx context.Context, conf *testPeersConfig, tcpNode host.Host, p2pPeer p2p.Peer) testResult {
-	testRes := testResult{Name: "DirectConn"}
-
-	log.Info(ctx, "Trying to establish direct connection...",
-		z.Any("timeout", conf.DirectConnectionTimeout),
-		z.Any("target", p2pPeer.Name))
-
-	var err error
-	for range int(conf.DirectConnectionTimeout.Seconds()) {
-		err = tcpNode.Connect(network.WithForceDirectDial(ctx, "relay_to_direct"), peer.AddrInfo{ID: p2pPeer.ID})
-		if err == nil {
-			break
-		}
-		time.Sleep(time.Second)
-	}
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	log.Info(ctx, "Direct connection established", z.Any("target", p2pPeer.Name))
-
-	conns := tcpNode.Network().ConnsToPeer(p2pPeer.ID)
-	if len(conns) < 2 {
-		return failedTestResult(testRes, errors.New("expected 2 connections to peer (relay and direct)", z.Int("connections", len(conns))))
-	}
-
-	testRes.Verdict = testVerdictOk
-
-	return testRes
-}
-
-func libp2pTCPPortOpenTest(ctx context.Context, cfg *testPeersConfig) testResult {
-	testRes := testResult{Name: "Libp2pTCPPortOpen"}
-
-	group, _ := errgroup.WithContext(ctx)
-
-	for _, addr := range cfg.P2P.TCPAddrs {
-		group.Go(func() error { return dialLibp2pTCPIP(ctx, addr) })
-	}
-
-	err := group.Wait()
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-
-	testRes.Verdict = testVerdictOk
-
-	return testRes
-}
-
-func relayPingTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
-	testRes := testResult{Name: "PingRelay"}
-
-	client := http.Client{}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	resp, err := client.Do(req)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode > 399 {
-		return failedTestResult(testRes, errors.New(httpStatusError(resp.StatusCode)))
-	}
-
-	testRes.Verdict = testVerdictOk
-
-	return testRes
-}
-
-func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string) testResult {
-	testRes := testResult{Name: "PingMeasureRelay"}
-
-	rtt, err := requestRTT(ctx, target, http.MethodGet, nil, 200)
-	if err != nil {
-		return failedTestResult(testRes, err)
-	}
-
-	testRes = evaluateRTT(rtt, testRes, thresholdRelayMeasureAvg, thresholdRelayMeasurePoor)
-
-	return testRes
 }


### PR DESCRIPTION
Simple refactoring and grouping of the functions in the `charon test` files. They grew quite a lot and thought some grouping would help. There is nothing new introduced (except comments), despite git's assumption of many additions and deletions.

category: refactor
ticket: none