### PR TITLE
*: bump linter v1.62

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.61.0
+          version: v1.62.0
       - name: notify failure
         if: failure() && github.ref == 'refs/heads/main'
         env:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -178,6 +178,7 @@ linters:
     - nonamedreturns
     - paralleltest
     - prealloc
+    - recvcheck # triggers a lot of false positives
     - tagliatelle
     - varnamelen
     - wsl

--- a/.pre-commit/run_linter.sh
+++ b/.pre-commit/run_linter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="1.61.0"
+VERSION="1.62.0"
 
 if ! command -v golangci-lint &> /dev/null
 then

--- a/app/obolapi/api_internal_test.go
+++ b/app/obolapi/api_internal_test.go
@@ -63,7 +63,7 @@ func TestHttpPost(t *testing.T) {
 				data, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
 				defer r.Body.Close()
-				require.Equal(t, string(data), `{"test_body_key": "test_body_value"}`)
+				require.JSONEq(t, string(data), `{"test_body_key": "test_body_value"}`)
 
 				w.WriteHeader(http.StatusOK)
 				_, err = w.Write([]byte(`"OK"`))

--- a/cmd/addvalidators_internal_test.go
+++ b/cmd/addvalidators_internal_test.go
@@ -217,9 +217,9 @@ func TestRunAddValidators(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, entries, 3)
 
-		require.True(t, strings.Contains(entries[0].Name(), "cluster-manifest"))
-		require.True(t, strings.Contains(entries[1].Name(), "deposit-data"))
-		require.True(t, strings.Contains(entries[2].Name(), "validator_keys"))
+		require.Contains(t, entries[0].Name(), "cluster-manifest")
+		require.Contains(t, entries[1].Name(), "deposit-data")
+		require.Contains(t, entries[2].Name(), "validator_keys")
 	})
 }
 

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -49,15 +49,9 @@ type ScoredPriority struct {
 	Score    int
 }
 
-// coreConsensus is an interface for the core/consensus.Component.
-type coreConsensus interface {
-	ProposePriority(context.Context, core.Duty, *pbv1.PriorityResult) error
-	SubscribePriority(func(context.Context, core.Duty, *pbv1.PriorityResult) error)
-}
-
 // NewComponent returns a new priority component.
 func NewComponent(ctx context.Context, tcpNode host.Host, peers []peer.ID, minRequired int, sendFunc p2p.SendReceiveFunc,
-	registerHandlerFunc p2p.RegisterHandlerFunc, consensus coreConsensus,
+	registerHandlerFunc p2p.RegisterHandlerFunc, consensus Consensus,
 	exchangeTimeout time.Duration, privkey *k1.PrivateKey, deadlineFunc func(duty core.Duty) (time.Time, bool),
 ) (*Component, error) {
 	verifier, err := newMsgVerifier(peers)


### PR DESCRIPTION
- bump linter to v1.62
- disable `recvcheck` linter (showed only false positives...)
- fixed requires in tests
- removed `coreConsensus` interface after discussion wtih @pinebit 

category: misc
ticket: none
