### PR TITLE
Dockerfile: add back chown

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,7 @@ RUN addgroup --gid "$GID" "$USER" \
   && chmod u+x /usr/local/bin/charon
 
 WORKDIR "/opt/$USER"
+RUN chown charon "/opt/$USER"
 USER charon
 
 ENTRYPOINT ["/usr/local/bin/charon"]


### PR DESCRIPTION
`chown /opt/charon` was removed previously, but it's required by the test command.

category: bug
ticket: none

