### PR TITLE
testutil: fixed compose files

### DIFF
--- a/testutil/compose/docker-compose.template
+++ b/testutil/compose/docker-compose.template
@@ -74,7 +74,7 @@ services:
     networks: [compose]
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v2.50.1}
     {{if .MonitoringPorts}}ports:
       - "9090:9090"
     {{end -}}
@@ -86,7 +86,7 @@ services:
 
   {{if .Monitoring}}
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:${GRAFANA_VERSION:-10.4.2}
     {{if .MonitoringPorts}}ports:
       - "3000:3000"
     {{end -}}
@@ -101,7 +101,7 @@ services:
       - ./grafana/dash_alerts.json:/etc/dashboards/dash_alerts.json
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:${JAEGER_VERSION:-1.46.0}
     networks: [compose]
     environment:
       SPAN_STORAGE_TYPE: memory
@@ -111,11 +111,12 @@ services:
     {{end}}
 
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:${LOKI_VERSION:-2.8.2}
     networks: [compose]
-    command: -config.file=/etc/loki/loki.yml
+    user: ":"
+    command: -config.file=/opt/loki/loki.yml
     volumes:
-      - ./loki/loki.yml:/etc/loki/loki.yml
+      - ./loki:/opt/loki
   {{end}}
 
 networks:

--- a/testutil/compose/static/loki/loki.yml
+++ b/testutil/compose/static/loki/loki.yml
@@ -29,10 +29,10 @@ schema_config:
 
 storage_config:
   boltdb:
-    directory: /tmp/loki/index
+    directory: /opt/loki/index
 
   filesystem:
-    directory: /tmp/loki/chunks
+    directory: /opt/loki/chunks
 
 limits_config:
   enforce_metric_name: false

--- a/testutil/compose/testdata/TestDockerCompose_run_yml.golden
+++ b/testutil/compose/testdata/TestDockerCompose_run_yml.golden
@@ -215,7 +215,7 @@ services:
     networks: [compose]
 
   prometheus:
-    image: prom/prometheus:latest
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v2.50.1}
     ports:
       - "9090:9090"
     networks: [compose]
@@ -226,7 +226,7 @@ services:
 
   
   grafana:
-    image: grafana/grafana:latest
+    image: grafana/grafana:${GRAFANA_VERSION:-10.4.2}
     ports:
       - "3000:3000"
     networks: [compose]
@@ -240,7 +240,7 @@ services:
       - ./grafana/dash_alerts.json:/etc/dashboards/dash_alerts.json
 
   jaeger:
-    image: jaegertracing/all-in-one:latest
+    image: jaegertracing/all-in-one:${JAEGER_VERSION:-1.46.0}
     networks: [compose]
     environment:
       SPAN_STORAGE_TYPE: memory
@@ -250,11 +250,12 @@ services:
     
 
   loki:
-    image: grafana/loki:latest
+    image: grafana/loki:${LOKI_VERSION:-2.8.2}
     networks: [compose]
-    command: -config.file=/etc/loki/loki.yml
+    user: ":"
+    command: -config.file=/opt/loki/loki.yml
     volumes:
-      - ./loki/loki.yml:/etc/loki/loki.yml
+      - ./loki:/opt/loki
   
 
 networks:


### PR DESCRIPTION
The problem was that our *compose* tool could not start a cluster: `compose new && compose auto`.

Our *compose* tool used `latest` selector in docker compose and this made the provided config files incompatible. I copied loki config from CDVN and set explicit Grafana stack versions from CDVN as well.
This seems fixed the problem.

category: bug
ticket: none
