### PR TITLE
app: eth2wrap latency logging

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -181,10 +181,10 @@ func latency(ctx context.Context, endpoint string, enableLogs bool) func() {
 		latencyHist.WithLabelValues(endpoint).Observe(rtt.Seconds())
 		if enableLogs {
 			log.Debug(ctx, "Beacon node call finished", z.Str("endpoint", endpoint))
-			// If BN call took more than 1 second, send WARN log
-			if rtt > time.Second {
-				log.Warn(ctx, "Beacon node call took longer than expected", nil, z.Str("endpoint", endpoint), z.Str("rtt", rtt.String()))
-			}
+		}
+		// If BN call took more than 1 second, send WARN log
+		if rtt > time.Second {
+			log.Warn(ctx, "Beacon node call took longer than expected", nil, z.Str("endpoint", endpoint), z.Str("rtt", rtt.String()))
 		}
 	}
 }

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -177,13 +177,13 @@ func latency(ctx context.Context, endpoint string, enableLogs bool) func() {
 	t0 := time.Now()
 
 	return func() {
-		rttSeconds := time.Since(t0).Seconds()
-		latencyHist.WithLabelValues(endpoint).Observe(rttSeconds)
+		rtt := time.Since(t0)
+		latencyHist.WithLabelValues(endpoint).Observe(rtt.Seconds())
 		if enableLogs {
 			log.Debug(ctx, "Beacon node call finished", z.Str("endpoint", endpoint))
 			// If BN call took more than 1 second, send WARN log
-			if rttSeconds > 1 {
-				log.Warn(ctx, "Beacon node call took longer than expected", nil, z.Str("endpoint", endpoint), z.F64("rtt_seconds", rttSeconds))
+			if rtt > time.Second {
+				log.Warn(ctx, "Beacon node call took longer than expected", nil, z.Str("endpoint", endpoint), z.Str("rtt", rtt.String()))
 			}
 		}
 	}

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -177,12 +177,13 @@ func latency(ctx context.Context, endpoint string, enableLogs bool) func() {
 	t0 := time.Now()
 
 	return func() {
-		rtt := time.Since(t0).Seconds()
-		latencyHist.WithLabelValues(endpoint).Observe(rtt)
+		rttSeconds := time.Since(t0).Seconds()
+		latencyHist.WithLabelValues(endpoint).Observe(rttSeconds)
 		if enableLogs {
 			log.Debug(ctx, "Beacon node call finished", z.Str("endpoint", endpoint))
-			if rtt > float64(time.Second) {
-				log.Warn(ctx, "Beacon node call took more than 1 second to fulfill", nil, z.Str("endpoint", endpoint), z.F64("rtt_seconds", rtt))
+			// If BN call took more than 1 second, send WARN log
+			if rttSeconds > 1 {
+				log.Warn(ctx, "Beacon node call took longer than expected", nil, z.Str("endpoint", endpoint), z.F64("rtt_seconds", rttSeconds))
 			}
 		}
 	}

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -171,10 +171,10 @@ func submit(ctx context.Context, clients []Client, work func(context.Context, Cl
 //
 //	defer latency("endpoint")()
 func latency(ctx context.Context, endpoint string, enableLogs bool) func() {
-	t0 := time.Now()
 	if enableLogs {
 		log.Debug(ctx, "Calling beacon node endpoint...", z.Str("endpoint", endpoint))
 	}
+	t0 := time.Now()
 
 	return func() {
 		rtt := time.Since(t0).Seconds()

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -575,6 +575,7 @@ func (m multi) NodeVersion(ctx context.Context, opts *api.NodeVersionOpts) (*api
 // Note this endpoint is cached in go-eth2-client.
 func (m multi) SubmitProposalPreparations(ctx context.Context, preparations []*apiv1.ProposalPreparation) error {
 	const label = "submit_proposal_preparations"
+	defer latency(ctx, label, true)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -112,7 +112,7 @@ func (m multi) SlotsPerEpoch(ctx context.Context) (uint64, error) {
 // SignedBeaconBlock fetches a signed beacon block given a block ID.
 func (m multi) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBlockOpts) (*api.Response[*spec.VersionedSignedBeaconBlock], error) {
 	const label = "signed_beacon_block"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*spec.VersionedSignedBeaconBlock], error) {
@@ -132,7 +132,7 @@ func (m multi) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 // AggregateAttestation fetches the aggregate attestation for the given options.
 func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*phase0.Attestation], error) {
 	const label = "aggregate_attestation"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*phase0.Attestation], error) {
@@ -152,7 +152,7 @@ func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 // SubmitAggregateAttestations submits aggregate attestations.
 func (m multi) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) error {
 	const label = "submit_aggregate_attestations"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -172,7 +172,7 @@ func (m multi) SubmitAggregateAttestations(ctx context.Context, aggregateAndProo
 // AttestationData fetches the attestation data for the given options.
 func (m multi) AttestationData(ctx context.Context, opts *api.AttestationDataOpts) (*api.Response[*phase0.AttestationData], error) {
 	const label = "attestation_data"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*phase0.AttestationData], error) {
@@ -192,7 +192,7 @@ func (m multi) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 // SubmitAttestations submits attestations.
 func (m multi) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) error {
 	const label = "submit_attestations"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -212,7 +212,7 @@ func (m multi) SubmitAttestations(ctx context.Context, attestations []*phase0.At
 // AttesterDuties obtains attester duties.
 func (m multi) AttesterDuties(ctx context.Context, opts *api.AttesterDutiesOpts) (*api.Response[[]*apiv1.AttesterDuty], error) {
 	const label = "attester_duties"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[[]*apiv1.AttesterDuty], error) {
@@ -253,7 +253,7 @@ func (m multi) DepositContract(ctx context.Context, opts *api.DepositContractOpt
 // If validatorIndicess is nil it will return all duties for the given epoch.
 func (m multi) SyncCommitteeDuties(ctx context.Context, opts *api.SyncCommitteeDutiesOpts) (*api.Response[[]*apiv1.SyncCommitteeDuty], error) {
 	const label = "sync_committee_duties"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[[]*apiv1.SyncCommitteeDuty], error) {
@@ -273,7 +273,7 @@ func (m multi) SyncCommitteeDuties(ctx context.Context, opts *api.SyncCommitteeD
 // SubmitSyncCommitteeMessages submits sync committee messages.
 func (m multi) SubmitSyncCommitteeMessages(ctx context.Context, messages []*altair.SyncCommitteeMessage) error {
 	const label = "submit_sync_committee_messages"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -293,7 +293,7 @@ func (m multi) SubmitSyncCommitteeMessages(ctx context.Context, messages []*alta
 // SubmitSyncCommitteeSubscriptions subscribes to sync committees.
 func (m multi) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscriptions []*apiv1.SyncCommitteeSubscription) error {
 	const label = "submit_sync_committee_subscriptions"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -313,7 +313,7 @@ func (m multi) SubmitSyncCommitteeSubscriptions(ctx context.Context, subscriptio
 // SyncCommitteeContribution provides a sync committee contribution.
 func (m multi) SyncCommitteeContribution(ctx context.Context, opts *api.SyncCommitteeContributionOpts) (*api.Response[*altair.SyncCommitteeContribution], error) {
 	const label = "sync_committee_contribution"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*altair.SyncCommitteeContribution], error) {
@@ -333,7 +333,7 @@ func (m multi) SyncCommitteeContribution(ctx context.Context, opts *api.SyncComm
 // SubmitSyncCommitteeContributions submits sync committee contributions.
 func (m multi) SubmitSyncCommitteeContributions(ctx context.Context, contributionAndProofs []*altair.SignedContributionAndProof) error {
 	const label = "submit_sync_committee_contributions"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -353,7 +353,7 @@ func (m multi) SubmitSyncCommitteeContributions(ctx context.Context, contributio
 // Proposal fetches a proposal for signing.
 func (m multi) Proposal(ctx context.Context, opts *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error) {
 	const label = "proposal"
-	defer latency(label)()
+	defer latency(ctx, label, true)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*api.VersionedProposal], error) {
@@ -393,7 +393,7 @@ func (m multi) BeaconBlockRoot(ctx context.Context, opts *api.BeaconBlockRootOpt
 // SubmitProposal submits a proposal.
 func (m multi) SubmitProposal(ctx context.Context, opts *api.SubmitProposalOpts) error {
 	const label = "submit_proposal"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -413,7 +413,7 @@ func (m multi) SubmitProposal(ctx context.Context, opts *api.SubmitProposalOpts)
 // SubmitBeaconCommitteeSubscriptions subscribes to beacon committees.
 func (m multi) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscriptions []*apiv1.BeaconCommitteeSubscription) error {
 	const label = "submit_beacon_committee_subscriptions"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -433,7 +433,7 @@ func (m multi) SubmitBeaconCommitteeSubscriptions(ctx context.Context, subscript
 // SubmitBlindedProposal submits a beacon block.
 func (m multi) SubmitBlindedProposal(ctx context.Context, opts *api.SubmitBlindedProposalOpts) error {
 	const label = "submit_blinded_proposal"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -453,7 +453,7 @@ func (m multi) SubmitBlindedProposal(ctx context.Context, opts *api.SubmitBlinde
 // SubmitValidatorRegistrations submits a validator registration.
 func (m multi) SubmitValidatorRegistrations(ctx context.Context, registrations []*api.VersionedSignedValidatorRegistration) error {
 	const label = "submit_validator_registrations"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {
@@ -473,7 +473,7 @@ func (m multi) SubmitValidatorRegistrations(ctx context.Context, registrations [
 // Fork fetches fork information for the given state.
 func (m multi) Fork(ctx context.Context, opts *api.ForkOpts) (*api.Response[*phase0.Fork], error) {
 	const label = "fork"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*phase0.Fork], error) {
@@ -493,7 +493,7 @@ func (m multi) Fork(ctx context.Context, opts *api.ForkOpts) (*api.Response[*pha
 // ForkSchedule provides details of past and future changes in the chain's fork version.
 func (m multi) ForkSchedule(ctx context.Context, opts *api.ForkScheduleOpts) (*api.Response[[]*phase0.Fork], error) {
 	const label = "fork_schedule"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[[]*phase0.Fork], error) {
@@ -533,7 +533,7 @@ func (m multi) Genesis(ctx context.Context, opts *api.GenesisOpts) (*api.Respons
 // NodeSyncing provides the state of the node's synchronization with the chain.
 func (m multi) NodeSyncing(ctx context.Context, opts *api.NodeSyncingOpts) (*api.Response[*apiv1.SyncState], error) {
 	const label = "node_syncing"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[*apiv1.SyncState], error) {
@@ -594,7 +594,7 @@ func (m multi) SubmitProposalPreparations(ctx context.Context, preparations []*a
 // ProposerDuties obtains proposer duties for the given options.
 func (m multi) ProposerDuties(ctx context.Context, opts *api.ProposerDutiesOpts) (*api.Response[[]*apiv1.ProposerDuty], error) {
 	const label = "proposer_duties"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[[]*apiv1.ProposerDuty], error) {
@@ -634,7 +634,7 @@ func (m multi) Spec(ctx context.Context, opts *api.SpecOpts) (*api.Response[map[
 // Validators provides the validators, with their balance and status, for the given options.
 func (m multi) Validators(ctx context.Context, opts *api.ValidatorsOpts) (*api.Response[map[phase0.ValidatorIndex]*apiv1.Validator], error) {
 	const label = "validators"
-	defer latency(label)()
+	defer latency(ctx, label, true)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*api.Response[map[phase0.ValidatorIndex]*apiv1.Validator], error) {
@@ -654,7 +654,7 @@ func (m multi) Validators(ctx context.Context, opts *api.ValidatorsOpts) (*api.R
 // SubmitVoluntaryExit submits a voluntary exit.
 func (m multi) SubmitVoluntaryExit(ctx context.Context, voluntaryExit *phase0.SignedVoluntaryExit) error {
 	const label = "submit_voluntary_exit"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients,
 		func(ctx context.Context, cl Client) error {

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -25,6 +25,11 @@ import (
 	"golang.org/x/tools/go/packages"
 )
 
+type latencyLog struct {
+	Latency bool
+	Log     bool
+}
+
 var (
 	tpl = `package eth2wrap
 
@@ -63,7 +68,7 @@ type Client interface {
     {{end -}}
 	func (m multi) {{.Name}}({{.Params}}) ({{.ResultTypes}}) {
 		const label = "{{.Label}}"
-		{{if .Latency}}defer latency(label)() {{end}}
+		{{if .Latency}}defer latency(ctx, label, {{.Log}})() {{end}}
 
 
 		{{.ResultNames}} := {{.DoFunc}}(ctx, m.clients,
@@ -95,42 +100,42 @@ type Client interface {
 {{end}}
 `
 
-	// interfaces defines all the interfaces to implement and whether to measure latency for each.
-	interfaces = map[string]bool{
-		"AggregateAttestationProvider":          true,
-		"AggregateAttestationsSubmitter":        true,
-		"AttestationDataProvider":               true,
-		"AttestationsSubmitter":                 true,
-		"AttesterDutiesProvider":                true,
-		"ProposalProvider":                      true,
-		"BeaconBlockRootProvider":               false,
-		"ProposalSubmitter":                     true,
-		"BeaconCommitteeSubscriptionsSubmitter": true,
-		"BlindedProposalProvider":               true,
-		"BlindedProposalSubmitter":              true,
-		"DepositContractProvider":               false,
-		"DomainProvider":                        false,
-		"ForkProvider":                          true,
-		"ForkScheduleProvider":                  true,
-		"GenesisProvider":                       false,
-		"GenesisTimeProvider":                   false,
-		"NodeSyncingProvider":                   true,
-		"NodeVersionProvider":                   false,
-		"ProposerDutiesProvider":                true,
-		"ProposalPreparationsSubmitter":         false,
-		"SlotDurationProvider":                  false,
-		"SlotsPerEpochProvider":                 false,
-		"SpecProvider":                          false,
-		"SignedBeaconBlockProvider":             true,
-		"SyncCommitteeDutiesProvider":           true,
-		"SyncCommitteeContributionProvider":     true,
-		"SyncCommitteeContributionsSubmitter":   true,
-		"SyncCommitteeMessagesSubmitter":        true,
-		"SyncCommitteeSubscriptionsSubmitter":   true,
-		"ValidatorsProvider":                    true,
-		"ValidatorRegistrationsSubmitter":       true,
-		"VoluntaryExitSubmitter":                true,
-		"SetForkVersion":                        true,
+	// interfaces defines all the interfaces to implement and whether to measure latency and logging for each.
+	interfaces = map[string]latencyLog{
+		"AggregateAttestationProvider":          {Latency: true, Log: false},
+		"AggregateAttestationsSubmitter":        {Latency: true, Log: false},
+		"AttestationDataProvider":               {Latency: true, Log: false},
+		"AttestationsSubmitter":                 {Latency: true, Log: false},
+		"AttesterDutiesProvider":                {Latency: true, Log: false},
+		"ProposalProvider":                      {Latency: true, Log: true},
+		"BeaconBlockRootProvider":               {Latency: false, Log: false},
+		"ProposalSubmitter":                     {Latency: true, Log: false},
+		"BeaconCommitteeSubscriptionsSubmitter": {Latency: true, Log: false},
+		"BlindedProposalProvider":               {Latency: true, Log: false},
+		"BlindedProposalSubmitter":              {Latency: true, Log: false},
+		"DepositContractProvider":               {Latency: false, Log: false},
+		"DomainProvider":                        {Latency: false, Log: false},
+		"ForkProvider":                          {Latency: true, Log: false},
+		"ForkScheduleProvider":                  {Latency: true, Log: false},
+		"GenesisProvider":                       {Latency: false, Log: false},
+		"GenesisTimeProvider":                   {Latency: false, Log: false},
+		"NodeSyncingProvider":                   {Latency: true, Log: false},
+		"NodeVersionProvider":                   {Latency: false, Log: false},
+		"ProposerDutiesProvider":                {Latency: true, Log: false},
+		"ProposalPreparationsSubmitter":         {Latency: false, Log: false},
+		"SlotDurationProvider":                  {Latency: false, Log: false},
+		"SlotsPerEpochProvider":                 {Latency: false, Log: false},
+		"SpecProvider":                          {Latency: false, Log: false},
+		"SignedBeaconBlockProvider":             {Latency: true, Log: false},
+		"SyncCommitteeDutiesProvider":           {Latency: true, Log: false},
+		"SyncCommitteeContributionProvider":     {Latency: true, Log: false},
+		"SyncCommitteeContributionsSubmitter":   {Latency: true, Log: false},
+		"SyncCommitteeMessagesSubmitter":        {Latency: true, Log: false},
+		"SyncCommitteeSubscriptionsSubmitter":   {Latency: true, Log: false},
+		"ValidatorsProvider":                    {Latency: true, Log: true},
+		"ValidatorRegistrationsSubmitter":       {Latency: true, Log: false},
+		"VoluntaryExitSubmitter":                {Latency: true, Log: false},
+		"SetForkVersion":                        {Latency: true, Log: false},
 	}
 
 	// addImport indicates which types need hardcoded imports.
@@ -153,6 +158,7 @@ type Method struct {
 	Name        string
 	Doc         string
 	Latency     bool
+	Log         bool
 	DoFunc      string
 	SuccessFunc string
 	params      []Field
@@ -348,7 +354,7 @@ func parseEth2Methods(pkg *packages.Package) ([]Method, []string, error) {
 					continue
 				}
 
-				latency, add := interfaces[typeSpec.Name.Name]
+				latencyLog, add := interfaces[typeSpec.Name.Name]
 				if !add {
 					continue
 				}
@@ -426,7 +432,8 @@ func parseEth2Methods(pkg *packages.Package) ([]Method, []string, error) {
 					methods = append(methods, Method{
 						Name:        name,
 						Doc:         doc,
-						Latency:     latency,
+						Latency:     latencyLog.Latency,
+						Log:         latencyLog.Log,
 						DoFunc:      dofunc,
 						SuccessFunc: successFunc,
 						params:      params,

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -122,7 +122,7 @@ type Client interface {
 		"NodeSyncingProvider":                   {Latency: true, Log: false},
 		"NodeVersionProvider":                   {Latency: false, Log: false},
 		"ProposerDutiesProvider":                {Latency: true, Log: false},
-		"ProposalPreparationsSubmitter":         {Latency: false, Log: false},
+		"ProposalPreparationsSubmitter":         {Latency: true, Log: true},
 		"SlotDurationProvider":                  {Latency: false, Log: false},
 		"SlotsPerEpochProvider":                 {Latency: false, Log: false},
 		"SpecProvider":                          {Latency: false, Log: false},

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -117,7 +117,7 @@ func (m multi) CompleteValidators(ctx context.Context) (CompleteValidators, erro
 
 func (m multi) ProposerConfig(ctx context.Context) (*eth2exp.ProposerConfigResponse, error) {
 	const label = "proposer_config"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (*eth2exp.ProposerConfigResponse, error) {
@@ -135,7 +135,7 @@ func (m multi) ProposerConfig(ctx context.Context) (*eth2exp.ProposerConfigRespo
 
 func (m multi) AggregateBeaconCommitteeSelections(ctx context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
 	const label = "aggregate_beacon_committee_selections"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) ([]*eth2exp.BeaconCommitteeSelection, error) {
@@ -153,7 +153,7 @@ func (m multi) AggregateBeaconCommitteeSelections(ctx context.Context, selection
 
 func (m multi) AggregateSyncCommitteeSelections(ctx context.Context, selections []*eth2exp.SyncCommitteeSelection) ([]*eth2exp.SyncCommitteeSelection, error) {
 	const label = "aggregate_sync_committee_selections"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) ([]*eth2exp.SyncCommitteeSelection, error) {
@@ -171,7 +171,7 @@ func (m multi) AggregateSyncCommitteeSelections(ctx context.Context, selections 
 
 func (m multi) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
 	const label = "block_attestations"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) ([]*eth2p0.Attestation, error) {
@@ -189,7 +189,7 @@ func (m multi) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0
 
 func (m multi) NodePeerCount(ctx context.Context) (int, error) {
 	const label = "node_peer_count"
-	defer latency(label)()
+	defer latency(ctx, label, false)()
 
 	res, err := provide(ctx, m.clients,
 		func(ctx context.Context, cl Client) (int, error) {


### PR DESCRIPTION
Adding logs for some beacon node calls RTT. In order to help tracking issues with underperforming beacon nodes, caused either by slow infrastructure/networking or issues from the beacon node itself.

Currently logs have been added only on the calls for:
- Proposal (GET /eth/v3/validator/blocks/{slot}) - fetches a proposal for signing and is known to be the bottleneck call to the BNs on proposals.
- Validators (POST /eth/v1/beacon/states/{state_id}/validators) - on some BNs this call is taking long time and is blocking the whole BN reachability and any calls to it.

I'm open to including more endpoints.

Fixing linter on one place.

category: feature
ticket: none