### PR TITLE
chore: fix some function names in comment

### DIFF
--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -204,7 +204,7 @@ func TestDefinitionVerify(t *testing.T) {
 	})
 }
 
-// randomOperator returns a random ETH1 private key and populated creator struct (excluding config signature).
+// randomCreator returns a random ETH1 private key and populated creator struct (excluding config signature).
 func randomCreator(t *testing.T) (*k1.PrivateKey, Creator) {
 	t.Helper()
 

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -67,7 +67,7 @@ func hashDefinition(d Definition, configOnly bool) ([32]byte, error) {
 	return resp, nil
 }
 
-// hashLegaacy hashes a legacy definition.
+// hashDefinitionLegacy hashes a legacy definition.
 func hashDefinitionLegacy(d Definition, hh ssz.HashWalker, configOnly bool) error {
 	vaddrs, err := d.LegacyValidatorAddresses()
 	if err != nil {
@@ -446,7 +446,7 @@ func hashDefinitionV1x8(d Definition, hh ssz.HashWalker, configOnly bool) error 
 	return hashDefinitionV1x8to9(d, hh, configOnly, nil)
 }
 
-// hashDefinitionV1x9OrLater hashes the new definition.
+// hashDefinitionV1x9orLater hashes the new definition.
 func hashDefinitionV1x9orLater(d Definition, hh ssz.HashWalker, configOnly bool) error {
 	return hashDefinitionV1x8to9(d, hh, configOnly, []hashExtraFields{
 		func(d Definition, hh ssz.HashWalker) error {


### PR DESCRIPTION


 fix some function names in comment
