### PR TITLE
Fix/typos in ssz_test.go and exchanger.go

### DIFF
--- a/core/ssz_test.go
+++ b/core/ssz_test.go
@@ -99,7 +99,7 @@ func TestSSZ(t *testing.T) {
 
 func TestMarshalUnsignedProto(t *testing.T) {
 	tests := []struct {
-		unsignedPtr func() any // Need any pointer to avoid wrapping in interface which doesnt' support fuzzing.
+		unsignedPtr func() any // Need any pointer to avoid wrapping in interface which doesn't' support fuzzing.
 		dutyType    core.DutyType
 	}{
 		{

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -102,7 +102,7 @@ func newExchanger(tcpNode host.Host, peerIdx int, peers []peer.ID, vals int, sig
 	return ex
 }
 
-// exchange exhanges partial signatures of lockhash/deposit-data among dkg participants and returns all the partial
+// exchange exchanges partial signatures of lockhash/deposit-data among dkg participants and returns all the partial
 // signatures of the group according to public key of each DV.
 func (e *exchanger) exchange(ctx context.Context, sigType sigType, set core.ParSignedDataSet) (map[core.PubKey][]core.ParSignedData, error) {
 	// Start the process by storing current peer's ParSignedDataSet


### PR DESCRIPTION
Corrected "doesnt'" to "doesn't"
- doesnt' support fuzzing
+ doesn't support fuzzing


Corrected "exhanges" to "exchanges"
- exchange exhanges partial signatures
+ exchange exchanges partial signatures
