### PR TITLE
build: allow golangci-lint parallel on .pre-commit

### DIFF
--- a/.pre-commit/run_linter.sh
+++ b/.pre-commit/run_linter.sh
@@ -14,4 +14,4 @@ if [[ $version_check != *"$VERSION"* ]]; then
     echo "golangci-lint version is not $VERSION"
 fi
 
-golangci-lint run
+golangci-lint run --allow-parallel-runners


### PR DESCRIPTION
Sometimes golangci-lint fails with `Parallel golangci-lint is running`, even if the previous run finished.

category: misc
ticket: none
