### PR TITLE
*: support electra in existing codebase; tests

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -19,6 +19,7 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	eth2e "github.com/attestantio/go-eth2-client/spec/electra"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -261,37 +262,108 @@ func TestCtxCancel(t *testing.T) {
 	}
 }
 
-func TestBlockAttestations(t *testing.T) {
-	atts := []*eth2spec.VersionedAttestation{
-		testutil.RandomDenebVersionedAttestation(),
-		testutil.RandomDenebVersionedAttestation(),
+func TestBlockAttestationsV2(t *testing.T) {
+	phase0Att1 := testutil.RandomPhase0Attestation()
+	phase0Att2 := testutil.RandomPhase0Attestation()
+	electraAtt1 := testutil.RandomElectraAttestation()
+	electraAtt2 := testutil.RandomElectraAttestation()
+
+	tests := []struct {
+		version          string
+		attestations     []*eth2spec.VersionedAttestation
+		serverJSONStruct any
+		expErr           string
+	}{
+		{
+			version: "electra",
+			attestations: []*eth2spec.VersionedAttestation{
+				{Version: eth2spec.DataVersionElectra, Electra: electraAtt1},
+				{Version: eth2spec.DataVersionElectra, Electra: electraAtt2},
+			},
+			serverJSONStruct: struct{ Data []*eth2e.Attestation }{Data: []*eth2e.Attestation{electraAtt1, electraAtt2}},
+			expErr:           "",
+		},
+		{
+			version: "deneb",
+			attestations: []*eth2spec.VersionedAttestation{
+				{Version: eth2spec.DataVersionDeneb, Deneb: phase0Att1},
+				{Version: eth2spec.DataVersionDeneb, Deneb: phase0Att2},
+			},
+			serverJSONStruct: struct{ Data []*eth2p0.Attestation }{Data: []*eth2p0.Attestation{phase0Att1, phase0Att2}},
+			expErr:           "",
+		},
+		{
+			version: "capella",
+			attestations: []*eth2spec.VersionedAttestation{
+				{Version: eth2spec.DataVersionCapella, Capella: phase0Att1},
+				{Version: eth2spec.DataVersionCapella, Capella: phase0Att2},
+			},
+			serverJSONStruct: struct{ Data []*eth2p0.Attestation }{Data: []*eth2p0.Attestation{phase0Att1, phase0Att2}},
+			expErr:           "",
+		},
+		{
+			version: "bellatrix",
+			attestations: []*eth2spec.VersionedAttestation{
+				{Version: eth2spec.DataVersionBellatrix, Bellatrix: phase0Att1},
+				{Version: eth2spec.DataVersionBellatrix, Bellatrix: phase0Att2},
+			},
+			serverJSONStruct: struct{ Data []*eth2p0.Attestation }{Data: []*eth2p0.Attestation{phase0Att1, phase0Att2}},
+			expErr:           "",
+		},
+		{
+			version: "altair",
+			attestations: []*eth2spec.VersionedAttestation{
+				{Version: eth2spec.DataVersionAltair, Altair: phase0Att1},
+				{Version: eth2spec.DataVersionAltair, Altair: phase0Att2},
+			},
+			serverJSONStruct: struct{ Data []*eth2p0.Attestation }{Data: []*eth2p0.Attestation{phase0Att1, phase0Att2}},
+			expErr:           "",
+		},
+		{
+			version: "phase0",
+			attestations: []*eth2spec.VersionedAttestation{
+				{Version: eth2spec.DataVersionPhase0, Phase0: phase0Att1},
+				{Version: eth2spec.DataVersionPhase0, Phase0: phase0Att2},
+			},
+			serverJSONStruct: struct{ Data []*eth2p0.Attestation }{Data: []*eth2p0.Attestation{phase0Att1, phase0Att2}},
+			expErr:           "",
+		},
+		{
+			version:          "unknown version",
+			attestations:     nil,
+			serverJSONStruct: struct{ Data []*eth2p0.Attestation }{Data: []*eth2p0.Attestation{phase0Att1, phase0Att2}},
+			expErr:           "failed to get consensus version",
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.version, func(t *testing.T) {
+			statusCode := http.StatusOK
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, http.MethodGet, r.Method)
+				require.Equal(t, "/eth/v2/beacon/blocks/head/attestations", r.URL.Path)
+				b, err := json.Marshal(test.serverJSONStruct)
+				require.NoError(t, err)
 
-	statusCode := http.StatusOK
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.Equal(t, http.MethodGet, r.Method)
-		require.Equal(t, "/eth/v2/beacon/blocks/head/attestations", r.URL.Path)
-		b, err := json.Marshal(struct {
-			Data []*eth2p0.Attestation
-		}{
-			Data: []*eth2p0.Attestation{atts[0].Deneb, atts[1].Deneb},
+				w.Header().Add("Eth-Consensus-Version", test.version)
+				w.WriteHeader(statusCode)
+				_, _ = w.Write(b)
+			}))
+
+			cl := eth2wrap.NewHTTPAdapterForT(t, srv.URL, time.Hour)
+			resp, err := cl.BlockAttestationsV2(context.Background(), "head")
+			if test.expErr != "" {
+				require.ErrorContains(t, err, test.expErr)
+			} else {
+				require.NoError(t, err)
+			}
+			require.Equal(t, test.attestations, resp)
+
+			statusCode = http.StatusNotFound
+			resp, err = cl.BlockAttestationsV2(context.Background(), "head")
+			require.NoError(t, err)
+			require.Empty(t, resp)
 		})
-		require.NoError(t, err)
-
-		w.Header().Add("Eth-Consensus-Version", "deneb")
-		w.WriteHeader(statusCode)
-		_, _ = w.Write(b)
-	}))
-
-	cl := eth2wrap.NewHTTPAdapterForT(t, srv.URL, time.Hour)
-	resp, err := cl.BlockAttestationsV2(context.Background(), "head")
-	require.NoError(t, err)
-	require.Equal(t, atts, resp)
-
-	statusCode = http.StatusNotFound
-	resp, err = cl.BlockAttestationsV2(context.Background(), "head")
-	require.NoError(t, err)
-	require.Empty(t, resp)
+	}
 }
 
 // TestOneError tests the case where one of the servers returns errors.

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -14,6 +14,7 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2electra "github.com/attestantio/go-eth2-client/api/v1/electra"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -174,6 +175,14 @@ func (h *synthWrapper) syntheticProposal(ctx context.Context, slot eth2p0.Slot, 
 		proposal.Deneb.Block.ProposerIndex = vIdx
 		proposal.Deneb.Block.Body.ExecutionPayload.FeeRecipient = feeRecipient
 		proposal.Deneb.Block.Body.ExecutionPayload.Transactions = fraction(proposal.Deneb.Block.Body.ExecutionPayload.Transactions)
+	case eth2spec.DataVersionElectra:
+		proposal.Electra = &eth2electra.BlockContents{}
+		proposal.Electra.Block = signedBlock.Electra.Message
+		proposal.Electra.Block.Body.Graffiti = GetSyntheticGraffiti()
+		proposal.Electra.Block.Slot = slot
+		proposal.Electra.Block.ProposerIndex = vIdx
+		proposal.Electra.Block.Body.ExecutionPayload.FeeRecipient = feeRecipient
+		proposal.Electra.Block.Body.ExecutionPayload.Transactions = fraction(proposal.Electra.Block.Body.ExecutionPayload.Transactions)
 	default:
 		return nil, errors.New("unsupported proposal version")
 	}
@@ -225,6 +234,8 @@ func IsSyntheticBlindedBlock(block *eth2api.VersionedSignedBlindedProposal) bool
 		graffiti = block.Capella.Message.Body.Graffiti
 	case eth2spec.DataVersionDeneb:
 		graffiti = block.Deneb.Message.Body.Graffiti
+	case eth2spec.DataVersionElectra:
+		graffiti = block.Electra.Message.Body.Graffiti
 	default:
 		return false
 	}
@@ -246,6 +257,8 @@ func IsSyntheticProposal(block *eth2api.VersionedSignedProposal) bool {
 		graffiti = block.Capella.Message.Body.Graffiti
 	case eth2spec.DataVersionDeneb:
 		graffiti = block.Deneb.SignedBlock.Message.Body.Graffiti
+	case eth2spec.DataVersionElectra:
+		graffiti = block.Electra.SignedBlock.Message.Body.Graffiti
 	default:
 		return false
 	}

--- a/app/eth2wrap/synthproposer_test.go
+++ b/app/eth2wrap/synthproposer_test.go
@@ -5,12 +5,15 @@ package eth2wrap_test
 import (
 	"context"
 	"fmt"
+	"math/big"
 	"net/http"
 	"testing"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2capella "github.com/attestantio/go-eth2-client/api/v1/capella"
+	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2electra "github.com/attestantio/go-eth2-client/api/v1/electra"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
@@ -24,143 +27,286 @@ import (
 func TestSynthProposer(t *testing.T) {
 	ctx := context.Background()
 
-	var (
-		set                        = beaconmock.ValidatorSetA
-		feeRecipient               = bellatrix.ExecutionAddress{0x00, 0x01, 0x02}
-		slotsPerEpoch              = 16
-		epoch         eth2p0.Epoch = 100
-		realBlockSlot              = eth2p0.Slot(slotsPerEpoch) * eth2p0.Slot(epoch)
-		done                       = make(chan struct{})
-		activeVals                 = 0
-	)
+	tests := []struct {
+		version                       eth2spec.DataVersion
+		versionedSignedBlock          *eth2spec.VersionedSignedBeaconBlock
+		beaconMockProposalFunc        func(context.Context, *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error)
+		populateBlockFunc             func(*eth2api.VersionedProposal) *eth2api.VersionedSignedBlindedProposal
+		createVersionedSignedProposal func(*eth2api.VersionedProposal) *eth2api.VersionedSignedProposal
+	}{
+		{
+			version:              eth2spec.DataVersionElectra,
+			versionedSignedBlock: testutil.RandomElectraVersionedSignedBeaconBlock(),
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				var block *eth2api.VersionedProposal
+				if opts.BuilderBoostFactor == nil || *opts.BuilderBoostFactor == 0 {
+					block = testutil.RandomElectraVersionedProposal()
+					block.Electra.Block.Slot = opts.Slot
+					block.Electra.Block.Body.RANDAOReveal = opts.RandaoReveal
+					block.Electra.Block.Body.Graffiti = opts.Graffiti
+					block.ExecutionValue = big.NewInt(1)
+					block.ConsensusValue = big.NewInt(1)
+				} else {
+					block = &eth2api.VersionedProposal{
+						Version:        eth2spec.DataVersionElectra,
+						ElectraBlinded: testutil.RandomElectraBlindedBeaconBlock(),
+					}
+					block.ElectraBlinded.Slot = opts.Slot
+					block.ElectraBlinded.Body.RANDAOReveal = opts.RandaoReveal
+					block.ElectraBlinded.Body.Graffiti = opts.Graffiti
+					block.ExecutionValue = big.NewInt(1)
+					block.ConsensusValue = big.NewInt(1)
+					block.Blinded = true
+				}
 
-	bmock, err := beaconmock.New(beaconmock.WithValidatorSet(set), beaconmock.WithSlotsPerEpoch(slotsPerEpoch))
-	require.NoError(t, err)
-
-	bmock.SubmitProposalFunc = func(ctx context.Context, opts *eth2api.SubmitProposalOpts) error {
-		require.Equal(t, realBlockSlot, opts.Proposal.Capella.Message.Slot)
-		close(done)
-
-		return nil
-	}
-
-	bmock.SubmitBlindedProposalFunc = func(ctx context.Context, opts *eth2api.SubmitBlindedProposalOpts) error {
-		require.Equal(t, realBlockSlot, opts.Proposal.Capella.Message.Slot)
-		close(done)
-
-		return nil
-	}
-
-	bmock.ProposerDutiesFunc = func(ctx context.Context, e eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
-		require.Equal(t, int(epoch), int(e))
-
-		return []*eth2v1.ProposerDuty{ // First validator is the proposer for first slot in the epoch.
-			{
-				PubKey:         set[1].Validator.PublicKey,
-				Slot:           realBlockSlot,
-				ValidatorIndex: set[1].Index,
+				return block, nil
 			},
-		}, nil
-	}
-	cached := bmock.CachedValidatorsFunc
-	bmock.CachedValidatorsFunc = func(ctx context.Context) (eth2wrap.ActiveValidators, eth2wrap.CompleteValidators, error) {
-		activeVals++
-		return cached(ctx)
-	}
-	bmock.SignedBeaconBlockFunc = func(ctx context.Context, blockID string) (*eth2spec.VersionedSignedBeaconBlock, error) {
-		resp := testutil.RandomCapellaVersionedSignedBeaconBlock()
+			populateBlockFunc: func(block *eth2api.VersionedProposal) *eth2api.VersionedSignedBlindedProposal {
+				return &eth2api.VersionedSignedBlindedProposal{
+					Version: eth2spec.DataVersionElectra,
+					Electra: &eth2electra.SignedBlindedBeaconBlock{
+						Message:   block.ElectraBlinded,
+						Signature: testutil.RandomEth2Signature(),
+					},
+				}
+			},
+			createVersionedSignedProposal: func(block *eth2api.VersionedProposal) *eth2api.VersionedSignedProposal {
+				signed := testutil.RandomElectraVersionedSignedProposal()
+				signed.Electra.SignedBlock.Message = block.Electra.Block
 
-		return resp, nil
+				return signed
+			},
+		},
+		{
+			version:              eth2spec.DataVersionDeneb,
+			versionedSignedBlock: testutil.RandomDenebVersionedSignedBeaconBlock(),
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				var block *eth2api.VersionedProposal
+				if opts.BuilderBoostFactor == nil || *opts.BuilderBoostFactor == 0 {
+					block = testutil.RandomDenebVersionedProposal()
+					block.Deneb.Block.Slot = opts.Slot
+					block.Deneb.Block.Body.RANDAOReveal = opts.RandaoReveal
+					block.Deneb.Block.Body.Graffiti = opts.Graffiti
+					block.ExecutionValue = big.NewInt(1)
+					block.ConsensusValue = big.NewInt(1)
+				} else {
+					block = &eth2api.VersionedProposal{
+						Version:      eth2spec.DataVersionDeneb,
+						DenebBlinded: testutil.RandomDenebBlindedBeaconBlock(),
+					}
+					block.DenebBlinded.Slot = opts.Slot
+					block.DenebBlinded.Body.RANDAOReveal = opts.RandaoReveal
+					block.DenebBlinded.Body.Graffiti = opts.Graffiti
+					block.ExecutionValue = big.NewInt(1)
+					block.ConsensusValue = big.NewInt(1)
+					block.Blinded = true
+				}
+
+				return block, nil
+			},
+			populateBlockFunc: func(block *eth2api.VersionedProposal) *eth2api.VersionedSignedBlindedProposal {
+				return &eth2api.VersionedSignedBlindedProposal{
+					Version: eth2spec.DataVersionDeneb,
+					Deneb: &eth2deneb.SignedBlindedBeaconBlock{
+						Message:   block.DenebBlinded,
+						Signature: testutil.RandomEth2Signature(),
+					},
+				}
+			},
+			createVersionedSignedProposal: func(block *eth2api.VersionedProposal) *eth2api.VersionedSignedProposal {
+				signed := testutil.RandomDenebVersionedSignedProposal()
+				signed.Deneb.SignedBlock.Message = block.Deneb.Block
+
+				return signed
+			},
+		},
+		{
+			version:              eth2spec.DataVersionCapella,
+			versionedSignedBlock: testutil.RandomCapellaVersionedSignedBeaconBlock(),
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				var block *eth2api.VersionedProposal
+				if opts.BuilderBoostFactor == nil || *opts.BuilderBoostFactor == 0 {
+					block = testutil.RandomCapellaVersionedProposal()
+					block.Capella.Slot = opts.Slot
+					block.Capella.Body.RANDAOReveal = opts.RandaoReveal
+					block.Capella.Body.Graffiti = opts.Graffiti
+					block.ExecutionValue = big.NewInt(1)
+					block.ConsensusValue = big.NewInt(1)
+				} else {
+					block = &eth2api.VersionedProposal{
+						Version:        eth2spec.DataVersionCapella,
+						CapellaBlinded: testutil.RandomCapellaBlindedBeaconBlock(),
+					}
+					block.CapellaBlinded.Slot = opts.Slot
+					block.CapellaBlinded.Body.RANDAOReveal = opts.RandaoReveal
+					block.CapellaBlinded.Body.Graffiti = opts.Graffiti
+					block.ExecutionValue = big.NewInt(1)
+					block.ConsensusValue = big.NewInt(1)
+					block.Blinded = true
+				}
+
+				return block, nil
+			},
+			populateBlockFunc: func(block *eth2api.VersionedProposal) *eth2api.VersionedSignedBlindedProposal {
+				return &eth2api.VersionedSignedBlindedProposal{
+					Version: eth2spec.DataVersionCapella,
+					Capella: &eth2capella.SignedBlindedBeaconBlock{
+						Message:   block.CapellaBlinded,
+						Signature: testutil.RandomEth2Signature(),
+					},
+				}
+			},
+			createVersionedSignedProposal: func(block *eth2api.VersionedProposal) *eth2api.VersionedSignedProposal {
+				signed := testutil.RandomCapellaVersionedSignedProposal()
+				signed.Capella.Message = block.Capella
+
+				return signed
+			},
+		},
 	}
 
-	eth2Cl := eth2wrap.WithSyntheticDuties(bmock)
+	for _, test := range tests {
+		t.Run(test.version.String(), func(t *testing.T) {
+			var (
+				set                        = beaconmock.ValidatorSetA
+				feeRecipient               = bellatrix.ExecutionAddress{0x00, 0x01, 0x02}
+				slotsPerEpoch              = 16
+				epoch         eth2p0.Epoch = 100
+				realBlockSlot              = eth2p0.Slot(slotsPerEpoch) * eth2p0.Slot(epoch)
+				done                       = make(chan struct{})
+				activeVals                 = 0
+			)
 
-	var preps []*eth2v1.ProposalPreparation
-	for vIdx := range set {
-		preps = append(preps, &eth2v1.ProposalPreparation{
-			ValidatorIndex: vIdx,
-			FeeRecipient:   feeRecipient,
+			bmock, err := beaconmock.New(beaconmock.WithValidatorSet(set), beaconmock.WithSlotsPerEpoch(slotsPerEpoch))
+			require.NoError(t, err)
+
+			bmock.SubmitProposalFunc = func(ctx context.Context, opts *eth2api.SubmitProposalOpts) error {
+				slot, err := opts.Proposal.Slot()
+				require.NoError(t, err)
+				require.Equal(t, realBlockSlot, slot)
+				close(done)
+
+				return nil
+			}
+
+			bmock.SubmitBlindedProposalFunc = func(ctx context.Context, opts *eth2api.SubmitBlindedProposalOpts) error {
+				slot, err := opts.Proposal.Slot()
+				require.NoError(t, err)
+				require.Equal(t, realBlockSlot, slot)
+				close(done)
+
+				return nil
+			}
+
+			bmock.ProposerDutiesFunc = func(ctx context.Context, e eth2p0.Epoch, indices []eth2p0.ValidatorIndex) ([]*eth2v1.ProposerDuty, error) {
+				require.Equal(t, int(epoch), int(e))
+
+				return []*eth2v1.ProposerDuty{ // First validator is the proposer for first slot in the epoch.
+					{
+						PubKey:         set[1].Validator.PublicKey,
+						Slot:           realBlockSlot,
+						ValidatorIndex: set[1].Index,
+					},
+				}, nil
+			}
+			cached := bmock.CachedValidatorsFunc
+			bmock.CachedValidatorsFunc = func(ctx context.Context) (eth2wrap.ActiveValidators, eth2wrap.CompleteValidators, error) {
+				activeVals++
+				return cached(ctx)
+			}
+			bmock.SignedBeaconBlockFunc = func(ctx context.Context, blockID string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+				resp := test.versionedSignedBlock
+
+				return resp, nil
+			}
+
+			bmock.ProposalFunc = test.beaconMockProposalFunc
+
+			eth2Cl := eth2wrap.WithSyntheticDuties(bmock)
+
+			var preps []*eth2v1.ProposalPreparation
+			for vIdx := range set {
+				preps = append(preps, &eth2v1.ProposalPreparation{
+					ValidatorIndex: vIdx,
+					FeeRecipient:   feeRecipient,
+				})
+			}
+			require.NoError(t, eth2Cl.SubmitProposalPreparations(ctx, preps))
+
+			// Get synthetic duties
+			opts := &eth2api.ProposerDutiesOpts{
+				Epoch:   epoch,
+				Indices: nil,
+			}
+			resp1, err := eth2Cl.ProposerDuties(ctx, opts)
+			require.NoError(t, err)
+			duties := resp1.Data
+			require.Len(t, duties, len(set))
+			require.Equal(t, 1, activeVals)
+
+			// Get synthetic duties again
+			resp2, err := eth2Cl.ProposerDuties(ctx, opts)
+			require.NoError(t, err)
+			duties2 := resp2.Data
+			require.Equal(t, duties, duties2) // Identical
+			require.Equal(t, 1, activeVals)   // Cached
+
+			// Submit blocks
+			for _, duty := range duties {
+				var bbf uint64 = 100
+				var graff [32]byte
+				copy(graff[:], "test")
+				opts1 := &eth2api.ProposalOpts{
+					Slot:               duty.Slot,
+					RandaoReveal:       testutil.RandomEth2Signature(),
+					Graffiti:           graff,
+					BuilderBoostFactor: &bbf,
+				}
+				resp, err := eth2Cl.Proposal(ctx, opts1)
+				require.NoError(t, err)
+
+				block := resp.Data
+				graffitiInBlock, err := block.Graffiti()
+				require.NoError(t, err)
+				feeRecipientInBlock, err := block.FeeRecipient()
+				require.NoError(t, err)
+				if resp.Data.Blinded {
+					if duty.Slot == realBlockSlot {
+						require.NotContains(t, string(graffitiInBlock[:]), "DO NOT SUBMIT")
+						require.NotEqual(t, feeRecipient, feeRecipientInBlock)
+					} else {
+						require.Equal(t, feeRecipient, feeRecipientInBlock)
+					}
+					require.Equal(t, test.version, block.Version)
+
+					signed := test.populateBlockFunc(block)
+					err = eth2Cl.SubmitBlindedProposal(ctx, &eth2api.SubmitBlindedProposalOpts{
+						Proposal: signed,
+					})
+					require.NoError(t, err)
+				} else {
+					if duty.Slot == realBlockSlot {
+						require.NotContains(t, string(graffitiInBlock[:]), "DO NOT SUBMIT")
+						require.NotEqual(t, feeRecipient, feeRecipientInBlock)
+					} else {
+						require.Contains(t, string(graffitiInBlock[:]), "DO NOT SUBMIT")
+						require.Equal(t, feeRecipient, feeRecipientInBlock)
+
+						continue
+					}
+					require.Equal(t, test.version, block.Version)
+
+					signed := test.createVersionedSignedProposal(block)
+					err = eth2Cl.SubmitProposal(ctx, &eth2api.SubmitProposalOpts{
+						Proposal: signed,
+					})
+				}
+				require.NoError(t, err)
+			}
+
+			<-done
 		})
 	}
-	require.NoError(t, eth2Cl.SubmitProposalPreparations(ctx, preps))
-
-	// Get synthetic duties
-	opts := &eth2api.ProposerDutiesOpts{
-		Epoch:   epoch,
-		Indices: nil,
-	}
-	resp1, err := eth2Cl.ProposerDuties(ctx, opts)
-	require.NoError(t, err)
-	duties := resp1.Data
-	require.Len(t, duties, len(set))
-	require.Equal(t, 1, activeVals)
-
-	// Get synthetic duties again
-	resp2, err := eth2Cl.ProposerDuties(ctx, opts)
-	require.NoError(t, err)
-	duties2 := resp2.Data
-	require.Equal(t, duties, duties2) // Identical
-	require.Equal(t, 1, activeVals)   // Cached
-
-	// Submit blocks
-	for _, duty := range duties {
-		var bbf uint64 = 100
-		var graff [32]byte
-		copy(graff[:], "test")
-		opts1 := &eth2api.ProposalOpts{
-			Slot:               duty.Slot,
-			RandaoReveal:       testutil.RandomEth2Signature(),
-			Graffiti:           graff,
-			BuilderBoostFactor: &bbf,
-		}
-		resp, err := eth2Cl.Proposal(ctx, opts1)
-		require.NoError(t, err)
-
-		if resp.Data.Blinded {
-			block := resp.Data
-			if duty.Slot == realBlockSlot {
-				require.NotContains(t, string(block.CapellaBlinded.Body.Graffiti[:]), "DO NOT SUBMIT")
-				require.NotEqual(t, feeRecipient, block.CapellaBlinded.Body.ExecutionPayloadHeader.FeeRecipient)
-			} else {
-				require.Equal(t, feeRecipient, block.CapellaBlinded.Body.ExecutionPayloadHeader.FeeRecipient)
-			}
-			require.Equal(t, eth2spec.DataVersionCapella, block.Version)
-
-			signed := &eth2api.VersionedSignedBlindedProposal{
-				Version: eth2spec.DataVersionCapella,
-				Capella: &eth2capella.SignedBlindedBeaconBlock{
-					Message:   block.CapellaBlinded,
-					Signature: testutil.RandomEth2Signature(),
-				},
-			}
-			err = eth2Cl.SubmitBlindedProposal(ctx, &eth2api.SubmitBlindedProposalOpts{
-				Proposal: signed,
-			})
-			require.NoError(t, err)
-		} else {
-			block := resp.Data
-
-			if duty.Slot == realBlockSlot {
-				require.NotContains(t, string(block.Capella.Body.Graffiti[:]), "DO NOT SUBMIT")
-				require.NotEqual(t, feeRecipient, block.Capella.Body.ExecutionPayload.FeeRecipient)
-			} else {
-				require.Contains(t, string(block.Capella.Body.Graffiti[:]), "DO NOT SUBMIT")
-				require.Equal(t, feeRecipient, block.Capella.Body.ExecutionPayload.FeeRecipient)
-
-				continue
-			}
-			require.Equal(t, eth2spec.DataVersionCapella, block.Version)
-
-			signed := testutil.RandomCapellaVersionedSignedProposal()
-			signed.Capella.Message = block.Capella
-			err = eth2Cl.SubmitProposal(ctx, &eth2api.SubmitProposalOpts{
-				Proposal: signed,
-			})
-		}
-		require.NoError(t, err)
-	}
-
-	<-done
 }
 
 func TestSynthProposerBlockNotFound(t *testing.T) {

--- a/core/fetcher/fetcher_internal_test.go
+++ b/core/fetcher/fetcher_internal_test.go
@@ -67,6 +67,21 @@ func TestVerifyFeeRecipient(t *testing.T) {
 				Blinded:      true,
 			},
 		},
+		{
+			name: "electra",
+			proposal: eth2api.VersionedProposal{
+				Version: eth2spec.DataVersionElectra,
+				Electra: testutil.RandomElectraVersionedProposal().Electra,
+			},
+		},
+		{
+			name: "electra blinded",
+			proposal: eth2api.VersionedProposal{
+				Version:        eth2spec.DataVersionElectra,
+				ElectraBlinded: testutil.RandomElectraBlindedBeaconBlock(),
+				Blinded:        true,
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -261,7 +261,7 @@ func TestParSigExVerifier(t *testing.T) {
 			Deneb: &eth2p0.SignedAggregateAndProof{
 				Message: &eth2p0.AggregateAndProof{
 					AggregatorIndex: 0,
-					Aggregate:       testutil.RandomAttestation(),
+					Aggregate:       testutil.RandomPhase0Attestation(),
 					SelectionProof:  testutil.RandomEth2Signature(),
 				},
 			},

--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -11,10 +11,13 @@ import (
 	eth2bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
 	eth2capella "github.com/attestantio/go-eth2-client/api/v1/capella"
 	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2electra "github.com/attestantio/go-eth2-client/api/v1/electra"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/electra"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
@@ -31,7 +34,31 @@ func TestSignedDataSetSignature(t *testing.T) {
 		data core.SignedData
 	}{
 		{
-			name: "versioned signed proposal",
+			name: "versioned signed proposal phase0",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionPhase0,
+					Phase0: &eth2p0.SignedBeaconBlock{
+						Message:   testutil.RandomPhase0BeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal altair",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionAltair,
+					Altair: &altair.SignedBeaconBlock{
+						Message:   testutil.RandomAltairBeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal bellatrix",
 			data: core.VersionedSignedProposal{
 				VersionedSignedProposal: eth2api.VersionedSignedProposal{
 					Version: eth2spec.DataVersionBellatrix,
@@ -43,21 +70,276 @@ func TestSignedDataSetSignature(t *testing.T) {
 			},
 		},
 		{
+			name: "versioned signed proposal bellatrix blinded",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionBellatrix,
+					BellatrixBlinded: &eth2bellatrix.SignedBlindedBeaconBlock{
+						Message:   testutil.RandomBellatrixBlindedBeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+					Blinded: true,
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal capella",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionCapella,
+					Capella: &capella.SignedBeaconBlock{
+						Message:   testutil.RandomCapellaBeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal capella blinded",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionCapella,
+					CapellaBlinded: &eth2capella.SignedBlindedBeaconBlock{
+						Message:   testutil.RandomCapellaBlindedBeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+					Blinded: true,
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal deneb",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionDeneb,
+					Deneb: &eth2deneb.SignedBlockContents{
+						SignedBlock: &deneb.SignedBeaconBlock{
+							Message:   testutil.RandomDenebBeaconBlock(),
+							Signature: testutil.RandomEth2Signature(),
+						},
+						KZGProofs: []deneb.KZGProof{},
+						Blobs:     []deneb.Blob{},
+					},
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal deneb blinded",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionDeneb,
+					DenebBlinded: &eth2deneb.SignedBlindedBeaconBlock{
+						Message:   testutil.RandomDenebBlindedBeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+					Blinded: true,
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal electra",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionElectra,
+					Electra: &eth2electra.SignedBlockContents{
+						SignedBlock: &electra.SignedBeaconBlock{
+							Message:   testutil.RandomElectraBeaconBlock(),
+							Signature: testutil.RandomEth2Signature(),
+						},
+						KZGProofs: []deneb.KZGProof{},
+						Blobs:     []deneb.Blob{},
+					},
+				},
+			},
+		},
+		{
+			name: "versioned signed proposal electra blinded",
+			data: core.VersionedSignedProposal{
+				VersionedSignedProposal: eth2api.VersionedSignedProposal{
+					Version: eth2spec.DataVersionElectra,
+					ElectraBlinded: &eth2electra.SignedBlindedBeaconBlock{
+						Message:   testutil.RandomElectraBlindedBeaconBlock(),
+						Signature: testutil.RandomEth2Signature(),
+					},
+					Blinded: true,
+				},
+			},
+		},
+		{
 			name: "signed beacon committee selection",
 			data: testutil.RandomCoreBeaconCommitteeSelection(),
 		},
 		{
-			name: "signed aggregate and proof",
+			name: "signed aggregate and proof phase0",
+			data: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionPhase0,
+					Phase0: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: 0,
+							Aggregate:       testutil.RandomPhase0Attestation(),
+							SelectionProof:  testutil.RandomEth2Signature(),
+						},
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed aggregate and proof altair",
+			data: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionAltair,
+					Altair: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: 0,
+							Aggregate:       testutil.RandomPhase0Attestation(),
+							SelectionProof:  testutil.RandomEth2Signature(),
+						},
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed aggregate and proof bellatrix",
+			data: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionBellatrix,
+					Bellatrix: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: 0,
+							Aggregate:       testutil.RandomPhase0Attestation(),
+							SelectionProof:  testutil.RandomEth2Signature(),
+						},
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed aggregate and proof capella",
+			data: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionCapella,
+					Capella: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: 0,
+							Aggregate:       testutil.RandomPhase0Attestation(),
+							SelectionProof:  testutil.RandomEth2Signature(),
+						},
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed aggregate and proof deneb",
 			data: core.VersionedSignedAggregateAndProof{
 				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
 					Version: eth2spec.DataVersionDeneb,
 					Deneb: &eth2p0.SignedAggregateAndProof{
 						Message: &eth2p0.AggregateAndProof{
 							AggregatorIndex: 0,
-							Aggregate:       testutil.RandomAttestation(),
+							Aggregate:       testutil.RandomPhase0Attestation(),
 							SelectionProof:  testutil.RandomEth2Signature(),
 						},
 						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed aggregate and proof electra",
+			data: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionElectra,
+					Electra: &electra.SignedAggregateAndProof{
+						Message: &electra.AggregateAndProof{
+							AggregatorIndex: 0,
+							Aggregate:       testutil.RandomElectraAttestation(),
+							SelectionProof:  testutil.RandomEth2Signature(),
+						},
+						Signature: testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed attestation phase0",
+			data: core.VersionedAttestation{
+				VersionedAttestation: eth2spec.VersionedAttestation{
+					Version: eth2spec.DataVersionPhase0,
+					Phase0: &eth2p0.Attestation{
+						AggregationBits: testutil.RandomBitList(1),
+						Data:            testutil.RandomAttestationData(),
+						Signature:       testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed attestation altair",
+			data: core.VersionedAttestation{
+				VersionedAttestation: eth2spec.VersionedAttestation{
+					Version: eth2spec.DataVersionAltair,
+					Altair: &eth2p0.Attestation{
+						AggregationBits: testutil.RandomBitList(1),
+						Data:            testutil.RandomAttestationData(),
+						Signature:       testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed attestation bellatrix",
+			data: core.VersionedAttestation{
+				VersionedAttestation: eth2spec.VersionedAttestation{
+					Version: eth2spec.DataVersionBellatrix,
+					Bellatrix: &eth2p0.Attestation{
+						AggregationBits: testutil.RandomBitList(1),
+						Data:            testutil.RandomAttestationData(),
+						Signature:       testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed attestation capella",
+			data: core.VersionedAttestation{
+				VersionedAttestation: eth2spec.VersionedAttestation{
+					Version: eth2spec.DataVersionCapella,
+					Capella: &eth2p0.Attestation{
+						AggregationBits: testutil.RandomBitList(1),
+						Data:            testutil.RandomAttestationData(),
+						Signature:       testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed attestation deneb",
+			data: core.VersionedAttestation{
+				VersionedAttestation: eth2spec.VersionedAttestation{
+					Version: eth2spec.DataVersionDeneb,
+					Deneb: &eth2p0.Attestation{
+						AggregationBits: testutil.RandomBitList(1),
+						Data:            testutil.RandomAttestationData(),
+						Signature:       testutil.RandomEth2Signature(),
+					},
+				},
+			},
+		},
+		{
+			name: "signed attestation electra",
+			data: core.VersionedAttestation{
+				VersionedAttestation: eth2spec.VersionedAttestation{
+					Version: eth2spec.DataVersionElectra,
+					Electra: &electra.Attestation{
+						AggregationBits: testutil.RandomBitList(1),
+						Data:            testutil.RandomAttestationData(),
+						Signature:       testutil.RandomEth2Signature(),
+						CommitteeBits:   testutil.RandomBitVec64(),
 					},
 				},
 			},
@@ -180,6 +462,10 @@ func TestNewVersionedSignedProposal(t *testing.T) {
 			version: eth2spec.DataVersionDeneb,
 		},
 		{
+			error:   "no electra proposal",
+			version: eth2spec.DataVersionElectra,
+		},
+		{
 			error:   "no bellatrix blinded proposal",
 			version: eth2spec.DataVersionBellatrix,
 			blinded: true,
@@ -192,6 +478,11 @@ func TestNewVersionedSignedProposal(t *testing.T) {
 		{
 			error:   "no deneb blinded proposal",
 			version: eth2spec.DataVersionDeneb,
+			blinded: true,
+		},
+		{
+			error:   "no electra blinded proposal",
+			version: eth2spec.DataVersionElectra,
 			blinded: true,
 		},
 	}
@@ -223,6 +514,92 @@ func TestNewPartialVersionedSignedProposal(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, psd.SignedData)
 	require.Equal(t, 3, psd.ShareIdx)
+}
+
+func TestNewVersionedSignedProposalFromBlindedProposal(t *testing.T) {
+	proposal, err := testutil.RandomElectraVersionedSignedBlindedProposal().ToBlinded()
+	require.NoError(t, err)
+
+	pvsp, err := core.NewVersionedSignedProposalFromBlindedProposal(&proposal)
+
+	require.NoError(t, err)
+	require.NotNil(t, pvsp.ElectraBlinded)
+}
+
+func TestNewPartialVersionedSignedBlindedProposal(t *testing.T) {
+	proposal, err := testutil.RandomElectraVersionedSignedBlindedProposal().ToBlinded()
+	require.NoError(t, err)
+
+	pvsp, err := core.NewPartialVersionedSignedBlindedProposal(&proposal, 3)
+
+	require.NoError(t, err)
+	require.NotNil(t, pvsp.SignedData)
+	require.Equal(t, 3, pvsp.ShareIdx)
+}
+
+func TestNewVersionedAttestation(t *testing.T) {
+	type testCase struct {
+		error   string
+		version eth2spec.DataVersion
+	}
+
+	tests := []testCase{
+		{
+			error:   "unknown version",
+			version: eth2spec.DataVersion(999),
+		},
+		{
+			error:   "no phase0 attestation",
+			version: eth2spec.DataVersionPhase0,
+		},
+		{
+			error:   "no altair attestation",
+			version: eth2spec.DataVersionAltair,
+		},
+		{
+			error:   "no bellatrix attestation",
+			version: eth2spec.DataVersionBellatrix,
+		},
+		{
+			error:   "no capella attestation",
+			version: eth2spec.DataVersionCapella,
+		},
+		{
+			error:   "no deneb attestation",
+			version: eth2spec.DataVersionDeneb,
+		},
+		{
+			error:   "no electra attestation",
+			version: eth2spec.DataVersionElectra,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.error, func(t *testing.T) {
+			_, err := core.NewVersionedAttestation(&eth2spec.VersionedAttestation{
+				Version: test.version,
+			})
+			require.ErrorContains(t, err, test.error)
+		})
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		attestation := testutil.RandomElectraCoreVersionedAttestation()
+
+		p, err := core.NewVersionedAttestation(&attestation.VersionedAttestation)
+		require.NoError(t, err)
+		require.Equal(t, attestation, p)
+	})
+}
+
+func TestNewPartialVersionedAttestation(t *testing.T) {
+	attestation := testutil.RandomElectraVersionedAttestation()
+
+	pva, err := core.NewPartialVersionedAttestation(attestation, 3)
+
+	require.NoError(t, err)
+	require.NotNil(t, pva.SignedData)
+	require.Equal(t, 3, pva.ShareIdx)
 }
 
 func TestVersionedSignedProposal(t *testing.T) {
@@ -312,6 +689,24 @@ func TestVersionedSignedProposal(t *testing.T) {
 				Blinded: true,
 			},
 		},
+		{
+			name: "electra",
+			proposal: eth2api.VersionedSignedProposal{
+				Version: eth2spec.DataVersionElectra,
+				Electra: testutil.RandomElectraVersionedSignedProposal().Electra,
+			},
+		},
+		{
+			name: "electra blinded",
+			proposal: eth2api.VersionedSignedProposal{
+				Version: eth2spec.DataVersionElectra,
+				ElectraBlinded: &eth2electra.SignedBlindedBeaconBlock{
+					Message:   testutil.RandomElectraBlindedBeaconBlock(),
+					Signature: testutil.RandomEth2Signature(),
+				},
+				Blinded: true,
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -347,6 +742,140 @@ func TestVersionedSignedProposal(t *testing.T) {
 				err = p2.UnmarshalJSON([]byte(js))
 				require.ErrorContains(t, err, unmarshalPrefix+test.proposal.Version.String())
 			}
+		})
+	}
+}
+
+func TestVersionedSignedAggregateAndProofUtilFunctions(t *testing.T) {
+	data := testutil.RandomAttestationData()
+	aggregationBits := testutil.RandomBitList(64)
+	type testCase struct {
+		name              string
+		aggregateAndProof core.VersionedSignedAggregateAndProof
+	}
+
+	tests := []testCase{
+		{
+			name: "phase0",
+			aggregateAndProof: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionPhase0,
+					Phase0: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: testutil.RandomVIdx(),
+							Aggregate: &eth2p0.Attestation{
+								AggregationBits: aggregationBits,
+								Data:            data,
+								Signature:       testutil.RandomEth2Signature(),
+							},
+							SelectionProof: testutil.RandomEth2Signature(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "altair",
+			aggregateAndProof: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionAltair,
+					Altair: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: testutil.RandomVIdx(),
+							Aggregate: &eth2p0.Attestation{
+								AggregationBits: aggregationBits,
+								Data:            data,
+								Signature:       testutil.RandomEth2Signature(),
+							},
+							SelectionProof: testutil.RandomEth2Signature(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "bellatrix",
+			aggregateAndProof: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionBellatrix,
+					Bellatrix: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: testutil.RandomVIdx(),
+							Aggregate: &eth2p0.Attestation{
+								AggregationBits: aggregationBits,
+								Data:            data,
+								Signature:       testutil.RandomEth2Signature(),
+							},
+							SelectionProof: testutil.RandomEth2Signature(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "capella",
+			aggregateAndProof: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionCapella,
+					Capella: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: testutil.RandomVIdx(),
+							Aggregate: &eth2p0.Attestation{
+								AggregationBits: aggregationBits,
+								Data:            data,
+								Signature:       testutil.RandomEth2Signature(),
+							},
+							SelectionProof: testutil.RandomEth2Signature(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "deneb",
+			aggregateAndProof: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionDeneb,
+					Deneb: &eth2p0.SignedAggregateAndProof{
+						Message: &eth2p0.AggregateAndProof{
+							AggregatorIndex: testutil.RandomVIdx(),
+							Aggregate: &eth2p0.Attestation{
+								AggregationBits: aggregationBits,
+								Data:            data,
+								Signature:       testutil.RandomEth2Signature(),
+							},
+							SelectionProof: testutil.RandomEth2Signature(),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "electra",
+			aggregateAndProof: core.VersionedSignedAggregateAndProof{
+				VersionedSignedAggregateAndProof: eth2spec.VersionedSignedAggregateAndProof{
+					Version: eth2spec.DataVersionElectra,
+					Electra: &electra.SignedAggregateAndProof{
+						Message: &electra.AggregateAndProof{
+							AggregatorIndex: testutil.RandomVIdx(),
+							Aggregate: &electra.Attestation{
+								AggregationBits: aggregationBits,
+								Data:            data,
+								Signature:       testutil.RandomEth2Signature(),
+								CommitteeBits:   testutil.RandomBitVec64(),
+							},
+							SelectionProof: testutil.RandomEth2Signature(),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, data, test.aggregateAndProof.Data())
+			require.Equal(t, aggregationBits, test.aggregateAndProof.AggregationBits())
 		})
 	}
 }

--- a/core/ssz_test.go
+++ b/core/ssz_test.go
@@ -14,6 +14,7 @@ import (
 	eth2bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
 	eth2capella "github.com/attestantio/go-eth2-client/api/v1/capella"
 	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2electra "github.com/attestantio/go-eth2-client/api/v1/electra"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
@@ -330,6 +331,24 @@ func TestV3SignedProposalSSZSerialisation(t *testing.T) {
 				Version: eth2spec.DataVersionDeneb,
 				DenebBlinded: &eth2deneb.SignedBlindedBeaconBlock{
 					Message:   testutil.RandomDenebBlindedBeaconBlock(),
+					Signature: testutil.RandomEth2Signature(),
+				},
+				Blinded: true,
+			},
+		},
+		{
+			name: "electra",
+			proposal: eth2api.VersionedSignedProposal{
+				Version: eth2spec.DataVersionElectra,
+				Electra: testutil.RandomElectraVersionedSignedProposal().Electra,
+			},
+		},
+		{
+			name: "electra blinded",
+			proposal: eth2api.VersionedSignedProposal{
+				Version: eth2spec.DataVersionElectra,
+				ElectraBlinded: &eth2electra.SignedBlindedBeaconBlock{
+					Message:   testutil.RandomElectraBlindedBeaconBlock(),
 					Signature: testutil.RandomEth2Signature(),
 				},
 				Blinded: true,

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -587,6 +587,7 @@ func (c Component) SubmitBlindedProposal(ctx context.Context, opts *eth2api.Subm
 			BellatrixBlinded: opts.Proposal.Bellatrix,
 			CapellaBlinded:   opts.Proposal.Capella,
 			DenebBlinded:     opts.Proposal.Deneb,
+			ElectraBlinded:   opts.Proposal.Electra,
 		},
 		BroadcastValidation: opts.BroadcastValidation,
 	}, prop); err != nil {

--- a/eth2util/types_test.go
+++ b/eth2util/types_test.go
@@ -9,6 +9,7 @@ import (
 	"math/rand"
 	"testing"
 
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
@@ -52,4 +53,94 @@ func TestUnmarshallingSignedEpoch(t *testing.T) {
 	testutil.RequireNoError(t, err)
 	require.Equal(t, sig, e2.Signature[:])
 	require.Equal(t, epoch, e2.Epoch)
+}
+
+func TestToETH2(t *testing.T) {
+	tests := []struct {
+		version         eth2util.DataVersion
+		expectedVersion eth2spec.DataVersion
+	}{
+		{
+			version:         eth2util.DataVersionUnknown,
+			expectedVersion: eth2spec.DataVersionUnknown,
+		},
+		{
+			version:         eth2util.DataVersionPhase0,
+			expectedVersion: eth2spec.DataVersionPhase0,
+		},
+		{
+			version:         eth2util.DataVersionAltair,
+			expectedVersion: eth2spec.DataVersionAltair,
+		},
+		{
+			version:         eth2util.DataVersionBellatrix,
+			expectedVersion: eth2spec.DataVersionBellatrix,
+		},
+		{
+			version:         eth2util.DataVersionCapella,
+			expectedVersion: eth2spec.DataVersionCapella,
+		},
+		{
+			version:         eth2util.DataVersionDeneb,
+			expectedVersion: eth2spec.DataVersionDeneb,
+		},
+		{
+			version:         eth2util.DataVersionElectra,
+			expectedVersion: eth2spec.DataVersionElectra,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.version.String(), func(t *testing.T) {
+			require.Equal(t, test.expectedVersion, test.version.ToETH2())
+		},
+		)
+	}
+}
+
+func TestDataVersionFromETH2(t *testing.T) {
+	tests := []struct {
+		version         eth2spec.DataVersion
+		expectedVersion eth2util.DataVersion
+		expectedErr     string
+	}{
+		{
+			version:         eth2spec.DataVersionUnknown,
+			expectedVersion: eth2util.DataVersionUnknown,
+			expectedErr:     "unknown data version",
+		},
+		{
+			version:         eth2spec.DataVersionPhase0,
+			expectedVersion: eth2util.DataVersionPhase0,
+		},
+		{
+			version:         eth2spec.DataVersionAltair,
+			expectedVersion: eth2util.DataVersionAltair,
+		},
+		{
+			version:         eth2spec.DataVersionBellatrix,
+			expectedVersion: eth2util.DataVersionBellatrix,
+		},
+		{
+			version:         eth2spec.DataVersionCapella,
+			expectedVersion: eth2util.DataVersionCapella,
+		},
+		{
+			version:         eth2spec.DataVersionDeneb,
+			expectedVersion: eth2util.DataVersionDeneb,
+		},
+		{
+			version:         eth2spec.DataVersionElectra,
+			expectedVersion: eth2util.DataVersionElectra,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.expectedVersion.String(), func(t *testing.T) {
+			actual, err := eth2util.DataVersionFromETH2(test.version)
+			if test.expectedErr != "" {
+				require.ErrorContains(t, err, test.expectedErr)
+			}
+			require.Equal(t, test.expectedVersion, actual)
+		},
+		)
+	}
 }

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -19,11 +19,13 @@ import (
 	eth2bellatrix "github.com/attestantio/go-eth2-client/api/v1/bellatrix"
 	eth2capella "github.com/attestantio/go-eth2-client/api/v1/capella"
 	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2electra "github.com/attestantio/go-eth2-client/api/v1/electra"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	"github.com/attestantio/go-eth2-client/spec/capella"
 	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/attestantio/go-eth2-client/spec/electra"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/holiman/uint256"
@@ -117,7 +119,7 @@ func RandomValidatorSet(t *testing.T, vals int) map[eth2p0.ValidatorIndex]*eth2v
 	return resp
 }
 
-func RandomAttestation() *eth2p0.Attestation {
+func RandomPhase0Attestation() *eth2p0.Attestation {
 	return &eth2p0.Attestation{
 		AggregationBits: RandomBitList(1),
 		Data:            RandomAttestationData(),
@@ -125,11 +127,29 @@ func RandomAttestation() *eth2p0.Attestation {
 	}
 }
 
+func RandomElectraAttestation() *electra.Attestation {
+	return &electra.Attestation{
+		AggregationBits: RandomBitList(1),
+		Data:            RandomAttestationData(),
+		Signature:       RandomEth2Signature(),
+		CommitteeBits:   RandomBitVec64(),
+	}
+}
+
 func RandomDenebCoreVersionedAttestation() core.VersionedAttestation {
 	return core.VersionedAttestation{
 		VersionedAttestation: eth2spec.VersionedAttestation{
 			Version: eth2spec.DataVersionDeneb,
-			Deneb:   RandomAttestation(),
+			Deneb:   RandomPhase0Attestation(),
+		},
+	}
+}
+
+func RandomElectraCoreVersionedAttestation() core.VersionedAttestation {
+	return core.VersionedAttestation{
+		VersionedAttestation: eth2spec.VersionedAttestation{
+			Version: eth2spec.DataVersionElectra,
+			Electra: RandomElectraAttestation(),
 		},
 	}
 }
@@ -137,7 +157,14 @@ func RandomDenebCoreVersionedAttestation() core.VersionedAttestation {
 func RandomDenebVersionedAttestation() *eth2spec.VersionedAttestation {
 	return &eth2spec.VersionedAttestation{
 		Version: eth2spec.DataVersionDeneb,
-		Deneb:   RandomAttestation(),
+		Deneb:   RandomPhase0Attestation(),
+	}
+}
+
+func RandomElectraVersionedAttestation() *eth2spec.VersionedAttestation {
+	return &eth2spec.VersionedAttestation{
+		Version: eth2spec.DataVersionElectra,
+		Electra: RandomElectraAttestation(),
 	}
 }
 
@@ -197,7 +224,7 @@ func RandomPhase0BeaconBlockBody() *eth2p0.BeaconBlockBody {
 		Graffiti:          RandomArray32(),
 		ProposerSlashings: []*eth2p0.ProposerSlashing{},
 		AttesterSlashings: []*eth2p0.AttesterSlashing{},
-		Attestations:      []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:      []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:          []*eth2p0.Deposit{},
 		VoluntaryExits:    []*eth2p0.SignedVoluntaryExit{},
 	}
@@ -224,7 +251,7 @@ func RandomAltairBeaconBlockBody() *altair.BeaconBlockBody {
 		Graffiti:          RandomArray32(),
 		ProposerSlashings: []*eth2p0.ProposerSlashing{},
 		AttesterSlashings: []*eth2p0.AttesterSlashing{},
-		Attestations:      []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:      []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:          []*eth2p0.Deposit{},
 		VoluntaryExits:    []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:     RandomSyncAggregate(),
@@ -259,7 +286,7 @@ func RandomBellatrixBeaconBlockBody() *bellatrix.BeaconBlockBody {
 		Graffiti:          RandomArray32(),
 		ProposerSlashings: []*eth2p0.ProposerSlashing{},
 		AttesterSlashings: []*eth2p0.AttesterSlashing{},
-		Attestations:      []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:      []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:          []*eth2p0.Deposit{},
 		VoluntaryExits:    []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:     RandomSyncAggregate(),
@@ -285,7 +312,7 @@ func RandomCapellaBeaconBlockBody() *capella.BeaconBlockBody {
 		Graffiti:              RandomArray32(),
 		ProposerSlashings:     []*eth2p0.ProposerSlashing{},
 		AttesterSlashings:     []*eth2p0.AttesterSlashing{},
-		Attestations:          []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:          []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:              []*eth2p0.Deposit{},
 		VoluntaryExits:        []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:         RandomSyncAggregate(),
@@ -366,6 +393,22 @@ func RandomDenebCoreVersionedSignedProposal() core.VersionedSignedProposal {
 	}
 }
 
+func RandomElectraCoreVersionedSignedProposal() core.VersionedSignedProposal {
+	return core.VersionedSignedProposal{
+		VersionedSignedProposal: eth2api.VersionedSignedProposal{
+			Version: eth2spec.DataVersionElectra,
+			Electra: &eth2electra.SignedBlockContents{
+				SignedBlock: &electra.SignedBeaconBlock{
+					Message:   RandomElectraBeaconBlock(),
+					Signature: RandomEth2Signature(),
+				},
+				KZGProofs: []deneb.KZGProof{},
+				Blobs:     []deneb.Blob{},
+			},
+		},
+	}
+}
+
 // RandomCapellaVersionedSignedBeaconBlock returns a random signed capella beacon block.
 func RandomCapellaVersionedSignedBeaconBlock() *eth2spec.VersionedSignedBeaconBlock {
 	return &eth2spec.VersionedSignedBeaconBlock{
@@ -383,6 +426,17 @@ func RandomDenebVersionedSignedBeaconBlock() *eth2spec.VersionedSignedBeaconBloc
 		Version: eth2spec.DataVersionDeneb,
 		Deneb: &deneb.SignedBeaconBlock{
 			Message:   RandomDenebBeaconBlock(),
+			Signature: RandomEth2Signature(),
+		},
+	}
+}
+
+// RandomElectraVersionedSignedBeaconBlock returns a random signed electra beacon block.
+func RandomElectraVersionedSignedBeaconBlock() *eth2spec.VersionedSignedBeaconBlock {
+	return &eth2spec.VersionedSignedBeaconBlock{
+		Version: eth2spec.DataVersionElectra,
+		Electra: &electra.SignedBeaconBlock{
+			Message:   RandomElectraBeaconBlock(),
 			Signature: RandomEth2Signature(),
 		},
 	}
@@ -414,6 +468,21 @@ func RandomDenebVersionedSignedProposal() *eth2api.VersionedSignedProposal {
 	}
 }
 
+// RandomElectraVersionedSignedProposal returns a random versioned signed proposal containing electra beacon block.
+func RandomElectraVersionedSignedProposal() *eth2api.VersionedSignedProposal {
+	return &eth2api.VersionedSignedProposal{
+		Version: eth2spec.DataVersionElectra,
+		Electra: &eth2electra.SignedBlockContents{
+			SignedBlock: &electra.SignedBeaconBlock{
+				Message:   RandomElectraBeaconBlock(),
+				Signature: RandomEth2Signature(),
+			},
+			KZGProofs: []deneb.KZGProof{},
+			Blobs:     []deneb.Blob{},
+		},
+	}
+}
+
 // RandomCapellaVersionedProposal returns a random versioned proposal containing capella beacon block.
 func RandomCapellaVersionedProposal() *eth2api.VersionedProposal {
 	return &eth2api.VersionedProposal{
@@ -428,6 +497,18 @@ func RandomDenebVersionedProposal() *eth2api.VersionedProposal {
 		Version: eth2spec.DataVersionDeneb,
 		Deneb: &eth2deneb.BlockContents{
 			Block:     RandomDenebBeaconBlock(),
+			KZGProofs: []deneb.KZGProof{},
+			Blobs:     []deneb.Blob{},
+		},
+	}
+}
+
+// RandomElectraVersionedProposal returns a random versioned proposal containing electra beacon block.
+func RandomElectraVersionedProposal() *eth2api.VersionedProposal {
+	return &eth2api.VersionedProposal{
+		Version: eth2spec.DataVersionElectra,
+		Electra: &eth2electra.BlockContents{
+			Block:     RandomElectraBeaconBlock(),
 			KZGProofs: []deneb.KZGProof{},
 			Blobs:     []deneb.Blob{},
 		},
@@ -455,7 +536,7 @@ func RandomBellatrixBlindedBeaconBlockBody() *eth2bellatrix.BlindedBeaconBlockBo
 		Graffiti:               RandomArray32(),
 		ProposerSlashings:      []*eth2p0.ProposerSlashing{},
 		AttesterSlashings:      []*eth2p0.AttesterSlashing{},
-		Attestations:           []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:           []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:               []*eth2p0.Deposit{},
 		VoluntaryExits:         []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:          RandomSyncAggregate(),
@@ -484,7 +565,7 @@ func RandomCapellaBlindedBeaconBlockBody() *eth2capella.BlindedBeaconBlockBody {
 		Graffiti:               RandomArray32(),
 		ProposerSlashings:      []*eth2p0.ProposerSlashing{},
 		AttesterSlashings:      []*eth2p0.AttesterSlashing{},
-		Attestations:           []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:           []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:               []*eth2p0.Deposit{},
 		VoluntaryExits:         []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:          RandomSyncAggregate(),
@@ -552,6 +633,19 @@ func RandomDenebVersionedSignedBlindedProposal() core.VersionedSignedProposal {
 	}
 }
 
+func RandomElectraVersionedSignedBlindedProposal() core.VersionedSignedProposal {
+	return core.VersionedSignedProposal{
+		VersionedSignedProposal: eth2api.VersionedSignedProposal{
+			Blinded: true,
+			Version: eth2spec.DataVersionElectra,
+			ElectraBlinded: &eth2electra.SignedBlindedBeaconBlock{
+				Message:   RandomElectraBlindedBeaconBlock(),
+				Signature: RandomEth2Signature(),
+			},
+		},
+	}
+}
+
 func RandomDenebBeaconBlock() *deneb.BeaconBlock {
 	return &deneb.BeaconBlock{
 		Slot:          RandomSlot(),
@@ -562,6 +656,16 @@ func RandomDenebBeaconBlock() *deneb.BeaconBlock {
 	}
 }
 
+func RandomElectraBeaconBlock() *electra.BeaconBlock {
+	return &electra.BeaconBlock{
+		Slot:          RandomSlot(),
+		ProposerIndex: RandomVIdx(),
+		ParentRoot:    RandomRoot(),
+		StateRoot:     RandomRoot(),
+		Body:          RandomElectraBeaconBlockBody(),
+	}
+}
+
 func RandomDenebBlindedBeaconBlock() *eth2deneb.BlindedBeaconBlock {
 	return &eth2deneb.BlindedBeaconBlock{
 		Slot:          RandomSlot(),
@@ -569,6 +673,16 @@ func RandomDenebBlindedBeaconBlock() *eth2deneb.BlindedBeaconBlock {
 		ParentRoot:    RandomRoot(),
 		StateRoot:     RandomRoot(),
 		Body:          RandomDenebBlindedBeaconBlockBody(),
+	}
+}
+
+func RandomElectraBlindedBeaconBlock() *eth2electra.BlindedBeaconBlock {
+	return &eth2electra.BlindedBeaconBlock{
+		Slot:          RandomSlot(),
+		ProposerIndex: RandomVIdx(),
+		ParentRoot:    RandomRoot(),
+		StateRoot:     RandomRoot(),
+		Body:          RandomElectraBlindedBeaconBlockBody(),
 	}
 }
 
@@ -583,13 +697,39 @@ func RandomDenebBeaconBlockBody() *deneb.BeaconBlockBody {
 		Graffiti:              RandomArray32(),
 		ProposerSlashings:     []*eth2p0.ProposerSlashing{},
 		AttesterSlashings:     []*eth2p0.AttesterSlashing{},
-		Attestations:          []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:          []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:              []*eth2p0.Deposit{},
 		VoluntaryExits:        []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:         RandomSyncAggregate(),
 		ExecutionPayload:      RandomDenebExecutionPayload(),
 		BLSToExecutionChanges: []*capella.SignedBLSToExecutionChange{},
 		BlobKZGCommitments:    []deneb.KZGCommitment{},
+	}
+}
+
+func RandomElectraBeaconBlockBody() *electra.BeaconBlockBody {
+	return &electra.BeaconBlockBody{
+		RANDAOReveal: RandomEth2Signature(),
+		ETH1Data: &eth2p0.ETH1Data{
+			DepositRoot:  RandomRoot(),
+			DepositCount: 0,
+			BlockHash:    RandomBytes32(),
+		},
+		Graffiti:              RandomArray32(),
+		ProposerSlashings:     []*eth2p0.ProposerSlashing{},
+		AttesterSlashings:     []*electra.AttesterSlashing{},
+		Attestations:          []*electra.Attestation{RandomElectraAttestation(), RandomElectraAttestation()},
+		Deposits:              []*eth2p0.Deposit{},
+		VoluntaryExits:        []*eth2p0.SignedVoluntaryExit{},
+		SyncAggregate:         RandomSyncAggregate(),
+		ExecutionPayload:      RandomDenebExecutionPayload(),
+		BLSToExecutionChanges: []*capella.SignedBLSToExecutionChange{},
+		BlobKZGCommitments:    []deneb.KZGCommitment{},
+		ExecutionRequests: &electra.ExecutionRequests{
+			Deposits:       []*electra.DepositRequest{},
+			Withdrawals:    []*electra.WithdrawalRequest{},
+			Consolidations: []*electra.ConsolidationRequest{},
+		},
 	}
 }
 
@@ -604,13 +744,39 @@ func RandomDenebBlindedBeaconBlockBody() *eth2deneb.BlindedBeaconBlockBody {
 		Graffiti:               RandomArray32(),
 		ProposerSlashings:      []*eth2p0.ProposerSlashing{},
 		AttesterSlashings:      []*eth2p0.AttesterSlashing{},
-		Attestations:           []*eth2p0.Attestation{RandomAttestation(), RandomAttestation()},
+		Attestations:           []*eth2p0.Attestation{RandomPhase0Attestation(), RandomPhase0Attestation()},
 		Deposits:               []*eth2p0.Deposit{},
 		VoluntaryExits:         []*eth2p0.SignedVoluntaryExit{},
 		SyncAggregate:          RandomSyncAggregate(),
 		ExecutionPayloadHeader: RandomDenebExecutionPayloadHeader(),
 		BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
 		BlobKZGCommitments:     []deneb.KZGCommitment{},
+	}
+}
+
+func RandomElectraBlindedBeaconBlockBody() *eth2electra.BlindedBeaconBlockBody {
+	return &eth2electra.BlindedBeaconBlockBody{
+		RANDAOReveal: RandomEth2Signature(),
+		ETH1Data: &eth2p0.ETH1Data{
+			DepositRoot:  RandomRoot(),
+			DepositCount: 0,
+			BlockHash:    RandomBytes32(),
+		},
+		Graffiti:               RandomArray32(),
+		ProposerSlashings:      []*eth2p0.ProposerSlashing{},
+		AttesterSlashings:      []*electra.AttesterSlashing{},
+		Attestations:           []*electra.Attestation{RandomElectraAttestation(), RandomElectraAttestation()},
+		Deposits:               []*eth2p0.Deposit{},
+		VoluntaryExits:         []*eth2p0.SignedVoluntaryExit{},
+		SyncAggregate:          RandomSyncAggregate(),
+		ExecutionPayloadHeader: RandomDenebExecutionPayloadHeader(),
+		BLSToExecutionChanges:  []*capella.SignedBLSToExecutionChange{},
+		BlobKZGCommitments:     []deneb.KZGCommitment{},
+		ExecutionRequests: &electra.ExecutionRequests{
+			Deposits:       []*electra.DepositRequest{},
+			Withdrawals:    []*electra.WithdrawalRequest{},
+			Consolidations: []*electra.ConsolidationRequest{},
+		},
 	}
 }
 
@@ -720,7 +886,7 @@ func RandomSyncCommitteeContribution() *altair.SyncCommitteeContribution {
 		Slot:              RandomSlot(),
 		BeaconBlockRoot:   RandomRoot(),
 		SubcommitteeIndex: rand.Uint64(),
-		AggregationBits:   RandomBitVec(),
+		AggregationBits:   RandomBitVec128(),
 		Signature:         RandomEth2Signature(),
 	}
 }
@@ -1110,7 +1276,7 @@ func RandomBitList(length int) bitfield.Bitlist {
 	return resp
 }
 
-func RandomBitVec() bitfield.Bitvector128 {
+func RandomBitVec128() bitfield.Bitvector128 {
 	size := 128
 	index := rand.Intn(size)
 	resp := bitfield.NewBitvector128()
@@ -1123,6 +1289,15 @@ func RandomBitVec4() bitfield.Bitvector4 {
 	size := 4
 	index := rand.Intn(size)
 	resp := bitfield.NewBitvector4()
+	resp.SetBitAt(uint64(index), true)
+
+	return resp
+}
+
+func RandomBitVec64() bitfield.Bitvector64 {
+	size := 64
+	index := rand.Intn(size)
+	resp := bitfield.NewBitvector64()
 	resp.SetBitAt(uint64(index), true)
 
 	return resp

--- a/testutil/validatormock/propose_test.go
+++ b/testutil/validatormock/propose_test.go
@@ -4,6 +4,8 @@ package validatormock_test
 
 import (
 	"context"
+	"fmt"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"sort"
@@ -123,49 +125,196 @@ func TestAttest(t *testing.T) {
 func TestProposeBlock(t *testing.T) {
 	ctx := context.Background()
 
-	// Configure beacon mock
-	valSet := beaconmock.ValidatorSetA
-	beaconMock, err := beaconmock.New(
-		beaconmock.WithValidatorSet(valSet),
-		beaconmock.WithDeterministicProposerDuties(0),
-	)
-	require.NoError(t, err)
+	tests := []struct {
+		version                string
+		jsonBeaconBlock        func(slotsPerEpoch uint64) []byte
+		beaconMockProposalFunc func(context.Context, *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error)
+	}{
+		{
+			version: "capella",
+			jsonBeaconBlock: func(slotsPerEpoch uint64) []byte {
+				block := testutil.RandomCapellaBeaconBlock()
+				block.Slot = eth2p0.Slot(slotsPerEpoch)
+				blockJSON, err := block.MarshalJSON()
+				require.NoError(t, err)
 
-	// Signature stub function
-	signFunc := func(key eth2p0.BLSPubKey, _ []byte) (eth2p0.BLSSignature, error) {
-		var sig eth2p0.BLSSignature
-		copy(sig[:], key[:])
+				return blockJSON
+			},
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				block := testutil.RandomCapellaVersionedProposal()
+				block.Capella.Slot = opts.Slot
+				block.Capella.Body.RANDAOReveal = opts.RandaoReveal
+				block.Capella.Body.Graffiti = opts.Graffiti
+				block.ExecutionValue = big.NewInt(1)
+				block.ConsensusValue = big.NewInt(1)
 
-		return sig, nil
+				return block, nil
+			},
+		},
+		{
+			version: "deneb",
+			jsonBeaconBlock: func(slotsPerEpoch uint64) []byte {
+				block := testutil.RandomDenebBeaconBlock()
+				block.Slot = eth2p0.Slot(slotsPerEpoch)
+				blockJSON, err := block.MarshalJSON()
+				require.NoError(t, err)
+
+				return blockJSON
+			},
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				block := testutil.RandomDenebVersionedProposal()
+				block.Deneb.Block.Slot = opts.Slot
+				block.Deneb.Block.Body.RANDAOReveal = opts.RandaoReveal
+				block.Deneb.Block.Body.Graffiti = opts.Graffiti
+				block.ExecutionValue = big.NewInt(1)
+				block.ConsensusValue = big.NewInt(1)
+
+				return block, nil
+			},
+		},
+		{
+			version: "electra",
+			jsonBeaconBlock: func(slotsPerEpoch uint64) []byte {
+				block := testutil.RandomElectraBeaconBlock()
+				block.Slot = eth2p0.Slot(slotsPerEpoch)
+				blockJSON, err := block.MarshalJSON()
+				require.NoError(t, err)
+
+				return blockJSON
+			},
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				block := testutil.RandomElectraVersionedProposal()
+				block.Electra.Block.Slot = opts.Slot
+				block.Electra.Block.Body.RANDAOReveal = opts.RandaoReveal
+				block.Electra.Block.Body.Graffiti = opts.Graffiti
+				block.ExecutionValue = big.NewInt(1)
+				block.ConsensusValue = big.NewInt(1)
+
+				return block, nil
+			},
+		},
+		{
+			version: "capella blinded",
+			jsonBeaconBlock: func(slotsPerEpoch uint64) []byte {
+				block := testutil.RandomCapellaBlindedBeaconBlock()
+				block.Slot = eth2p0.Slot(slotsPerEpoch)
+				blockJSON, err := block.MarshalJSON()
+				require.NoError(t, err)
+
+				return blockJSON
+			},
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				block := &eth2api.VersionedProposal{
+					Version:        eth2spec.DataVersionCapella,
+					CapellaBlinded: testutil.RandomCapellaBlindedBeaconBlock(),
+				}
+				block.CapellaBlinded.Slot = opts.Slot
+				block.CapellaBlinded.Body.RANDAOReveal = opts.RandaoReveal
+				block.CapellaBlinded.Body.Graffiti = opts.Graffiti
+				block.ExecutionValue = big.NewInt(1)
+				block.ConsensusValue = big.NewInt(1)
+				block.Blinded = true
+
+				return block, nil
+			},
+		},
+		{
+			version: "deneb blinded",
+			jsonBeaconBlock: func(slotsPerEpoch uint64) []byte {
+				block := testutil.RandomDenebBeaconBlock()
+				block.Slot = eth2p0.Slot(slotsPerEpoch)
+				blockJSON, err := block.MarshalJSON()
+				require.NoError(t, err)
+
+				return blockJSON
+			},
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				block := &eth2api.VersionedProposal{
+					Version:      eth2spec.DataVersionDeneb,
+					DenebBlinded: testutil.RandomDenebBlindedBeaconBlock(),
+				}
+				block.DenebBlinded.Slot = opts.Slot
+				block.DenebBlinded.Body.RANDAOReveal = opts.RandaoReveal
+				block.DenebBlinded.Body.Graffiti = opts.Graffiti
+				block.ExecutionValue = big.NewInt(1)
+				block.ConsensusValue = big.NewInt(1)
+				block.Blinded = true
+
+				return block, nil
+			},
+		},
+		{
+			version: "electra blinded",
+			jsonBeaconBlock: func(slotsPerEpoch uint64) []byte {
+				block := testutil.RandomElectraBeaconBlock()
+				block.Slot = eth2p0.Slot(slotsPerEpoch)
+				blockJSON, err := block.MarshalJSON()
+				require.NoError(t, err)
+
+				return blockJSON
+			},
+			beaconMockProposalFunc: func(_ context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error) {
+				block := &eth2api.VersionedProposal{
+					Version:        eth2spec.DataVersionElectra,
+					ElectraBlinded: testutil.RandomElectraBlindedBeaconBlock(),
+				}
+				block.ElectraBlinded.Slot = opts.Slot
+				block.ElectraBlinded.Body.RANDAOReveal = opts.RandaoReveal
+				block.ElectraBlinded.Body.Graffiti = opts.Graffiti
+				block.ExecutionValue = big.NewInt(1)
+				block.ConsensusValue = big.NewInt(1)
+				block.Blinded = true
+
+				return block, nil
+			},
+		},
 	}
 
-	slotsPerEpoch, err := beaconMock.SlotsPerEpoch(ctx)
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.version, func(t *testing.T) {
+			// Configure beacon mock
+			valSet := beaconmock.ValidatorSetA
+			beaconMock, err := beaconmock.New(
+				beaconmock.WithValidatorSet(valSet),
+				beaconmock.WithDeterministicProposerDuties(0),
+			)
+			require.NoError(t, err)
 
-	block := testutil.RandomPhase0BeaconBlock()
-	block.Slot = eth2p0.Slot(slotsPerEpoch)
+			beaconMock.ProposalFunc = test.beaconMockProposalFunc
 
-	mockVAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		testResponse := []byte(`{"version":"phase0","data":`)
-		blockJSON, err := block.MarshalJSON()
-		require.NoError(t, err)
+			// Signature stub function
+			signFunc := func(key eth2p0.BLSPubKey, _ []byte) (eth2p0.BLSSignature, error) {
+				var sig eth2p0.BLSSignature
+				copy(sig[:], key[:])
 
-		testResponse = append(testResponse, blockJSON...)
-		testResponse = append(testResponse, []byte(`}`)...)
-		require.NoError(t, err)
+				return sig, nil
+			}
 
-		_, _ = w.Write(testResponse)
-	}))
-	defer mockVAPI.Close()
+			slotsPerEpoch, err := beaconMock.SlotsPerEpoch(ctx)
+			require.NoError(t, err)
 
-	provider := addrWrap{
-		Client: beaconMock,
-		addr:   mockVAPI.URL,
+			mockVAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				testResponse := []byte(fmt.Sprintf(`{"version":"%v","data":`, test.version))
+				blockJSON := test.jsonBeaconBlock(slotsPerEpoch)
+
+				testResponse = append(testResponse, blockJSON...)
+				testResponse = append(testResponse, []byte(`}`)...)
+				require.NoError(t, err)
+
+				_, _ = w.Write(testResponse)
+			}))
+			defer mockVAPI.Close()
+
+			provider := addrWrap{
+				Client: beaconMock,
+				addr:   mockVAPI.URL,
+			}
+
+			// Call propose block function
+			err = validatormock.ProposeBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch))
+			require.NoError(t, err)
+		})
 	}
-
-	// Call propose block function
-	err = validatormock.ProposeBlock(ctx, provider, signFunc, eth2p0.Slot(slotsPerEpoch))
-	require.NoError(t, err)
 }
 
 func TestProposeBlindedBlock(t *testing.T) {


### PR DESCRIPTION
On first look it seems like a big PR, but it consists of 2 main things:
1. Adding electra version support to all switch cases throughout the codebase.
2. Adding tests for electra + improving the test coverage of already existing versions.

category: feature
ticket: none
