### PR TITLE
fix: refresh validator by slot instead of by head

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -467,10 +467,8 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 		ctx = log.WithCtx(ctx, z.Bool("first_refresh", firstValCacheRefresh))
 
-		log.Debug(ctx, "Refreshing validator cache")
-
 		valCache.Trim()
-		_, _, err := valCache.Get(ctx)
+		_, _, err := valCache.GetBySlot(ctx, slot.Slot)
 		if err != nil {
 			log.Error(ctx, "Cannot refresh validator cache", err)
 			return err

--- a/app/app.go
+++ b/app/app.go
@@ -467,6 +467,8 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 		ctx = log.WithCtx(ctx, z.Bool("first_refresh", firstValCacheRefresh))
 
+		log.Info(ctx, "Refreshing validator cache")
+
 		valCache.Trim()
 		_, _, err := valCache.GetBySlot(ctx, slot.Slot)
 		if err != nil {

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -148,7 +148,7 @@ func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveVali
 	defer c.mu.Unlock()
 
 	opts := &eth2api.ValidatorsOpts{
-		State:   strconv.Itoa(int(slot)),
+		State:   strconv.FormatUint(slot, 10),
 		PubKeys: c.pubkeys,
 	}
 

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -4,13 +4,17 @@ package eth2wrap
 
 import (
 	"context"
+	"strconv"
 	"sync"
+	"time"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 // ActiveValidators is a map of active validator indices to pubkeys.
@@ -112,6 +116,60 @@ func (c *ValidatorCache) Get(ctx context.Context) (ActiveValidators, CompleteVal
 	if err != nil {
 		return nil, nil, err
 	}
+	vals := eth2Resp.Data
+
+	resp := make(ActiveValidators)
+	for _, val := range vals {
+		if val == nil || val.Validator == nil {
+			return nil, nil, errors.New("validator data cannot be nil")
+		}
+
+		if !val.Status.IsActive() {
+			continue
+		}
+
+		resp[val.Index] = val.Validator.PublicKey
+	}
+
+	c.active = resp
+	c.complete = eth2Resp.Data
+
+	return resp, eth2Resp.Data, nil
+}
+
+// GetBySlot fetches active and complete validator by slot populating the cache.
+func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveValidators, CompleteValidators, error) {
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	opts := &eth2api.ValidatorsOpts{
+		State:   strconv.Itoa(int(slot)),
+		PubKeys: c.pubkeys,
+	}
+
+	var eth2Resp *eth2api.Response[map[eth2p0.ValidatorIndex]*eth2v1.Validator]
+	var err error
+	maxRetries := 20
+	retryDelay := 100 * time.Millisecond
+
+	for retryCount := 0; retryCount < maxRetries; retryCount++ {
+		eth2Resp, err = c.eth2Cl.Validators(ctx, opts)
+		if err == nil {
+			break
+		}
+
+		sleepDuration := retryDelay * time.Duration(retryCount+1)
+		time.Sleep(sleepDuration)
+
+		log.Info(ctx, "Retrying fetching validators by slot", z.U64("slot", slot), z.Int("retryCount", retryCount+1), z.Err(err))
+	}
+
+	if err != nil {
+		log.Error(ctx, "Failed to fetch validators by slot after maximum retries", err, z.U64("slot", slot))
+		return nil, nil, wrapError(ctx, err, "Failed to fetch validators by slot after maximum retries")
+	}
+
 	vals := eth2Resp.Data
 
 	resp := make(ActiveValidators)

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -168,7 +168,6 @@ func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveVali
 	}
 
 	if err != nil {
-		log.Error(ctx, "Failed to fetch validators by slot after maximum retries", err, z.U64("slot", slot))
 		return nil, nil, wrapError(ctx, err, "Failed to fetch validators by slot after maximum retries")
 	}
 

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -17,7 +17,7 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 )
 
-var (
+const (
 	maxRetries = 20
 	retryDelay = 100 * time.Millisecond
 )
@@ -188,7 +188,7 @@ func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveVali
 	}
 
 	c.active = active
-	c.complete = eth2Resp.Data
+	c.complete = complete
 
-	return active, eth2Resp.Data, nil
+	return active, complete, nil
 }

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -90,7 +90,6 @@ func TestValidatorCache(t *testing.T) {
 }
 
 func TestGetBySlot(t *testing.T) {
-
 	// Create a mock client.
 	eth2Cl, err := beaconmock.New()
 	require.NoError(t, err)
@@ -138,7 +137,7 @@ func TestGetBySlot(t *testing.T) {
 				},
 			}, nil
 		default:
-			return nil, nil
+			return beaconmock.ValidatorSet{}, nil
 		}
 	}
 
@@ -148,6 +147,7 @@ func TestGetBySlot(t *testing.T) {
 	active, complete, err := valCache.GetBySlot(ctx, 1)
 	require.NoError(t, err)
 	require.Len(t, active, 1)
+	require.Equal(t, pubkeys[1], active[1])
 	require.Len(t, complete, 2)
 
 	active, complete, err = valCache.GetBySlot(ctx, 2)

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -12,6 +12,7 @@ import (
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/testutil"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
@@ -155,7 +156,7 @@ func TestGetBySlot(t *testing.T) {
 			}, nil
 
 		default:
-			return beaconmock.ValidatorSet{}, nil
+			return nil, errors.New("no slot found")
 		}
 	}
 
@@ -177,4 +178,7 @@ func TestGetBySlot(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, active, 0)
 	require.Len(t, complete, 2)
+
+	_, _, err = valCache.GetBySlot(ctx, 3)
+	require.Error(t, err)
 }

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -136,6 +136,24 @@ func TestGetBySlot(t *testing.T) {
 					},
 				},
 			}, nil
+		case "11":
+			return beaconmock.ValidatorSet{
+				0: &eth2v1.Validator{
+					Index:  0,
+					Status: eth2v1.ValidatorStatePendingQueued,
+					Validator: &eth2p0.Validator{
+						PublicKey: pubkeys[0],
+					},
+				},
+				1: &eth2v1.Validator{
+					Index:  1,
+					Status: eth2v1.ValidatorStatePendingQueued,
+					Validator: &eth2p0.Validator{
+						PublicKey: pubkeys[1],
+					},
+				},
+			}, nil
+
 		default:
 			return beaconmock.ValidatorSet{}, nil
 		}
@@ -153,5 +171,10 @@ func TestGetBySlot(t *testing.T) {
 	active, complete, err = valCache.GetBySlot(ctx, 2)
 	require.NoError(t, err)
 	require.Len(t, active, 2)
+	require.Len(t, complete, 2)
+
+	active, complete, err = valCache.GetBySlot(ctx, 11)
+	require.NoError(t, err)
+	require.Len(t, active, 0)
 	require.Len(t, complete, 2)
 }


### PR DESCRIPTION
Add method `GetBySlot` to fetch active/complete validator by slot.
In cases where the beacon node is slow, fetching validators by `head` would lead to outdated information (specifically regarding its active status). By fetching by slot we guarantee to get the up-to-date information.
The downside here is that this request is slower because it might take multiple requests until the beacon node has the information regarding the slot. 


category: bug
ticket: none
