### PR TITLE
core: add committee index to attestations requests

### DIFF
--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -297,7 +297,7 @@ func (db *MemDB) storeAttestationUnsafe(pubkey core.PubKey, unsignedData core.Un
 	// Store key and value for PubKeyByAttestation
 	pKey := pkKey{
 		Slot:       uint64(attData.Data.Slot),
-		CommIdx:    uint64(attData.Data.Index),
+		CommIdx:    uint64(attData.Duty.CommitteeIndex),
 		ValCommIdx: attData.Duty.ValidatorCommitteeIndex,
 	}
 	if value, ok := db.attPubKeys[pKey]; ok {
@@ -312,7 +312,7 @@ func (db *MemDB) storeAttestationUnsafe(pubkey core.PubKey, unsignedData core.Un
 	// Store key and value for AwaitAttestation
 	aKey := attKey{
 		Slot:    uint64(attData.Data.Slot),
-		CommIdx: uint64(attData.Data.Index),
+		CommIdx: uint64(attData.Duty.CommitteeIndex),
 	}
 
 	if value, ok := db.attDuties[aKey]; ok {

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -91,6 +91,7 @@ func TestMemDB(t *testing.T) {
 			CommitteeLength:         commLen,
 			ValidatorCommitteeIndex: valCommIdxA,
 			CommitteesAtSlot:        notZero,
+			CommitteeIndex:          commIdx,
 		},
 	}
 	unsignedB := core.AttestationData{
@@ -99,6 +100,7 @@ func TestMemDB(t *testing.T) {
 			CommitteeLength:         commLen,
 			ValidatorCommitteeIndex: valCommIdxB,
 			CommitteesAtSlot:        notZero,
+			CommitteeIndex:          commIdx,
 		},
 	}
 
@@ -436,7 +438,7 @@ func TestDutyExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure it exists
-	pk, err := db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Data.Index), att1.Duty.ValidatorCommitteeIndex)
+	pk, err := db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), att1.Duty.ValidatorCommitteeIndex)
 	require.NoError(t, err)
 	require.NotEmpty(t, pk)
 
@@ -452,7 +454,7 @@ func TestDutyExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pubkey not found.
-	_, err = db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Data.Index), att1.Duty.ValidatorCommitteeIndex)
+	_, err = db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), att1.Duty.ValidatorCommitteeIndex)
 	require.Error(t, err)
 }
 

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -211,6 +211,7 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot uint64, defSet c
 		opts := &eth2api.AggregateAttestationOpts{
 			Slot:                eth2p0.Slot(slot),
 			AttestationDataRoot: dataRoot,
+			CommitteeIndex:      attDef.CommitteeIndex,
 		}
 		eth2Resp, err := f.eth2Cl.AggregateAttestation(ctx, opts)
 		if err != nil {

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1073,9 +1073,15 @@ func aggregateAttestation(p eth2client.AggregateAttestationProvider) handlerFunc
 			return nil, nil, err
 		}
 
+		committeeIndex, err := uintQuery(query, "committee_index")
+		if err != nil {
+			return nil, nil, err
+		}
+
 		opts := &eth2api.AggregateAttestationOpts{
 			Slot:                eth2p0.Slot(slot),
 			AttestationDataRoot: attDataRoot,
+			CommitteeIndex:      eth2p0.CommitteeIndex(committeeIndex),
 		}
 		eth2Resp, err := p.AggregateAttestation(ctx, opts)
 		if err != nil {

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -454,6 +454,7 @@ func getAggregateAttestation(ctx context.Context, eth2Cl eth2wrap.Client, datas 
 		opts := &eth2api.AggregateAttestationOpts{
 			Slot:                data.Slot,
 			AttestationDataRoot: root,
+			CommitteeIndex:      commIdx,
 		}
 		eth2Resp, err := eth2Cl.AggregateAttestation(ctx, opts)
 		if err != nil {


### PR DESCRIPTION
Previously the committee index was found under attestation structure's `Data.Index` field. However, in Electra that's not the case. Couple of structures needed refactoring because of that.

Note that this makes attestations successful, however, aggregations are still not working based on my tests with Lighthouse CL. [This PR](https://github.com/sigp/lighthouse/pull/6926) should fix that though.

category: feature
ticket: none
