### PR TITLE
cmd: fixed loaded keys ordering

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -592,7 +592,7 @@ func getKeys(splitKeysDir string) ([]tbls.PrivateKey, error) {
 		return nil, err
 	}
 
-	return files.Keys(), nil
+	return files.SequencedKeys()
 }
 
 // generateKeys generates numDVs amount of tbls.PrivateKeys.


### PR DESCRIPTION
In `create cluster` using `--split-keys` charon loads keystores in unordered fashion. In other places we apply `SequencedKeys()` that sorts the keys by index. Applied the same logic to `create cluster` implementation.

category: bug
ticket: none