### PR TITLE
*: bump go-eth2-client and update atts and aggs

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -237,6 +237,7 @@ func TestFallback(t *testing.T) {
 						return true
 					}
 				}
+
 				return false
 			}
 
@@ -247,7 +248,6 @@ func TestFallback(t *testing.T) {
 					require.True(t, called, "primary client %d was not called", i)
 				}
 				require.True(t, atLeastOneCalled(fallbackCalled), "at least one fallback client should have been called")
-
 			} else {
 				require.True(t, atLeastOneCalled(primaryCalled), "at least one primary client should have been called")
 			}

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -264,14 +264,14 @@ func (db *MemDB) AwaitSyncContribution(ctx context.Context, slot, subcommIdx uin
 }
 
 // PubKeyByAttestation implements core.DutyDB, see its godoc.
-func (db *MemDB) PubKeyByAttestation(_ context.Context, slot, commIdx, valCommIdx uint64) (core.PubKey, error) {
+func (db *MemDB) PubKeyByAttestation(_ context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error) {
 	db.mu.Lock()
 	defer db.mu.Unlock()
 
 	key := pkKey{
-		Slot:       slot,
-		CommIdx:    commIdx,
-		ValCommIdx: valCommIdx,
+		Slot:    slot,
+		CommIdx: commIdx,
+		ValIdx:  valIdx,
 	}
 
 	pubkey, ok := db.attPubKeys[key]
@@ -296,9 +296,9 @@ func (db *MemDB) storeAttestationUnsafe(pubkey core.PubKey, unsignedData core.Un
 
 	// Store key and value for PubKeyByAttestation
 	pKey := pkKey{
-		Slot:       uint64(attData.Data.Slot),
-		CommIdx:    uint64(attData.Duty.CommitteeIndex),
-		ValCommIdx: attData.Duty.ValidatorCommitteeIndex,
+		Slot:    uint64(attData.Data.Slot),
+		CommIdx: uint64(attData.Duty.CommitteeIndex),
+		ValIdx:  uint64(attData.Duty.ValidatorIndex),
 	}
 	if value, ok := db.attPubKeys[pKey]; ok {
 		if value != pubkey {
@@ -576,9 +576,9 @@ type attKey struct {
 
 // pkKey is the key to lookup pubkeys by attestation in the DB.
 type pkKey struct {
-	Slot       uint64
-	CommIdx    uint64
-	ValCommIdx uint64
+	Slot    uint64
+	CommIdx uint64
+	ValIdx  uint64
 }
 
 // aggKey is the key to lookup an aggregated attestation by root in the DB.

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -92,6 +92,7 @@ func TestMemDB(t *testing.T) {
 			ValidatorCommitteeIndex: valCommIdxA,
 			CommitteesAtSlot:        notZero,
 			CommitteeIndex:          commIdx,
+			ValidatorIndex:          vIdxA,
 		},
 	}
 	unsignedB := core.AttestationData{
@@ -101,6 +102,7 @@ func TestMemDB(t *testing.T) {
 			ValidatorCommitteeIndex: valCommIdxB,
 			CommitteesAtSlot:        notZero,
 			CommitteeIndex:          commIdx,
+			ValidatorIndex:          vIdxB,
 		},
 	}
 
@@ -438,7 +440,7 @@ func TestDutyExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure it exists
-	pk, err := db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), att1.Duty.ValidatorCommitteeIndex)
+	pk, err := db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), uint64(att1.Duty.ValidatorIndex))
 	require.NoError(t, err)
 	require.NotEmpty(t, pk)
 
@@ -454,7 +456,7 @@ func TestDutyExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pubkey not found.
-	_, err = db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), att1.Duty.ValidatorCommitteeIndex)
+	_, err = db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), uint64(att1.Duty.ValidatorIndex))
 	require.Error(t, err)
 }
 

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -534,8 +534,9 @@ type versionedRawBlockJSON struct {
 
 // versionedRawAttestationJSON is a custom VersionedAttestation serialiser.
 type versionedRawAttestationJSON struct {
-	Version     eth2util.DataVersion `json:"version"`
-	Attestation json.RawMessage      `json:"attestation"`
+	Version        eth2util.DataVersion   `json:"version"`
+	ValidatorIndex *eth2p0.ValidatorIndex `json:"validator_index"`
+	Attestation    json.RawMessage        `json:"attestation"`
 }
 
 // versionedRawAggregateAndProofJSON is a custom VersionedAttestation serialiser.
@@ -706,8 +707,9 @@ func (a VersionedAttestation) MarshalJSON() ([]byte, error) {
 	}
 
 	resp, err := json.Marshal(versionedRawAttestationJSON{
-		Version:     version,
-		Attestation: attestation,
+		Version:        version,
+		ValidatorIndex: a.ValidatorIndex,
+		Attestation:    attestation,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal wrapper")
@@ -769,6 +771,8 @@ func (a *VersionedAttestation) UnmarshalJSON(b []byte) error {
 	default:
 		return errors.New("unknown attestation version", z.Str("version", a.Version.String()))
 	}
+
+	resp.ValidatorIndex = raw.ValidatorIndex
 
 	a.VersionedAttestation = resp
 

--- a/core/testdata/TestJSONSerialisation_VersionedAggregatedAttestation.json.golden
+++ b/core/testdata/TestJSONSerialisation_VersionedAggregatedAttestation.json.golden
@@ -1,5 +1,6 @@
 {
   "version": 5,
+  "validator_index": null,
   "attestation": {
     "aggregation_bits": "0x0272908d45b01601",
     "data": {

--- a/core/testdata/TestJSONSerialisation_VersionedAttestation.json.golden
+++ b/core/testdata/TestJSONSerialisation_VersionedAttestation.json.golden
@@ -1,5 +1,6 @@
 {
   "version": 5,
+  "validator_index": null,
   "attestation": {
     "aggregation_bits": "0x0272908d45b01601",
     "data": {

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -168,8 +168,9 @@ func (a VersionedAggregatedAttestation) MarshalJSON() ([]byte, error) {
 	}
 
 	resp, err := json.Marshal(versionedRawAttestationJSON{
-		Version:     version,
-		Attestation: aggregatedAttestation,
+		Version:        version,
+		ValidatorIndex: a.ValidatorIndex,
+		Attestation:    aggregatedAttestation,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "marshal wrapper")
@@ -251,6 +252,7 @@ func (a *VersionedAggregatedAttestation) UnmarshalJSON(input []byte) error {
 	default:
 		return errors.New("unknown attestation version", z.Str("version", a.Version.String()))
 	}
+	resp.ValidatorIndex = raw.ValidatorIndex
 
 	a.VersionedAttestation = resp
 

--- a/core/validatorapi/eth2types.go
+++ b/core/validatorapi/eth2types.go
@@ -93,6 +93,11 @@ type validatorResponse struct {
 	Data                v1Validator `json:"data"`
 }
 
+type aggregateAttestationV2Response struct {
+	Version string `json:"version"`
+	Data    any    `json:"data"`
+}
+
 type aggregateBeaconCommitteeSelectionsJSON struct {
 	Data []*eth2exp.BeaconCommitteeSelection `json:"data"`
 }

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -194,7 +194,7 @@ type Component struct {
 
 	// Registered input functions
 
-	pubKeyByAttFunc           func(ctx context.Context, slot, commIdx, valCommIdx uint64) (core.PubKey, error)
+	pubKeyByAttFunc           func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error)
 	awaitAttFunc              func(ctx context.Context, slot, commIdx uint64) (*eth2p0.AttestationData, error)
 	awaitProposalFunc         func(ctx context.Context, slot uint64) (*eth2api.VersionedProposal, error)
 	awaitSyncContributionFunc func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
@@ -224,7 +224,7 @@ func (c *Component) RegisterAwaitSyncContribution(fn func(ctx context.Context, s
 
 // RegisterPubKeyByAttestation registers a function to query pubkeys by attestation.
 // It only supports a single function, since it is an input of the component.
-func (c *Component) RegisterPubKeyByAttestation(fn func(ctx context.Context, slot, commIdx, valCommIdx uint64) (core.PubKey, error)) {
+func (c *Component) RegisterPubKeyByAttestation(fn func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error)) {
 	c.pubKeyByAttFunc = fn
 }
 
@@ -295,27 +295,22 @@ func (c Component) SubmitAttestations(ctx context.Context, attestationOpts *eth2
 		}
 		slot := uint64(attData.Slot)
 
-		// Determine the validator that sent this by mapping values from original AttestationDuty via the dutyDB
-		attAggregationBits, err := att.AggregationBits()
-		if err != nil {
-			return errors.Wrap(err, "get attestation aggregation bits")
-		}
-		attAggregationIndices := attAggregationBits.BitIndices()
-		// expected only 1 index here, as it is a single attestation
-		if len(attAggregationIndices) != 1 {
-			return errors.New("unexpected number of aggregation bits",
-				z.Str("aggbits", fmt.Sprintf("%#x", []byte(attAggregationBits))))
-		}
-
 		attCommitteeIndex, err := att.CommitteeIndex()
 		if err != nil {
 			return errors.Wrap(err, "get attestation committee index")
 		}
 
-		pubkey, err := c.pubKeyByAttFunc(ctx, slot, uint64(attCommitteeIndex), uint64(attAggregationIndices[0]))
+		// pre-electra attestations were stored in DB with unique validator committee index
+		// post-electra attestations cannot be identified by validator committee index and we use the validator index in the chain
+		valIdxOrValCommIdx, err := fetchAttestationPubKeyIdentifier(att)
+		if err != nil {
+			return errors.Wrap(err, "fetch attestation pubkey identifier")
+		}
+
+		pubkey, err := c.pubKeyByAttFunc(ctx, slot, uint64(attCommitteeIndex), uint64(valIdxOrValCommIdx))
 		if err != nil {
 			return errors.Wrap(err, "failed to find pubkey", z.U64("slot", slot),
-				z.Int("commIdx", int(attCommitteeIndex)), z.Int("valCommIdx", attAggregationIndices[0]))
+				z.U64("commIdx", uint64(attCommitteeIndex)), z.U64("valIdx", uint64(valIdxOrValCommIdx)))
 		}
 
 		parSigData, err := core.NewPartialVersionedAttestation(att, c.shareIdx)
@@ -354,6 +349,41 @@ func (c Component) SubmitAttestations(ctx context.Context, attestationOpts *eth2
 	}
 
 	return nil
+}
+
+func fetchAttestationPubKeyIdentifier(att *eth2spec.VersionedAttestation) (int, error) {
+	switch att.Version {
+	case eth2spec.DataVersionPhase0:
+		return aggBitsIndex(att)
+	case eth2spec.DataVersionAltair:
+		return aggBitsIndex(att)
+	case eth2spec.DataVersionBellatrix:
+		return aggBitsIndex(att)
+	case eth2spec.DataVersionCapella:
+		return aggBitsIndex(att)
+	case eth2spec.DataVersionDeneb:
+		return aggBitsIndex(att)
+	case eth2spec.DataVersionElectra:
+		return int(*att.ValidatorIndex), nil
+	default:
+		return 0, errors.New("unknown version")
+	}
+}
+
+func aggBitsIndex(att *eth2spec.VersionedAttestation) (int, error) {
+	// Determine the validator that sent this by mapping values from original AttestationDuty via the dutyDB
+	attAggregationBits, err := att.AggregationBits()
+	if err != nil {
+		return 0, errors.Wrap(err, "get attestation aggregation bits")
+	}
+	attAggregationIndices := attAggregationBits.BitIndices()
+	// expected only 1 index here, as it is a single attestation
+	if len(attAggregationIndices) != 1 {
+		return 0, errors.New("unexpected number of aggregation bits",
+			z.Str("aggbits", fmt.Sprintf("%#x", []byte(attAggregationBits))))
+	}
+
+	return attAggregationIndices[0], nil
 }
 
 func (c Component) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.Response[*eth2api.VersionedProposal], error) {

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/prometheus/client_golang v1.20.5
 	github.com/prometheus/client_model v0.6.1
 	github.com/protolambda/eth2-shuffle v1.1.0
-	github.com/prysmaticlabs/go-bitfield v0.0.0-20240328144219-a1caa50c3a1e
+	github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15
 	github.com/r3labs/sse/v2 v2.10.0
 	github.com/rs/zerolog v1.33.0
 	github.com/showwin/speedtest-go v1.7.10
@@ -101,7 +101,7 @@ require (
 	github.com/docker/go-connections v0.5.0 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
 	github.com/elastic/gosigar v0.14.3 // indirect
-	github.com/emicklei/dot v1.6.2 // indirect
+	github.com/emicklei/dot v1.6.4 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/felixge/fgprof v0.9.5 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -133,7 +133,7 @@ require (
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jdx/go-netrc v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.11 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.8 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect
 	github.com/koron/go-ssdp v0.0.4 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
@@ -146,7 +146,7 @@ require (
 	github.com/libp2p/go-yamux/v4 v4.0.1 // indirect
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd // indirect
-	github.com/mattn/go-colorable v0.1.13 // indirect
+	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/miekg/dns v1.1.62 // indirect
 	github.com/mikioh/tcpinfo v0.0.0-20190314235526-30a79bb1804b // indirect
@@ -245,7 +245,7 @@ require (
 	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
-	golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 // indirect
+	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/grpc v1.69.4 // indirect
@@ -267,4 +267,4 @@ replace github.com/coinbase/kryptology => github.com/ObolNetwork/kryptology v0.0
 // replace github.com/attestantio/go-eth2-client => github.com/ObolNetwork/go-eth2-client v0.21.11-0.20240822135044-f0a5b21e02c6
 
 // Replace go-eth2-client version with the electra branch
-replace github.com/attestantio/go-eth2-client => github.com/attestantio/go-eth2-client v0.23.1-0.20250127133620-39cd237a54a9
+replace github.com/attestantio/go-eth2-client => github.com/attestantio/go-eth2-client v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -47,8 +47,8 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/attestantio/go-builder-client v0.5.3 h1:4YFT0u823JvF4Uesj7SEG8f0De1uxLrVioOgKZYPl3I=
 github.com/attestantio/go-builder-client v0.5.3/go.mod h1:RaWc8K2SjyU19sL5UinOQ8n4vTZBrEQzsNuMWpNmwK4=
-github.com/attestantio/go-eth2-client v0.23.1-0.20250127133620-39cd237a54a9 h1:0GjrZ5f9JwgeXUA8t0iFSBSnQn8CwHl2KMm79CcFprM=
-github.com/attestantio/go-eth2-client v0.23.1-0.20250127133620-39cd237a54a9/go.mod h1:vy5jU/uDZ2+RcVzq5BfnG+bQ3/6uu9DGwCrGsPtjJ1A=
+github.com/attestantio/go-eth2-client v0.24.0 h1:lGVbcnhlBwRglt1Zs56JOCgXVyLWKFZOmZN8jKhE7Ws=
+github.com/attestantio/go-eth2-client v0.24.0/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=
@@ -158,8 +158,8 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
 github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
-github.com/emicklei/dot v1.6.2 h1:08GN+DD79cy/tzN6uLCT84+2Wk9u+wvqP+Hkx/dIR8A=
-github.com/emicklei/dot v1.6.2/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
+github.com/emicklei/dot v1.6.4 h1:cG9ycT67d9Yw22G+mAb4XiuUz6E6H1S0zePp/5Cwe/c=
+github.com/emicklei/dot v1.6.4/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
@@ -326,8 +326,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.17.11 h1:In6xLpyWOi1+C7tXUUWv2ot1QvBjxevKAaI6IXrJmUc=
 github.com/klauspost/compress v1.17.11/go.mod h1:pMDklpSncoRMuLFrf1W9Ss9KT+0rH90U12bZKk7uwG0=
-github.com/klauspost/cpuid/v2 v2.2.8 h1:+StwCXwm9PdpiEkPyzBXIy+M9KUb4ODm0Zarf1kS5BM=
-github.com/klauspost/cpuid/v2 v2.2.8/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
+github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/klauspost/pgzip v1.2.6 h1:8RXeL5crjEUFnR2/Sn6GJNWtSQ3Dk8pq4CL3jvdDyjU=
 github.com/klauspost/pgzip v1.2.6/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/koron/go-ssdp v0.0.4 h1:1IDwrghSKYM7yLf7XCzbByg2sJ/JcNOZRXS2jczTwz0=
@@ -376,8 +376,9 @@ github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJ
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd h1:br0buuQ854V8u83wA0rVZ8ttrq5CpaPZdvrK0LP2lOk=
 github.com/marten-seemann/tcp v0.0.0-20210406111302-dfbc87cc63fd/go.mod h1:QuCEs1Nt24+FYQEqAAncTDPJIuGs+LxK1MCiFL25pMU=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
+github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
+github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -548,8 +549,8 @@ github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0leargg
 github.com/prometheus/procfs v0.15.1/go.mod h1:fB45yRUv8NstnjriLhBQLuOUt+WW4BsoGhij/e3PBqk=
 github.com/protolambda/eth2-shuffle v1.1.0 h1:gixIBI84IeugTwwHXm8vej1bSSEhueBCSryA4lAKRLU=
 github.com/protolambda/eth2-shuffle v1.1.0/go.mod h1:FhA2c0tN15LTC+4T9DNVm+55S7uXTTjQ8TQnBuXlkF8=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20240328144219-a1caa50c3a1e h1:ATgOe+abbzfx9kCPeXIW4fiWyDdxlwHw07j8UGhdTd4=
-github.com/prysmaticlabs/go-bitfield v0.0.0-20240328144219-a1caa50c3a1e/go.mod h1:wmuf/mdK4VMD+jA9ThwcUKjg3a2XWM9cVfFYjDyY4j4=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15 h1:lC8kiphgdOBTcbTvo8MwkvpKjO0SlAgjv4xIK5FGJ94=
+github.com/prysmaticlabs/go-bitfield v0.0.0-20240618144021-706c95b2dd15/go.mod h1:8svFBIKKu31YriBG/pNizo9N0Jr9i5PQ+dFkxWg3x5k=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
 github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
 github.com/quic-go/qpack v0.5.1 h1:giqksBPnT/HDtZ6VhtFKgoLOWmlyo9Ei6u9PqzIMbhI=
@@ -881,8 +882,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028 h1:+cNy6SZtPcJQH3LJVLOSmiC7MMxXNOb3PU/VUEz+EhU=
-golang.org/x/xerrors v0.0.0-20231012003039-104605ab7028/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da h1:noIWHXmPHxILtqtCOPIhSt0ABwskkZKjD3bXGnZGpNY=
+golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da/go.mod h1:NDW/Ps6MPRej6fsCIbMTohpP40sJ/P/vI1MoTEGwX90=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.1.0/go.mod h1:UGEZY7KEX120AnNLIHFMKIo4obdJhkp2tPbaPlQx13Y=

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -129,7 +129,7 @@ func RandomPhase0Attestation() *eth2p0.Attestation {
 
 func RandomElectraAttestation() *electra.Attestation {
 	return &electra.Attestation{
-		AggregationBits: RandomBitList(1),
+		AggregationBits: RandomBitList(64),
 		Data:            RandomAttestationDataPhase0(),
 		Signature:       RandomEth2Signature(),
 		CommitteeBits:   RandomBitVec64(),

--- a/testutil/validatormock/testdata/TestAttest_0_attestations.golden
+++ b/testutil/validatormock/testdata/TestAttest_0_attestations.golden
@@ -1,6 +1,7 @@
 [
  {
   "Version": "deneb",
+  "ValidatorIndex": null,
   "Phase0": null,
   "Altair": null,
   "Bellatrix": null,
@@ -26,6 +27,7 @@
  },
  {
   "Version": "deneb",
+  "ValidatorIndex": null,
   "Phase0": null,
   "Altair": null,
   "Bellatrix": null,
@@ -51,6 +53,7 @@
  },
  {
   "Version": "deneb",
+  "ValidatorIndex": null,
   "Phase0": null,
   "Altair": null,
   "Bellatrix": null,

--- a/testutil/validatormock/testdata/TestAttest_1_attestations.golden
+++ b/testutil/validatormock/testdata/TestAttest_1_attestations.golden
@@ -1,6 +1,7 @@
 [
  {
   "Version": "deneb",
+  "ValidatorIndex": null,
   "Phase0": null,
   "Altair": null,
   "Bellatrix": null,


### PR DESCRIPTION
Previously we have had `Attestation` object sent to the `/eth/v1/beacon/pool/attestations`, however, now in electra, those are `SingleAttestation`s. [Link to the BN API](https://ethereum.github.io/beacon-APIs/?urls.primaryName=dev#/Beacon/submitPoolAttestationsV2). This required some changes...

Change of the key used for recognising attestations in our memory. Previously part of the key was the **validator's index inside the committee**, however, now as it is `SingleAttestation` there are no aggregation bits from which we can derive that. We use now the new field inside the `VersionedAttestation` - `ValidatorIndex`. This allows us to uniquely identify the validator alongside with the other keys. Note that the current changes **are not** compatible with deneb. There are multiple places where we are not compatible with deneb, one prominent one is not supporting v1 endpoints. This is something to be addressed in separate PR.

category: feature
ticket: none
