### PR TITLE
app/peerinfo: reduce nickname mapping logs

### DIFF
--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -205,8 +205,11 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			name := p2p.PeerName(peerID)
 
 			p.nicknamesMu.Lock()
+			prevNickname, ok := p.nicknames[name]
 			p.nicknames[name] = resp.GetNickname()
-			log.Info(ctx, "Peer name to nickname mappings", z.Any("nicknames", p.nicknames))
+			if !ok || prevNickname != resp.GetNickname() {
+				log.Info(ctx, "Peer name to nickname mappings", z.Any("nicknames", p.nicknames))
+			}
 			p.nicknamesMu.Unlock()
 
 			// Validator git hash with regex.


### PR DESCRIPTION
Peerinfo protocol was logging nickname mappings every tick (1 minute) which leads to too much repeated information in logs.
Updated logic to only log when nicknames change.

category: refactor
ticket: none
