### PR TITLE
eth2util: fix beacon node headers validation/parsing

### DIFF
--- a/eth2util/helpers.go
+++ b/eth2util/helpers.go
@@ -5,6 +5,7 @@ package eth2util
 import (
 	"context"
 	"encoding/hex"
+	"fmt"
 	"regexp"
 	"strings"
 	"unicode"
@@ -24,7 +25,7 @@ func ValidateBeaconNodeHeaders(headers []string) error {
 		// The pattern ([^=,]+) captures any string that does not contain '=' or ','.
 		// The composition of patterns ([^=,]+)=([^=,]+) captures a pair of header and its corresponding value.
 		// We use ^ at the start and $ at the end to ensure exact match.
-		headerPattern := regexp.MustCompile(`^([^=,]+)=([^=,]+)$`)
+		headerPattern := regexp.MustCompile(`^([^=,]+)=([^,]+)$`)
 		for _, header := range headers {
 			if !headerPattern.MatchString(header) {
 				return errors.New("beacon node headers must be comma separated values formatted as header=value")
@@ -49,7 +50,8 @@ func ParseBeaconNodeHeaders(headers []string) (map[string]string, error) {
 	}
 
 	for _, header := range headers {
-		pair := strings.Split(header, "=")
+		pair := strings.SplitN(header, "=", 2)
+		fmt.Println(pair)
 		parsedHeaders[pair[0]] = pair[1]
 	}
 

--- a/eth2util/helpers.go
+++ b/eth2util/helpers.go
@@ -22,7 +22,8 @@ import (
 func ValidateBeaconNodeHeaders(headers []string) error {
 	if len(headers) > 0 {
 		// The pattern ([^=,]+) captures any string that does not contain '=' or ','.
-		// The composition of patterns ([^=,]+)=([^=,]+) captures a pair of header and its corresponding value.
+		// The pattern ([^,]+) captures any string that does not contain ','.
+		// The composition of patterns ([^=,]+)=([^,]+) captures a pair of header and its corresponding value.
 		// We use ^ at the start and $ at the end to ensure exact match.
 		headerPattern := regexp.MustCompile(`^([^=,]+)=([^,]+)$`)
 		for _, header := range headers {

--- a/eth2util/helpers.go
+++ b/eth2util/helpers.go
@@ -5,7 +5,6 @@ package eth2util
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"regexp"
 	"strings"
 	"unicode"
@@ -51,7 +50,6 @@ func ParseBeaconNodeHeaders(headers []string) (map[string]string, error) {
 
 	for _, header := range headers {
 		pair := strings.SplitN(header, "=", 2)
-		fmt.Println(pair)
 		parsedHeaders[pair[0]] = pair[1]
 	}
 

--- a/eth2util/helpers_test.go
+++ b/eth2util/helpers_test.go
@@ -129,6 +129,11 @@ func TestValidateBeaconNodeHeaders(t *testing.T) {
 			headers: []string{",,"},
 			valid:   false,
 		},
+		{
+			name:    "value contains equal sign",
+			headers: []string{"header=Authorization: Basic bmljZXRyeQ=="},
+			valid:   true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -163,6 +168,11 @@ func TestParseBeaconNodeHeaders(t *testing.T) {
 			name:    "two pairs",
 			headers: []string{"header-1=value-1", "header-2=value-2"},
 			want:    map[string]string{"header-1": "value-1", "header-2": "value-2"},
+		},
+		{
+			name:    "value contains equal sign",
+			headers: []string{"header=Authorization: Basic bmljZXRyeQ=="},
+			want:    map[string]string{"header": "Authorization: Basic bmljZXRyeQ=="},
 		},
 	}
 

--- a/eth2util/helpers_test.go
+++ b/eth2util/helpers_test.go
@@ -131,7 +131,7 @@ func TestValidateBeaconNodeHeaders(t *testing.T) {
 		},
 		{
 			name:    "value contains equal sign",
-			headers: []string{"header=Authorization: Basic bmljZXRyeQ=="},
+			headers: []string{"Authorization=Basic bmljZXRyeQ=="},
 			valid:   true,
 		},
 	}
@@ -171,8 +171,8 @@ func TestParseBeaconNodeHeaders(t *testing.T) {
 		},
 		{
 			name:    "value contains equal sign",
-			headers: []string{"header=Authorization: Basic bmljZXRyeQ=="},
-			want:    map[string]string{"header": "Authorization: Basic bmljZXRyeQ=="},
+			headers: []string{"Authorization=Basic bmljZXRyeQ=="},
+			want:    map[string]string{"Authorization": "Basic bmljZXRyeQ=="},
 		},
 	}
 


### PR DESCRIPTION
Beacon node headers parsing would fail to parse a value containing equal sign, for example `Authorization=Basic bmljZXRyeQ==`.
Fixed validation and parsing logic to accept values with equal signs.

category: bug
ticket: none
