### PR TITLE
ci: update golangci-lint name rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -94,7 +94,7 @@ linters-settings:
         arguments:
          - 'fmt.Printf'
          - 'fmt.Println'
-      - name: imports-blacklist
+      - name: imports-blocklist
         arguments:
          - "errors" # Prefer ./app/errors
          - "github.com/pkg/errors" # Prefer ./app/errors

--- a/app/errors/errors.go
+++ b/app/errors/errors.go
@@ -5,7 +5,7 @@
 package errors
 
 import (
-	stderrors "errors"
+	stderrors "errors" //nolint:revive // Allow import of stdlib errors package.
 	"fmt"
 
 	"go.uber.org/zap"

--- a/app/errors/go113.go
+++ b/app/errors/go113.go
@@ -4,7 +4,7 @@
 package errors
 
 import (
-	stderrors "errors"
+	stderrors "errors" //nolint:revive // Allow import of stdlib errors package.
 )
 
 // This file was copied from github.com/pkg/errors/go113.go. It ensures this package is compatible


### PR DESCRIPTION
Update golangci-lint name rule from `imports-blacklist` to `imports-blocklist` following the change from [this](https://github.com/mgechev/revive/pull/969) PR.

category: misc
ticket: none
