### PR TITLE
*: support v1 endpoints on electra

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -50,6 +50,8 @@ var (
 	_ Client = (*httpAdapter)(nil)
 	_ Client = multi{}
 	_ Client = (*lazy)(nil)
+
+	ErrEndpointNotFound = errors.New("Endpoint not found")
 )
 
 // Instrument returns a new multi instrumented client using the provided clients as backends

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -51,7 +51,7 @@ var (
 	_ Client = multi{}
 	_ Client = (*lazy)(nil)
 
-	ErrEndpointNotFound = errors.New("Endpoint not found")
+	ErrEndpointNotFound = errors.New("endpoint not found")
 )
 
 // Instrument returns a new multi instrumented client using the provided clients as backends

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -130,13 +130,13 @@ func (m multi) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 	return res0, err
 }
 
-// AggregateAttestation fetches the aggregate attestation for the given options.
-func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+// AggregateAttestation fetches the aggregate attestation for the given options to v1 beacon node endpoint.
+func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*phase0.Attestation], error) {
 	const label = "aggregate_attestation"
 	defer latency(ctx, label, false)()
 
 	res0, err := provide(ctx, m.clients, m.fallbacks,
-		func(ctx context.Context, args provideArgs) (*api.Response[*spec.VersionedAttestation], error) {
+		func(ctx context.Context, args provideArgs) (*api.Response[*phase0.Attestation], error) {
 			return args.client.AggregateAttestation(ctx, opts)
 		},
 		isAggregateAttestationOk, m.selector,
@@ -150,14 +150,54 @@ func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 	return res0, err
 }
 
-// SubmitAggregateAttestations submits aggregate attestations.
-func (m multi) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
+// AggregateAttestationV2 fetches the aggregate attestation for the given options to v2 beacon node endpoint.
+func (m multi) AggregateAttestationV2(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+	const label = "aggregate_attestation_v2"
+	defer latency(ctx, label, false)()
+
+	res0, err := provide(ctx, m.clients, m.fallbacks,
+		func(ctx context.Context, args provideArgs) (*api.Response[*spec.VersionedAttestation], error) {
+			return args.client.AggregateAttestationV2(ctx, opts)
+		},
+		isAggregateAttestationOkV2, m.selector,
+	)
+
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return res0, err
+}
+
+// SubmitAggregateAttestations submits aggregate attestations to v1 beacon node endpoint.
+func (m multi) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) error {
 	const label = "submit_aggregate_attestations"
 	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) error {
-			return args.client.SubmitAggregateAttestations(ctx, opts)
+			return args.client.SubmitAggregateAttestations(ctx, aggregateAndProofs)
+		},
+		m.selector,
+	)
+
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return err
+}
+
+// SubmitAggregateAttestationsV2 submits aggregate attestations to v2 beacon node endpoint..
+func (m multi) SubmitAggregateAttestationsV2(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
+	const label = "submit_aggregate_attestations_v2"
+	defer latency(ctx, label, false)()
+
+	err := submit(ctx, m.clients, m.fallbacks,
+		func(ctx context.Context, args provideArgs) error {
+			return args.client.SubmitAggregateAttestationsV2(ctx, opts)
 		},
 		m.selector,
 	)
@@ -190,14 +230,34 @@ func (m multi) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 	return res0, err
 }
 
-// SubmitAttestations submits attestations.
-func (m multi) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
+// SubmitAttestations submits attestations on v1 BN endpoint.
+func (m multi) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) error {
 	const label = "submit_attestations"
 	defer latency(ctx, label, false)()
 
 	err := submit(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) error {
-			return args.client.SubmitAttestations(ctx, opts)
+			return args.client.SubmitAttestations(ctx, attestations)
+		},
+		m.selector,
+	)
+
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return err
+}
+
+// SubmitAttestationsV2 submits attestations on v2 BN endpoint.
+func (m multi) SubmitAttestationsV2(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
+	const label = "submit_attestations_v2"
+	defer latency(ctx, label, false)()
+
+	err := submit(ctx, m.clients, m.fallbacks,
+		func(ctx context.Context, args provideArgs) error {
+			return args.client.SubmitAttestationsV2(ctx, opts)
 		},
 		m.selector,
 	)
@@ -769,8 +829,8 @@ func (l *lazy) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 	return cl.SignedBeaconBlock(ctx, opts)
 }
 
-// AggregateAttestation fetches the aggregate attestation for the given options.
-func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (res0 *api.Response[*spec.VersionedAttestation], err error) {
+// AggregateAttestation fetches the aggregate attestation for the given options to v1 beacon node endpoint.
+func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (res0 *api.Response[*phase0.Attestation], err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
 		return res0, err
@@ -779,14 +839,34 @@ func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 	return cl.AggregateAttestation(ctx, opts)
 }
 
-// SubmitAggregateAttestations submits aggregate attestations.
-func (l *lazy) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) (err error) {
+// AggregateAttestationV2 fetches the aggregate attestation for the given options to v2 beacon node endpoint.
+func (l *lazy) AggregateAttestationV2(ctx context.Context, opts *api.AggregateAttestationOpts) (res0 *api.Response[*spec.VersionedAttestation], err error) {
+	cl, err := l.getOrCreateClient(ctx)
+	if err != nil {
+		return res0, err
+	}
+
+	return cl.AggregateAttestationV2(ctx, opts)
+}
+
+// SubmitAggregateAttestations submits aggregate attestations to v1 beacon node endpoint.
+func (l *lazy) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) (err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	return cl.SubmitAggregateAttestations(ctx, opts)
+	return cl.SubmitAggregateAttestations(ctx, aggregateAndProofs)
+}
+
+// SubmitAggregateAttestationsV2 submits aggregate attestations to v2 beacon node endpoint..
+func (l *lazy) SubmitAggregateAttestationsV2(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) (err error) {
+	cl, err := l.getOrCreateClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitAggregateAttestationsV2(ctx, opts)
 }
 
 // AttestationData fetches the attestation data for the given options.
@@ -799,14 +879,24 @@ func (l *lazy) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 	return cl.AttestationData(ctx, opts)
 }
 
-// SubmitAttestations submits attestations.
-func (l *lazy) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) (err error) {
+// SubmitAttestations submits attestations on v1 BN endpoint.
+func (l *lazy) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) (err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
 		return err
 	}
 
-	return cl.SubmitAttestations(ctx, opts)
+	return cl.SubmitAttestations(ctx, attestations)
+}
+
+// SubmitAttestationsV2 submits attestations on v2 BN endpoint.
+func (l *lazy) SubmitAttestationsV2(ctx context.Context, opts *api.SubmitAttestationsOpts) (err error) {
+	cl, err := l.getOrCreateClient(ctx)
+	if err != nil {
+		return err
+	}
+
+	return cl.SubmitAttestationsV2(ctx, opts)
 }
 
 // AttesterDuties obtains attester duties.

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -146,8 +146,9 @@ type Client interface {
 
 	// successFuncs indicates which endpoints have custom success functions.
 	successFuncs = map[string]string{
-		"NodeSyncing":          "isSyncStateOk",
-		"AggregateAttestation": "isAggregateAttestationOk",
+		"NodeSyncing":            "isSyncStateOk",
+		"AggregateAttestation":   "isAggregateAttestationOk",
+		"AggregateAttestationV2": "isAggregateAttestationOkV2",
 	}
 
 	skipImport = map[string]bool{

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -233,9 +233,9 @@ func (h *httpAdapter) BlockAttestationsV2(ctx context.Context, stateID string) (
 		}
 		if strings.Contains(string(respBody), "Block not found") {
 			return nil, nil // No block for slot, so no attestations.
-		} else {
-			return nil, errors.Wrap(err, ErrEndpointNotFound.Error(), z.Int("status", resp.StatusCode))
 		}
+
+		return nil, errors.Wrap(err, ErrEndpointNotFound.Error(), z.Int("status", resp.StatusCode))
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("request block attestations failed", z.Int("status", resp.StatusCode))
 	}

--- a/app/eth2wrap/mocks/client.go
+++ b/app/eth2wrap/mocks/client.go
@@ -81,11 +81,41 @@ func (_m *Client) Address() string {
 }
 
 // AggregateAttestation provides a mock function with given fields: ctx, opts
-func (_m *Client) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+func (_m *Client) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*phase0.Attestation], error) {
 	ret := _m.Called(ctx, opts)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AggregateAttestation")
+	}
+
+	var r0 *api.Response[*phase0.Attestation]
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *api.AggregateAttestationOpts) (*api.Response[*phase0.Attestation], error)); ok {
+		return rf(ctx, opts)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, *api.AggregateAttestationOpts) *api.Response[*phase0.Attestation]); ok {
+		r0 = rf(ctx, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*api.Response[*phase0.Attestation])
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, *api.AggregateAttestationOpts) error); ok {
+		r1 = rf(ctx, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// AggregateAttestationV2 provides a mock function with given fields: ctx, opts
+func (_m *Client) AggregateAttestationV2(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
+	ret := _m.Called(ctx, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AggregateAttestationV2")
 	}
 
 	var r0 *api.Response[*spec.VersionedAttestation]
@@ -948,11 +978,29 @@ func (_m *Client) Spec(ctx context.Context, opts *api.SpecOpts) (*api.Response[m
 }
 
 // SubmitAggregateAttestations provides a mock function with given fields: ctx, aggregateAndProofs
-func (_m *Client) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs *api.SubmitAggregateAttestationsOpts) error {
+func (_m *Client) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*phase0.SignedAggregateAndProof) error {
 	ret := _m.Called(ctx, aggregateAndProofs)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SubmitAggregateAttestations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*phase0.SignedAggregateAndProof) error); ok {
+		r0 = rf(ctx, aggregateAndProofs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SubmitAggregateAttestationsV2 provides a mock function with given fields: ctx, aggregateAndProofs
+func (_m *Client) SubmitAggregateAttestationsV2(ctx context.Context, aggregateAndProofs *api.SubmitAggregateAttestationsOpts) error {
+	ret := _m.Called(ctx, aggregateAndProofs)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SubmitAggregateAttestationsV2")
 	}
 
 	var r0 error
@@ -966,11 +1014,29 @@ func (_m *Client) SubmitAggregateAttestations(ctx context.Context, aggregateAndP
 }
 
 // SubmitAttestations provides a mock function with given fields: ctx, attestations
-func (_m *Client) SubmitAttestations(ctx context.Context, attestations *api.SubmitAttestationsOpts) error {
+func (_m *Client) SubmitAttestations(ctx context.Context, attestations []*phase0.Attestation) error {
 	ret := _m.Called(ctx, attestations)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SubmitAttestations")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*phase0.Attestation) error); ok {
+		r0 = rf(ctx, attestations)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SubmitAttestationsV2 provides a mock function with given fields: ctx, attestations
+func (_m *Client) SubmitAttestationsV2(ctx context.Context, attestations *api.SubmitAttestationsOpts) error {
+	ret := _m.Called(ctx, attestations)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SubmitAttestationsV2")
 	}
 
 	var r0 error

--- a/app/eth2wrap/success.go
+++ b/app/eth2wrap/success.go
@@ -6,6 +6,7 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 )
 
 // isSyncStateOk returns true if the sync state is not syncing.
@@ -14,6 +15,11 @@ func isSyncStateOk(resp *eth2api.Response[*eth2v1.SyncState]) bool {
 }
 
 // isAggregateAttestationOk returns true if the aggregate attestation is not nil (which can happen if the subscription wasn't successful).
-func isAggregateAttestationOk(resp *eth2api.Response[*eth2spec.VersionedAttestation]) bool {
+func isAggregateAttestationOk(resp *eth2api.Response[*eth2p0.Attestation]) bool {
+	return resp.Data != nil
+}
+
+// isAggregateAttestationOkV2 returns true if the aggregate attestation is not nil (which can happen if the subscription wasn't successful).
+func isAggregateAttestationOkV2(resp *eth2api.Response[*eth2spec.VersionedAttestation]) bool {
 	return resp.Data != nil
 }

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -90,6 +90,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 				)
 			}
 		}
+
 		return err
 
 	case core.DutyProposer:

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -54,7 +54,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 			return err
 		}
 
-		err = b.eth2Cl.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
+		err = b.eth2Cl.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
 		if err != nil && strings.Contains(err.Error(), "PriorAttestationKnown") {
 			// Lighthouse isn't idempotent, so just swallow this non-issue.
 			// See reference github.com/attestantio/go-eth2-client@v0.11.7/multi/submitattestations.go:38
@@ -167,7 +167,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 			return err
 		}
 
-		err = b.eth2Cl.SubmitAggregateAttestations(ctx, aggAndProofs)
+		err = b.eth2Cl.SubmitAggregateAttestationsV2(ctx, aggAndProofs)
 		if err == nil {
 			log.Info(ctx, "Successfully submitted attestation aggregations to beacon node",
 				z.Any("delay", b.delayFunc(duty.Slot)))

--- a/core/bcast/bcast_test.go
+++ b/core/bcast/bcast_test.go
@@ -102,7 +102,7 @@ func attData(t *testing.T, mock *beaconmock.Mock) test {
 	asserted := make(chan struct{})
 
 	var submitted int
-	mock.SubmitAttestationsFunc = func(ctx context.Context, attestations *eth2api.SubmitAttestationsOpts) error {
+	mock.SubmitAttestationsV2Func = func(ctx context.Context, attestations *eth2api.SubmitAttestationsOpts) error {
 		require.Len(t, attestations.Attestations, 1)
 		require.Equal(t, aggData.VersionedAttestation, *attestations.Attestations[0])
 
@@ -242,7 +242,7 @@ func aggregateAttestationData(t *testing.T, mock *beaconmock.Mock) test {
 		VersionedSignedAggregateAndProof: *aggAndProof,
 	}
 
-	mock.SubmitAggregateAttestationsFunc = func(ctx context.Context, aggregateAndProofs *eth2api.SubmitAggregateAttestationsOpts) error {
+	mock.SubmitAggregateAttestationsV2Func = func(ctx context.Context, aggregateAndProofs *eth2api.SubmitAggregateAttestationsOpts) error {
 		require.Equal(t, aggAndProof, aggregateAndProofs.SignedAggregateAndProofs[0])
 		close(asserted)
 

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -17,8 +17,9 @@ import (
 )
 
 const (
-	attV1 = iota + 1
-	attV2 = iota + 1
+	_ = iota
+	attV1
+	attV2
 )
 
 // NewMemDB returns a new in-memory dutyDB instance.

--- a/core/dutydb/memory_internal_test.go
+++ b/core/dutydb/memory_internal_test.go
@@ -24,7 +24,7 @@ func TestCancelledQueries(t *testing.T) {
 	_, err := db.AwaitAttestation(ctx, slot, 0)
 	require.ErrorContains(t, err, "shutdown")
 
-	_, err = db.AwaitAggAttestation(ctx, slot, eth2p0.Root{})
+	_, err = db.AwaitAggAttestationV2(ctx, slot, eth2p0.Root{})
 	require.ErrorContains(t, err, "shutdown")
 
 	_, err = db.AwaitProposal(ctx, slot)
@@ -37,10 +37,10 @@ func TestCancelledQueries(t *testing.T) {
 	require.NotEmpty(t, db.contribQueries)
 	require.NotEmpty(t, db.attQueries)
 	require.NotEmpty(t, db.proQueries)
-	require.NotEmpty(t, db.aggQueries)
+	require.NotEmpty(t, db.aggQueriesV2)
 
 	// Resolve queries
-	db.resolveAggQueriesUnsafe()
+	db.resolveAggQueriesV2Unsafe()
 	db.resolveAttQueriesUnsafe()
 	db.resolveContribQueriesUnsafe()
 	db.resolveProQueriesUnsafe()
@@ -49,7 +49,7 @@ func TestCancelledQueries(t *testing.T) {
 	require.Empty(t, db.contribQueries)
 	require.Empty(t, db.attQueries)
 	require.Empty(t, db.proQueries)
-	require.Empty(t, db.aggQueries)
+	require.Empty(t, db.aggQueriesV2)
 }
 
 type noopDeadliner struct{}

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -224,15 +224,11 @@ func TestMemDBAggregator(t *testing.T) {
 	const queries = 3
 
 	for range queries {
-		att := testutil.RandomDenebVersionedAttestation()
-		aggAttest, err := core.NewVersionedAggregatedAttestation(att)
-		require.NoError(t, err)
+		agg := testutil.RandomPhase0Attestation()
 		set := core.UnsignedDataSet{
-			testutil.RandomCorePubKey(t): aggAttest,
+			testutil.RandomCorePubKey(t): core.NewAggregatedAttestation(agg),
 		}
-		attData, err := att.Data()
-		require.NoError(t, err)
-		slot := uint64(attData.Slot)
+		slot := uint64(agg.Data.Slot)
 
 		errCh := make(chan error, 1)
 		go func() {
@@ -240,13 +236,13 @@ func TestMemDBAggregator(t *testing.T) {
 			errCh <- err
 		}()
 
-		root, err := attData.HashTreeRoot()
+		root, err := agg.Data.HashTreeRoot()
 		require.NoError(t, err)
 		err = <-errCh
 		require.NoError(t, err)
 		resp, err := db.AwaitAggAttestation(ctx, slot, root)
 		require.NoError(t, err)
-		require.Equal(t, att, resp)
+		require.Equal(t, agg, resp)
 	}
 }
 

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -440,7 +440,7 @@ func TestDutyExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Ensure it exists
-	pk, err := db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), uint64(att1.Duty.ValidatorIndex))
+	pk, err := db.PubKeyByAttestationV2(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), uint64(att1.Duty.ValidatorIndex))
 	require.NoError(t, err)
 	require.NotEmpty(t, pk)
 
@@ -456,7 +456,7 @@ func TestDutyExpiry(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pubkey not found.
-	_, err = db.PubKeyByAttestation(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), uint64(att1.Duty.ValidatorIndex))
+	_, err = db.PubKeyByAttestationV2(ctx, uint64(att1.Data.Slot), uint64(att1.Duty.CommitteeIndex), uint64(att1.Duty.ValidatorIndex))
 	require.Error(t, err)
 }
 

--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -22,6 +22,7 @@ var (
 	_ Eth2SignedData = VersionedSignedValidatorRegistration{}
 	_ Eth2SignedData = SignedRandao{}
 	_ Eth2SignedData = BeaconCommitteeSelection{}
+	_ Eth2SignedData = SignedAggregateAndProof{}
 	_ Eth2SignedData = VersionedSignedAggregateAndProof{}
 	_ Eth2SignedData = SignedSyncMessage{}
 	_ Eth2SignedData = SignedSyncContributionAndProof{}
@@ -122,6 +123,16 @@ func (BeaconCommitteeSelection) DomainName() signing.DomainName {
 
 func (s BeaconCommitteeSelection) Epoch(ctx context.Context, eth2Cl eth2wrap.Client) (eth2p0.Epoch, error) {
 	return eth2util.EpochFromSlot(ctx, eth2Cl, s.Slot)
+}
+
+// Implement Eth2SignedData for SignedAggregateAndProof.
+
+func (SignedAggregateAndProof) DomainName() signing.DomainName {
+	return signing.DomainAggregateAndProof
+}
+
+func (s SignedAggregateAndProof) Epoch(ctx context.Context, eth2Cl eth2wrap.Client) (eth2p0.Epoch, error) {
+	return eth2util.EpochFromSlot(ctx, eth2Cl, s.Message.Aggregate.Data.Slot)
 }
 
 // Implement Eth2SignedData for SignedAggregateAndProof.

--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	_ Eth2SignedData = VersionedSignedProposal{}
+	_ Eth2SignedData = Attestation{}
 	_ Eth2SignedData = VersionedAttestation{}
 	_ Eth2SignedData = SignedVoluntaryExit{}
 	_ Eth2SignedData = VersionedSignedValidatorRegistration{}
@@ -58,6 +59,16 @@ func (p VersionedSignedProposal) Epoch(ctx context.Context, eth2Cl eth2wrap.Clie
 }
 
 // Implement Eth2SignedData for Attestation.
+
+func (Attestation) DomainName() signing.DomainName {
+	return signing.DomainBeaconAttester
+}
+
+func (a Attestation) Epoch(_ context.Context, _ eth2wrap.Client) (eth2p0.Epoch, error) {
+	return a.Attestation.Data.Target.Epoch, nil
+}
+
+// Implement Eth2SignedData for VersionedAttestation.
 
 func (VersionedAttestation) DomainName() signing.DomainName {
 	return signing.DomainBeaconAttester

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -67,9 +67,12 @@ func (f *Fetcher) Fetch(ctx context.Context, duty core.Duty, defSet core.DutyDef
 	case core.DutyBuilderProposer:
 		return core.ErrDeprecatedDutyBuilderProposer
 	case core.DutyAggregator:
-		unsignedSet, err = f.fetchAggregatorData(ctx, duty.Slot, defSet)
+		unsignedSet, err = f.fetchAggregatorDataV2(ctx, duty.Slot, defSet)
 		if err != nil {
-			return errors.Wrap(err, "fetch aggregator data")
+			unsignedSet, err = f.fetchAggregatorData(ctx, duty.Slot, defSet)
+			if err != nil {
+				return errors.Wrap(err, "fetch aggregator data")
+			}
 		} else if len(unsignedSet) == 0 { // No aggregators found in this slot
 			return nil
 		}
@@ -157,6 +160,86 @@ func (f *Fetcher) fetchAttesterData(ctx context.Context, slot uint64, defSet cor
 // fetchAggregatorData fetches the attestation aggregation data.
 func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot uint64, defSet core.DutyDefinitionSet) (core.UnsignedDataSet, error) {
 	// We may have multiple aggregators in the same committee, use the same aggregated attestation in that case.
+	aggAttByCommIdx := make(map[eth2p0.CommitteeIndex]*eth2p0.Attestation)
+
+	resp := make(core.UnsignedDataSet)
+	for pubkey, dutyDef := range defSet {
+		attDef, ok := dutyDef.(core.AttesterDefinition)
+		if !ok {
+			return core.UnsignedDataSet{}, errors.New("invalid attester definition")
+		}
+
+		// Query AggSigDB for DutyPrepareAggregator to get beacon committee selections.
+		prepAggData, err := f.aggSigDBFunc(ctx, core.NewPrepareAggregatorDuty(slot), pubkey)
+		if err != nil {
+			return core.UnsignedDataSet{}, err
+		}
+
+		selection, ok := prepAggData.(core.BeaconCommitteeSelection)
+		if !ok {
+			return core.UnsignedDataSet{}, errors.New("invalid beacon committee selection")
+		}
+
+		ok, err = eth2exp.IsAttAggregator(ctx, f.eth2Cl, attDef.CommitteeLength, selection.SelectionProof)
+		if err != nil {
+			return core.UnsignedDataSet{}, err
+		} else if !ok {
+			log.Debug(ctx, "Attester not selected for aggregation duty", z.Any("pubkey", pubkey))
+			continue
+		}
+		log.Info(ctx, "Resolved attester aggregation duty", z.Any("pubkey", pubkey))
+
+		aggAtt, ok := aggAttByCommIdx[attDef.CommitteeIndex]
+		if ok {
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt,
+			}
+
+			// Skips querying aggregate attestation for aggregators of same committee.
+			continue
+		}
+
+		// Query DutyDB for Attestation data to get attestation data root.
+		attData, err := f.awaitAttDataFunc(ctx, slot, uint64(attDef.CommitteeIndex))
+		if err != nil {
+			return core.UnsignedDataSet{}, err
+		}
+
+		dataRoot, err := attData.HashTreeRoot()
+		if err != nil {
+			return core.UnsignedDataSet{}, err
+		}
+
+		// Query BN for aggregate attestation.
+		opts := &eth2api.AggregateAttestationOpts{
+			Slot:                eth2p0.Slot(slot),
+			AttestationDataRoot: dataRoot,
+		}
+		eth2Resp, err := f.eth2Cl.AggregateAttestation(ctx, opts)
+		if err != nil {
+			return core.UnsignedDataSet{}, err
+		}
+
+		aggAtt = eth2Resp.Data
+		if aggAtt == nil {
+			// Some beacon nodes return nil if the root is not found, return retryable error.
+			// This could happen if the beacon node didn't subscribe to the correct subnet.
+			return core.UnsignedDataSet{}, errors.New("aggregate attestation not found by root (retryable)", z.Hex("root", dataRoot[:]))
+		}
+
+		aggAttByCommIdx[attDef.CommitteeIndex] = aggAtt
+
+		resp[pubkey] = core.AggregatedAttestation{
+			Attestation: *aggAtt,
+		}
+	}
+
+	return resp, nil
+}
+
+// fetchAggregatorDataV2 fetches the attestation aggregation data.
+func (f *Fetcher) fetchAggregatorDataV2(ctx context.Context, slot uint64, defSet core.DutyDefinitionSet) (core.UnsignedDataSet, error) {
+	// We may have multiple aggregators in the same committee, use the same aggregated attestation in that case.
 	aggAttByCommIdx := make(map[eth2p0.CommitteeIndex]*eth2spec.VersionedAttestation)
 
 	resp := make(core.UnsignedDataSet)
@@ -188,8 +271,35 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot uint64, defSet c
 
 		aggAtt, ok := aggAttByCommIdx[attDef.CommitteeIndex]
 		if ok {
-			resp[pubkey] = core.VersionedAggregatedAttestation{
-				VersionedAttestation: *aggAtt,
+			switch aggAtt.Version {
+			case eth2spec.DataVersionPhase0:
+				resp[pubkey] = core.AggregatedAttestation{
+					Attestation: *aggAtt.Phase0,
+				}
+			case eth2spec.DataVersionAltair:
+				resp[pubkey] = core.AggregatedAttestation{
+					Attestation: *aggAtt.Altair,
+				}
+			case eth2spec.DataVersionBellatrix:
+				resp[pubkey] = core.AggregatedAttestation{
+					Attestation: *aggAtt.Bellatrix,
+				}
+			case eth2spec.DataVersionCapella:
+				resp[pubkey] = core.AggregatedAttestation{
+					Attestation: *aggAtt.Capella,
+				}
+			case eth2spec.DataVersionDeneb:
+				resp[pubkey] = core.AggregatedAttestation{
+					Attestation: *aggAtt.Deneb,
+				}
+			case eth2spec.DataVersionElectra:
+				resp[pubkey] = core.VersionedAggregatedAttestation{
+					VersionedAttestation: *aggAtt,
+				}
+			default:
+				resp[pubkey] = core.VersionedAggregatedAttestation{
+					VersionedAttestation: *aggAtt,
+				}
 			}
 
 			// Skips querying aggregate attestation for aggregators of same committee.
@@ -227,8 +337,35 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot uint64, defSet c
 
 		aggAttByCommIdx[attDef.CommitteeIndex] = aggAtt
 
-		resp[pubkey] = core.VersionedAggregatedAttestation{
-			VersionedAttestation: *aggAtt,
+		switch eth2Resp.Data.Version {
+		case eth2spec.DataVersionPhase0:
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt.Phase0,
+			}
+		case eth2spec.DataVersionAltair:
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt.Altair,
+			}
+		case eth2spec.DataVersionBellatrix:
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt.Bellatrix,
+			}
+		case eth2spec.DataVersionCapella:
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt.Capella,
+			}
+		case eth2spec.DataVersionDeneb:
+			resp[pubkey] = core.AggregatedAttestation{
+				Attestation: *aggAtt.Deneb,
+			}
+		case eth2spec.DataVersionElectra:
+			resp[pubkey] = core.VersionedAggregatedAttestation{
+				VersionedAttestation: *aggAtt,
+			}
+		default:
+			resp[pubkey] = core.VersionedAggregatedAttestation{
+				VersionedAttestation: *aggAtt,
+			}
 		}
 	}
 

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -213,7 +213,7 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot uint64, defSet c
 			AttestationDataRoot: dataRoot,
 			CommitteeIndex:      attDef.CommitteeIndex,
 		}
-		eth2Resp, err := f.eth2Cl.AggregateAttestation(ctx, opts)
+		eth2Resp, err := f.eth2Cl.AggregateAttestationV2(ctx, opts)
 		if err != nil {
 			return core.UnsignedDataSet{}, err
 		}

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -144,7 +144,7 @@ func TestFetchAggregator(t *testing.T) {
 	require.NoError(t, err)
 
 	var aggAttCallCount int
-	bmock.AggregateAttestationFunc = func(ctx context.Context, slot eth2p0.Slot, root eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
+	bmock.AggregateAttestationV2Func = func(ctx context.Context, slot eth2p0.Slot, root eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
 		aggAttCallCount--
 		if nilAggregate {
 			return nil, nil //nolint:nilnil // This reproduces what go-eth2-client does

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -105,28 +105,24 @@ func TestFetchAggregator(t *testing.T) {
 		vIdxB: testutil.RandomCorePubKey(t),
 	}
 
-	attA := testutil.RandomDenebVersionedAttestation()
-	attB := testutil.RandomDenebVersionedAttestation()
-	attAData, err := attA.Data()
-	require.NoError(t, err)
-	attBData, err := attB.Data()
-	require.NoError(t, err)
-	attByCommIdx := map[uint64]*eth2spec.VersionedAttestation{
-		uint64(attAData.Index): attA,
-		uint64(attBData.Index): attB,
+	attA := testutil.RandomPhase0Attestation()
+	attB := testutil.RandomPhase0Attestation()
+	attByCommIdx := map[uint64]*eth2p0.Attestation{
+		uint64(attA.Data.Index): attA,
+		uint64(attB.Data.Index): attB,
 	}
 
 	newDefSet := func(commLength uint64, sameCommitteeIndex bool) core.DutyDefinitionSet {
 		dutyA := testutil.RandomAttestationDuty(t)
 		dutyA.CommitteeLength = commLength
-		dutyA.CommitteeIndex = attAData.Index
+		dutyA.CommitteeIndex = attA.Data.Index
 		dutyB := testutil.RandomAttestationDuty(t)
 		dutyB.CommitteeLength = commLength
-		dutyB.CommitteeIndex = attBData.Index
+		dutyB.CommitteeIndex = attB.Data.Index
 
 		if sameCommitteeIndex {
-			dutyB.CommitteeIndex = attAData.Index
-			attBData.Index = attAData.Index
+			dutyB.CommitteeIndex = attA.Data.Index
+			attB.Data.Index = attA.Data.Index
 		}
 
 		return map[core.PubKey]core.DutyDefinition{
@@ -144,15 +140,13 @@ func TestFetchAggregator(t *testing.T) {
 	require.NoError(t, err)
 
 	var aggAttCallCount int
-	bmock.AggregateAttestationV2Func = func(ctx context.Context, slot eth2p0.Slot, root eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
+	bmock.AggregateAttestationFunc = func(ctx context.Context, slot eth2p0.Slot, root eth2p0.Root) (*eth2p0.Attestation, error) {
 		aggAttCallCount--
 		if nilAggregate {
 			return nil, nil //nolint:nilnil // This reproduces what go-eth2-client does
 		}
 		for _, att := range attByCommIdx {
-			attData, err := att.Data()
-			require.NoError(t, err)
-			dataRoot, err := attData.HashTreeRoot()
+			dataRoot, err := att.Data.HashTreeRoot()
 			require.NoError(t, err)
 			if dataRoot == root {
 				return att, nil
@@ -170,7 +164,7 @@ func TestFetchAggregator(t *testing.T) {
 	})
 
 	fetch.RegisterAwaitAttData(func(ctx context.Context, slot uint64, commIdx uint64) (*eth2p0.AttestationData, error) {
-		return attByCommIdx[commIdx].Data()
+		return attByCommIdx[commIdx].Data, nil
 	})
 
 	done := errors.New("done")
@@ -179,14 +173,12 @@ func TestFetchAggregator(t *testing.T) {
 		require.Len(t, resDataSet, 2)
 
 		for _, aggAtt := range resDataSet {
-			aggregated, ok := aggAtt.(core.VersionedAggregatedAttestation)
+			aggregated, ok := aggAtt.(core.AggregatedAttestation)
 			require.True(t, ok)
 
-			aggregatedData, err := aggregated.VersionedAttestation.Data()
-			require.NoError(t, err)
-			att, ok := attByCommIdx[uint64(aggregatedData.Index)]
+			att, ok := attByCommIdx[uint64(aggregated.Attestation.Data.Index)]
 			require.True(t, ok)
-			require.Equal(t, aggregated.VersionedAttestation, *att)
+			require.Equal(t, aggregated.Attestation, *att)
 		}
 
 		return done

--- a/core/proto.go
+++ b/core/proto.go
@@ -113,11 +113,18 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSigned
 		}
 		signedData = s
 	case DutyAggregator:
-		var s VersionedSignedAggregateAndProof
-		if err := unmarshal(data.GetData(), &s); err != nil {
-			return ParSignedData{}, errors.Wrap(err, "unmarshal signed aggregate and proof")
+		var s SignedAggregateAndProof
+		err := unmarshal(data.GetData(), &s)
+		if err == nil {
+			signedData = s
+		} else {
+			var sv VersionedSignedAggregateAndProof
+			err = unmarshal(data.GetData(), &sv)
+			if err != nil {
+				return ParSignedData{}, errors.Wrap(err, "unmarshal signed aggregate and proof")
+			}
+			signedData = sv
 		}
-		signedData = s
 	case DutySyncMessage:
 		var s SignedSyncMessage
 		if err := unmarshal(data.GetData(), &s); err != nil {

--- a/core/proto.go
+++ b/core/proto.go
@@ -62,11 +62,18 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSigned
 	var signedData SignedData
 	switch typ {
 	case DutyAttester:
-		var a VersionedAttestation
-		if err := unmarshal(data.GetData(), &a); err != nil {
-			return ParSignedData{}, errors.Wrap(err, "unmarshal attestation")
+		var a Attestation
+		err := unmarshal(data.GetData(), &a)
+		if err == nil {
+			signedData = a
+		} else {
+			var av VersionedAttestation
+			err = unmarshal(data.GetData(), &av)
+			if err != nil {
+				return ParSignedData{}, errors.Wrap(err, "unmarshal attestation")
+			}
+			signedData = av
 		}
-		signedData = a
 	case DutyProposer:
 		var b VersionedSignedProposal
 		if err := unmarshal(data.GetData(), &b); err != nil {

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -39,6 +39,7 @@ var (
 	_ SignedData = VersionedSignedValidatorRegistration{}
 	_ SignedData = SignedRandao{}
 	_ SignedData = BeaconCommitteeSelection{}
+	_ SignedData = SignedAggregateAndProof{}
 	_ SignedData = VersionedSignedAggregateAndProof{}
 	_ SignedData = SignedSyncMessage{}
 	_ SignedData = SyncContributionAndProof{}
@@ -49,6 +50,7 @@ var (
 	_ ssz.Marshaler   = VersionedSignedProposal{}
 	_ ssz.Marshaler   = Attestation{}
 	_ ssz.Marshaler   = VersionedAttestation{}
+	_ ssz.Marshaler   = SignedAggregateAndProof{}
 	_ ssz.Marshaler   = VersionedSignedAggregateAndProof{}
 	_ ssz.Marshaler   = SignedSyncMessage{}
 	_ ssz.Marshaler   = SyncContributionAndProof{}
@@ -56,6 +58,7 @@ var (
 	_ ssz.Unmarshaler = new(VersionedSignedProposal)
 	_ ssz.Unmarshaler = new(Attestation)
 	_ ssz.Unmarshaler = new(VersionedAttestation)
+	_ ssz.Unmarshaler = new(SignedAggregateAndProof)
 	_ ssz.Unmarshaler = new(VersionedSignedAggregateAndProof)
 	_ ssz.Unmarshaler = new(SignedSyncMessage)
 	_ ssz.Unmarshaler = new(SyncContributionAndProof)

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -90,6 +90,12 @@ func WithTracing() WireOption {
 
 			return clone.DutyDBPubKeyByAttestation(ctx, slot, commIdx, valCommIdx)
 		}
+		w.DutyDBPubKeyByAttestationV2 = func(parent context.Context, slot, commIdx, valCommIdx uint64) (PubKey, error) {
+			ctx, span := tracer.Start(parent, "core/dutydb.PubKeyByAttestationV2")
+			defer span.End()
+
+			return clone.DutyDBPubKeyByAttestationV2(ctx, slot, commIdx, valCommIdx)
+		}
 		w.ParSigDBStoreInternal = func(parent context.Context, duty Duty, set ParSignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/parsigdb.StoreInternal")
 			defer span.End()

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -239,22 +239,14 @@ func TestInclusion(t *testing.T) {
 	}
 
 	// Create some duties
-	att1 := testutil.RandomDenebVersionedAttestation()
-	att1.Deneb.Data.Index = 0
-	att1Data, err := att1.Data()
-	require.NoError(t, err)
-	att1Duty := core.NewAttesterDuty(uint64(att1Data.Slot))
+	att1 := testutil.RandomPhase0Attestation()
+	att1Duty := core.NewAttesterDuty(uint64(att1.Data.Slot))
 
-	agg2 := testutil.RandomDenebVersionedSignedAggregateAndProof()
-	slot, err := agg2.Slot()
-	require.NoError(t, err)
-	agg2Duty := core.NewAggregatorDuty(uint64(slot))
+	agg2 := testutil.RandomSignedAggregateAndProof()
+	agg2Duty := core.NewAggregatorDuty(uint64(agg2.Message.Aggregate.Data.Slot))
 
-	att3 := testutil.RandomDenebVersionedAttestation()
-	att3.Deneb.Data.Index = 1
-	att3Data, err := att3.Data()
-	require.NoError(t, err)
-	att3Duty := core.NewAttesterDuty(uint64(att3Data.Slot))
+	att3 := testutil.RandomPhase0Attestation()
+	att3Duty := core.NewAttesterDuty(uint64(att3.Data.Slot))
 
 	block4 := testutil.RandomDenebVersionedSignedProposal()
 	block4Duty := core.NewProposerDuty(uint64(block4.Deneb.SignedBlock.Message.Slot))
@@ -267,15 +259,11 @@ func TestInclusion(t *testing.T) {
 	}
 
 	// Submit all duties
-	incl1, err := core.NewVersionedAttestation(att1)
+	err := incl.Submitted(att1Duty, "", core.NewAttestation(att1), 0)
 	require.NoError(t, err)
-	err = incl.Submitted(att1Duty, "", incl1, 0)
+	err = incl.Submitted(agg2Duty, "", core.NewSignedAggregateAndProof(agg2), 0)
 	require.NoError(t, err)
-	err = incl.Submitted(agg2Duty, "", core.NewVersionedSignedAggregateAndProof(agg2), 0)
-	require.NoError(t, err)
-	incl3, err := core.NewVersionedAttestation(att3)
-	require.NoError(t, err)
-	err = incl.Submitted(att3Duty, "", incl3, 0)
+	err = incl.Submitted(att3Duty, "", core.NewAttestation(att3), 0)
 	require.NoError(t, err)
 
 	coreBlock4, err := core.NewVersionedSignedProposal(block4)
@@ -286,46 +274,24 @@ func TestInclusion(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a mock block with the 1st and 2nd attestations.
-	att1Root, err := att1.Deneb.Data.HashTreeRoot()
+	att1Root, err := att1.Data.HashTreeRoot()
 	require.NoError(t, err)
-	att2Root, err := agg2.Deneb.Message.Aggregate.Data.HashTreeRoot()
+	att2Root, err := agg2.Message.Aggregate.Data.HashTreeRoot()
 	require.NoError(t, err)
 	// Add some random aggregation bits to the attestation
-	addRandomBits(att1.Deneb.AggregationBits)
-	addRandomBits(agg2.Deneb.Message.Aggregate.AggregationBits)
+	addRandomBits(att1.AggregationBits)
+	addRandomBits(agg2.Message.Aggregate.AggregationBits)
 
-	att1CommIdx, err := att1.CommitteeIndex()
-	require.NoError(t, err)
-	att1AggBits, err := att1.AggregationBits()
-	require.NoError(t, err)
-
-	att3CommIdx, err := att3.CommitteeIndex()
-	require.NoError(t, err)
-	att3AggBits, err := att3.AggregationBits()
-	require.NoError(t, err)
-
-	block := blockV2{
+	block := block{
 		Slot: block4Duty.Slot,
-		AttestationsByDataRoot: map[eth2p0.Root]*eth2spec.VersionedAttestation{
+		AttestationsByDataRoot: map[eth2p0.Root]*eth2p0.Attestation{
 			att1Root: att1,
-			att2Root: {Version: eth2spec.DataVersionDeneb, Deneb: agg2.Deneb.Message.Aggregate},
-		},
-		BeaconCommitees: []*statecomm.StateCommittee{
-			{
-				Index:      att1CommIdx,
-				Slot:       att1Data.Slot,
-				Validators: []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex((att1AggBits.BitIndices()[0]))},
-			},
-			{
-				Index:      att3CommIdx,
-				Slot:       att3Data.Slot,
-				Validators: []eth2p0.ValidatorIndex{eth2p0.ValidatorIndex((att3AggBits.BitIndices()[0]))},
-			},
+			att2Root: agg2.Message.Aggregate,
 		},
 	}
 
 	// Check the block
-	incl.CheckBlockV2(context.Background(), block)
+	incl.CheckBlock(context.Background(), block)
 
 	// Assert that the 1st and 2nd duty was included
 	duties := []core.Duty{att1Duty, agg2Duty}

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -190,7 +190,7 @@ func TestDuplicateAttData(t *testing.T) {
 			require.NoError(t, err)
 
 			// Assert that the block to check contains all bitlists above.
-			incl.checkBlockFunc = func(ctx context.Context, block block) {
+			incl.checkBlockV2Func = func(ctx context.Context, block blockV2) {
 				require.Len(t, block.AttestationsByDataRoot, 1)
 				att, ok := block.AttestationsByDataRoot[attDataRoot]
 				require.True(t, ok)
@@ -304,7 +304,7 @@ func TestInclusion(t *testing.T) {
 	att3AggBits, err := att3.AggregationBits()
 	require.NoError(t, err)
 
-	block := block{
+	block := blockV2{
 		Slot: block4Duty.Slot,
 		AttestationsByDataRoot: map[eth2p0.Root]*eth2spec.VersionedAttestation{
 			att1Root: att1,
@@ -325,7 +325,7 @@ func TestInclusion(t *testing.T) {
 	}
 
 	// Check the block
-	incl.CheckBlock(context.Background(), block)
+	incl.CheckBlockV2(context.Background(), block)
 
 	// Assert that the 1st and 2nd duty was included
 	duties := []core.Duty{att1Duty, agg2Duty}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -128,7 +128,7 @@ func NewRouter(ctx context.Context, h Handler, eth2Cl eth2wrap.Client, builderEn
 		{
 			Name:    "submit_attestations_v2",
 			Path:    "/eth/v2/beacon/pool/attestations",
-			Handler: submitAttestations(h),
+			Handler: submitAttestationsV2(h),
 			Methods: []string{http.MethodPost},
 		},
 		{
@@ -218,13 +218,13 @@ func NewRouter(ctx context.Context, h Handler, eth2Cl eth2wrap.Client, builderEn
 		{
 			Name:    "aggregate_attestation",
 			Path:    "/eth/v2/validator/aggregate_attestation",
-			Handler: aggregateAttestation(h),
+			Handler: aggregateAttestationV2(h),
 			Methods: []string{http.MethodGet},
 		},
 		{
 			Name:    "submit_aggregate_and_proofs",
 			Path:    "/eth/v2/validator/aggregate_and_proofs",
-			Handler: submitAggregateAttestations(h),
+			Handler: submitAggregateAttestationsV2(h),
 			Methods: []string{http.MethodPost},
 		},
 		{
@@ -460,7 +460,7 @@ func attestationData(p eth2client.AttestationDataProvider) handlerFunc {
 }
 
 // submitAttestations returns a handler function for the attestation submitter endpoint.
-func submitAttestations(p eth2client.AttestationsSubmitter) handlerFunc {
+func submitAttestationsV2(p eth2client.AttestationsSubmitter) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
 		versionedAtts := []*eth2spec.VersionedAttestation{}
 
@@ -483,7 +483,7 @@ func submitAttestations(p eth2client.AttestationsSubmitter) handlerFunc {
 				versionedAtts = append(versionedAtts, &versionedAtt)
 			}
 
-			return nil, nil, p.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{Attestations: versionedAtts})
+			return nil, nil, p.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: versionedAtts})
 		}
 
 		denebAtts := new([]eth2p0.Attestation)
@@ -498,7 +498,7 @@ func submitAttestations(p eth2client.AttestationsSubmitter) handlerFunc {
 				versionedAtts = append(versionedAtts, &versionedAgg)
 			}
 
-			return nil, nil, p.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{
+			return nil, nil, p.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{
 				Attestations: versionedAtts,
 			})
 		}
@@ -1068,7 +1068,7 @@ func proposerConfig(p eth2exp.ProposerConfigProvider) handlerFunc {
 	}
 }
 
-func aggregateAttestation(p eth2client.AggregateAttestationProvider) handlerFunc {
+func aggregateAttestationV2(p eth2client.AggregateAttestationProvider) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, query url.Values, _ contentType, _ []byte) (any, http.Header, error) {
 		slot, err := uintQuery(query, "slot")
 		if err != nil {
@@ -1090,7 +1090,7 @@ func aggregateAttestation(p eth2client.AggregateAttestationProvider) handlerFunc
 			AttestationDataRoot: attDataRoot,
 			CommitteeIndex:      eth2p0.CommitteeIndex(committeeIndex),
 		}
-		eth2Resp, err := p.AggregateAttestation(ctx, opts)
+		eth2Resp, err := p.AggregateAttestationV2(ctx, opts)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -1156,7 +1156,7 @@ func createAggregateAttestation(aggAtt *eth2spec.VersionedAttestation) (*aggrega
 	return &res, nil
 }
 
-func submitAggregateAttestations(s eth2client.AggregateAttestationsSubmitter) handlerFunc {
+func submitAggregateAttestationsV2(s eth2client.AggregateAttestationsSubmitter) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
 		aggs := []*eth2spec.VersionedSignedAggregateAndProof{}
 
@@ -1171,7 +1171,7 @@ func submitAggregateAttestations(s eth2client.AggregateAttestationsSubmitter) ha
 				aggs = append(aggs, &versionedAgg)
 			}
 
-			return nil, nil, s.SubmitAggregateAttestations(ctx, &eth2api.SubmitAggregateAttestationsOpts{
+			return nil, nil, s.SubmitAggregateAttestationsV2(ctx, &eth2api.SubmitAggregateAttestationsOpts{
 				SignedAggregateAndProofs: aggs,
 			})
 		}
@@ -1188,7 +1188,7 @@ func submitAggregateAttestations(s eth2client.AggregateAttestationsSubmitter) ha
 				aggs = append(aggs, &versionedAgg)
 			}
 
-			return nil, nil, s.SubmitAggregateAttestations(ctx, &eth2api.SubmitAggregateAttestationsOpts{
+			return nil, nil, s.SubmitAggregateAttestationsV2(ctx, &eth2api.SubmitAggregateAttestationsOpts{
 				SignedAggregateAndProofs: aggs,
 			})
 		}

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -122,7 +122,7 @@ func NewRouter(ctx context.Context, h Handler, eth2Cl eth2wrap.Client, builderEn
 		{
 			Name:    "submit_attestations",
 			Path:    "/eth/v1/beacon/pool/attestations",
-			Handler: respond404("/eth/v1/beacon/pool/attestations"),
+			Handler: submitAttestations(h),
 			Methods: []string{http.MethodPost},
 		},
 		{
@@ -217,12 +217,24 @@ func NewRouter(ctx context.Context, h Handler, eth2Cl eth2wrap.Client, builderEn
 		},
 		{
 			Name:    "aggregate_attestation",
+			Path:    "/eth/v1/validator/aggregate_attestation",
+			Handler: aggregateAttestation(h),
+			Methods: []string{http.MethodGet},
+		},
+		{
+			Name:    "aggregate_attestation_v2",
 			Path:    "/eth/v2/validator/aggregate_attestation",
 			Handler: aggregateAttestationV2(h),
 			Methods: []string{http.MethodGet},
 		},
 		{
 			Name:    "submit_aggregate_and_proofs",
+			Path:    "/eth/v1/validator/aggregate_and_proofs",
+			Handler: submitAggregateAttestations(h),
+			Methods: []string{http.MethodPost},
+		},
+		{
+			Name:    "submit_aggregate_and_proofs_v2",
 			Path:    "/eth/v2/validator/aggregate_and_proofs",
 			Handler: submitAggregateAttestationsV2(h),
 			Methods: []string{http.MethodPost},
@@ -459,7 +471,20 @@ func attestationData(p eth2client.AttestationDataProvider) handlerFunc {
 	}
 }
 
-// submitAttestations returns a handler function for the attestation submitter endpoint.
+// submitAttestations returns a handler function for the attestation submitter v1 endpoint.
+func submitAttestations(p eth2client.AttestationsSubmitter) handlerFunc {
+	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
+		var atts []*eth2p0.Attestation
+		err := unmarshal(typ, body, &atts)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unmarshal attestations")
+		}
+
+		return nil, nil, p.SubmitAttestations(ctx, atts)
+	}
+}
+
+// submitAttestationsV2 returns a handler function for the attestation submitter v2 endpoint.
 func submitAttestationsV2(p eth2client.AttestationsSubmitter) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
 		versionedAtts := []*eth2spec.VersionedAttestation{}
@@ -474,6 +499,8 @@ func submitAttestationsV2(p eth2client.AttestationsSubmitter) handlerFunc {
 					Version:        eth2spec.DataVersionElectra,
 					ValidatorIndex: &electraAtt.AttesterIndex,
 					Electra: &electra.Attestation{
+						// the VersionedAttestation object will be converted back to SingleAttestation object inside go-eth2-client's SubmitAttestationsV2,
+						// SingleAttestation object disregards AggregationBits, so this empty Bitlist is safe
 						AggregationBits: bitfield.NewBitlist(0),
 						Data:            electraAtt.Data,
 						Signature:       electraAtt.Signature,
@@ -1068,6 +1095,36 @@ func proposerConfig(p eth2exp.ProposerConfigProvider) handlerFunc {
 	}
 }
 
+func aggregateAttestation(p eth2client.AggregateAttestationProvider) handlerFunc {
+	return func(ctx context.Context, _ map[string]string, query url.Values, _ contentType, _ []byte) (any, http.Header, error) {
+		slot, err := uintQuery(query, "slot")
+		if err != nil {
+			return nil, nil, err
+		}
+
+		var attDataRoot eth2p0.Root
+		if err := hexQueryFixed(query, "attestation_data_root", attDataRoot[:]); err != nil {
+			return nil, nil, err
+		}
+
+		opts := &eth2api.AggregateAttestationOpts{
+			Slot:                eth2p0.Slot(slot),
+			AttestationDataRoot: attDataRoot,
+		}
+		eth2Resp, err := p.AggregateAttestation(ctx, opts)
+		if err != nil {
+			return nil, nil, err
+		}
+		data := eth2Resp.Data
+
+		return struct {
+			Data *eth2p0.Attestation `json:"data"`
+		}{
+			Data: data,
+		}, nil, nil
+	}
+}
+
 func aggregateAttestationV2(p eth2client.AggregateAttestationProvider) handlerFunc {
 	return func(ctx context.Context, _ map[string]string, query url.Values, _ contentType, _ []byte) (any, http.Header, error) {
 		slot, err := uintQuery(query, "slot")
@@ -1154,6 +1211,23 @@ func createAggregateAttestation(aggAtt *eth2spec.VersionedAttestation) (*aggrega
 	}
 
 	return &res, nil
+}
+
+func submitAggregateAttestations(s eth2client.AggregateAttestationsSubmitter) handlerFunc {
+	return func(ctx context.Context, _ map[string]string, _ url.Values, typ contentType, body []byte) (any, http.Header, error) {
+		var aggs []*eth2p0.SignedAggregateAndProof
+		err := unmarshal(typ, body, &aggs)
+		if err != nil {
+			return nil, nil, errors.Wrap(err, "unmarshal signed aggregate and proofs")
+		}
+
+		err = s.SubmitAggregateAttestations(ctx, aggs)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		return nil, nil, nil
+	}
 }
 
 func submitAggregateAttestationsV2(s eth2client.AggregateAttestationsSubmitter) handlerFunc {

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -198,7 +198,8 @@ type Component struct {
 	awaitAttFunc              func(ctx context.Context, slot, commIdx uint64) (*eth2p0.AttestationData, error)
 	awaitProposalFunc         func(ctx context.Context, slot uint64) (*eth2api.VersionedProposal, error)
 	awaitSyncContributionFunc func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
-	awaitAggAttFunc           func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)
+	awaitAggAttFunc           func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2p0.Attestation, error)
+	awaitAggAttV2Func         func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)
 	awaitAggSigDBFunc         func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
 	dutyDefFunc               func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
 	subs                      []func(context.Context, core.Duty, core.ParSignedDataSet) error
@@ -237,7 +238,7 @@ func (c *Component) RegisterGetDutyDefinition(fn func(ctx context.Context, duty 
 // RegisterAwaitAggAttestation registers a function to query an aggregated attestation.
 // It supports a single function, since it is an input of the component.
 func (c *Component) RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)) {
-	c.awaitAggAttFunc = fn
+	c.awaitAggAttV2Func = fn
 }
 
 // RegisterAwaitAggSigDB registers a function to query aggregated signed data from aggSigDB.
@@ -273,7 +274,69 @@ func (c Component) AttestationData(parent context.Context, opts *eth2api.Attesta
 }
 
 // SubmitAttestations implements the eth2client.AttestationsSubmitter for the router.
-func (c Component) SubmitAttestations(ctx context.Context, attestationOpts *eth2api.SubmitAttestationsOpts) error {
+func (c Component) SubmitAttestations(ctx context.Context, attestations []*eth2p0.Attestation) error {
+	duty := core.NewAttesterDuty(uint64(attestations[0].Data.Slot))
+	if len(attestations) > 0 {
+		// Pick the first attestation slot to use as trace root.
+		var span trace.Span
+		ctx, span = core.StartDutyTrace(ctx, duty, "core/validatorapi.SubmitAttestations")
+		defer span.End()
+	}
+
+	setsBySlot := make(map[uint64]core.ParSignedDataSet)
+	for _, att := range attestations {
+		slot := uint64(att.Data.Slot)
+
+		// Determine the validator that sent this by mapping values from original AttestationDuty via the dutyDB
+		indices := att.AggregationBits.BitIndices()
+		if len(indices) != 1 {
+			return errors.New("unexpected number of aggregation bits",
+				z.Str("aggbits", fmt.Sprintf("%#x", []byte(att.AggregationBits))))
+		}
+
+		pubkey, err := c.pubKeyByAttFunc(ctx, slot, uint64(att.Data.Index), uint64(indices[0]))
+		if err != nil {
+			return errors.Wrap(err, "failed to find pubkey", z.U64("slot", slot),
+				z.Int("commIdx", int(att.Data.Index)), z.Int("valCommIdx", indices[0]))
+		}
+
+		parSigData := core.NewPartialAttestation(att, c.shareIdx)
+
+		// Verify attestation signature
+		err = c.verifyPartialSig(ctx, parSigData, pubkey)
+		if err != nil {
+			return err
+		}
+
+		// Encode partial signed data and add to a set
+		set, ok := setsBySlot[slot]
+		if !ok {
+			set = make(core.ParSignedDataSet)
+			setsBySlot[slot] = set
+		}
+
+		set[pubkey] = parSigData
+	}
+
+	// Send sets to subscriptions.
+	for slot, set := range setsBySlot {
+		duty := core.NewAttesterDuty(slot)
+		ctx := log.WithCtx(ctx, z.Any("duty", duty))
+
+		for _, sub := range c.subs {
+			// No need to clone since sub auto clones.
+			err := sub(ctx, duty, set)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// SubmitAttestationsV2 implements the eth2client.AttestationsSubmitter for the router.
+func (c Component) SubmitAttestationsV2(ctx context.Context, attestationOpts *eth2api.SubmitAttestationsOpts) error {
 	attestations := attestationOpts.Attestations
 	att0Data, err := attestations[0].Data()
 	if err != nil {
@@ -283,7 +346,7 @@ func (c Component) SubmitAttestations(ctx context.Context, attestationOpts *eth2
 	if len(attestations) > 0 {
 		// Pick the first attestation slot to use as trace root.
 		var span trace.Span
-		ctx, span = core.StartDutyTrace(ctx, duty, "core/validatorapi.SubmitAttestations")
+		ctx, span = core.StartDutyTrace(ctx, duty, "core/validatorapi.SubmitAttestationsV2")
 		defer span.End()
 	}
 
@@ -832,8 +895,19 @@ func (c Component) AggregateBeaconCommitteeSelections(ctx context.Context, selec
 
 // AggregateAttestation returns the aggregate attestation for the given attestation root.
 // It does a blocking query to DutyAggregator unsigned data from dutyDB.
-func (c Component) AggregateAttestation(ctx context.Context, opts *eth2api.AggregateAttestationOpts) (*eth2api.Response[*eth2spec.VersionedAttestation], error) {
+func (c Component) AggregateAttestation(ctx context.Context, opts *eth2api.AggregateAttestationOpts) (*eth2api.Response[*eth2p0.Attestation], error) {
 	aggAtt, err := c.awaitAggAttFunc(ctx, uint64(opts.Slot), opts.AttestationDataRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrapResponse(aggAtt), nil
+}
+
+// AggregateAttestationV2 returns the aggregate attestation for the given attestation root.
+// It does a blocking query to DutyAggregator unsigned data from dutyDB.
+func (c Component) AggregateAttestationV2(ctx context.Context, opts *eth2api.AggregateAttestationOpts) (*eth2api.Response[*eth2spec.VersionedAttestation], error) {
+	aggAtt, err := c.awaitAggAttV2Func(ctx, uint64(opts.Slot), opts.AttestationDataRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -844,7 +918,66 @@ func (c Component) AggregateAttestation(ctx context.Context, opts *eth2api.Aggre
 // SubmitAggregateAttestations receives partially signed aggregateAndProofs.
 // - It verifies partial signature on AggregateAndProof.
 // - It then calls all the subscribers for further steps on partially signed aggregate and proof.
-func (c Component) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs *eth2api.SubmitAggregateAttestationsOpts) error {
+func (c Component) SubmitAggregateAttestations(ctx context.Context, aggregateAndProofs []*eth2p0.SignedAggregateAndProof) error {
+	vals, err := c.eth2Cl.ActiveValidators(ctx)
+	if err != nil {
+		return err
+	}
+
+	psigsBySlot := make(map[eth2p0.Slot]core.ParSignedDataSet)
+	for _, agg := range aggregateAndProofs {
+		slot := agg.Message.Aggregate.Data.Slot
+		eth2Pubkey, ok := vals[agg.Message.AggregatorIndex]
+		if !ok {
+			return errors.New("validator not found")
+		}
+
+		pk, err := core.PubKeyFromBytes(eth2Pubkey[:])
+		if err != nil {
+			return err
+		}
+
+		// Verify inner selection proof (outcome of DutyPrepareAggregator).
+		if !c.insecureTest {
+			err = signing.VerifyAggregateAndProofSelection(ctx, c.eth2Cl, tbls.PublicKey(eth2Pubkey), agg.Message)
+			if err != nil {
+				return err
+			}
+		}
+
+		parSigData := core.NewPartialSignedAggregateAndProof(agg, c.shareIdx)
+
+		// Verify outer partial signature.
+		err = c.verifyPartialSig(ctx, parSigData, pk)
+		if err != nil {
+			return err
+		}
+
+		_, ok = psigsBySlot[slot]
+		if !ok {
+			psigsBySlot[slot] = make(core.ParSignedDataSet)
+		}
+
+		psigsBySlot[slot][pk] = parSigData
+	}
+
+	for slot, data := range psigsBySlot {
+		duty := core.NewAggregatorDuty(uint64(slot))
+		for _, sub := range c.subs {
+			err = sub(ctx, duty, data)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// SubmitAggregateAttestationsV2 receives partially signed aggregateAndProofs.
+// - It verifies partial signature on AggregateAndProof.
+// - It then calls all the subscribers for further steps on partially signed aggregate and proof.
+func (c Component) SubmitAggregateAttestationsV2(ctx context.Context, aggregateAndProofs *eth2api.SubmitAggregateAttestationsOpts) error {
 	aggsAndProofs := aggregateAndProofs.SignedAggregateAndProofs
 	vals, err := c.eth2Cl.ActiveValidators(ctx)
 	if err != nil {
@@ -875,7 +1008,7 @@ func (c Component) SubmitAggregateAttestations(ctx context.Context, aggregateAnd
 
 		// Verify inner selection proof (outcome of DutyPrepareAggregator).
 		if !c.insecureTest {
-			err = signing.VerifyAggregateAndProofSelection(ctx, c.eth2Cl, tbls.PublicKey(eth2Pubkey), agg)
+			err = signing.VerifyAggregateAndProofSelectionV2(ctx, c.eth2Cl, tbls.PublicKey(eth2Pubkey), agg)
 			if err != nil {
 				return err
 			}

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -244,7 +244,13 @@ func (c *Component) RegisterGetDutyDefinition(fn func(ctx context.Context, duty 
 
 // RegisterAwaitAggAttestation registers a function to query an aggregated attestation.
 // It supports a single function, since it is an input of the component.
-func (c *Component) RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)) {
+func (c *Component) RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2p0.Attestation, error)) {
+	c.awaitAggAttFunc = fn
+}
+
+// RegisterAwaitAggAttestationV2 registers a function to query an aggregated attestation.
+// It supports a single function, since it is an input of the component.
+func (c *Component) RegisterAwaitAggAttestationV2(fn func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)) {
 	c.awaitAggAttV2Func = fn
 }
 

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -206,7 +206,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, 30000000, nil)
 	require.NoError(t, err)
 
-	vapi.RegisterPubKeyByAttestationV2(func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error) {
+	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error) {
 		require.EqualValues(t, slot, epochSlot)
 		require.EqualValues(t, commIdx, vIdx)
 		require.EqualValues(t, valIdx, 0)
@@ -224,7 +224,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	})
 
 	// Configure beacon mock to call validator API for submissions
-	bmock.SubmitAttestationsV2Func = vapi.SubmitAttestationsV2
+	bmock.SubmitAttestationsFunc = vapi.SubmitAttestations
 
 	signer, err := validatormock.NewSigner(secret)
 	require.NoError(t, err)

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -52,8 +52,8 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 		commIdx     = 456
 		vIdxA       = 1
 		vIdxB       = 2
-		valCommIdxA = vIdxA
-		valCommIdxB = vIdxB
+		valCommIdxA = 4
+		valCommIdxB = 5
 		commLen     = 8
 	)
 
@@ -68,8 +68,10 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 	aggBitsA := bitfield.NewBitlist(commLen)
 	aggBitsA.SetBitAt(valCommIdxA, true)
 
+	valIdxAMut := eth2p0.ValidatorIndex(uint64(vIdxA))
 	attA := &eth2spec.VersionedAttestation{
-		Version: eth2spec.DataVersionDeneb,
+		Version:        eth2spec.DataVersionDeneb,
+		ValidatorIndex: &valIdxAMut,
 		Deneb: &eth2p0.Attestation{
 			AggregationBits: aggBitsA,
 			Data: &eth2p0.AttestationData{
@@ -85,8 +87,10 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 	aggBitsB := bitfield.NewBitlist(commLen)
 	aggBitsB.SetBitAt(valCommIdxB, true)
 
+	valIdxBMut := eth2p0.ValidatorIndex(uint64(vIdxB))
 	attB := &eth2spec.VersionedAttestation{
-		Version: eth2spec.DataVersionDeneb,
+		Version:        eth2spec.DataVersionDeneb,
+		ValidatorIndex: &valIdxBMut,
 		Deneb: &eth2p0.Attestation{
 			AggregationBits: aggBitsB,
 			Data: &eth2p0.AttestationData{
@@ -101,8 +105,8 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 
 	atts := []*eth2spec.VersionedAttestation{attA, attB}
 
-	component.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx uint64) (core.PubKey, error) {
-		return pubkeysByIdx[eth2p0.ValidatorIndex(valCommIdx)], nil
+	component.RegisterPubKeyByAttestationV2(func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error) {
+		return pubkeysByIdx[eth2p0.ValidatorIndex(valIdx)], nil
 	})
 
 	component.Subscribe(func(ctx context.Context, duty core.Duty, set core.ParSignedDataSet) error {
@@ -135,7 +139,7 @@ func TestComponent_InvalidSubmitAttestations(t *testing.T) {
 		slot       = 123
 		commIdx    = 456
 		vIdx       = 1
-		valCommIdx = vIdx
+		valCommIdx = 3
 		commLen    = 8
 	)
 
@@ -146,23 +150,20 @@ func TestComponent_InvalidSubmitAttestations(t *testing.T) {
 	aggBits.SetBitAt(valCommIdx, true)
 	aggBits.SetBitAt(valCommIdx+1, true)
 
-	att := &eth2spec.VersionedAttestation{
-		Version: eth2spec.DataVersionDeneb,
-		Deneb: &eth2p0.Attestation{
-			AggregationBits: aggBits,
-			Data: &eth2p0.AttestationData{
-				Slot:   slot,
-				Index:  commIdx,
-				Source: &eth2p0.Checkpoint{},
-				Target: &eth2p0.Checkpoint{},
-			},
-			Signature: eth2p0.BLSSignature{},
+	att := &eth2p0.Attestation{
+		AggregationBits: aggBits,
+		Data: &eth2p0.AttestationData{
+			Slot:   slot,
+			Index:  commIdx,
+			Source: &eth2p0.Checkpoint{},
+			Target: &eth2p0.Checkpoint{},
 		},
+		Signature: eth2p0.BLSSignature{},
 	}
 
-	atts := []*eth2spec.VersionedAttestation{att}
+	atts := []*eth2p0.Attestation{att}
 
-	err = component.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
+	err = component.SubmitAttestations(ctx, atts)
 	require.Error(t, err)
 }
 
@@ -205,10 +206,10 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, 30000000, nil)
 	require.NoError(t, err)
 
-	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valCommIdx uint64) (core.PubKey, error) {
+	vapi.RegisterPubKeyByAttestationV2(func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error) {
 		require.EqualValues(t, slot, epochSlot)
 		require.EqualValues(t, commIdx, vIdx)
-		require.EqualValues(t, valCommIdx, 0)
+		require.EqualValues(t, valIdx, 0)
 
 		return corePubKey, nil
 	})
@@ -312,7 +313,7 @@ func TestSignAndVerify(t *testing.T) {
 	// Setup validatorapi component.
 	vapi, err := validatorapi.NewComponent(bmock, allPubSharesByKey, shareIdx, nil, false, 30000000, nil)
 	require.NoError(t, err)
-	vapi.RegisterPubKeyByAttestation(func(context.Context, uint64, uint64, uint64) (core.PubKey, error) {
+	vapi.RegisterPubKeyByAttestationV2(func(context.Context, uint64, uint64, uint64) (core.PubKey, error) {
 		return core.PubKeyFromBytes(pubkey[:])
 	})
 
@@ -327,11 +328,13 @@ func TestSignAndVerify(t *testing.T) {
 		return nil
 	})
 
+	vIdx := eth2p0.ValidatorIndex(1)
 	// Create and submit attestation.
 	aggBits := bitfield.NewBitlist(1)
 	aggBits.SetBitAt(0, true)
 	att := eth2spec.VersionedAttestation{
-		Version: eth2spec.DataVersionDeneb,
+		Version:        eth2spec.DataVersionDeneb,
+		ValidatorIndex: &vIdx,
 		Deneb: &eth2p0.Attestation{
 			AggregationBits: aggBits,
 			Data:            &attData,

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -122,7 +122,7 @@ func TestComponent_ValidSubmitAttestations(t *testing.T) {
 		return nil
 	})
 
-	err = component.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
+	err = component.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
 	require.NoError(t, err)
 }
 
@@ -162,7 +162,7 @@ func TestComponent_InvalidSubmitAttestations(t *testing.T) {
 
 	atts := []*eth2spec.VersionedAttestation{att}
 
-	err = component.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
+	err = component.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
 	require.Error(t, err)
 }
 
@@ -223,7 +223,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	})
 
 	// Configure beacon mock to call validator API for submissions
-	bmock.SubmitAttestationsFunc = vapi.SubmitAttestations
+	bmock.SubmitAttestationsV2Func = vapi.SubmitAttestationsV2
 
 	signer, err := validatormock.NewSigner(secret)
 	require.NoError(t, err)
@@ -338,7 +338,7 @@ func TestSignAndVerify(t *testing.T) {
 			Signature:       sig,
 		},
 	}
-	err = vapi.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{Attestations: []*eth2spec.VersionedAttestation{&att}})
+	err = vapi.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: []*eth2spec.VersionedAttestation{&att}})
 	require.NoError(t, err)
 	wg.Wait()
 }
@@ -1893,7 +1893,7 @@ func TestComponent_SubmitAggregateAttestations(t *testing.T) {
 		return nil
 	})
 
-	require.NoError(t, vapi.SubmitAggregateAttestations(ctx, &eth2api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: []*eth2spec.VersionedSignedAggregateAndProof{agg}}))
+	require.NoError(t, vapi.SubmitAggregateAttestationsV2(ctx, &eth2api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: []*eth2spec.VersionedSignedAggregateAndProof{agg}}))
 }
 
 func TestComponent_SubmitAggregateAttestationVerify(t *testing.T) {
@@ -1950,7 +1950,7 @@ func TestComponent_SubmitAggregateAttestationVerify(t *testing.T) {
 		return nil
 	})
 
-	err = vapi.SubmitAggregateAttestations(ctx, &eth2api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: []*eth2spec.VersionedSignedAggregateAndProof{signedAggProof}})
+	err = vapi.SubmitAggregateAttestationsV2(ctx, &eth2api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: []*eth2spec.VersionedSignedAggregateAndProof{signedAggProof}})
 	require.NoError(t, err)
 	<-done
 }

--- a/eth2util/signing/signing.go
+++ b/eth2util/signing/signing.go
@@ -79,7 +79,23 @@ func GetDataRoot(ctx context.Context, eth2Cl eth2wrap.Client, name DomainName, e
 
 // VerifyAggregateAndProofSelection verifies the eth2p0.AggregateAndProof with the provided pubkey.
 // Refer get_slot_signature from https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#aggregation-selection.
-func VerifyAggregateAndProofSelection(ctx context.Context, eth2Cl eth2wrap.Client, pubkey tbls.PublicKey, agg *eth2spec.VersionedSignedAggregateAndProof) error {
+func VerifyAggregateAndProofSelection(ctx context.Context, eth2Cl eth2wrap.Client, pubkey tbls.PublicKey, agg *eth2p0.AggregateAndProof) error {
+	epoch, err := eth2util.EpochFromSlot(ctx, eth2Cl, agg.Aggregate.Data.Slot)
+	if err != nil {
+		return err
+	}
+
+	sigRoot, err := eth2util.SlotHashRoot(agg.Aggregate.Data.Slot)
+	if err != nil {
+		return errors.Wrap(err, "cannot get hash root of slot")
+	}
+
+	return Verify(ctx, eth2Cl, DomainSelectionProof, epoch, sigRoot, agg.SelectionProof, pubkey)
+}
+
+// VerifyAggregateAndProofSelectionV2 verifies the eth2p0.AggregateAndProof with the provided pubkey.
+// Refer get_slot_signature from https://github.com/ethereum/consensus-specs/blob/dev/specs/phase0/validator.md#aggregation-selection.
+func VerifyAggregateAndProofSelectionV2(ctx context.Context, eth2Cl eth2wrap.Client, pubkey tbls.PublicKey, agg *eth2spec.VersionedSignedAggregateAndProof) error {
 	slot, err := agg.Slot()
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -267,4 +267,4 @@ replace github.com/coinbase/kryptology => github.com/ObolNetwork/kryptology v0.0
 // replace github.com/attestantio/go-eth2-client => github.com/ObolNetwork/go-eth2-client v0.21.11-0.20240822135044-f0a5b21e02c6
 
 // Replace go-eth2-client version with the electra branch
-replace github.com/attestantio/go-eth2-client => github.com/attestantio/go-eth2-client v0.24.0
+replace github.com/attestantio/go-eth2-client => github.com/ObolNetwork/go-eth2-client v0.24.1-0.20250213170417-18ce11f7e20b

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERo
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/Microsoft/hcsshim v0.12.9 h1:2zJy5KA+l0loz1HzEGqyNnjd3fyZA31ZBCGKacp6lLg=
 github.com/Microsoft/hcsshim v0.12.9/go.mod h1:fJ0gkFAna6ukt0bLdKB8djt4XIJhF/vEPuoIWYVvZ8Y=
+github.com/ObolNetwork/go-eth2-client v0.24.1-0.20250213170417-18ce11f7e20b h1:ngAp+PEOtQgw3DeAghk0Q9y7voyhhi9pmKvnm4R7x0E=
+github.com/ObolNetwork/go-eth2-client v0.24.1-0.20250213170417-18ce11f7e20b/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
 github.com/ObolNetwork/kryptology v0.0.0-20231016091344-eed023b6cac8 h1:IXoKQKGzebwtIzKADtZyAjL3MIr0m3zQFxlSxxWIdCU=
 github.com/ObolNetwork/kryptology v0.0.0-20231016091344-eed023b6cac8/go.mod h1:qcn33Qgj0WVLH1nuXqPt8JHY+yZabhyKxI5dHRk0fbo=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
@@ -47,8 +49,6 @@ github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYW
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/attestantio/go-builder-client v0.5.3 h1:4YFT0u823JvF4Uesj7SEG8f0De1uxLrVioOgKZYPl3I=
 github.com/attestantio/go-builder-client v0.5.3/go.mod h1:RaWc8K2SjyU19sL5UinOQ8n4vTZBrEQzsNuMWpNmwK4=
-github.com/attestantio/go-eth2-client v0.24.0 h1:lGVbcnhlBwRglt1Zs56JOCgXVyLWKFZOmZN8jKhE7Ws=
-github.com/attestantio/go-eth2-client v0.24.0/go.mod h1:/KTLN3WuH1xrJL7ZZrpBoWM1xCCihnFbzequD5L+83o=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.5 h1:VvXlSJBzZpA/zum6Sj74hxwYI2DIxRWuNIoXAzHZz5o=

--- a/testutil/beaconmock/beaconmock_fuzz.go
+++ b/testutil/beaconmock/beaconmock_fuzz.go
@@ -116,7 +116,7 @@ func WithBeaconMockFuzzer() Option {
 			return block, nil
 		}
 
-		mock.AggregateAttestationFunc = func(context.Context, eth2p0.Slot, eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
+		mock.AggregateAttestationV2Func = func(context.Context, eth2p0.Slot, eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
 			var att *eth2spec.VersionedAttestation
 			fuzz.New().Fuzz(&att)
 

--- a/testutil/beaconmock/beaconmock_test.go
+++ b/testutil/beaconmock/beaconmock_test.go
@@ -70,7 +70,7 @@ func TestAttestationStore(t *testing.T) {
 		Slot:                0,
 		AttestationDataRoot: root,
 	}
-	bmockResp, err := bmock.AggregateAttestation(ctx, aggAttOpts) // Slot is ignored.
+	bmockResp, err := bmock.AggregateAttestationV2(ctx, aggAttOpts) // Slot is ignored.
 	require.NoError(t, err)
 	att := bmockResp.Data.Deneb
 	require.Equal(t, attData, att.Data)
@@ -79,7 +79,7 @@ func TestAttestationStore(t *testing.T) {
 		Slot:                attData.Slot,
 		AttestationDataRoot: eth2p0.Root{},
 	}
-	_, err = bmock.AggregateAttestation(ctx, aggAttopts2) // Not found
+	_, err = bmock.AggregateAttestationV2(ctx, aggAttopts2) // Not found
 	require.Error(t, err)
 
 	// New attestation data with much larger slots delete old ones.
@@ -94,6 +94,6 @@ func TestAttestationStore(t *testing.T) {
 		Slot:                0,
 		AttestationDataRoot: root,
 	}
-	_, err = bmock.AggregateAttestation(ctx, aggDataOpts) // Deleted.
+	_, err = bmock.AggregateAttestationV2(ctx, aggDataOpts) // Deleted.
 	require.Error(t, err)
 }

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -548,7 +548,18 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		AttestationDataFunc: func(ctx context.Context, slot eth2p0.Slot, index eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error) {
 			return attStore.NewAttestationData(ctx, slot, index)
 		},
-		AggregateAttestationFunc: func(_ context.Context, _ eth2p0.Slot, root eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
+		AggregateAttestationFunc: func(_ context.Context, _ eth2p0.Slot, root eth2p0.Root) (*eth2p0.Attestation, error) {
+			attData, err := attStore.AttestationDataByRoot(root)
+			if err != nil {
+				return nil, err
+			}
+
+			return &eth2p0.Attestation{
+				AggregationBits: bitfield.NewBitlist(0),
+				Data:            attData,
+			}, nil
+		},
+		AggregateAttestationV2Func: func(_ context.Context, _ eth2p0.Slot, root eth2p0.Root) (*eth2spec.VersionedAttestation, error) {
 			attData, err := attStore.AttestationDataByRoot(root)
 			if err != nil {
 				return nil, err
@@ -571,7 +582,10 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		ValidatorsByPubKeyFunc: func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 			return nil, nil
 		},
-		SubmitAttestationsFunc: func(context.Context, *eth2api.SubmitAttestationsOpts) error {
+		SubmitAttestationsFunc: func(context.Context, []*eth2p0.Attestation) error {
+			return nil
+		},
+		SubmitAttestationsV2Func: func(context.Context, *eth2api.SubmitAttestationsOpts) error {
 			return nil
 		},
 		SubmitProposalFunc: func(context.Context, *eth2api.SubmitProposalOpts) error {
@@ -600,7 +614,10 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		AggregateBeaconCommitteeSelectionsFunc: func(_ context.Context, selections []*eth2exp.BeaconCommitteeSelection) ([]*eth2exp.BeaconCommitteeSelection, error) {
 			return selections, nil
 		},
-		SubmitAggregateAttestationsFunc: func(context.Context, *eth2api.SubmitAggregateAttestationsOpts) error {
+		SubmitAggregateAttestationsFunc: func(context.Context, []*eth2p0.SignedAggregateAndProof) error {
+			return nil
+		},
+		SubmitAggregateAttestationsV2Func: func(context.Context, *eth2api.SubmitAggregateAttestationsOpts) error {
 			return nil
 		},
 		SlotsPerEpochFunc: func(ctx context.Context) (uint64, error) {

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -854,6 +854,13 @@ func RandomCoreSyncCommitteeSelection() core.SyncCommitteeSelection {
 	return core.NewSyncCommitteeSelection(RandomSyncCommitteeSelection())
 }
 
+func RandomSignedAggregateAndProof() *eth2p0.SignedAggregateAndProof {
+	return &eth2p0.SignedAggregateAndProof{
+		Message:   RandomAggregateAndProof(),
+		Signature: RandomEth2Signature(),
+	}
+}
+
 func RandomDenebVersionedSignedAggregateAndProof() *eth2spec.VersionedSignedAggregateAndProof {
 	return &eth2spec.VersionedSignedAggregateAndProof{
 		Version: eth2spec.DataVersionDeneb,

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -345,7 +345,7 @@ func attest(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, slot
 		}
 	}
 
-	err := eth2Cl.SubmitAttestations(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
+	err := eth2Cl.SubmitAttestationsV2(ctx, &eth2api.SubmitAttestationsOpts{Attestations: atts})
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +430,7 @@ func aggregate(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, s
 		})
 	}
 
-	if err := eth2Cl.SubmitAggregateAttestations(ctx, &eth2api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: aggs}); err != nil {
+	if err := eth2Cl.SubmitAggregateAttestationsV2(ctx, &eth2api.SubmitAggregateAttestationsOpts{SignedAggregateAndProofs: aggs}); err != nil {
 		return false, err
 	}
 
@@ -456,7 +456,7 @@ func getAggregateAttestation(ctx context.Context, eth2Cl eth2wrap.Client, datas 
 			AttestationDataRoot: root,
 			CommitteeIndex:      commIdx,
 		}
-		eth2Resp, err := eth2Cl.AggregateAttestation(ctx, opts)
+		eth2Resp, err := eth2Cl.AggregateAttestationV2(ctx, opts)
 		if err != nil {
 			return nil, err
 		}

--- a/testutil/validatormock/propose_test.go
+++ b/testutil/validatormock/propose_test.go
@@ -61,11 +61,11 @@ func TestAttest(t *testing.T) {
 			// Callback to collect attestations
 			var atts []*eth2spec.VersionedAttestation
 			var aggs *eth2api.SubmitAggregateAttestationsOpts
-			beaconMock.SubmitAttestationsFunc = func(_ context.Context, attestations *eth2api.SubmitAttestationsOpts) error {
+			beaconMock.SubmitAttestationsV2Func = func(_ context.Context, attestations *eth2api.SubmitAttestationsOpts) error {
 				atts = attestations.Attestations
 				return nil
 			}
-			beaconMock.SubmitAggregateAttestationsFunc = func(_ context.Context, aggAndProofs *eth2api.SubmitAggregateAttestationsOpts) error {
+			beaconMock.SubmitAggregateAttestationsV2Func = func(_ context.Context, aggAndProofs *eth2api.SubmitAggregateAttestationsOpts) error {
 				aggs = aggAndProofs
 				return nil
 			}


### PR DESCRIPTION
Bring back support to v1 endpoints regarding attestations and aggregations. With this PR the electra branch works on both deneb and electra.

category: feature
ticket: none
