### PR TITLE
feat: add fallback beacon node metric

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -47,11 +47,11 @@ var (
 	}, []string{"endpoint"})
 
 	usingFallbackGauge = promauto.NewGauge(prometheus.GaugeOpts{
-        Namespace: "app",
-        Subsystem: "eth2",
-        Name:      "using_fallback",
-        Help:      "Indicates if client is using fallback (1) or primary (0) beacon node",
-    })
+		Namespace: "app",
+		Subsystem: "eth2",
+		Name:      "using_fallback",
+		Help:      "Indicates if client is using fallback (1) or primary (0) beacon node",
+	})
 
 	// Interface assertions.
 	_ Client = (*httpAdapter)(nil)
@@ -155,10 +155,10 @@ func provide[O any](ctx context.Context, clients []Client, fallbacks []Client,
 	runForkJoin := func(clients []Client, isFallback bool) (O, error) {
 
 		if isFallback {
-            usingFallbackGauge.Set(1)
-        } else {
-            usingFallbackGauge.Set(0)
-        }
+			usingFallbackGauge.Set(1)
+		} else {
+			usingFallbackGauge.Set(0)
+		}
 
 		fork, join, cancel := forkjoin.New(ctx, work,
 			forkjoin.WithoutFailFast(),

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -46,6 +46,13 @@ var (
 		Help:      "Total number of errors returned by eth2 beacon node requests",
 	}, []string{"endpoint"})
 
+	usingFallbackGauge = promauto.NewGauge(prometheus.GaugeOpts{
+        Namespace: "app",
+        Subsystem: "eth2",
+        Name:      "using_fallback",
+        Help:      "Indicates if client is using fallback (1) or primary (0) beacon node",
+    })
+
 	// Interface assertions.
 	_ Client = (*httpAdapter)(nil)
 	_ Client = multi{}
@@ -145,7 +152,14 @@ func provide[O any](ctx context.Context, clients []Client, fallbacks []Client,
 
 	zero := func() O { var z O; return z }()
 
-	runForkJoin := func(clients []Client) (O, error) {
+	runForkJoin := func(clients []Client, isFallback bool) (O, error) {
+
+		if isFallback {
+            usingFallbackGauge.Set(1)
+        } else {
+            usingFallbackGauge.Set(0)
+        }
+
 		fork, join, cancel := forkjoin.New(ctx, work,
 			forkjoin.WithoutFailFast(),
 			forkjoin.WithWorkers(len(clients)),
@@ -184,12 +198,12 @@ func provide[O any](ctx context.Context, clients []Client, fallbacks []Client,
 		return nokResp.Output, nokResp.Err
 	}
 
-	output, err := runForkJoin(clients)
+	output, err := runForkJoin(clients, false)
 	if err == nil || ctx.Err() != nil || len(fallbacks) == 0 {
 		return output, err
 	}
 
-	return runForkJoin(fallbacks)
+	return runForkJoin(fallbacks, true)
 }
 
 type empty struct{}

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -153,7 +153,6 @@ func provide[O any](ctx context.Context, clients []Client, fallbacks []Client,
 	zero := func() O { var z O; return z }()
 
 	runForkJoin := func(clients []Client, isFallback bool) (O, error) {
-
 		if isFallback {
 			usingFallbackGauge.Set(1)
 		} else {

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -236,6 +236,7 @@ func TestFallback(t *testing.T) {
 						return true
 					}
 				}
+
 				return false
 			}
 
@@ -246,7 +247,6 @@ func TestFallback(t *testing.T) {
 					require.True(t, called, "primary client %d was not called", i)
 				}
 				require.True(t, atLeastOneCalled(fallbackCalled), "at least one fallback client should have been called")
-
 			} else {
 				require.True(t, atLeastOneCalled(primaryCalled), "at least one primary client should have been called")
 			}

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -176,7 +176,7 @@ func TestGetBySlot(t *testing.T) {
 
 	active, complete, err = valCache.GetBySlot(ctx, 11)
 	require.NoError(t, err)
-	require.Len(t, active, 0)
+	require.Empty(t, active)
 	require.Len(t, complete, 2)
 
 	_, _, err = valCache.GetBySlot(ctx, 3)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -17,6 +17,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_beacon_node_version` | Gauge | Constant gauge with label set to the node version of the upstream beacon node | `version` |
 | `app_eth2_errors_total` | Counter | Total number of errors returned by eth2 beacon node requests | `endpoint` |
 | `app_eth2_latency_seconds` | Histogram | Latency in seconds for eth2 beacon node requests | `endpoint` |
+| `app_eth2_using_fallback` | Gauge | Indicates if client is using fallback (1) or primary (0) beacon node |  |
 | `app_git_commit` | Gauge | Constant gauge with label set to current git commit hash | `git_hash` |
 | `app_health_checks` | Gauge | Application health checks by name and severity. Set to 1 for failing, 0 for ok. | `severity, name` |
 | `app_health_metrics_high_cardinality` | Gauge | Metrics with high cardinality by name. | `name` |


### PR DESCRIPTION
Add `app_eth2_using_fallback` gauge metric to track how often nodes rely on fallback  beacon nodes.  This can be queried, for example, using promql `min_over_time(app_eth2_using_fallback[30s]) == 1` to see if any node has been only using the fallback beacon node for the last 30 seconds.

category: feature
ticket: none
