### PR TITLE
*: support v2 calls for deneb fork

### DIFF
--- a/core/tracing.go
+++ b/core/tracing.go
@@ -90,11 +90,11 @@ func WithTracing() WireOption {
 
 			return clone.DutyDBPubKeyByAttestation(ctx, slot, commIdx, valCommIdx)
 		}
-		w.DutyDBPubKeyByAttestationV2 = func(parent context.Context, slot, commIdx, valCommIdx uint64) (PubKey, error) {
+		w.DutyDBPubKeyByAttestationV2 = func(parent context.Context, slot, commIdx, valIdx uint64) (PubKey, error) {
 			ctx, span := tracer.Start(parent, "core/dutydb.PubKeyByAttestationV2")
 			defer span.End()
 
-			return clone.DutyDBPubKeyByAttestationV2(ctx, slot, commIdx, valCommIdx)
+			return clone.DutyDBPubKeyByAttestationV2(ctx, slot, commIdx, valIdx)
 		}
 		w.ParSigDBStoreInternal = func(parent context.Context, duty Duty, set ParSignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/parsigdb.StoreInternal")


### PR DESCRIPTION
We have experienced issues with Prysm VC v5.3.0 running on Deneb. In comparison to the other 4 VCs tested, Prysm v5.3.0 was sending Deneb data to Electra-enabled v2 endpoints. Those v2 endpoints allow, by spec, deneb data, so it's not an issue per se supporting that. It required some fiddling on our end though.

category: bug
ticket: none