### PR TITLE
app: add nickname label to metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -221,6 +221,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 
 	log.Info(ctx, "Lock file loaded",
 		z.Str("peer_name", p2p.PeerName(tcpNode.ID())),
+		z.Str("nickname", conf.Nickname),
 		z.Int("peer_index", nodeIdx.PeerIdx),
 		z.Str("cluster_name", cluster.GetName()),
 		z.Str("cluster_hash", lockHashHex),
@@ -233,6 +234,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		"cluster_hash":    lockHashHex,
 		"cluster_name":    cluster.GetName(),
 		"cluster_peer":    p2p.PeerName(tcpNode.ID()),
+		"nickname":        conf.Nickname,
 		"cluster_network": network,
 		"charon_version":  version.Version.String(),
 	}

--- a/app/peerinfo/metrics.go
+++ b/app/peerinfo/metrics.go
@@ -67,5 +67,5 @@ var (
 		Name:        "nickname",
 		Help:        "Constant gauge with nickname label set to peer's charon nickname.",
 		ConstLabels: nil,
-	}, []string{"peer", "nickname"})
+	}, []string{"peer", "peer_nickname"})
 )

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -29,7 +29,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_peerinfo_clock_offset_seconds` | Gauge | Peer clock offset in seconds | `peer` |
 | `app_peerinfo_git_commit` | Gauge | Constant gauge with git_hash label set to peer`s git commit hash. | `peer, git_hash` |
 | `app_peerinfo_index` | Gauge | Constant gauge set to the peer index in the cluster definition | `peer` |
-| `app_peerinfo_nickname` | Gauge | Constant gauge with nickname label set to peer`s charon nickname. | `peer, nickname` |
+| `app_peerinfo_nickname` | Gauge | Constant gauge with nickname label set to peer`s charon nickname. | `peer, peer_nickname` |
 | `app_peerinfo_start_time_secs` | Gauge | Constant gauge set to the peer start time of the binary in unix seconds | `peer` |
 | `app_peerinfo_version` | Gauge | Constant gauge with version label set to peer`s charon version. | `peer, version` |
 | `app_peerinfo_version_support` | Gauge | Set to 1 if the peer`s version is supported by (compatible with) the current version, else 0 if unsupported. | `peer` |


### PR DESCRIPTION
Add `nickname` label to Prometheus metrics.

category: feature
ticket: none
