### PR TITLE
*: improve latency buckets

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -37,6 +37,7 @@ var (
 		Subsystem: "eth2",
 		Name:      "latency_seconds",
 		Help:      "Latency in seconds for eth2 beacon node requests",
+		Buckets:   []float64{.01, .025, .05, .1, .25, .5, .75, 1, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3, 5},
 	}, []string{"endpoint"})
 
 	errorCount = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/core/consensus/metrics/metrics.go
+++ b/core/consensus/metrics/metrics.go
@@ -28,6 +28,7 @@ var (
 		Subsystem: "consensus",
 		Name:      "duration_seconds",
 		Help:      "Duration of the consensus process by protocol, duty, and timer",
+		Buckets:   []float64{.01, .025, .05, .1, .25, .5, .75, 1, 1.25, 1.5, 1.75, 2.0, 2.25, 2.5, 2.75, 3, 5},
 	}, []string{"protocol", "duty", "timer"})
 
 	consensusTimeout = promauto.NewCounterVec(prometheus.CounterOpts{


### PR DESCRIPTION
Currently we are using default buckets of:
0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10
This makes it quite difficult to use the data in order to improve the consensus.

By using more granular numbers in the realistic spectrum, we can achieve better segmentation.

category: feature
ticket: none
