### PR TITLE
refactor: return nil when error has already been checked

### DIFF
--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -91,7 +91,7 @@ func (l *lazy) getOrCreateClient(ctx context.Context) (Client, error) {
 
 	l.setClient(cl)
 
-	return cl, err
+	return cl, nil
 }
 
 func (l *lazy) SetForkVersion(forkVersion [4]byte) {

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -1894,7 +1894,7 @@ func (s SignedSyncContributionAndProof) SetSignature(sig Signature) (SignedData,
 
 	resp.SignedContributionAndProof.Signature = sig.ToETH2()
 
-	return resp, err
+	return resp, nil
 }
 
 func (s SignedSyncContributionAndProof) Clone() (SignedData, error) {

--- a/core/unsigneddata.go
+++ b/core/unsigneddata.go
@@ -543,7 +543,7 @@ func (s SyncContribution) Clone() (UnsignedData, error) {
 		return nil, errors.Wrap(err, "clone sync contribution")
 	}
 
-	return resp, err
+	return resp, nil
 }
 
 func (s SyncContribution) MarshalJSON() ([]byte, error) {


### PR DESCRIPTION
Since err != nil has been judged before, nil is returned directly here, which is more obvious, readable and less error-prone.

category: misc
ticket: none