### PR TITLE
main: fix mockery install

### DIFF
--- a/tools.go
+++ b/tools.go
@@ -20,7 +20,7 @@ import (
 //go:generate go install golang.org/x/tools/cmd/stringer
 
 //go:generate echo Installing tools: mockery
-//go install github.com/vektra/mockery/v2@v2.42.1
+//go:generate go install github.com/vektra/mockery/v2@v2.42.1
 
 //go:generate echo Installing tools: protobuf
 //go:generate go install github.com/bufbuild/buf/cmd/buf@latest


### PR DESCRIPTION
In `tools.go` mockery install script lacked `go:generate` at the beginning. 

category: bug
ticket: #000
