### PR TITLE
vapi: return 415 on ssz unmarshaling failures

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1448,7 +1448,7 @@ func unmarshal(typ contentType, body []byte, v any) error {
 		unmarshaller, ok := v.(ssz.Unmarshaler)
 		if !ok {
 			return apiError{
-				StatusCode: http.StatusInternalServerError,
+				StatusCode: http.StatusUnsupportedMediaType,
 				Message:    "internal type doesn't support ssz unmarshalling",
 				Err:        errors.New("internal type doesn't support ssz unmarshalling"),
 			}
@@ -1457,7 +1457,7 @@ func unmarshal(typ contentType, body []byte, v any) error {
 		err := unmarshaller.UnmarshalSSZ(body)
 		if err != nil {
 			return apiError{
-				StatusCode: http.StatusBadRequest,
+				StatusCode: http.StatusUnsupportedMediaType,
 				Message:    "failed parsing ssz request body",
 				Err:        err,
 			}


### PR DESCRIPTION
Some VCs can force SSZ on all requests, even though they are not officially in the spec (i.e.: /eth/v1/validator/duties/attester/{epoch}). On 415 they fallback to JSON. However, those 415 fallbacks fail on our end because we officially support SSZ, but then on parsing the payload to SSZ we return 500.

category: bug
ticket: none

