### PR TITLE
cmd: increase test command timeout tests x1000

### DIFF
--- a/cmd/testbeacon_internal_test.go
+++ b/cmd/testbeacon_internal_test.go
@@ -91,7 +91,7 @@ func TestBeaconTest(t *testing.T) {
 					OutputJSON: "",
 					Quiet:      false,
 					TestCases:  nil,
-					Timeout:    100 * time.Nanosecond,
+					Timeout:    100 * time.Microsecond,
 				},
 				Endpoints: []string{endpoint1, endpoint2},
 			},

--- a/cmd/testinfra_internal_test.go
+++ b/cmd/testinfra_internal_test.go
@@ -85,7 +85,7 @@ func TestInfraTest(t *testing.T) {
 					OutputJSON: "",
 					Quiet:      false,
 					TestCases:  nil,
-					Timeout:    100 * time.Nanosecond,
+					Timeout:    100 * time.Microsecond,
 				},
 				DiskIOBlockSizeKb: 1,
 				DiskTestTool:      DiskTestToolMock{},

--- a/cmd/testmev_internal_test.go
+++ b/cmd/testmev_internal_test.go
@@ -120,7 +120,7 @@ func TestMEVTest(t *testing.T) {
 					OutputJSON: "",
 					Quiet:      false,
 					TestCases:  nil,
-					Timeout:    100 * time.Nanosecond,
+					Timeout:    100 * time.Microsecond,
 				},
 				Endpoints: []string{endpoint1, endpoint2},
 			},

--- a/cmd/testvalidator_internal_test.go
+++ b/cmd/testvalidator_internal_test.go
@@ -67,7 +67,7 @@ func TestValidatorTest(t *testing.T) {
 				testConfig: testConfig{
 					OutputJSON: "",
 					Quiet:      false,
-					Timeout:    100 * time.Nanosecond,
+					Timeout:    100 * time.Microsecond,
 				},
 				APIAddress: validatorAPIAddress,
 			},


### PR DESCRIPTION
Sometimes we see those tests failing, because the timeout of the context is so short, the program cannot even reach the point where all processes are started (i.e.: when testing with 2 MEV relays, we get output of only 1).

category: test
ticket: none
