### PR TITLE
app/fetcher: add custom graffiti

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -501,7 +501,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	graffitiBuilder, err := fetcher.NewGraffitiBuilder(pubkeys, conf.Graffiti, conf.GraffitiDisableClientAppend)
+	graffitiBuilder, err := fetcher.NewGraffitiBuilder(pubkeys, conf.Graffiti, conf.GraffitiDisableClientAppend, eth2Cl)
 	if err != nil {
 		return err
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -501,14 +501,11 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	graffitiFunc, err := fetcher.GetGraffitiFunc(pubkeys, conf.Graffiti, conf.GraffitiDisableClientAppend)
+	graffitiBuilder, err := fetcher.NewGraffitiBuilder(pubkeys, conf.Graffiti, conf.GraffitiDisableClientAppend)
 	if err != nil {
 		return err
 	}
-	getGraffitiFunc := func(pubkey core.PubKey) [32]byte {
-		return graffitiFunc(pubkeys, pubkey, conf.Graffiti, conf.GraffitiDisableClientAppend)
-	}
-	fetch, err := fetcher.New(eth2Cl, feeRecipientFunc, conf.BuilderAPI, getGraffitiFunc)
+	fetch, err := fetcher.New(eth2Cl, feeRecipientFunc, conf.BuilderAPI, graffitiBuilder)
 	if err != nil {
 		return err
 	}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -100,8 +100,8 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringSliceVar(&config.BeaconNodeHeaders, "beacon-node-headers", nil, "Comma separated list of headers formatted as header=value")
 	cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
 	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API.")
-	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma-separated list of graffiti strings to include in block proposals. If possible appends OB (Obol) suffix to graffiti. Maximum 32 ASCII characters per graffiti.")
-	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending OB suffix to beacon proposal graffiti.")
+	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends \" OB<CL_YPE>\" suffix to graffiti. Maximum 27 bytes per graffiti.")
+	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending our suffix to graffiti. Increases maximum bytes per graffiti to 32.")
 
 	wrapPreRunE(cmd, func(cc *cobra.Command, _ []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {
@@ -116,6 +116,15 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 		err := eth2util.ValidateBeaconNodeHeaders(config.BeaconNodeHeaders)
 		if err != nil {
 			return err
+		}
+		maxGraffitiBytes := 27
+		if config.GraffitiDisableClientAppend {
+			maxGraffitiBytes = 32
+		}
+		for _, g := range config.Graffiti {
+			if len(g) > maxGraffitiBytes {
+				return errors.New("graffiti string length is greater than maximum size")
+			}
 		}
 
 		return nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -101,7 +101,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
 	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API.")
 	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends \"OB<CL_TYPE>\" suffix to graffiti. Maximum 28 bytes per graffiti.")
-	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending our suffix to graffiti. Increases maximum bytes per graffiti to 32.")
+	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending \"OB<CL_TYPE>\" suffix to graffiti. Increases maximum bytes per graffiti to 32.")
 
 	wrapPreRunE(cmd, func(cc *cobra.Command, _ []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -100,7 +100,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringSliceVar(&config.BeaconNodeHeaders, "beacon-node-headers", nil, "Comma separated list of headers formatted as header=value")
 	cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
 	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API.")
-	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends \" OB<CL_YPE>\" suffix to graffiti. Maximum 27 bytes per graffiti.")
+	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends \"OB<CL_TYPE>\" suffix to graffiti. Maximum 28 bytes per graffiti.")
 	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending our suffix to graffiti. Increases maximum bytes per graffiti to 32.")
 
 	wrapPreRunE(cmd, func(cc *cobra.Command, _ []string) error {
@@ -117,7 +117,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 		if err != nil {
 			return err
 		}
-		maxGraffitiBytes := 27
+		maxGraffitiBytes := 28
 		if config.GraffitiDisableClientAppend {
 			maxGraffitiBytes = 32
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -100,7 +100,7 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringSliceVar(&config.BeaconNodeHeaders, "beacon-node-headers", nil, "Comma separated list of headers formatted as header=value")
 	cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
 	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API.")
-	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma separated list of graffiti strings to include in block proposals.")
+	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma separated list of graffiti strings to include in block proposals. Maximum 32 ASCII characters per graffiti.")
 	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending the charon name to the client graffiti.")
 
 	wrapPreRunE(cmd, func(cc *cobra.Command, _ []string) error {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -100,6 +100,8 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringSliceVar(&config.BeaconNodeHeaders, "beacon-node-headers", nil, "Comma separated list of headers formatted as header=value")
 	cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
 	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API.")
+	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma separated list of graffiti strings to include in block proposals.")
+	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending the charon name to the client graffiti.")
 
 	wrapPreRunE(cmd, func(cc *cobra.Command, _ []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -100,8 +100,8 @@ func bindRunFlags(cmd *cobra.Command, config *app.Config) {
 	cmd.Flags().StringSliceVar(&config.BeaconNodeHeaders, "beacon-node-headers", nil, "Comma separated list of headers formatted as header=value")
 	cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
 	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API.")
-	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma separated list of graffiti strings to include in block proposals. Maximum 32 ASCII characters per graffiti.")
-	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending the charon name to the client graffiti.")
+	cmd.Flags().StringSliceVar(&config.Graffiti, "graffiti", nil, "Comma-separated list of graffiti strings to include in block proposals. If possible appends OB (Obol) suffix to graffiti. Maximum 32 ASCII characters per graffiti.")
+	cmd.Flags().BoolVar(&config.GraffitiDisableClientAppend, "graffiti-disable-client-append", false, "Disables appending OB suffix to beacon proposal graffiti.")
 
 	wrapPreRunE(cmd, func(cc *cobra.Command, _ []string) error {
 		if len(config.BeaconNodeAddrs) == 0 && !config.SimnetBMock {

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -21,12 +21,12 @@ import (
 )
 
 // New returns a new fetcher instance.
-func New(eth2Cl eth2wrap.Client, feeRecipientFunc func(core.PubKey) string, builderEnabled bool, getGraffitiFunc func(core.PubKey) [32]byte) (*Fetcher, error) {
+func New(eth2Cl eth2wrap.Client, feeRecipientFunc func(core.PubKey) string, builderEnabled bool, graffitiBuilder *GraffitiBuilder) (*Fetcher, error) {
 	return &Fetcher{
 		eth2Cl:           eth2Cl,
 		feeRecipientFunc: feeRecipientFunc,
 		builderEnabled:   builderEnabled,
-		getGraffitiFunc:  getGraffitiFunc,
+		graffitiBuilder:  graffitiBuilder,
 	}, nil
 }
 
@@ -38,7 +38,7 @@ type Fetcher struct {
 	aggSigDBFunc     func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
 	awaitAttDataFunc func(ctx context.Context, slot, commIdx uint64) (*eth2p0.AttestationData, error)
 	builderEnabled   bool
-	getGraffitiFunc  func(core.PubKey) [32]byte
+	graffitiBuilder  *GraffitiBuilder
 }
 
 // Subscribe registers a callback for fetched duties.
@@ -395,7 +395,7 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot uint64, defSet cor
 		opts := &eth2api.ProposalOpts{
 			Slot:               eth2p0.Slot(slot),
 			RandaoReveal:       randao,
-			Graffiti:           f.getGraffitiFunc(pubkey),
+			Graffiti:           f.graffitiBuilder.GetGraffiti(pubkey),
 			BuilderBoostFactor: &bbf,
 		}
 		eth2Resp, err := f.eth2Cl.Proposal(ctx, opts)

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -9,14 +9,17 @@ import (
 	"math"
 	"testing"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/prysmaticlabs/go-bitfield"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap/mocks"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/fetcher"
 	"github.com/obolnetwork/charon/eth2util/eth2exp"
@@ -275,10 +278,12 @@ func TestFetchBlocks(t *testing.T) {
 		pubkeysByIdx[vIdxB]: randaoB,
 	}
 
+	eth2Cl := mocks.NewClient(t)
+	eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: ""}, nil).Once()
 	graffitiBuilder, err := fetcher.NewGraffitiBuilder(
 		[]core.PubKey{pubkeysByIdx[vIdxA], pubkeysByIdx[vIdxB]},
 		[]string{graffitiAString, graffitiBString},
-		true,
+		true, eth2Cl,
 	)
 	require.NoError(t, err)
 

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -38,7 +38,7 @@ func NewGraffitiBuilder(pubkeys []core.PubKey, graffiti []string, disableClientA
 
 	for _, g := range graffiti {
 		if len(g) > 32 {
-			return nil, errors.New("graffiti length is greater than 32 characters")
+			return nil, errors.New("graffiti length is greater than 32 bytes")
 		}
 	}
 

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -15,7 +15,7 @@ import (
 	"github.com/obolnetwork/charon/core"
 )
 
-const obolToken = " OB"
+const obolToken = "OB"
 
 func ClientGraffitiMappings() map[string]string {
 	return map[string]string{

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -119,6 +119,7 @@ func defaultGraffiti() [32]byte {
 	return graffitiBytes
 }
 
+// fetchBeaconNodeToken queries the beacon node for the product token
 func fetchBeaconNodeToken(eth2Cl eth2wrap.Client) string {
 	eth2Resp, err := eth2Cl.NodeVersion(context.Background(), &eth2api.NodeVersionOpts{})
 	if err != nil {

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -21,7 +21,7 @@ func ClientGraffitiMappings() map[string]string {
 	return map[string]string{
 		"Teku":       "TK",
 		"Lighthouse": "LH",
-		"LodeStar":   "LS",
+		"Lodestar":   "LS",
 		"Prysm":      "PY",
 		"Nimbus":     "NB",
 		"Grandine":   "GD",

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -29,8 +29,7 @@ func NewGraffitiBuilder(pubkeys []core.PubKey, graffiti []string, disableClientA
 			builder.graffiti[pubkey] = builder.defaultGraffiti
 		}
 
-	
-	return builder, nil
+		return builder, nil
 	}
 
 	if len(graffiti) > 1 && len(graffiti) != len(pubkeys) {
@@ -49,7 +48,6 @@ func NewGraffitiBuilder(pubkeys []core.PubKey, graffiti []string, disableClientA
 		for _, pubkey := range pubkeys {
 			builder.graffiti[pubkey] = buildGraffiti(singleGraffiti, disableClientAppend)
 		}
-
 
 		return builder, nil
 	}

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -17,6 +17,14 @@ import (
 
 const obolToken = " OB"
 
+var tokens map[string]string = map[string]string{
+	"Teku":       "TK",
+	"Lighthouse": "LH",
+	"LodeStar":   "LS",
+	"Prysm":      "PY",
+	"Nimbus":     "NB",
+}
+
 type GraffitiBuilder struct {
 	defaultGraffiti [32]byte
 	graffiti        map[core.PubKey][32]byte
@@ -112,26 +120,15 @@ func defaultGraffiti() [32]byte {
 }
 
 func fetchBeaconNodeToken(eth2Cl eth2wrap.Client) string {
-	var token string
 	eth2Resp, err := eth2Cl.NodeVersion(context.Background(), &eth2api.NodeVersionOpts{})
 	if err != nil {
 		return ""
 	}
 
 	productToken := strings.Split(eth2Resp.Data, "/")[0]
-	switch productToken {
-	case "Teku":
-		token = "TK"
-	case "Lighthouse":
-		token = "LH"
-	case "LodeStar":
-		token = "LS"
-	case "Prysm":
-		token = "PY"
-	case "Nimbus":
-		token = "NB"
-	default:
-		token = ""
+	token, ok := tokens[productToken]
+	if !ok {
+		return ""
 	}
 
 	return token

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -3,9 +3,9 @@
 package fetcher
 
 import (
-	"errors"
 	"fmt"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/core"
 )
@@ -60,13 +60,14 @@ func NewGraffitiBuilder(pubkeys []core.PubKey, graffiti []string, disableClientA
 	return builder, nil
 }
 
-// getGraffiti returns the graffiti for a given pubkey or the default graffiti
+// GetGraffiti returns the graffiti for a given pubkey or the default graffiti
 func (g *GraffitiBuilder) GetGraffiti(pubkey core.PubKey) [32]byte {
-	if graffiti, ok := g.graffiti[pubkey]; !ok {
+	graffiti, ok := g.graffiti[pubkey]
+	if !ok {
 		return g.defaultGraffiti
-	} else {
-		return graffiti
 	}
+
+	return graffiti
 }
 
 // buildGraffiti builds the graffiti with optional obolSignature

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -1,0 +1,87 @@
+// Copyright © 2022-2025 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package fetcher
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/obolnetwork/charon/app/version"
+	"github.com/obolnetwork/charon/core"
+)
+
+const obolSignature = " OB"
+
+// GraffitiFunc is a type that describes a function that returns a graffiti for a validator.
+type GraffitiFunc func(pubkeys []core.PubKey, pubkey core.PubKey, graffiti []string, disable bool) [32]byte
+
+// GetGraffitiFunc returns a GraffitiFunc based on the number of validators and CLI graffiti flags provided.
+func GetGraffitiFunc(pubkeys []core.PubKey, graffiti []string, disableClientAppend bool) (GraffitiFunc, error) {
+	if graffiti == nil {
+		return getDefaultGraffiti, nil
+	}
+
+	if len(graffiti) > len(pubkeys) {
+		return nil, errors.New("graffiti length is greater than the number of validators")
+	}
+
+	for _, g := range graffiti {
+		if len(g) > 32 {
+			return nil, errors.New("graffiti length is greater than 32 characters")
+		}
+	}
+
+	if len(graffiti) == 1 {
+		if len(graffiti[0])+len(obolSignature) > 32 || disableClientAppend {
+			return getEqualGraffitiWithoutAppend, nil
+		}
+
+		return getEqualGraffitiWithAppend, nil
+	}
+
+	return getGraffitiPerValidator, nil
+}
+
+// getDefaultGraffiti returns a graffiti with the version and commit hash.
+func getDefaultGraffiti(pubkeys []core.PubKey, pubkey core.PubKey, graffiti []string, _ bool) [32]byte {
+	var graffitiBytes [32]byte
+	commitSHA, _ := version.GitCommit()
+	copy(graffitiBytes[:], fmt.Sprintf("charon/%v-%s", version.Version, commitSHA))
+
+	return graffitiBytes
+}
+
+// getEqualGraffitiWithAppend returns a graffiti with the first graffiti string and Obol appended.
+func getEqualGraffitiWithAppend(pubkeys []core.PubKey, pubkey core.PubKey, graffiti []string, _ bool) [32]byte {
+	var graffitiBytes [32]byte
+	copy(graffitiBytes[:], graffiti[0]+obolSignature)
+
+	return graffitiBytes
+}
+
+// getEqualGraffitiWithoutAppend returns a graffiti with the first graffiti string.
+func getEqualGraffitiWithoutAppend(pubkeys []core.PubKey, pubkey core.PubKey, graffiti []string, _ bool) [32]byte {
+	var graffitiBytes [32]byte
+	copy(graffitiBytes[:], graffiti[0])
+
+	return graffitiBytes
+}
+
+// getGraffitiPerValidator returns a graffiti based on the validator's public key.
+func getGraffitiPerValidator(pubkeys []core.PubKey, pubkey core.PubKey, graffiti []string, disableClientAppend bool) [32]byte {
+	var graffitiBytes [32]byte
+
+	idx := slices.Index(pubkeys, pubkey)
+	if idx == -1 {
+		return getDefaultGraffiti(pubkeys, pubkey, graffiti, disableClientAppend)
+	}
+
+	if len(graffiti[idx])+len(obolSignature) > 32 || disableClientAppend {
+		copy(graffitiBytes[:], graffiti[idx])
+	} else {
+		copy(graffitiBytes[:], graffiti[idx]+obolSignature)
+	}
+
+	return graffitiBytes
+}

--- a/core/fetcher/graffiti.go
+++ b/core/fetcher/graffiti.go
@@ -19,7 +19,7 @@ const obolToken = "OB"
 
 func ClientGraffitiMappings() map[string]string {
 	return map[string]string{
-		"Teku":       "TK",
+		"teku":       "TK",
 		"Lighthouse": "LH",
 		"Lodestar":   "LS",
 		"Prysm":      "PY",

--- a/core/fetcher/graffiti_internal_test.go
+++ b/core/fetcher/graffiti_internal_test.go
@@ -25,6 +25,20 @@ func TestFetchBeaconNodeToken(t *testing.T) {
 		require.Equal(t, "", token)
 	})
 
+	t.Run("fetch token unexpected response", func(t *testing.T) {
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: "IncorrectUserAgent"}, nil).Once()
+		token := fetchBeaconNodeToken(eth2Cl)
+		require.Equal(t, "", token)
+	})
+
+	t.Run("fetch token not predicted in map", func(t *testing.T) {
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: "Dune/v1.3 (Windows)"}, nil).Once()
+		token := fetchBeaconNodeToken(eth2Cl)
+		require.Equal(t, "", token)
+	})
+
 	t.Run("fetch token", func(t *testing.T) {
 		eth2Cl := mocks.NewClient(t)
 		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: "Lighthouse/v0.1.5 (Linux x86_64)"}, nil).Once()

--- a/core/fetcher/graffiti_internal_test.go
+++ b/core/fetcher/graffiti_internal_test.go
@@ -3,7 +3,6 @@
 package fetcher
 
 import (
-	"crypto/rand"
 	"fmt"
 	"testing"
 
@@ -14,31 +13,23 @@ import (
 	"github.com/obolnetwork/charon/testutil"
 )
 
-// randomString returns a random string of length n.
-func randomString(n int) string {
-	b := make([]byte, n)
-	_, _ = rand.Read(b)
-
-	return string(b)
-}
-
 func TestNewGraffitiBuilder(t *testing.T) {
 	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t)}
 
 	t.Run("graffiti length greater than pubkeys", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, []string{randomString(10), randomString(15), randomString(20), randomString(25)}, false)
+		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(15), testutil.RandomBytesAsString(20), testutil.RandomBytesAsString(25)}, false)
 		require.Nil(t, builder)
 		require.Error(t, err)
 	})
 
 	t.Run("graffiti length lesser than pubkeys", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, []string{randomString(10), randomString(15)}, false)
+		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(15)}, false)
 		require.Nil(t, builder)
 		require.Error(t, err)
 	})
 
 	t.Run("graffiti length greater than 32 characters", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, []string{randomString(33)}, false)
+		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(33)}, false)
 		require.Nil(t, builder)
 		require.Error(t, err)
 	})
@@ -79,7 +70,7 @@ func TestNewGraffitiBuilder(t *testing.T) {
 	})
 
 	t.Run("single graffiti with space for signature", func(t *testing.T) {
-		graffiti := randomString(32 - len(obolSignature))
+		graffiti := testutil.RandomBytesAsString(32 - len(obolSignature))
 		builder, err := NewGraffitiBuilder(pubkeys, []string{graffiti}, false)
 		require.NoError(t, err)
 
@@ -92,7 +83,7 @@ func TestNewGraffitiBuilder(t *testing.T) {
 	})
 
 	t.Run("single graffiti without space for signature", func(t *testing.T) {
-		graffiti := randomString(32 - len(obolSignature) + 1)
+		graffiti := testutil.RandomBytesAsString(32 - len(obolSignature) + 1)
 		builder, err := NewGraffitiBuilder(pubkeys, []string{graffiti}, false)
 		require.NoError(t, err)
 
@@ -105,7 +96,7 @@ func TestNewGraffitiBuilder(t *testing.T) {
 	})
 
 	t.Run("multiple graffiti", func(t *testing.T) {
-		graffiti := []string{randomString(10), randomString(32 - len(obolSignature)), randomString(32 - len(obolSignature) + 1)}
+		graffiti := []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(32 - len(obolSignature)), testutil.RandomBytesAsString(32 - len(obolSignature) + 1)}
 		expectedGraffiti := []string{graffiti[0] + obolSignature, graffiti[1] + obolSignature, graffiti[2]}
 		builder, err := NewGraffitiBuilder(pubkeys, graffiti, false)
 		require.NoError(t, err)

--- a/core/fetcher/graffiti_internal_test.go
+++ b/core/fetcher/graffiti_internal_test.go
@@ -3,65 +3,136 @@
 package fetcher
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/eth2wrap/mocks"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/testutil"
 )
 
+func TestFetchBeaconNodeToken(t *testing.T) {
+	t.Run("fetch token error", func(t *testing.T) {
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(nil, errors.New("")).Once()
+		token := fetchBeaconNodeToken(eth2Cl)
+		require.Equal(t, "", token)
+	})
+
+	t.Run("fetch token", func(t *testing.T) {
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: "Lighthouse/v0.1.5 (Linux x86_64)"}, nil).Once()
+		token := fetchBeaconNodeToken(eth2Cl)
+		require.Equal(t, "LH", token)
+	})
+}
+
+func TestBuildGraffiti(t *testing.T) {
+	t.Run("disable client append", func(t *testing.T) {
+		graffiti := testutil.RandomBytesAsString(10)
+		token := "BN"
+		result := buildGraffiti(graffiti, token, true)
+
+		var expected [32]byte
+		copy(expected[:], graffiti)
+
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("space for both signatures", func(t *testing.T) {
+		graffiti := testutil.RandomBytesAsString(10)
+		token := "BN"
+		result := buildGraffiti(graffiti, token, false)
+
+		var expected [32]byte
+		copy(expected[:], graffiti+obolToken+token)
+
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("space for obolToken only", func(t *testing.T) {
+		graffiti := testutil.RandomBytesAsString(32 - len(obolToken))
+		token := "BN"
+		result := buildGraffiti(graffiti, token, false)
+
+		var expected [32]byte
+		copy(expected[:], graffiti+obolToken)
+
+		require.Equal(t, expected, result)
+	})
+
+	t.Run("no space for any signature", func(t *testing.T) {
+		graffiti := testutil.RandomBytesAsString(32 - len(obolToken) + 1)
+		token := "BN"
+		result := buildGraffiti(graffiti, token, false)
+
+		var expected [32]byte
+		copy(expected[:], graffiti)
+
+		require.Equal(t, expected, result)
+	})
+}
+
+func TestDefaultGraffiti(t *testing.T) {
+	defaultGraffiti := defaultGraffiti()
+
+	var graffitiBytes [32]byte
+	commitSHA, _ := version.GitCommit()
+	copy(graffitiBytes[:], fmt.Sprintf("charon/%v-%s", version.Version, commitSHA))
+
+	require.Equal(t, graffitiBytes, defaultGraffiti)
+}
+
+func TestGetGraffiti(t *testing.T) {
+	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t)}
+	graffiti := [][32]byte{{1}, {2}}
+
+	builder := &GraffitiBuilder{
+		defaultGraffiti: defaultGraffiti(),
+		graffiti: map[core.PubKey][32]byte{
+			pubkeys[0]: graffiti[0],
+			pubkeys[1]: graffiti[1],
+		},
+	}
+
+	require.Equal(t, graffiti[0], builder.GetGraffiti(pubkeys[0]))
+	require.Equal(t, graffiti[1], builder.GetGraffiti(pubkeys[1]))
+	require.Equal(t, defaultGraffiti(), builder.GetGraffiti(testutil.RandomCorePubKey(t)))
+}
+
 func TestNewGraffitiBuilder(t *testing.T) {
 	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t)}
 
 	t.Run("graffiti length greater than pubkeys", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(15), testutil.RandomBytesAsString(20), testutil.RandomBytesAsString(25)}, false)
+		eth2Cl := mocks.NewClient(t)
+		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(15), testutil.RandomBytesAsString(20), testutil.RandomBytesAsString(25)}, false, eth2Cl)
 		require.Nil(t, builder)
 		require.Error(t, err)
 	})
 
 	t.Run("graffiti length lesser than pubkeys", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(15)}, false)
+		eth2Cl := mocks.NewClient(t)
+		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(15)}, false, eth2Cl)
 		require.Nil(t, builder)
 		require.Error(t, err)
 	})
 
 	t.Run("graffiti length greater than 32 characters", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(33)}, false)
+		eth2Cl := mocks.NewClient(t)
+		builder, err := NewGraffitiBuilder(pubkeys, []string{testutil.RandomBytesAsString(33)}, false, eth2Cl)
 		require.Nil(t, builder)
 		require.Error(t, err)
 	})
 
-	t.Run("default graffiti", func(t *testing.T) {
-		defaultGraffiti := defaultGraffiti()
-
-		var graffitiBytes [32]byte
-		commitSHA, _ := version.GitCommit()
-		copy(graffitiBytes[:], fmt.Sprintf("charon/%v-%s", version.Version, commitSHA))
-
-		require.Equal(t, graffitiBytes, defaultGraffiti)
-	})
-
-	t.Run("get graffiti", func(t *testing.T) {
-		graffiti := [][32]byte{{1}, {2}}
-
-		builder := &GraffitiBuilder{
-			defaultGraffiti: defaultGraffiti(),
-			graffiti: map[core.PubKey][32]byte{
-				pubkeys[0]: graffiti[0],
-				pubkeys[1]: graffiti[1],
-			},
-		}
-
-		require.Equal(t, graffiti[0], builder.GetGraffiti(pubkeys[0]))
-		require.Equal(t, graffiti[1], builder.GetGraffiti(pubkeys[1]))
-		require.Equal(t, defaultGraffiti(), builder.GetGraffiti(testutil.RandomCorePubKey(t)))
-	})
-
 	t.Run("nil graffiti", func(t *testing.T) {
-		builder, err := NewGraffitiBuilder(pubkeys, nil, false)
+		eth2Cl := mocks.NewClient(t)
+		builder, err := NewGraffitiBuilder(pubkeys, nil, false, eth2Cl)
 		require.NoError(t, err)
 
 		for _, pubkey := range pubkeys {
@@ -70,21 +141,25 @@ func TestNewGraffitiBuilder(t *testing.T) {
 	})
 
 	t.Run("single graffiti with space for signature", func(t *testing.T) {
-		graffiti := testutil.RandomBytesAsString(32 - len(obolSignature))
-		builder, err := NewGraffitiBuilder(pubkeys, []string{graffiti}, false)
+		graffiti := testutil.RandomBytesAsString(32 - len(obolToken))
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: ""}, nil).Once()
+		builder, err := NewGraffitiBuilder(pubkeys, []string{graffiti}, false, eth2Cl)
 		require.NoError(t, err)
 
 		for _, pubkey := range pubkeys {
 			var expected [32]byte
-			copy(expected[:], graffiti+obolSignature)
+			copy(expected[:], graffiti+obolToken)
 
 			require.Equal(t, expected, builder.GetGraffiti(pubkey))
 		}
 	})
 
 	t.Run("single graffiti without space for signature", func(t *testing.T) {
-		graffiti := testutil.RandomBytesAsString(32 - len(obolSignature) + 1)
-		builder, err := NewGraffitiBuilder(pubkeys, []string{graffiti}, false)
+		graffiti := testutil.RandomBytesAsString(32 - len(obolToken) + 1)
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: ""}, nil).Once()
+		builder, err := NewGraffitiBuilder(pubkeys, []string{graffiti}, false, eth2Cl)
 		require.NoError(t, err)
 
 		for _, pubkey := range pubkeys {
@@ -96,9 +171,11 @@ func TestNewGraffitiBuilder(t *testing.T) {
 	})
 
 	t.Run("multiple graffiti", func(t *testing.T) {
-		graffiti := []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(32 - len(obolSignature)), testutil.RandomBytesAsString(32 - len(obolSignature) + 1)}
-		expectedGraffiti := []string{graffiti[0] + obolSignature, graffiti[1] + obolSignature, graffiti[2]}
-		builder, err := NewGraffitiBuilder(pubkeys, graffiti, false)
+		graffiti := []string{testutil.RandomBytesAsString(10), testutil.RandomBytesAsString(32 - len(obolToken)), testutil.RandomBytesAsString(32 - len(obolToken) + 1)}
+		expectedGraffiti := []string{graffiti[0] + obolToken, graffiti[1] + obolToken, graffiti[2]}
+		eth2Cl := mocks.NewClient(t)
+		eth2Cl.On("NodeVersion", mock.Anything, mock.Anything).Return(&eth2api.Response[string]{Data: ""}, nil).Once()
+		builder, err := NewGraffitiBuilder(pubkeys, graffiti, false, eth2Cl)
 		require.NoError(t, err)
 
 		for idx, pubkey := range pubkeys {

--- a/core/fetcher/graffiti_internal_test.go
+++ b/core/fetcher/graffiti_internal_test.go
@@ -1,0 +1,167 @@
+// Copyright © 2022-2025 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package fetcher
+
+import (
+	"crypto/rand"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/version"
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+// randomString returns a random string of length n.
+func randomString(n int) string {
+	b := make([]byte, n)
+	_, _ = rand.Read(b)
+
+	return string(b)
+}
+
+func TestGetGraffitiFunc(t *testing.T) {
+	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t), testutil.RandomCorePubKey(t)}
+
+	t.Run("graffiti length greater than pubkeys", func(t *testing.T) {
+		fn, err := GetGraffitiFunc(pubkeys, []string{randomString(10), randomString(15), randomString(20)}, false)
+		require.Nil(t, fn)
+		require.Error(t, err)
+	})
+
+	t.Run("graffiti length greater than 32 characters", func(t *testing.T) {
+		fn, err := GetGraffitiFunc(pubkeys, []string{randomString(33)}, false)
+		require.Nil(t, fn)
+		require.Error(t, err)
+	})
+
+	tests := []struct {
+		name                string
+		graffiti            []string
+		disableClientAppend bool
+		expected            GraffitiFunc
+	}{
+		{
+			name:                "nil graffiti - with append",
+			disableClientAppend: false,
+			expected:            getDefaultGraffiti,
+		},
+		{
+			name:                "nil graffiti - without append",
+			disableClientAppend: true,
+			expected:            getDefaultGraffiti,
+		},
+		{
+			name:                "single graffiti - space for signature - with append",
+			graffiti:            []string{randomString(32 - len(obolSignature))},
+			disableClientAppend: false,
+			expected:            getEqualGraffitiWithAppend,
+		},
+		{
+			name:                "single graffiti - space for signature - without append",
+			graffiti:            []string{randomString(32 - len(obolSignature))},
+			disableClientAppend: true,
+			expected:            getEqualGraffitiWithoutAppend,
+		},
+		{
+			name:                "single graffiti - no space for signature - with append",
+			graffiti:            []string{randomString(32 - len(obolSignature) + 1)},
+			disableClientAppend: false,
+			expected:            getEqualGraffitiWithoutAppend,
+		},
+		{
+			name:                "single graffiti - no space for signature - without append",
+			graffiti:            []string{randomString(32 - len(obolSignature) + 1)},
+			disableClientAppend: true,
+			expected:            getEqualGraffitiWithoutAppend,
+		},
+		{
+			name:     "multiple graffiti",
+			graffiti: []string{randomString(32 - len(obolSignature)), randomString(32 - len(obolSignature) + 1)},
+			expected: getGraffitiPerValidator,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fn, err := GetGraffitiFunc(pubkeys, tt.graffiti, tt.disableClientAppend)
+			require.NoError(t, err)
+			require.Equal(t, reflect.ValueOf(tt.expected).Pointer(), reflect.ValueOf(fn).Pointer())
+		})
+	}
+}
+
+func TestGetDefaultGraffiti(t *testing.T) {
+	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t)}
+	graffiti := []string{}
+
+	graffitiBytes := getDefaultGraffiti(pubkeys, pubkeys[0], graffiti, false)
+	commitSHA, _ := version.GitCommit()
+	var expected [32]byte
+	copy(expected[:], fmt.Sprintf("charon/%v-%s", version.Version, commitSHA))
+
+	require.Equal(t, expected, graffitiBytes)
+	require.LessOrEqual(t, len(graffitiBytes), 32)
+}
+
+func TestGetEqualGraffitiWithAppend(t *testing.T) {
+	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t)}
+	graffiti := randomString(10)
+
+	graffitiBytes := getEqualGraffitiWithAppend(pubkeys, pubkeys[0], []string{graffiti}, false)
+	var expected [32]byte
+	copy(expected[:], graffiti+obolSignature)
+
+	require.Equal(t, expected, graffitiBytes)
+	require.LessOrEqual(t, len(graffitiBytes), 32)
+}
+
+func TestGetEqualGraffitiWithoutAppend(t *testing.T) {
+	pubkeys := []core.PubKey{testutil.RandomCorePubKey(t)}
+	graffiti := randomString(32 - len(obolSignature) + 1)
+
+	graffitiBytes := getEqualGraffitiWithoutAppend(pubkeys, pubkeys[0], []string{graffiti}, false)
+	var expected [32]byte
+	copy(expected[:], graffiti)
+
+	require.Equal(t, expected, graffitiBytes)
+	require.LessOrEqual(t, len(graffitiBytes), 32)
+}
+
+func TestGetGraffitiPerValidator(t *testing.T) {
+	pubkeys := []core.PubKey{
+		testutil.RandomCorePubKey(t),
+		testutil.RandomCorePubKey(t),
+		testutil.RandomCorePubKey(t),
+	}
+	graffiti := []string{randomString(10), randomString(32 - len(obolSignature)), randomString(32 - len(obolSignature) + 1)}
+
+	t.Run("invalid pubkey", func(t *testing.T) {
+		graffitiBytes := getGraffitiPerValidator(pubkeys, "invalid_pubkey", graffiti, false)
+		expected := getDefaultGraffiti(pubkeys, "", graffiti, false)
+
+		require.Equal(t, expected, graffitiBytes)
+		require.LessOrEqual(t, len(graffitiBytes), 32)
+	})
+
+	t.Run("graffiti space for signature", func(t *testing.T) {
+		graffitiBytes := getGraffitiPerValidator(pubkeys, pubkeys[1], graffiti, false)
+		var expected [32]byte
+		copy(expected[:], graffiti[1]+obolSignature)
+
+		require.Equal(t, expected, graffitiBytes)
+		require.LessOrEqual(t, len(graffitiBytes), 32)
+	})
+
+	t.Run("graffiti no space for signature", func(t *testing.T) {
+		graffitiBytes := getGraffitiPerValidator(pubkeys, pubkeys[2], graffiti, false)
+		var expected [32]byte
+		copy(expected[:], graffiti[2])
+
+		require.Equal(t, expected, graffitiBytes)
+		require.LessOrEqual(t, len(graffitiBytes), 32)
+	})
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,8 +169,8 @@ Flags:
       --feature-set string                       Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings              Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings               Comma-separated list of features to enable, overriding the default minimum feature set.
-      --graffiti strings                         Comma-separated list of graffiti strings to include in block proposals. If possible appends OB (Obol) suffix to graffiti. Maximum 32 ASCII characters per graffiti.
-      --graffiti-disable-client-append           Disables appending OB suffix to beacon proposal graffiti.
+      --graffiti strings                         Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends " OB<CL_YPE>" suffix to graffiti. Maximum 27 bytes per graffiti.
+      --graffiti-disable-client-append           Disables appending our suffix to graffiti. Increases maximum bytes per graffiti to 32.
   -h, --help                                     Help for run
       --jaeger-address string                    [DISABLED] Listening address for jaeger tracing.
       --jaeger-service string                    [DISABLED] Service name used for jaeger tracing.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,7 +169,7 @@ Flags:
       --feature-set string                       Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings              Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings               Comma-separated list of features to enable, overriding the default minimum feature set.
-      --graffiti strings                         Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends " OB<CL_YPE>" suffix to graffiti. Maximum 27 bytes per graffiti.
+      --graffiti strings                         Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends "OB<CL_TYPE>" suffix to graffiti. Maximum 28 bytes per graffiti.
       --graffiti-disable-client-append           Disables appending our suffix to graffiti. Increases maximum bytes per graffiti to 32.
   -h, --help                                     Help for run
       --jaeger-address string                    [DISABLED] Listening address for jaeger tracing.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -170,7 +170,7 @@ Flags:
       --feature-set-disable strings              Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings               Comma-separated list of features to enable, overriding the default minimum feature set.
       --graffiti strings                         Comma-separated list or single graffiti string to include in block proposals. List maps to validator's public key in cluster lock. Appends "OB<CL_TYPE>" suffix to graffiti. Maximum 28 bytes per graffiti.
-      --graffiti-disable-client-append           Disables appending our suffix to graffiti. Increases maximum bytes per graffiti to 32.
+      --graffiti-disable-client-append           Disables appending "OB<CL_TYPE>" suffix to graffiti. Increases maximum bytes per graffiti to 32.
   -h, --help                                     Help for run
       --jaeger-address string                    [DISABLED] Listening address for jaeger tracing.
       --jaeger-service string                    [DISABLED] Service name used for jaeger tracing.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,6 +169,8 @@ Flags:
       --feature-set string                       Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings              Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings               Comma-separated list of features to enable, overriding the default minimum feature set.
+      --graffiti strings                         Comma separated list of graffiti strings to include in block proposals. Maximum 32 ASCII characters per graffiti.
+      --graffiti-disable-client-append           Disables appending the charon name to the client graffiti.
   -h, --help                                     Help for run
       --jaeger-address string                    [DISABLED] Listening address for jaeger tracing.
       --jaeger-service string                    [DISABLED] Service name used for jaeger tracing.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -169,8 +169,8 @@ Flags:
       --feature-set string                       Minimum feature set to enable by default: alpha, beta, or stable. Warning: modify at own risk. (default "stable")
       --feature-set-disable strings              Comma-separated list of features to disable, overriding the default minimum feature set.
       --feature-set-enable strings               Comma-separated list of features to enable, overriding the default minimum feature set.
-      --graffiti strings                         Comma separated list of graffiti strings to include in block proposals. Maximum 32 ASCII characters per graffiti.
-      --graffiti-disable-client-append           Disables appending the charon name to the client graffiti.
+      --graffiti strings                         Comma-separated list of graffiti strings to include in block proposals. If possible appends OB (Obol) suffix to graffiti. Maximum 32 ASCII characters per graffiti.
+      --graffiti-disable-client-append           Disables appending OB suffix to beacon proposal graffiti.
   -h, --help                                     Help for run
       --jaeger-address string                    [DISABLED] Listening address for jaeger tracing.
       --jaeger-service string                    [DISABLED] Service name used for jaeger tracing.

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -165,6 +165,7 @@ type Mock struct {
 	SubmitProposalPreparationsFunc         func(ctx context.Context, preparations []*eth2v1.ProposalPreparation) error
 	ForkScheduleFunc                       func(context.Context, *eth2api.ForkScheduleOpts) ([]*eth2p0.Fork, error)
 	ProposerConfigFunc                     func(context.Context) (*eth2exp.ProposerConfigResponse, error)
+	NodeVersionFunc                        func(context.Context, *eth2api.NodeVersionOpts) (*eth2api.Response[string], error)
 }
 
 func (m Mock) AggregateAttestation(ctx context.Context, opts *eth2api.AggregateAttestationOpts) (*eth2api.Response[*eth2p0.Attestation], error) {
@@ -385,6 +386,10 @@ func (m Mock) SlotsPerEpoch(ctx context.Context) (uint64, error) {
 
 func (m Mock) ProposerConfig(ctx context.Context) (*eth2exp.ProposerConfigResponse, error) {
 	return m.ProposerConfigFunc(ctx)
+}
+
+func (m Mock) NodeVersion(ctx context.Context, opts *eth2api.NodeVersionOpts) (*eth2api.Response[string], error) {
+	return m.NodeVersionFunc(ctx, opts)
 }
 
 func (Mock) SetForkVersion([4]byte) {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -678,7 +678,7 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		ProposerConfigFunc: func(context.Context) (*eth2exp.ProposerConfigResponse, error) {
 			return nil, nil
 		},
-		NodeVersionFunc: func(ctx context.Context, nvo *eth2api.NodeVersionOpts) (*eth2api.Response[string], error) {
+		NodeVersionFunc: func(_ context.Context, _ *eth2api.NodeVersionOpts) (*eth2api.Response[string], error) {
 			return &eth2api.Response[string]{Data: "charon/static_beacon_mock"}, nil
 		},
 	}

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -678,6 +678,9 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		ProposerConfigFunc: func(context.Context) (*eth2exp.ProposerConfigResponse, error) {
 			return nil, nil
 		},
+		NodeVersionFunc: func(ctx context.Context, nvo *eth2api.NodeVersionOpts) (*eth2api.Response[string], error) {
+			return &eth2api.Response[string]{Data: "charon/static_beacon_mock"}, nil
+		},
 	}
 }
 

--- a/testutil/random.go
+++ b/testutil/random.go
@@ -1243,6 +1243,13 @@ func RandomChecksummedETHAddress(t *testing.T, seed int) string {
 	return eth2util.PublicKeyToAddress(publicKey)
 }
 
+func RandomBytesAsString(length int) string {
+	b := make([]byte, length)
+	_, _ = NewSeedRand().Read(b)
+
+	return string(b)
+}
+
 func RandomBytes96() []byte {
 	return RandomBytes96Seed(NewSeedRand())
 }


### PR DESCRIPTION
Allow users to set a global or per validator public key custom graffiti to their beacon block proposals.

Add two new CLI flags:
- `graffiti`: a comma-separated list of graffiti to add to beacon block proposals
- `graffiti-disable-client-append`: a boolean value to disable appending obol signature to custom graffiti.

category: feature
ticket: #3608 

