### PR TITLE
*: bump go to 1.24

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,9 +1,9 @@
 name: Setup go
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Setup go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: "1.24"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,15 +13,15 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main*" ]
+    branches: ["main*"]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ "main*" ]
+    branches: ["main*"]
   schedule:
-    - cron: '18 19 * * 6'
+    - cron: "18 19 * * 6"
 
 env:
-  GOLANG_VERSION: '1.23'
+  GOLANG_VERSION: "1.24"
 
 jobs:
   analyze:
@@ -35,48 +35,47 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: [ 'go' ]
+        language: ["go"]
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GOLANG_VERSION }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GOLANG_VERSION }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file.
-        # Prefix the list here with "+" to use these queries and those in the config file.
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
 
-        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
+          # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
 
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+      #   If the Autobuild fails above, remove it and uncomment the following three lines.
+      #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines.
-    #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
+      # - run: |
+      #   echo "Run, Build Application using script"
+      #   ./location_of_script_within_repo/buildscript.sh
 
-    # - run: |
-    #   echo "Run, Build Application using script"
-    #   ./location_of_script_within_repo/buildscript.sh
-
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
-      with:
-        category: "/language:${{matrix.language}}"
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.63.4
+          version: v2.0.1
       - name: notify failure
         if: failure() && github.ref == 'refs/heads/main'
         env:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
           version: v2.0.1
       - name: notify failure

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -144,6 +144,8 @@ linters:
       ignore-sigs:
         - github.com/obolnetwork/charon/
         - github.com/attestantio/go-eth2-client
+    usetesting:
+      context-background: false # causes data races
   exclusions:
     generated: lax
     presets:
@@ -164,7 +166,7 @@ linters:
       - path: (.+)\.go$
         text: error returned from interface method should be wrapped
       - path: (.+)\.go$
-        text: 'defer: prefer not to defer chains of function calls'
+        text: "defer: prefer not to defer chains of function calls"
       - path: (.+)\.go$
         text: avoid control coupling
       - path: (.+)\.go$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,165 +1,16 @@
+version: "2"
 run:
-  timeout: 5m
   go: "1.24"
-linters-settings:
-  cyclop:
-    max-complexity: 15
-    skip-tests: true
-  dupl:
-    # tokens count to trigger issue, 150 by default
-    threshold: 400
-  depguard:
-    rules:
-      main:
-        deny:
-          - pkg: "github.com/pkg/errors"
-            desc: Prefer ./app/errors
-          - pkg: "github.com/golang/protobuf"
-            desc: Prefer google.golang.org/protobuf
-          - pkg: "github.com/gogo/protobuf/proto"
-            desc: Prefer google.golang.org/protobuf
-  exhaustive:
-    default-signifies-exhaustive: true
-  forbidigo:
-    forbid:
-      - 'fmt\.Print.*(# Avoid debug logging)?'
-      - 'fmt\.Errorf.*(# Prefer app/errors.Wrap)?'
-  gci:
-    sections:
-      - prefix(github.com/obolnetwork/charon)
-  gocritic:
-    disabled-checks:
-      - ifElseChain
-  govet:
-    enable-all: true
-    disable:
-      - fieldalignment
-      - shadow
-  importas:
-    no-unaliased: true
-    alias:
-      - pkg: github.com/attestantio/go-eth2-client/spec/phase0
-        alias: eth2p0
-      - pkg: github.com/attestantio/go-eth2-client/api/v1
-        alias: eth2v1
-      - pkg: github.com/attestantio/go-eth2-client/api
-        alias: eth2api
-      - pkg: github.com/attestantio/go-eth2-client/spec
-        alias: eth2spec
-      - pkg: github.com/attestantio/go-eth2-client/http
-        alias: eth2http
-      - pkg: github.com/attestantio/go-eth2-client/mock
-        alias: eth2mock
-      - pkg: github.com/attestantio/go-eth2-client/api/v1/bellatrix
-        alias: eth2bellatrix
-      - pkg: github.com/attestantio/go-eth2-client/api/v1/capella
-        alias: eth2capella
-      - pkg: github.com/decred/dcrd/dcrec/secp256k1/v4
-        alias: k1
-      - pkg: github.com/obolnetwork/charon/cluster/manifestpb/v1
-        alias: manifestpb
-  nlreturn:
-    block-size: 2
-  revive:
-    enable-all-rules: true
-    severity: warning
-    rules:
-      # Disabled revive rules
-      - name: banned-characters
-        disabled: true
-      - name: add-constant
-        disabled: true
-      - name: file-header
-        disabled: true
-      - name: function-result-limit
-        disabled: true
-      - name: cyclomatic
-        disabled: true
-      - name: line-length-limit
-        disabled: true
-      - name: max-public-structs
-        disabled: true
-      - name: argument-limit
-        disabled: true
-      - name: function-length
-        disabled: true
-      - name: cognitive-complexity
-        disabled: true
-      - name: comment-spacings
-        disabled: true # Doesn't support latest go spec comments
-      - name: range-val-address
-        disabled: true # It is not an issue for go versions >=1.22
-      # Some configured revive rules
-      - name: unhandled-error
-        arguments:
-          - "fmt.Printf"
-          - "fmt.Println"
-      - name: imports-blocklist
-        arguments:
-          - "errors" # Prefer ./app/errors
-          - "github.com/pkg/errors" # Prefer ./app/errors
-          - "github.com/golang/protobuf" # Prefer google.golang.org/protobuf
-          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
-          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
-  staticcheck:
-    checks:
-      - "all"
-      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.
-  testpackage:
-    skip-regexp: internal_test\.go
-  wrapcheck:
-    ignoreSigs:
-      - github.com/obolnetwork/charon/
-      - github.com/attestantio/go-eth2-client
-  testifylint:
-    disable:
-      - expected-actual
-    go-require:
-      ignore-http-handlers: true
-  gosec:
-    excludes:
-      # Flags for potentially-unsafe casting of ints, seems good,
-      # but currently is really unstable with no clear way to make the linter pass.
-      # https://github.com/securego/gosec/issues/1187
-      - G115
-
-issues:
-  fix: true
-  max-same-issues: 0
-  max-issues-per-linter: 0
-  exclude-rules:
-    - path: '(.+)_test\.go'
-      linters:
-        - bodyclose
-        - gosec
-        - noctx
-        - revive
-    - path: "eth2wrap"
-      linters:
-        - importas
-  exclude:
-    - "error returned from interface method should be wrapped" # Relax wrapcheck
-    - "defer: prefer not to defer chains of function calls" # Relax revive
-    - "avoid control coupling" # Relax revive
-    - "shadows an import name" # Relax revive
-    - "confusing-naming" # Relax revive
-    - "nested-structs" # Relax revive
-    - "0xhex" # Relax revive and staticcheck about our custom struct tag
-    - 'shadow: declaration of "err" shadows declaration' # Relax govet
-
 linters:
-  enable-all: true
+  default: all
   disable:
-    # Keep disabled
-    - intrange
     - containedctx
     - contextcheck
     - cyclop
+    - err113
     - exhaustruct
-    - exportloopref # It is not an issue for go versions >=1.22
-    - funlen
     - forcetypeassert
-    - gci
+    - funlen
     - gochecknoglobals
     - gocognit
     - gocyclo
@@ -168,8 +19,9 @@ linters:
     - gomoddirectives
     - inamedparam
     - interfacebloat
+    - intrange
     - ireturn
-    - lll # Think about adding this (max line length)
+    - lll
     - maintidx
     - mnd
     - musttag
@@ -177,8 +29,177 @@ linters:
     - nonamedreturns
     - paralleltest
     - prealloc
-    - recvcheck # triggers a lot of false positives
+    - recvcheck
     - tagliatelle
     - varnamelen
     - wsl
-    - err113
+  settings:
+    cyclop:
+      max-complexity: 15
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: github.com/pkg/errors
+              desc: Prefer ./app/errors
+            - pkg: github.com/golang/protobuf
+              desc: Prefer google.golang.org/protobuf
+            - pkg: github.com/gogo/protobuf/proto
+              desc: Prefer google.golang.org/protobuf
+    dupl:
+      threshold: 400
+    exhaustive:
+      default-signifies-exhaustive: true
+    forbidigo:
+      forbid:
+        - pattern: fmt\.Print.*(# Avoid debug logging)?
+        - pattern: fmt\.Errorf.*(# Prefer app/errors.Wrap)?
+    gocritic:
+      disabled-checks:
+        - ifElseChain
+    gosec:
+      excludes:
+        - G115
+    govet:
+      disable:
+        - fieldalignment
+        - shadow
+      enable-all: true
+    importas:
+      alias:
+        - pkg: github.com/attestantio/go-eth2-client/spec/phase0
+          alias: eth2p0
+        - pkg: github.com/attestantio/go-eth2-client/api/v1
+          alias: eth2v1
+        - pkg: github.com/attestantio/go-eth2-client/api
+          alias: eth2api
+        - pkg: github.com/attestantio/go-eth2-client/spec
+          alias: eth2spec
+        - pkg: github.com/attestantio/go-eth2-client/http
+          alias: eth2http
+        - pkg: github.com/attestantio/go-eth2-client/mock
+          alias: eth2mock
+        - pkg: github.com/attestantio/go-eth2-client/api/v1/bellatrix
+          alias: eth2bellatrix
+        - pkg: github.com/attestantio/go-eth2-client/api/v1/capella
+          alias: eth2capella
+        - pkg: github.com/decred/dcrd/dcrec/secp256k1/v4
+          alias: k1
+        - pkg: github.com/obolnetwork/charon/cluster/manifestpb/v1
+          alias: manifestpb
+      no-unaliased: true
+    nlreturn:
+      block-size: 2
+    revive:
+      severity: warning
+      enable-all-rules: true
+      rules:
+        - name: banned-characters
+          disabled: true
+        - name: add-constant
+          disabled: true
+        - name: file-header
+          disabled: true
+        - name: function-result-limit
+          disabled: true
+        - name: cyclomatic
+          disabled: true
+        - name: line-length-limit
+          disabled: true
+        - name: max-public-structs
+          disabled: true
+        - name: argument-limit
+          disabled: true
+        - name: function-length
+          disabled: true
+        - name: cognitive-complexity
+          disabled: true
+        - name: comment-spacings
+          disabled: true
+        - name: range-val-address
+          disabled: true
+        - name: unhandled-error
+          arguments:
+            - fmt.Printf
+            - fmt.Println
+        - name: imports-blocklist
+          arguments:
+            - errors
+            - github.com/pkg/errors
+            - github.com/golang/protobuf
+            - github.com/gogo/protobuf/proto
+            - github.com/prometheus/client_golang/prometheus/promauto
+    staticcheck:
+      checks:
+        - -SA1019
+        - all
+    testifylint:
+      disable:
+        - expected-actual
+      go-require:
+        ignore-http-handlers: true
+    testpackage:
+      skip-regexp: internal_test\.go
+    wrapcheck:
+      ignore-sigs:
+        - github.com/obolnetwork/charon/
+        - github.com/attestantio/go-eth2-client
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - bodyclose
+          - gosec
+          - noctx
+          - revive
+        path: (.+)_test\.go
+      - linters:
+          - importas
+        path: eth2wrap
+      - path: (.+)\.go$
+        text: error returned from interface method should be wrapped
+      - path: (.+)\.go$
+        text: 'defer: prefer not to defer chains of function calls'
+      - path: (.+)\.go$
+        text: avoid control coupling
+      - path: (.+)\.go$
+        text: shadows an import name
+      - path: (.+)\.go$
+        text: confusing-naming
+      - path: (.+)\.go$
+        text: nested-structs
+      - path: (.+)\.go$
+        text: 0xhex
+      - path: (.+)\.go$
+        text: 'shadow: declaration of "err" shadows declaration'
+      - linters:
+          - cyclop
+        path: (.+)_test\.go
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+  fix: true
+formatters:
+  enable:
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - prefix(github.com/obolnetwork/charon)
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 5m
-  go: "1.23"
+  go: "1.24"
 linters-settings:
   cyclop:
     max-complexity: 15
@@ -92,19 +92,19 @@ linters-settings:
       # Some configured revive rules
       - name: unhandled-error
         arguments:
-         - 'fmt.Printf'
-         - 'fmt.Println'
+          - "fmt.Printf"
+          - "fmt.Println"
       - name: imports-blocklist
         arguments:
-         - "errors" # Prefer ./app/errors
-         - "github.com/pkg/errors" # Prefer ./app/errors
-         - "github.com/golang/protobuf" # Prefer google.golang.org/protobuf
-         - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
-         - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
+          - "errors" # Prefer ./app/errors
+          - "github.com/pkg/errors" # Prefer ./app/errors
+          - "github.com/golang/protobuf" # Prefer google.golang.org/protobuf
+          - "github.com/gogo/protobuf/proto" # Prefer google.golang.org/protobuf
+          - "github.com/prometheus/client_golang/prometheus/promauto" # Prefer ./app/promauto
   staticcheck:
     checks:
-     - "all"
-     - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.
+      - "all"
+      - "-SA1019" # Ignoring since github.com/drand/kyber/sign/bls uses Proof Of Possession as does Ethereum.
   testpackage:
     skip-regexp: internal_test\.go
   wrapcheck:
@@ -134,7 +134,7 @@ issues:
         - gosec
         - noctx
         - revive
-    - path: 'eth2wrap'
+    - path: "eth2wrap"
       linters:
         - importas
   exclude:
@@ -145,7 +145,7 @@ issues:
     - "confusing-naming" # Relax revive
     - "nested-structs" # Relax revive
     - "0xhex" # Relax revive and staticcheck about our custom struct tag
-    - "shadow: declaration of \"err\" shadows declaration" # Relax govet
+    - 'shadow: declaration of "err" shadows declaration' # Relax govet
 
 linters:
   enable-all: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
     rev: v0.0.4
     hooks:
       - id: check-go-version
-        args: [ -v=go1.23 ] # Only check minor version locally
+        args: [-v=go1.24] # Only check minor version locally
         pass_filenames: false
-        additional_dependencies: [ packaging ]
+        additional_dependencies: [packaging]
       - id: check-licence-header
-        types: [ file, go ]
+        types: [file, go]
         exclude: ".pb.go"
 
   - repo: https://github.com/corverroos/fiximports
@@ -37,7 +37,7 @@ repos:
     rev: v0.4.0
     hooks:
       - id: go-fmt
-        args: [ -w, -s ] # simplify code and write result to (source) file instead of stdout
+        args: [-w, -s] # simplify code and write result to (source) file instead of stdout
 
   # Then run code validators (on the formatted code)
 
@@ -47,25 +47,25 @@ repos:
         name: golangci-lint
         language: script
         entry: .pre-commit/run_linter.sh
-        types: [ file, go ]
+        types: [file, go]
       - id: run-go-tests
         name: run-go-tests
         language: script
         entry: .pre-commit/run_tests.sh
-        types: [ file, go ]
+        types: [file, go]
       - id: run-buf
         name: run-buf
         language: script
         entry: .pre-commit/run_buf.sh
-        types: [ file, proto ]
+        types: [file, proto]
       - id: run-regexp
         name: run-regexp
         language: script
         entry: .pre-commit/run_regexp.sh
-        types: [ file, go ]
+        types: [file, go]
         exclude: "_test.go"
       - id: run-testutil
         name: run-testutil
         language: script
         entry: .pre-commit/run_testutil.sh
-        types: [ file, go ]
+        types: [file, go]

--- a/.pre-commit/run_linter.sh
+++ b/.pre-commit/run_linter.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 
-VERSION="1.63.4"
+VERSION="2.0.1"
 
-if ! command -v golangci-lint &> /dev/null
-then
+if ! command -v golangci-lint &>/dev/null; then
     echo "golangci-lint could not be found"
     exit 1
 fi

--- a/app/app.go
+++ b/app/app.go
@@ -794,10 +794,11 @@ func calculateTrackerDelay(ctx context.Context, cl eth2wrap.Client, now time.Tim
 	const maxDelayTime = time.Second * 10 // We want to delay at most 10 seconds
 	const minDelaySlots = 2               // But we do not want to delay less than 2 slots
 
-	genesisTime, err := cl.GenesisTime(ctx)
+	genesis, err := cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return 0, err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -840,7 +840,7 @@ func eth2PubKeys(cluster *manifestpb.Cluster) ([]eth2p0.BLSPubKey, error) {
 
 // newETH2Client returns a new eth2client for the configured timeouts; it is either a beaconmock for
 // simnet or a multi http client to a real beacon node.
-func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager, cluster *manifestpb.Cluster, forkVersion []byte, bnTimeout time.Duration, submissionBnTimeout time.Duration) (eth2wrap.Client, eth2wrap.Client, error) {
+func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager, cluster *manifestpb.Cluster, forkVersion []byte, bnTimeout time.Duration, submissionBnTimeout time.Duration) (eth2Cl eth2wrap.Client, submissionEth2Cl eth2wrap.Client, err error) {
 	pubkeys, err := eth2PubKeys(cluster)
 	if err != nil {
 		return nil, nil, err
@@ -929,12 +929,12 @@ func newETH2Client(ctx context.Context, conf Config, life *lifecycle.Manager, cl
 		return nil, nil, err
 	}
 
-	eth2Cl, err := configureEth2Client(ctx, forkVersion, conf.FallbackBeaconNodeAddrs, conf.BeaconNodeAddrs, beaconNodeHeaders, bnTimeout, conf.SyntheticBlockProposals)
+	eth2Cl, err = configureEth2Client(ctx, forkVersion, conf.FallbackBeaconNodeAddrs, conf.BeaconNodeAddrs, beaconNodeHeaders, bnTimeout, conf.SyntheticBlockProposals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "new eth2 http client")
 	}
 
-	submissionEth2Cl, err := configureEth2Client(ctx, forkVersion, conf.FallbackBeaconNodeAddrs, conf.BeaconNodeAddrs, beaconNodeHeaders, submissionBnTimeout, conf.SyntheticBlockProposals)
+	submissionEth2Cl, err = configureEth2Client(ctx, forkVersion, conf.FallbackBeaconNodeAddrs, conf.BeaconNodeAddrs, beaconNodeHeaders, submissionBnTimeout, conf.SyntheticBlockProposals)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "new submission eth2 http client")
 	}

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -45,7 +45,6 @@ type Client interface {
 	eth2client.ForkProvider
 	eth2client.ForkScheduleProvider
 	eth2client.GenesisProvider
-	eth2client.GenesisTimeProvider
 	eth2client.NodeSyncingProvider
 	eth2client.NodeVersionProvider
 	eth2client.ProposalPreparationsSubmitter
@@ -775,26 +774,6 @@ func (m multi) GenesisDomain(ctx context.Context, domainType phase0.DomainType) 
 	return res0, err
 }
 
-// GenesisTime provides the genesis time of the chain.
-// Note this endpoint is cached in go-eth2-client.
-func (m multi) GenesisTime(ctx context.Context) (time.Time, error) {
-	const label = "genesis_time"
-
-	res0, err := provide(ctx, m.clients, m.fallbacks,
-		func(ctx context.Context, args provideArgs) (time.Time, error) {
-			return args.client.GenesisTime(ctx)
-		},
-		nil, m.selector,
-	)
-
-	if err != nil {
-		incError(label)
-		err = wrapError(ctx, err, label)
-	}
-
-	return res0, err
-}
-
 // SlotDuration provides the duration of a slot of the chain.
 //
 // Deprecated: use Spec()
@@ -1152,14 +1131,4 @@ func (l *lazy) GenesisDomain(ctx context.Context, domainType phase0.DomainType) 
 	}
 
 	return cl.GenesisDomain(ctx, domainType)
-}
-
-// GenesisTime provides the genesis time of the chain.
-func (l *lazy) GenesisTime(ctx context.Context) (res0 time.Time, err error) {
-	cl, err := l.getOrCreateClient(ctx)
-	if err != nil {
-		return res0, err
-	}
-
-	return cl.GenesisTime(ctx)
 }

--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -320,16 +320,18 @@ func TestErrors(t *testing.T) {
 	t.Run("zero net op error", func(t *testing.T) {
 		bmock, err := beaconmock.New()
 		require.NoError(t, err)
-		bmock.GenesisTimeFunc = func(context.Context) (time.Time, error) {
-			return time.Time{}, new(net.OpError)
+		bmock.GenesisFunc = func(context.Context, *eth2api.GenesisOpts) (*eth2v1.Genesis, error) {
+			return &eth2v1.Genesis{
+				GenesisTime: time.Time{},
+			}, new(net.OpError)
 		}
 		eth2Cl, err := eth2wrap.Instrument([]eth2wrap.Client{bmock}, nil)
 		require.NoError(t, err)
 
-		_, err = eth2Cl.GenesisTime(ctx)
+		_, err = eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 		log.Error(ctx, "See this error log for fields", err)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "beacon api genesis_time: network operation error: :")
+		require.ErrorContains(t, err, "beacon api genesis: network operation error: :")
 	})
 
 	t.Run("eth2api error", func(t *testing.T) {

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -119,7 +119,6 @@ type Client interface {
 		"ForkProvider":                          {Latency: true, Log: false},
 		"ForkScheduleProvider":                  {Latency: true, Log: false},
 		"GenesisProvider":                       {Latency: false, Log: false},
-		"GenesisTimeProvider":                   {Latency: false, Log: false},
 		"NodeSyncingProvider":                   {Latency: true, Log: false},
 		"NodeVersionProvider":                   {Latency: false, Log: false},
 		"ProposerDutiesProvider":                {Latency: true, Log: false},

--- a/app/eth2wrap/mocks/client.go
+++ b/app/eth2wrap/mocks/client.go
@@ -591,34 +591,6 @@ func (_m *Client) GenesisDomain(ctx context.Context, domainType phase0.DomainTyp
 	return r0, r1
 }
 
-// GenesisTime provides a mock function with given fields: ctx
-func (_m *Client) GenesisTime(ctx context.Context) (time.Time, error) {
-	ret := _m.Called(ctx)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GenesisTime")
-	}
-
-	var r0 time.Time
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context) (time.Time, error)); ok {
-		return rf(ctx)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context) time.Time); ok {
-		r0 = rf(ctx)
-	} else {
-		r0 = ret.Get(0).(time.Time)
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
-		r1 = rf(ctx)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // IsActive provides a mock function with given fields:
 func (_m *Client) IsActive() bool {
 	ret := _m.Called()

--- a/app/eth2wrap/synthproposer.go
+++ b/app/eth2wrap/synthproposer.go
@@ -119,7 +119,7 @@ func (h *synthWrapper) syntheticProposal(ctx context.Context, slot eth2p0.Slot, 
 		opts := &eth2api.SignedBeaconBlockOpts{
 			Block: fmt.Sprint(prev),
 		}
-		signed, err := h.Client.SignedBeaconBlock(ctx, opts)
+		signed, err := h.SignedBeaconBlock(ctx, opts)
 		if err != nil {
 			if z.ContainsField(err, z.Int("status_code", http.StatusNotFound)) {
 				continue

--- a/app/obolapi/exit_model_test.go
+++ b/app/obolapi/exit_model_test.go
@@ -40,7 +40,7 @@ func Test_PartialExitRequest(t *testing.T) {
 	var other obolapi.PartialExitRequest
 	err = other.UnmarshalJSON(jbytes)
 	require.NoError(t, err)
-	require.EqualValues(t, other, pr)
+	require.Equal(t, other, pr)
 
 	err = pr.HashTreeRootWith(ssz.DefaultHasherPool.Get())
 	require.NoError(t, err)

--- a/app/tracer/trace_test.go
+++ b/app/tracer/trace_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/obolnetwork/charon/app/tracer"
 )
 
-func TestDefaultNoopTracer(_ *testing.T) {
+func TestDefaultNoopTracer(t *testing.T) {
 	// This just shouldn't panic.
-	ctx, span := tracer.Start(context.Background(), "root")
+	ctx, span := tracer.Start(t.Context(), "root")
 	defer span.End()
 
 	inner(ctx)

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -91,9 +91,9 @@ func (v SemVer) String() string {
 		return fmt.Sprintf("v%d.%d", v.major, v.minor)
 	} else if v.semVerType == typePatch {
 		return fmt.Sprintf("v%d.%d.%d", v.major, v.minor, v.patch)
+	default:
+		return fmt.Sprintf("v%d.%d.%d-%s", v.major, v.minor, v.patch, v.preRelease)
 	}
-
-	return fmt.Sprintf("v%d.%d.%d-%s", v.major, v.minor, v.patch, v.preRelease)
 }
 
 // PreRelease returns true if v represents a tag for a pre-release.

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -44,12 +44,13 @@ func GitCommit() (hash string, timestamp string) {
 	}
 
 	for _, s := range info.Settings {
-		if s.Key == "vcs.revision" {
+		switch s.Key {
+		case "vcs.revision":
 			if len(s.Value) < hashLen {
 				hashLen = len(s.Value)
 			}
 			hash = s.Value[:hashLen]
-		} else if s.Key == "vcs.time" {
+		case "vcs.time":
 			timestamp = s.Value
 		}
 	}
@@ -87,13 +88,14 @@ type SemVer struct {
 
 // String returns the string representation of the semantic version.
 func (v SemVer) String() string {
-	if v.semVerType == typeMinor {
+	switch v.semVerType {
+	case typeMinor:
 		return fmt.Sprintf("v%d.%d", v.major, v.minor)
-	} else if v.semVerType == typePatch {
+	case typePatch:
 		return fmt.Sprintf("v%d.%d.%d", v.major, v.minor, v.patch)
-	default:
-		return fmt.Sprintf("v%d.%d.%d-%s", v.major, v.minor, v.patch, v.preRelease)
 	}
+
+	return fmt.Sprintf("v%d.%d.%d-%s", v.major, v.minor, v.patch, v.preRelease)
 }
 
 // PreRelease returns true if v represents a tag for a pre-release.

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -93,9 +93,9 @@ func (v SemVer) String() string {
 		return fmt.Sprintf("v%d.%d", v.major, v.minor)
 	case typePatch:
 		return fmt.Sprintf("v%d.%d.%d", v.major, v.minor, v.patch)
+	default:
+		return fmt.Sprintf("v%d.%d.%d-%s", v.major, v.minor, v.patch, v.preRelease)
 	}
-
-	return fmt.Sprintf("v%d.%d.%d-%s", v.major, v.minor, v.patch, v.preRelease)
 }
 
 // PreRelease returns true if v represents a tag for a pre-release.

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -31,10 +31,11 @@ func wireValidatorMock(ctx context.Context, conf Config, eth2Cl eth2wrap.Client,
 		return err
 	}
 
-	genesisTime, err := eth2Cl.GenesisTime(ctx)
+	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {

--- a/cluster/manifest/helpers.go
+++ b/cluster/manifest/helpers.go
@@ -160,6 +160,7 @@ func to0xHex(b []byte) string {
 	return fmt.Sprintf("%#x", b)
 }
 
+// nolint: unparam
 // to0xHex returns bytes represented by the hex string.
 func from0xHex(s string, length int) ([]byte, error) {
 	if s == "" {

--- a/cluster/manifest/load_test.go
+++ b/cluster/manifest/load_test.go
@@ -145,8 +145,8 @@ func testLoadLegacy(t *testing.T, version string) {
 	require.EqualValues(t, lock.Threshold, cluster.GetThreshold())
 	require.Equal(t, lock.DKGAlgorithm, cluster.GetDkgAlgorithm())
 	require.Equal(t, lock.ForkVersion, cluster.GetForkVersion())
-	require.Equal(t, len(lock.Validators), len(cluster.GetValidators()))
-	require.Equal(t, len(lock.Operators), len(cluster.GetOperators()))
+	require.Len(t, cluster.GetValidators(), len(lock.Validators))
+	require.Len(t, cluster.GetOperators(), len(lock.Operators))
 
 	for i, validator := range cluster.GetValidators() {
 		require.Equal(t, lock.Validators[i].PubKey, validator.GetPublicKey())

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -172,7 +172,7 @@ func TestCmdFlags(t *testing.T) {
 
 			// Set envs (only for duration of the test)
 			for k, v := range test.Envs {
-				require.NoError(t, os.Setenv(k, v))
+				t.Setenv(k, v)
 			}
 
 			_ = testutil.CreateTempCharonDir(t)

--- a/cmd/combine/combine_test.go
+++ b/cmd/combine/combine_test.go
@@ -59,14 +59,14 @@ func TestCombineCannotLoadKeystore(t *testing.T) {
 
 	// for each ENR, create a slice of keys to hold
 	// each set will be len(lock.Definition.Operators)
-	secrets := make([][]tbls.PrivateKey, len(lock.Definition.Operators))
+	secrets := make([][]tbls.PrivateKey, len(lock.Operators))
 
 	// populate key sets
-	for enrIdx := range len(lock.Definition.Operators) {
+	for enrIdx := range len(lock.Operators) {
 		keyIdx := enrIdx
 		for range lock.NumValidators {
 			secrets[enrIdx] = append(secrets[enrIdx], rawSecrets[keyIdx])
-			keyIdx += len(lock.Definition.Operators)
+			keyIdx += len(lock.Operators)
 		}
 	}
 
@@ -297,14 +297,14 @@ func combineTest(
 
 	// for each ENR, create a slice of keys to hold
 	// each set will be len(lock.Definition.Operators)
-	secrets := make([][]tbls.PrivateKey, len(lock.Definition.Operators))
+	secrets := make([][]tbls.PrivateKey, len(lock.Operators))
 
 	// populate key sets
-	for enrIdx := range len(lock.Definition.Operators) {
+	for enrIdx := range len(lock.Operators) {
 		keyIdx := enrIdx
 		for range lock.NumValidators {
 			secrets[enrIdx] = append(secrets[enrIdx], rawSecrets[keyIdx])
-			keyIdx += len(lock.Definition.Operators)
+			keyIdx += len(lock.Operators)
 		}
 	}
 
@@ -412,14 +412,14 @@ func runTwice(t *testing.T, force bool, processErr require.ErrorAssertionFunc) {
 
 	// for each ENR, create a slice of keys to hold
 	// each set will be len(lock.Definition.Operators)
-	secrets := make([][]tbls.PrivateKey, len(lock.Definition.Operators))
+	secrets := make([][]tbls.PrivateKey, len(lock.Operators))
 
 	// populate key sets
-	for enrIdx := range len(lock.Definition.Operators) {
+	for enrIdx := range len(lock.Operators) {
 		keyIdx := enrIdx
 		for range lock.NumValidators {
 			secrets[enrIdx] = append(secrets[enrIdx], rawSecrets[keyIdx])
-			keyIdx += len(lock.Definition.Operators)
+			keyIdx += len(lock.Operators)
 		}
 	}
 

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -1086,6 +1086,7 @@ func writeLockToAPI(ctx context.Context, publishAddr string, lock cluster.Lock) 
 	return cl.LaunchpadURLForLock(lock), nil
 }
 
+// nolint: revive // Not really confusing here as they are passed as arguments as well.
 // validateAddresses checks if we have sufficient addresses. It also fills addresses slices if only one is provided.
 func validateAddresses(numVals int, feeRecipientAddrs []string, withdrawalAddrs []string) ([]string, []string, error) {
 	if len(feeRecipientAddrs) != numVals && len(feeRecipientAddrs) != 1 {

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -382,7 +382,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 			}
 		}
 
-		require.Len(t, vals, lock.Definition.NumValidators)
+		require.Len(t, vals, lock.NumValidators)
 
 		if conf.DefFile != "" {
 			// Config hash and creator should remain the same
@@ -815,7 +815,7 @@ func TestKeymanager(t *testing.T) {
 		csb, err := tbls.RecoverSecret(shares, minNodes, 3)
 		require.NoError(t, err)
 
-		require.EqualValues(t, secret1, csb)
+		require.Equal(t, secret1, csb)
 	})
 
 	t.Run("some unsuccessful", func(t *testing.T) {
@@ -994,7 +994,7 @@ func newKeymanagerHandler(ctx context.Context, t *testing.T, id int, results cha
 		var req mockKeymanagerReq
 		require.NoError(t, json.Unmarshal(data, &req))
 
-		require.Equal(t, len(req.Keystores), len(req.Passwords))
+		require.Len(t, req.Passwords, len(req.Keystores))
 		require.Len(t, req.Keystores, 1) // Since we split only 1 key
 
 		var ks keystore.Keystore

--- a/cmd/relay/p2p.go
+++ b/cmd/relay/p2p.go
@@ -60,7 +60,6 @@ func startP2P(ctx context.Context, config Config, key *k1.PrivateKey, reporter m
 	relayResources.Limit.Data = 32 * (1 << 20) // 32MB
 	relayResources.Limit.Duration = time.Hour
 	relayResources.BufferSize = 64 * (1 << 10) // 64KB
-	relayResources.MaxReservationsPerPeer = config.MaxResPerPeer
 	relayResources.MaxReservationsPerIP = config.MaxResPerPeer
 	relayResources.MaxReservations = config.MaxConns
 	relayResources.MaxCircuits = config.MaxResPerPeer

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -44,7 +44,7 @@ func TestBindPrivKeyFlag(t *testing.T) {
 
 			// Set envs (only for duration of the test)
 			for k, v := range test.Envs {
-				require.NoError(t, os.Setenv(k, v))
+				t.Setenv(k, v)
 			}
 
 			t.Cleanup(func() {

--- a/cmd/testpeers_internal_test.go
+++ b/cmd/testpeers_internal_test.go
@@ -403,7 +403,7 @@ func testWriteFile(t *testing.T, expectedRes testCategoryResult, path string) {
 	}
 
 	require.Equal(t, expectedRes.CategoryName, actualRes.CategoryName)
-	require.Equal(t, len(expectedRes.Targets), len(actualRes.Targets))
+	require.Len(t, actualRes.Targets, len(expectedRes.Targets))
 	checkFinalScore := true
 	for targetName, testResults := range actualRes.Targets {
 		for idx, testRes := range testResults {
@@ -415,7 +415,7 @@ func testWriteFile(t *testing.T, expectedRes testCategoryResult, path string) {
 			}
 			require.Equal(t, expectedRes.Targets[targetName][idx].IsAcceptable, testRes.IsAcceptable)
 			if expectedRes.Targets[targetName][idx].Error.error != nil {
-				require.ErrorContains(t, testRes.Error.error, expectedRes.Targets[targetName][idx].Error.error.Error())
+				require.ErrorContains(t, testRes.Error.error, expectedRes.Targets[targetName][idx].Error.Error())
 			} else {
 				require.NoError(t, testRes.Error.error)
 			}

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -109,8 +109,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 			return errors.New("invalid proposal")
 		}
 
-		switch block.Blinded {
-		case true:
+		if block.Blinded {
 			var blinded eth2api.VersionedSignedBlindedProposal
 
 			blinded, err = block.ToBlinded()
@@ -121,7 +120,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 			err = b.eth2Cl.SubmitBlindedProposal(ctx, &eth2api.SubmitBlindedProposalOpts{
 				Proposal: &blinded,
 			})
-		default:
+		} else {
 			err = b.eth2Cl.SubmitProposal(ctx, &eth2api.SubmitProposalOpts{
 				Proposal: &block.VersionedSignedProposal,
 			})

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -407,10 +407,11 @@ func setToAttestationsV2(set core.SignedDataSet) ([]*eth2spec.VersionedAttestati
 
 // newDelayFunc returns a function that calculates the delay since the start of a slot.
 func newDelayFunc(ctx context.Context, eth2Cl eth2wrap.Client) (func(slot uint64) time.Duration, error) {
-	genesis, err := eth2Cl.GenesisTime(ctx)
+	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return nil, err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
@@ -423,7 +424,7 @@ func newDelayFunc(ctx context.Context, eth2Cl eth2wrap.Client) (func(slot uint64
 	}
 
 	return func(slot uint64) time.Duration {
-		slotStart := genesis.Add(slotDuration * time.Duration(slot))
+		slotStart := genesisTime.Add(slotDuration * time.Duration(slot))
 		return time.Since(slotStart)
 	}, nil
 }

--- a/core/consensus/controller_test.go
+++ b/core/consensus/controller_test.go
@@ -75,7 +75,7 @@ func TestConsensusController(t *testing.T) {
 	})
 
 	t.Run("unsupported protocol id", func(t *testing.T) {
-		err := controller.SetCurrentConsensusForProtocol(context.TODO(), "boo")
+		err := controller.SetCurrentConsensusForProtocol(t.Context(), "boo")
 		require.ErrorContains(t, err, "unsupported protocol id")
 	})
 }

--- a/core/consensus/qbft/msg_internal_test.go
+++ b/core/consensus/qbft/msg_internal_test.go
@@ -86,7 +86,7 @@ func TestNewMsg(t *testing.T) {
 
 	require.Equal(t, msg.Value(), hash1)
 	require.Equal(t, msg.PreparedValue(), hash2)
-	require.EqualValues(t, msg.Values(), values)
+	require.Equal(t, msg.Values(), values)
 }
 
 func TestPartialLegacyNewMsg(t *testing.T) {

--- a/core/consensus/qbft/qbft_test.go
+++ b/core/consensus/qbft/qbft_test.go
@@ -130,7 +130,7 @@ func testQBFTConsensus(t *testing.T, threshold, nodes int) {
 			results <- set
 			return nil
 		})
-		c.Start(context.TODO())
+		c.Start(t.Context())
 
 		components = append(components, c)
 	}
@@ -161,7 +161,7 @@ func testQBFTConsensus(t *testing.T, threshold, nodes int) {
 			if count == 0 {
 				result = res
 			} else {
-				require.EqualValues(t, result, res)
+				require.Equal(t, result, res)
 			}
 			count++
 		}

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -199,10 +199,11 @@ func getCurrDuty(duties map[Duty]bool, deadlineFunc DeadlineFunc) (Duty, time.Ti
 
 // NewDutyDeadlineFunc returns the function that provides duty deadlines or false if the duty never deadlines.
 func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineFunc, error) {
-	genesis, err := eth2Cl.GenesisTime(ctx)
+	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return nil, err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
@@ -220,7 +221,7 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 			return time.Time{}, false
 		}
 
-		start := genesis.Add(duration * time.Duration(duty.Slot))
+		start := genesisTime.Add(duration * time.Duration(duty.Slot))
 		delta := duration * time.Duration(lateFactor)
 		if delta < lateMin {
 			delta = lateMin

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -23,7 +23,7 @@ import (
 const lateFactor = 5
 
 // lateMin defines the minimum absolute value of the lateFactor.
-const lateMin = time.Second * 30 //nolint:revive // Min suffix is minimum not minute.
+const lateMin = time.Second * 30
 
 // DeadlineFunc is a function that returns the deadline for a duty.
 type DeadlineFunc func(Duty) (time.Time, bool)

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -273,15 +273,15 @@ func (db *MemDB) AwaitAggAttestation(ctx context.Context, slot uint64, attestati
 
 		switch aggAtt.Version {
 		case eth2spec.DataVersionPhase0:
-			return aggAtt.VersionedAttestation.Phase0, nil
+			return aggAtt.Phase0, nil
 		case eth2spec.DataVersionAltair:
-			return aggAtt.VersionedAttestation.Altair, nil
+			return aggAtt.Altair, nil
 		case eth2spec.DataVersionBellatrix:
-			return aggAtt.VersionedAttestation.Bellatrix, nil
+			return aggAtt.Bellatrix, nil
 		case eth2spec.DataVersionCapella:
-			return aggAtt.VersionedAttestation.Capella, nil
+			return aggAtt.Capella, nil
 		case eth2spec.DataVersionDeneb:
-			return aggAtt.VersionedAttestation.Deneb, nil
+			return aggAtt.Deneb, nil
 		default:
 			return nil, errors.New("unsupported versioned aggregated attestation for v1 endpoint", z.Str("version", aggAtt.Version.String()))
 		}
@@ -507,12 +507,12 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) (int,
 
 // storeAggAttestationUnsafeV1 stores the unsigned aggregated attestation. It is unsafe since it assumes the lock is held.
 func (db *MemDB) storeAggAttestationUnsafeV1(aggAtt core.AggregatedAttestation) error {
-	aggRoot, err := aggAtt.Attestation.Data.HashTreeRoot()
+	aggRoot, err := aggAtt.Data.HashTreeRoot()
 	if err != nil {
 		return errors.Wrap(err, "hash aggregated attestation root")
 	}
 
-	slot := uint64(aggAtt.Attestation.Data.Slot)
+	slot := uint64(aggAtt.Data.Slot)
 
 	// Store key and value for PubKeyByAttestation
 	key := aggKey{
@@ -543,7 +543,7 @@ func (db *MemDB) storeAggAttestationUnsafeV1(aggAtt core.AggregatedAttestation) 
 
 // storeAggAttestationUnsafeV2 stores the unsigned versioned aggregated attestation. It is unsafe since it assumes the lock is held.
 func (db *MemDB) storeAggAttestationUnsafeV2(aggAtt core.VersionedAggregatedAttestation) error {
-	aggAttData, err := aggAtt.VersionedAttestation.Data()
+	aggAttData, err := aggAtt.Data()
 	if err != nil {
 		return err
 	}
@@ -593,7 +593,7 @@ func (db *MemDB) storeSyncContributionUnsafe(unsignedData core.UnsignedData) err
 		return errors.New("invalid unsigned sync committee contribution")
 	}
 
-	contribRoot, err := contrib.SyncCommitteeContribution.HashTreeRoot()
+	contribRoot, err := contrib.HashTreeRoot()
 	if err != nil {
 		return errors.Wrap(err, "hash sync committee contribution")
 	}

--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -66,7 +66,7 @@ func (Attestation) DomainName() signing.DomainName {
 }
 
 func (a Attestation) Epoch(_ context.Context, _ eth2wrap.Client) (eth2p0.Epoch, error) {
-	return a.Attestation.Data.Target.Epoch, nil
+	return a.Data.Target.Epoch, nil
 }
 
 // Implement Eth2SignedData for VersionedAttestation.

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -71,12 +71,12 @@ func TestFetchAttester(t *testing.T) {
 		dutyDataA := resDataSet[pubkeysByIdx[vIdxA]].(core.AttestationData)
 		require.EqualValues(t, slot, dutyDataA.Data.Slot)
 		require.EqualValues(t, vIdxA, dutyDataA.Data.Index)
-		require.EqualValues(t, dutyA, dutyDataA.Duty)
+		require.Equal(t, dutyA, dutyDataA.Duty)
 
 		dutyDataB := resDataSet[pubkeysByIdx[vIdxB]].(core.AttestationData)
 		require.EqualValues(t, slot, dutyDataB.Data.Slot)
 		require.EqualValues(t, vIdxB, dutyDataB.Data.Index)
-		require.EqualValues(t, dutyB, dutyDataB.Duty)
+		require.Equal(t, dutyB, dutyDataB.Duty)
 
 		return nil
 	})
@@ -176,7 +176,7 @@ func TestFetchAggregator(t *testing.T) {
 			aggregated, ok := aggAtt.(core.AggregatedAttestation)
 			require.True(t, ok)
 
-			att, ok := attByCommIdx[uint64(aggregated.Attestation.Data.Index)]
+			att, ok := attByCommIdx[uint64(aggregated.Data.Index)]
 			require.True(t, ok)
 			require.Equal(t, aggregated.Attestation, *att)
 		}
@@ -533,32 +533,32 @@ func assertRandao(t *testing.T, randao eth2p0.BLSSignature, block core.Versioned
 
 	switch block.Version {
 	case eth2spec.DataVersionPhase0:
-		require.EqualValues(t, randao, block.Phase0.Body.RANDAOReveal)
+		require.Equal(t, randao, block.Phase0.Body.RANDAOReveal)
 	case eth2spec.DataVersionAltair:
-		require.EqualValues(t, randao, block.Altair.Body.RANDAOReveal)
+		require.Equal(t, randao, block.Altair.Body.RANDAOReveal)
 	case eth2spec.DataVersionBellatrix:
 		if block.Blinded {
-			require.EqualValues(t, randao, block.BellatrixBlinded.Body.RANDAOReveal)
+			require.Equal(t, randao, block.BellatrixBlinded.Body.RANDAOReveal)
 		} else {
-			require.EqualValues(t, randao, block.Bellatrix.Body.RANDAOReveal)
+			require.Equal(t, randao, block.Bellatrix.Body.RANDAOReveal)
 		}
 	case eth2spec.DataVersionCapella:
 		if block.Blinded {
-			require.EqualValues(t, randao, block.CapellaBlinded.Body.RANDAOReveal)
+			require.Equal(t, randao, block.CapellaBlinded.Body.RANDAOReveal)
 		} else {
-			require.EqualValues(t, randao, block.Capella.Body.RANDAOReveal)
+			require.Equal(t, randao, block.Capella.Body.RANDAOReveal)
 		}
 	case eth2spec.DataVersionDeneb:
 		if block.Blinded {
-			require.EqualValues(t, randao, block.DenebBlinded.Body.RANDAOReveal)
+			require.Equal(t, randao, block.DenebBlinded.Body.RANDAOReveal)
 		} else {
-			require.EqualValues(t, randao, block.Deneb.Block.Body.RANDAOReveal)
+			require.Equal(t, randao, block.Deneb.Block.Body.RANDAOReveal)
 		}
 	case eth2spec.DataVersionElectra:
 		if block.Blinded {
-			require.EqualValues(t, randao, block.ElectraBlinded.Body.RANDAOReveal)
+			require.Equal(t, randao, block.ElectraBlinded.Body.RANDAOReveal)
 		} else {
-			require.EqualValues(t, randao, block.Electra.Block.Body.RANDAOReveal)
+			require.Equal(t, randao, block.Electra.Block.Body.RANDAOReveal)
 		}
 	default:
 		require.Fail(t, "invalid block")

--- a/core/gater.go
+++ b/core/gater.go
@@ -45,10 +45,11 @@ func NewDutyGater(ctx context.Context, eth2Cl eth2wrap.Client, opts ...func(*dut
 		opt(&o)
 	}
 
-	genesisTime, err := eth2Cl.GenesisTime(ctx)
+	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return nil, err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -4,6 +4,7 @@ package priority_test
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -163,12 +164,10 @@ func prioToAny(prio int) *anypb.Any {
 
 func requireAnyDuty(t *testing.T, anyOf []core.Duty, actual core.Duty) {
 	t.Helper()
-	for _, msg := range anyOf {
-		if msg == actual {
-			return
-		}
+	if slices.Contains(anyOf, actual) {
+		return
 	}
-	require.Fail(t, "not anyOf: %#v\nactual: %#v\n", anyOf, actual)
+	require.Fail(t, "slice does not contain duty", "not anyOf: %#v\nactual: %#v\n", anyOf, actual)
 }
 
 func mustResultsToText(msgs []*pbv1.PriorityTopicResult) string {

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -433,7 +433,7 @@ func testQBFT(t *testing.T, test test) {
 			for _, commit := range qCommit {
 				// Ensure that all results are the same
 				for _, previous := range results {
-					require.EqualValues(t, previous.Value(), commit.Value(), "commit values")
+					require.Equal(t, previous.Value(), commit.Value(), "commit values")
 				}
 				if !test.RandomRound {
 					require.EqualValues(t, test.DecideRound, commit.Round(), "wrong decide round")

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -550,10 +550,11 @@ func (s *Scheduler) trimDuties(epoch uint64) {
 // newSlotTicker returns a blocking channel that will be populated with new slots in real time.
 // It is also populated with the current slot immediately.
 func newSlotTicker(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) (<-chan core.Slot, error) {
-	genesis, err := eth2Cl.GenesisTime(ctx)
+	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return nil, err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
@@ -572,9 +573,9 @@ func newSlotTicker(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.
 	}
 
 	currentSlot := func() core.Slot {
-		chainAge := clock.Since(genesis)
+		chainAge := clock.Since(genesisTime)
 		slot := int64(chainAge / slotDuration)
-		startTime := genesis.Add(time.Duration(slot) * slotDuration)
+		startTime := genesisTime.Add(time.Duration(slot) * slotDuration)
 
 		return core.Slot{
 			Slot:          uint64(slot),
@@ -656,19 +657,20 @@ func resolveActiveValidators(ctx context.Context, eth2Cl eth2wrap.Client, submit
 // waitChainStart blocks until the beacon chain has started.
 func waitChainStart(ctx context.Context, eth2Cl eth2wrap.Client, clock clockwork.Clock) {
 	for ctx.Err() == nil {
-		genesis, err := eth2Cl.GenesisTime(ctx)
+		genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 		if err != nil {
-			log.Error(ctx, "Failure getting genesis time", err)
+			log.Error(ctx, "Failure getting genesis", err)
 			clock.Sleep(time.Second * 5) // TODO(corver): Improve backoff
 
 			continue
 		}
+		genesisTime := genesis.Data.GenesisTime
 
 		now := clock.Now()
-		if now.Before(genesis) {
-			delta := genesis.Sub(now)
+		if now.Before(genesisTime) {
+			delta := genesisTime.Sub(now)
 			log.Info(ctx, "Sleeping until genesis time",
-				z.Str("genesis", genesis.String()), z.Str("sleep", delta.String()))
+				z.Str("genesisTime", genesisTime.String()), z.Str("sleep", delta.String()))
 			clock.Sleep(delta)
 
 			continue

--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -144,9 +144,13 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 		return nil, core.ErrDeprecatedDutyBuilderProposer
 	}
 
-	slotsPerEpoch, err := s.eth2Cl.SlotsPerEpoch(ctx)
+	respSpec, err := s.eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
 		return nil, err
+	}
+	slotsPerEpoch, ok := respSpec.Data["SLOTS_PER_EPOCH"].(uint64)
+	if !ok {
+		return nil, errors.New("fetch slots per epoch")
 	}
 
 	epoch := duty.Slot / slotsPerEpoch

--- a/core/scheduler/scheduler_test.go
+++ b/core/scheduler/scheduler_test.go
@@ -118,14 +118,18 @@ func TestSchedulerWait(t *testing.T) {
 			eth2Cl, err := beaconmock.New()
 			require.NoError(t, err)
 
-			eth2Cl.GenesisTimeFunc = func(context.Context) (time.Time, error) {
+			eth2Cl.GenesisFunc = func(context.Context, *eth2api.GenesisOpts) (*eth2v1.Genesis, error) {
 				var err error
 				if test.GenesisErrs > 0 {
 					err = errors.New("mock error")
 					test.GenesisErrs--
 				}
 
-				return t0.Add(test.GenesisAfter), err
+				time := t0.Add(test.GenesisAfter)
+
+				return &eth2v1.Genesis{
+					GenesisTime: time,
+				}, err
 			}
 
 			eth2Cl.NodeSyncingFunc = func(context.Context, *eth2api.NodeSyncingOpts) (*eth2v1.SyncState, error) {

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -391,32 +391,32 @@ func (p VersionedSignedProposal) MarshalJSON() ([]byte, error) {
 	switch p.Version {
 	// No proposal nil checks since `NewVersionedSignedProposal` assumed.
 	case eth2spec.DataVersionPhase0:
-		marshaller = p.VersionedSignedProposal.Phase0
+		marshaller = p.Phase0
 	case eth2spec.DataVersionAltair:
-		marshaller = p.VersionedSignedProposal.Altair
+		marshaller = p.Altair
 	case eth2spec.DataVersionBellatrix:
 		if p.Blinded {
-			marshaller = p.VersionedSignedProposal.BellatrixBlinded
+			marshaller = p.BellatrixBlinded
 		} else {
-			marshaller = p.VersionedSignedProposal.Bellatrix
+			marshaller = p.Bellatrix
 		}
 	case eth2spec.DataVersionCapella:
 		if p.Blinded {
-			marshaller = p.VersionedSignedProposal.CapellaBlinded
+			marshaller = p.CapellaBlinded
 		} else {
-			marshaller = p.VersionedSignedProposal.Capella
+			marshaller = p.Capella
 		}
 	case eth2spec.DataVersionDeneb:
 		if p.Blinded {
-			marshaller = p.VersionedSignedProposal.DenebBlinded
+			marshaller = p.DenebBlinded
 		} else {
-			marshaller = p.VersionedSignedProposal.Deneb
+			marshaller = p.Deneb
 		}
 	case eth2spec.DataVersionElectra:
 		if p.Blinded {
-			marshaller = p.VersionedSignedProposal.ElectraBlinded
+			marshaller = p.ElectraBlinded
 		} else {
-			marshaller = p.VersionedSignedProposal.Electra
+			marshaller = p.Electra
 		}
 	default:
 		return nil, errors.New("unknown version")
@@ -1010,7 +1010,7 @@ func (r VersionedSignedValidatorRegistration) MarshalJSON() ([]byte, error) {
 	var marshaller json.Marshaler
 	switch r.Version {
 	case eth2spec.BuilderVersionV1:
-		marshaller = r.VersionedSignedValidatorRegistration.V1
+		marshaller = r.V1
 	default:
 		return nil, errors.New("unknown version")
 	}
@@ -1086,7 +1086,7 @@ type SignedRandao struct {
 }
 
 func (s SignedRandao) MessageRoot() ([32]byte, error) {
-	return s.SignedEpoch.HashTreeRoot()
+	return s.HashTreeRoot()
 }
 
 func (s SignedRandao) Signature() Signature {
@@ -1788,15 +1788,15 @@ type SyncContributionAndProof struct {
 // Refer: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#aggregation-selection.
 func (s SyncContributionAndProof) MessageRoot() ([32]byte, error) {
 	data := altair.SyncAggregatorSelectionData{
-		Slot:              s.ContributionAndProof.Contribution.Slot,
-		SubcommitteeIndex: s.ContributionAndProof.Contribution.SubcommitteeIndex,
+		Slot:              s.Contribution.Slot,
+		SubcommitteeIndex: s.Contribution.SubcommitteeIndex,
 	}
 
 	return data.HashTreeRoot()
 }
 
 func (s SyncContributionAndProof) Signature() Signature {
-	return SigFromETH2(s.ContributionAndProof.SelectionProof)
+	return SigFromETH2(s.SelectionProof)
 }
 
 func (s SyncContributionAndProof) SetSignature(sig Signature) (SignedData, error) {

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -6,11 +6,12 @@ import (
 	"context"
 	"hash/fnv"
 	"strconv"
-	"strings"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 
 	"github.com/obolnetwork/charon/app/tracer"
 )
@@ -26,7 +27,7 @@ func StartDutyTrace(ctx context.Context, duty Duty, spanName string, opts ...tra
 	copy(traceID[:], h.Sum(nil))
 
 	var outerSpan, innerSpan trace.Span
-	ctx, outerSpan = tracer.Start(tracer.RootedCtx(ctx, traceID), "core/duty."+strings.Title(duty.Type.String()))
+	ctx, outerSpan = tracer.Start(tracer.RootedCtx(ctx, traceID), "core/duty."+cases.Title(language.English).String(duty.Type.String()))
 	ctx, innerSpan = tracer.Start(ctx, spanName, opts...)
 
 	slotStr := strconv.FormatUint(duty.Slot, 10)

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -558,10 +558,11 @@ func reportAttInclusion(ctx context.Context, sub submission, block block) {
 
 // NewInclusion returns a new InclusionChecker.
 func NewInclusion(ctx context.Context, eth2Cl eth2wrap.Client, trackerInclFunc trackerInclFunc) (*InclusionChecker, error) {
-	genesis, err := eth2Cl.GenesisTime(ctx)
+	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return nil, err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
@@ -584,7 +585,7 @@ func NewInclusion(ctx context.Context, eth2Cl eth2wrap.Client, trackerInclFunc t
 	return &InclusionChecker{
 		core:             inclCore,
 		eth2Cl:           eth2Cl,
-		genesis:          genesis,
+		genesis:          genesisTime,
 		slotDuration:     slotDuration,
 		checkBlockFunc:   inclCore.CheckBlock,
 		checkBlockV2Func: inclCore.CheckBlockV2,

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -647,6 +647,7 @@ func (a *InclusionChecker) checkBlock(ctx context.Context, slot uint64) error {
 	attsV2, err := a.eth2Cl.BlockAttestationsV2(ctx, strconv.FormatUint(slot, 10))
 	if err != nil {
 		if errors.Is(err, eth2wrap.ErrEndpointNotFound) {
+			//nolint:staticcheck // depreacted BlockAttestations pre-electra is fine.
 			atts, err := a.eth2Cl.BlockAttestations(ctx, strconv.FormatUint(slot, 10))
 			if err != nil {
 				return err

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -536,10 +536,10 @@ func newUnsupportedIgnorer() func(ctx context.Context, duty core.Duty, failed bo
 
 // analyseParticipation returns a count of partial signatures submitted (correct and unexpected) by share index
 // and total expected partial signatures for the given duty.
-func analyseParticipation(duty core.Duty, allEvents map[core.Duty][]event) (map[int]int, map[int]int, int) {
+func analyseParticipation(duty core.Duty, allEvents map[core.Duty][]event) (resp map[int]int, unexpectedShares map[int]int, pubkeyMapLen int) {
 	// Set of shareIdx of participated peers.
-	resp := make(map[int]int)
-	unexpectedShares := make(map[int]int)
+	resp = make(map[int]int)
+	unexpectedShares = make(map[int]int)
 
 	// Dedup participation for each validator per peer for the given duty. Each peer can submit any number of partial signatures.
 	type dedupKey struct {
@@ -568,8 +568,9 @@ func analyseParticipation(duty core.Duty, allEvents map[core.Duty][]event) (map[
 			}
 		}
 	}
+	pubkeyMapLen = len(pubkeyMap)
 
-	return resp, unexpectedShares, len(pubkeyMap)
+	return resp, unexpectedShares, pubkeyMapLen
 }
 
 // isParSigEventExpected returns true if a partial signature event is expected for the given duty and pubkey.

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -36,13 +36,14 @@ func TestBackwardsCompatability(t *testing.T) {
 
 	const sentinel = core.DutyType(14)
 	for i := core.DutyUnknown; i <= sentinel; i++ {
-		if i == core.DutyUnknown {
+		switch i {
+		case core.DutyUnknown:
 			require.False(t, i.Valid())
 			require.Equal(t, "unknown", i.String())
-		} else if i == sentinel {
+		case sentinel:
 			require.False(t, i.Valid())
-			require.Equal(t, "", i.String())
-		} else {
+			require.Empty(t, i.String())
+		default:
 			require.True(t, i.Valid())
 			require.NotEmpty(t, i.String())
 		}
@@ -83,7 +84,7 @@ func TestAllDutyTypes(t *testing.T) {
 func TestNewBuilderRegistrationDuty(t *testing.T) {
 	d := core.NewBuilderRegistrationDuty(1)
 
-	require.EqualValues(t, core.DutyBuilderRegistration, d.Type)
+	require.Equal(t, core.DutyBuilderRegistration, d.Type)
 	require.Equal(t, "1/builder_registration", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -91,7 +92,7 @@ func TestNewBuilderRegistrationDuty(t *testing.T) {
 func TestNewSignatureDuty(t *testing.T) {
 	d := core.NewSignatureDuty(1)
 
-	require.EqualValues(t, core.DutySignature, d.Type)
+	require.Equal(t, core.DutySignature, d.Type)
 	require.Equal(t, "1/signature", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -99,7 +100,7 @@ func TestNewSignatureDuty(t *testing.T) {
 func TestNewPrepareAggregatorDuty(t *testing.T) {
 	d := core.NewPrepareAggregatorDuty(1)
 
-	require.EqualValues(t, core.DutyPrepareAggregator, d.Type)
+	require.Equal(t, core.DutyPrepareAggregator, d.Type)
 	require.Equal(t, "1/prepare_aggregator", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -107,7 +108,7 @@ func TestNewPrepareAggregatorDuty(t *testing.T) {
 func TestNewAggregatorDuty(t *testing.T) {
 	d := core.NewAggregatorDuty(1)
 
-	require.EqualValues(t, core.DutyAggregator, d.Type)
+	require.Equal(t, core.DutyAggregator, d.Type)
 	require.Equal(t, "1/aggregator", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -115,7 +116,7 @@ func TestNewAggregatorDuty(t *testing.T) {
 func TestNewSyncMessageDuty(t *testing.T) {
 	d := core.NewSyncMessageDuty(1)
 
-	require.EqualValues(t, core.DutySyncMessage, d.Type)
+	require.Equal(t, core.DutySyncMessage, d.Type)
 	require.Equal(t, "1/sync_message", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -123,7 +124,7 @@ func TestNewSyncMessageDuty(t *testing.T) {
 func TestNewPrepareSyncContributionDuty(t *testing.T) {
 	d := core.NewPrepareSyncContributionDuty(1)
 
-	require.EqualValues(t, core.DutyPrepareSyncContribution, d.Type)
+	require.Equal(t, core.DutyPrepareSyncContribution, d.Type)
 	require.Equal(t, "1/prepare_sync_contribution", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -131,7 +132,7 @@ func TestNewPrepareSyncContributionDuty(t *testing.T) {
 func TestNewSyncContributionDuty(t *testing.T) {
 	d := core.NewSyncContributionDuty(1)
 
-	require.EqualValues(t, core.DutySyncContribution, d.Type)
+	require.Equal(t, core.DutySyncContribution, d.Type)
 	require.Equal(t, "1/sync_contribution", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }
@@ -139,7 +140,7 @@ func TestNewSyncContributionDuty(t *testing.T) {
 func TestNewInfoSyncDuty(t *testing.T) {
 	d := core.NewInfoSyncDuty(1)
 
-	require.EqualValues(t, core.DutyInfoSync, d.Type)
+	require.Equal(t, core.DutyInfoSync, d.Type)
 	require.Equal(t, "1/info_sync", d.String())
 	require.EqualValues(t, 1, d.Slot)
 }

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1433,7 +1433,8 @@ func unmarshal(typ contentType, body []byte, v any) error {
 		}
 	}
 
-	if typ == contentTypeJSON {
+	switch typ {
+	case contentTypeJSON:
 		err := json.Unmarshal(body, v)
 		if err != nil {
 			return apiError{
@@ -1444,7 +1445,7 @@ func unmarshal(typ contentType, body []byte, v any) error {
 		}
 
 		return nil
-	} else if typ == contentTypeSSZ {
+	case contentTypeSSZ:
 		unmarshaller, ok := v.(ssz.Unmarshaler)
 		if !ok {
 			return apiError{

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -855,7 +855,7 @@ func TestRouter(t *testing.T) {
 
 			require.Len(t, res, 2)
 			require.EqualValues(t, val1, res[val1].Index)
-			require.EqualValues(t, eth2v1.ValidatorStateActiveOngoing, res[val1].Status)
+			require.Equal(t, eth2v1.ValidatorStateActiveOngoing, res[val1].Status)
 		}
 
 		testRouter(t, handler, callback)
@@ -896,7 +896,7 @@ func TestRouter(t *testing.T) {
 
 			require.Len(t, res, 2)
 			require.EqualValues(t, 1, res[1].Index)
-			require.EqualValues(t, eth2v1.ValidatorStateActiveOngoing, res[1].Status)
+			require.Equal(t, eth2v1.ValidatorStateActiveOngoing, res[1].Status)
 		}
 
 		testRouter(t, handler, callback)
@@ -1329,7 +1329,7 @@ func TestRouter(t *testing.T) {
 
 			require.Equal(t, resp.Data.Slot, slot)
 			require.EqualValues(t, resp.Data.SubcommitteeIndex, subcommIdx)
-			require.EqualValues(t, resp.Data.BeaconBlockRoot, beaconBlockRoot)
+			require.Equal(t, resp.Data.BeaconBlockRoot, beaconBlockRoot)
 		}
 
 		testRouter(t, handler, callback)

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -327,7 +327,7 @@ func TestRawRouter(t *testing.T) {
 	})
 
 	t.Run("get validators with post", func(t *testing.T) {
-		simpleValidatorsFunc := func(_ context.Context, opts *eth2api.ValidatorsOpts) (*eth2api.Response[map[eth2p0.ValidatorIndex]*eth2v1.Validator], error) { //nolint:golint,unparam
+		simpleValidatorsFunc := func(_ context.Context, opts *eth2api.ValidatorsOpts) (*eth2api.Response[map[eth2p0.ValidatorIndex]*eth2v1.Validator], error) { //nolint:unparam
 			res := make(map[eth2p0.ValidatorIndex]*eth2v1.Validator)
 			if len(opts.Indices) == 0 {
 				opts.Indices = []eth2p0.ValidatorIndex{12, 35}

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -1059,31 +1059,6 @@ func TestRouter(t *testing.T) {
 		testRouter(t, handler, callback)
 	})
 
-	t.Run("submit randao blinded block", func(t *testing.T) {
-		handler := testHandler{
-			ProposalFunc: func(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.Response[*eth2api.VersionedProposal], error) {
-				return &eth2api.Response[*eth2api.VersionedProposal]{}, errors.New("not implemented")
-			},
-		}
-
-		callback := func(ctx context.Context, cl *eth2http.Service) {
-			slot := eth2p0.Slot(1)
-			randaoReveal := testutil.RandomEth2Signature()
-			graffiti := testutil.RandomArray32()
-
-			opts := &eth2api.BlindedProposalOpts{
-				Slot:         slot,
-				RandaoReveal: randaoReveal,
-				Graffiti:     graffiti,
-			}
-			res, err := cl.BlindedProposal(ctx, opts)
-			require.Error(t, err)
-			require.Nil(t, res)
-		}
-
-		testRouter(t, handler, callback)
-	})
-
 	t.Run("submit block phase0", func(t *testing.T) {
 		block1 := &eth2api.VersionedSignedProposal{
 			Version: eth2spec.DataVersionPhase0,

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -807,10 +807,13 @@ func (c Component) SubmitVoluntaryExit(ctx context.Context, exit *eth2p0.SignedV
 		return err
 	}
 
-	// Use 1st slot in exit epoch for duty.
-	slotsPerEpoch, err := c.eth2Cl.SlotsPerEpoch(ctx)
+	respSpec, err := c.eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
 		return err
+	}
+	slotsPerEpoch, ok := respSpec.Data["SLOTS_PER_EPOCH"].(uint64)
+	if !ok {
+		return errors.New("fetch slots per epoch")
 	}
 
 	duty := core.NewVoluntaryExit(slotsPerEpoch * uint64(exit.Message.Epoch))

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -569,38 +569,32 @@ func propDataMatchesDuty(opts *eth2api.SubmitProposalOpts, prop *eth2api.Version
 	case eth2spec.DataVersionAltair:
 		return checkHashes(prop.Altair, opts.Proposal.Altair.Message)
 	case eth2spec.DataVersionBellatrix:
-		switch prop.Blinded {
-		case false:
-			return checkHashes(prop.Bellatrix, opts.Proposal.Bellatrix.Message)
-		case true:
+		if prop.Blinded {
 			return checkHashes(prop.BellatrixBlinded, opts.Proposal.BellatrixBlinded.Message)
 		}
+
+		return checkHashes(prop.Bellatrix, opts.Proposal.Bellatrix.Message)
 	case eth2spec.DataVersionCapella:
-		switch prop.Blinded {
-		case false:
-			return checkHashes(prop.Capella, opts.Proposal.Capella.Message)
-		case true:
+		if prop.Blinded {
 			return checkHashes(prop.CapellaBlinded, opts.Proposal.CapellaBlinded.Message)
 		}
+
+		return checkHashes(prop.Capella, opts.Proposal.Capella.Message)
 	case eth2spec.DataVersionDeneb:
-		switch prop.Blinded {
-		case false:
-			return checkHashes(prop.Deneb.Block, opts.Proposal.Deneb.SignedBlock.Message)
-		case true:
+		if prop.Blinded {
 			return checkHashes(prop.DenebBlinded, opts.Proposal.DenebBlinded.Message)
 		}
+
+		return checkHashes(prop.Deneb.Block, opts.Proposal.Deneb.SignedBlock.Message)
 	case eth2spec.DataVersionElectra:
-		switch prop.Blinded {
-		case false:
-			return checkHashes(prop.Electra.Block, opts.Proposal.Electra.SignedBlock.Message)
-		case true:
+		if prop.Blinded {
 			return checkHashes(prop.ElectraBlinded, opts.Proposal.ElectraBlinded.Message)
 		}
+
+		return checkHashes(prop.Electra.Block, opts.Proposal.Electra.SignedBlock.Message)
 	default:
 		return errors.New("unexpected block version", z.Str("version", prop.Version.String()))
 	}
-
-	return nil
 }
 
 func (c Component) SubmitProposal(ctx context.Context, opts *eth2api.SubmitProposalOpts) error {

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -207,7 +207,7 @@ func TestSubmitAttestations_Verify(t *testing.T) {
 	require.NoError(t, err)
 
 	vapi.RegisterPubKeyByAttestation(func(ctx context.Context, slot, commIdx, valIdx uint64) (core.PubKey, error) {
-		require.EqualValues(t, slot, epochSlot)
+		require.Equal(t, slot, epochSlot)
 		require.EqualValues(t, commIdx, vIdx)
 		require.EqualValues(t, valIdx, 0)
 

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1635,8 +1635,10 @@ func TestComponent_SubmitValidatorRegistration(t *testing.T) {
 
 	unsigned := testutil.RandomValidatorRegistration(t)
 	unsigned.Pubkey = eth2Pubkey
-	unsigned.Timestamp, err = bmock.GenesisTime(ctx) // Set timestamp to genesis which should result in epoch 0 and slot 0.
+	genesis, err := bmock.Genesis(ctx, &eth2api.GenesisOpts{})
 	require.NoError(t, err)
+	genesisTime := genesis.Data.GenesisTime
+	unsigned.Timestamp = genesisTime // Set timestamp to genesis which should result in epoch 0 and slot 0.
 
 	// Sign validator (builder) registration
 	sigRoot, err := unsigned.HashTreeRoot()
@@ -1713,8 +1715,10 @@ func TestComponent_SubmitValidatorRegistrationInvalidSignature(t *testing.T) {
 
 	unsigned := testutil.RandomValidatorRegistration(t)
 	unsigned.Pubkey = eth2Pubkey
-	unsigned.Timestamp, err = bmock.GenesisTime(ctx) // Set timestamp to genesis which should result in epoch 0 and slot 0.
+	genesis, err := bmock.Genesis(ctx, &eth2api.GenesisOpts{})
 	require.NoError(t, err)
+	genesisTime := genesis.Data.GenesisTime
+	unsigned.Timestamp = genesisTime // Set timestamp to genesis which should result in epoch 0 and slot 0.
 
 	vapi.RegisterGetDutyDefinition(func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error) {
 		return core.DutyDefinitionSet{corePubKey: nil}, nil
@@ -1772,8 +1776,9 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 	pk, err := core.PubKeyFromBytes(pubkey[:])
 	require.NoError(t, err)
 
-	genesis, err := bmock.GenesisTime(ctx)
+	genesis, err := bmock.Genesis(ctx, &eth2api.GenesisOpts{})
 	require.NoError(t, err)
+	genesisTime := genesis.Data.GenesisTime
 	respSpec, err := bmock.Spec(ctx, &eth2api.SpecOpts{})
 	require.NoError(t, err)
 	slotDuration, ok := respSpec.Data["SECONDS_PER_SLOT"].(time.Duration)
@@ -1790,7 +1795,7 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 					Enabled:  true,
 					GasLimit: 30000000,
 					Overrides: map[string]string{
-						"timestamp":  strconv.FormatInt(genesis.Add(slotDuration).Unix(), 10),
+						"timestamp":  strconv.FormatInt(genesisTime.Add(slotDuration).Unix(), 10),
 						"public_key": string(pk),
 					},
 				},

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -1774,8 +1774,10 @@ func TestComponent_TekuProposerConfig(t *testing.T) {
 
 	genesis, err := bmock.GenesisTime(ctx)
 	require.NoError(t, err)
-	slotDuration, err := bmock.SlotDuration(ctx)
+	respSpec, err := bmock.Spec(ctx, &eth2api.SpecOpts{})
 	require.NoError(t, err)
+	slotDuration, ok := respSpec.Data["SECONDS_PER_SLOT"].(time.Duration)
+	require.True(t, ok)
 
 	eth2pk, err := pk.ToETH2()
 	require.NoError(t, err)

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -434,7 +434,7 @@ func setupP2P(ctx context.Context, key *k1.PrivateKey, conf Config, peers []p2p.
 // when all peers are connected.
 func startSyncProtocol(ctx context.Context, tcpNode host.Host, key *k1.PrivateKey, defHash []byte,
 	peerIDs []peer.ID, onFailure func(), testConfig TestConfig,
-) (func(context.Context) error, func(context.Context) error, error) {
+) (stepSyncFunc func(context.Context) error, shutdownFunc func(context.Context) error, err error) {
 	// Sign definition hash with charon-enr-private-key
 	// Note: libp2p signing does another hash of the defHash.
 
@@ -512,7 +512,7 @@ func startSyncProtocol(ctx context.Context, tcpNode host.Host, key *k1.PrivateKe
 	}
 
 	var step int
-	stepSyncFunc := func(ctx context.Context) error {
+	stepSyncFunc = func(ctx context.Context) error {
 		// Start next step ourselves by incrementing our step client side
 		step++
 		for _, client := range clients {
@@ -534,7 +534,7 @@ func startSyncProtocol(ctx context.Context, tcpNode host.Host, key *k1.PrivateKe
 	}
 
 	// Shutdown function stops all clients and server
-	shutdownFunc := func(ctx context.Context) error {
+	shutdownFunc = func(ctx context.Context) error {
 		for _, client := range clients {
 			err := client.Shutdown(ctx)
 			if err != nil {

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -427,7 +427,7 @@ func verifyDistValidators(t *testing.T, lock cluster.Lock, def cluster.Definitio
 		uniqueSigs := make(map[string]struct{})
 		for i, amount := range depositAmounts {
 			pdd := val.PartialDepositData[i]
-			require.EqualValues(t, val.PubKey, pdd.PubKey)
+			require.Equal(t, val.PubKey, pdd.PubKey)
 			require.EqualValues(t, amount, pdd.Amount)
 			uniqueSigs[hex.EncodeToString(pdd.Signature)] = struct{}{}
 		}
@@ -440,11 +440,11 @@ func verifyDistValidators(t *testing.T, lock cluster.Lock, def cluster.Definitio
 		}
 
 		// Assert Builder Registration
-		require.EqualValues(t, val.PubKey, val.BuilderRegistration.Message.PubKey)
-		require.EqualValues(t, registration.DefaultGasLimit, val.BuilderRegistration.Message.GasLimit)
+		require.Equal(t, val.PubKey, val.BuilderRegistration.Message.PubKey)
+		require.Equal(t, registration.DefaultGasLimit, val.BuilderRegistration.Message.GasLimit)
 		timestamp, err := eth2util.ForkVersionToGenesisTime(lock.ForkVersion)
 		require.NoError(t, err)
-		require.EqualValues(t, timestamp, val.BuilderRegistration.Message.Timestamp)
+		require.Equal(t, timestamp, val.BuilderRegistration.Message.Timestamp)
 
 		// Verify registration signatures
 		eth2Reg, err := registration.NewMessage(eth2p0.BLSPubKey(val.BuilderRegistration.Message.PubKey),
@@ -464,7 +464,7 @@ func verifyDistValidators(t *testing.T, lock cluster.Lock, def cluster.Definitio
 		err = tbls.Verify(pubkey, sigRoot[:], sig)
 		require.NoError(t, err)
 
-		require.EqualValues(t,
+		require.Equal(t,
 			lock.ValidatorAddresses[j].FeeRecipientAddress,
 			fmt.Sprintf("%#x", val.BuilderRegistration.Message.FeeRecipient),
 		)

--- a/dkg/sync/client.go
+++ b/dkg/sync/client.go
@@ -223,7 +223,7 @@ func (c *Client) connect(ctx context.Context) (network.Stream, error) {
 	)
 
 	for {
-		s, err := c.tcpNode.NewStream(network.WithUseTransient(ctx, "sync"), c.peer, protocolID)
+		s, err := c.tcpNode.NewStream(network.WithAllowLimitedConn(ctx, "sync"), c.peer, protocolID)
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		} else if err != nil {

--- a/eth2util/deposit/deposit_test.go
+++ b/eth2util/deposit/deposit_test.go
@@ -59,9 +59,9 @@ func TestNewMessage(t *testing.T) {
 
 			require.NoError(t, err)
 			if test.compouding {
-				require.EqualValues(t, []byte{0x02}, msg.WithdrawalCredentials[:1])
+				require.Equal(t, []byte{0x02}, msg.WithdrawalCredentials[:1])
 			} else {
-				require.EqualValues(t, []byte{0x01}, msg.WithdrawalCredentials[:1])
+				require.Equal(t, []byte{0x01}, msg.WithdrawalCredentials[:1])
 			}
 		})
 	}
@@ -301,5 +301,5 @@ func TestDedupAmounts(t *testing.T) {
 
 	amounts = deposit.DedupAmounts(amounts)
 
-	require.EqualValues(t, []eth2p0.Gwei{0, 100, 300, 500}, amounts)
+	require.Equal(t, []eth2p0.Gwei{0, 100, 300, 500}, amounts)
 }

--- a/eth2util/helpers.go
+++ b/eth2util/helpers.go
@@ -10,6 +10,7 @@ import (
 	"unicode"
 
 	eth2client "github.com/attestantio/go-eth2-client"
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"golang.org/x/crypto/sha3"
@@ -58,10 +59,14 @@ func ParseBeaconNodeHeaders(headers []string) (map[string]string, error) {
 }
 
 // EpochFromSlot returns epoch calculated from given slot.
-func EpochFromSlot(ctx context.Context, eth2Cl eth2client.SlotsPerEpochProvider, slot eth2p0.Slot) (eth2p0.Epoch, error) {
-	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+func EpochFromSlot(ctx context.Context, eth2Cl eth2client.SpecProvider, slot eth2p0.Slot) (eth2p0.Epoch, error) {
+	respSpec, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
-		return 0, errors.Wrap(err, "getting slots per epoch")
+		return 0, errors.Wrap(err, "getting spec")
+	}
+	slotsPerEpoch, ok := respSpec.Data["SLOTS_PER_EPOCH"].(uint64)
+	if !ok {
+		return 0, errors.New("fetch slots per epoch")
 	}
 
 	return eth2p0.Epoch(uint64(slot) / slotsPerEpoch), nil

--- a/eth2util/keymanager/keymanager_test.go
+++ b/eth2util/keymanager/keymanager_test.go
@@ -68,7 +68,7 @@ func TestImportKeystores(t *testing.T) {
 
 			var req mockKeymanagerReq
 			require.NoError(t, json.Unmarshal(data, &req))
-			require.Equal(t, len(req.Keystores), len(req.Passwords))
+			require.Len(t, req.Passwords, len(req.Keystores))
 			require.Equal(t, len(req.Keystores), numSecrets)
 
 			for i := range numSecrets {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/obolnetwork/charon
 
-go 1.23
+go 1.24
 
 require (
 	github.com/attestantio/go-builder-client v0.5.3

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	golang.org/x/crypto v0.33.0
 	golang.org/x/sync v0.11.0
 	golang.org/x/term v0.29.0
+	golang.org/x/text v0.22.0
 	golang.org/x/time v0.10.0
 	golang.org/x/tools v0.30.0
 	google.golang.org/protobuf v1.36.5
@@ -243,7 +244,6 @@ require (
 	golang.org/x/mod v0.23.0 // indirect
 	golang.org/x/net v0.35.0 // indirect
 	golang.org/x/sys v0.30.0 // indirect
-	golang.org/x/text v0.22.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250106144421-5f5ef82da422 // indirect

--- a/p2p/p2p_internal_test.go
+++ b/p2p/p2p_internal_test.go
@@ -76,7 +76,7 @@ func TestFilterAdvertisedAddrs(t *testing.T) {
 			for _, mAddr := range res {
 				resStr = append(resStr, mAddr.String())
 			}
-			require.EqualValues(t, test.result, resStr)
+			require.Equal(t, test.result, resStr)
 		})
 	}
 }

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -275,7 +275,7 @@ func SendReceive(ctx context.Context, tcpNode host.Host, peerID peer.ID,
 	}
 
 	// Circuit relay connections are transient
-	s, err := tcpNode.NewStream(network.WithUseTransient(ctx, ""), peerID, o.protocols...)
+	s, err := tcpNode.NewStream(network.WithAllowLimitedConn(ctx, ""), peerID, o.protocols...)
 	if err != nil {
 		return errors.Wrap(err, "new stream", z.Any("protocols", o.protocols))
 	}
@@ -326,7 +326,7 @@ func Send(ctx context.Context, tcpNode host.Host, protoID protocol.ID, peerID pe
 		opt(&o)
 	}
 	// Circuit relay connections are transient
-	s, err := tcpNode.NewStream(network.WithUseTransient(ctx, ""), peerID, o.protocols...)
+	s, err := tcpNode.NewStream(network.WithAllowLimitedConn(ctx, ""), peerID, o.protocols...)
 	if err != nil {
 		return errors.Wrap(err, "tcpNode stream")
 	}

--- a/tbls/herumi.go
+++ b/tbls/herumi.go
@@ -24,7 +24,6 @@ var initOnce = sync.Once{}
 //nolint:gochecknoinits
 func init() {
 	initOnce.Do(func() {
-		//nolint:nosnakecase
 		if err := bls.Init(bls.BLS12_381); err != nil {
 			panic(errors.Wrap(err, "cannot initialize Herumi BLS"))
 		}

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -146,7 +146,7 @@ type Mock struct {
 	SubmitVoluntaryExitFunc                func(context.Context, *eth2p0.SignedVoluntaryExit) error
 	ValidatorsByPubKeyFunc                 func(context.Context, string, []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
 	ValidatorsFunc                         func(context.Context, *eth2api.ValidatorsOpts) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error)
-	GenesisTimeFunc                        func(context.Context) (time.Time, error)
+	GenesisFunc                            func(context.Context, *eth2api.GenesisOpts) (*eth2v1.Genesis, error)
 	NodeSyncingFunc                        func(context.Context, *eth2api.NodeSyncingOpts) (*eth2v1.SyncState, error)
 	SubmitValidatorRegistrationsFunc       func(context.Context, []*eth2api.VersionedSignedValidatorRegistration) error
 	SlotsPerEpochFunc                      func(context.Context) (uint64, error)
@@ -297,6 +297,15 @@ func (m Mock) CompleteValidators(ctx context.Context) (eth2wrap.CompleteValidato
 	return complete, err
 }
 
+func (m Mock) Genesis(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.Response[*eth2v1.Genesis], error) {
+	genesis, err := m.GenesisFunc(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return wrapResponse(genesis), nil
+}
+
 // Deprecated: use BlockAttestationsV2(ctx context.Context, stateID string) ([]*spec.VersionedAttestation, error)
 func (m Mock) BlockAttestations(ctx context.Context, stateID string) ([]*eth2p0.Attestation, error) {
 	return m.BlockAttestationsFunc(ctx, stateID)
@@ -328,10 +337,6 @@ func (m Mock) SubmitVoluntaryExit(ctx context.Context, exit *eth2p0.SignedVolunt
 
 func (m Mock) ValidatorsByPubKey(ctx context.Context, stateID string, validatorPubKeys []eth2p0.BLSPubKey) (map[eth2p0.ValidatorIndex]*eth2v1.Validator, error) {
 	return m.ValidatorsByPubKeyFunc(ctx, stateID, validatorPubKeys)
-}
-
-func (m Mock) GenesisTime(ctx context.Context) (time.Time, error) {
-	return m.GenesisTimeFunc(ctx)
 }
 
 func (m Mock) SubmitValidatorRegistrations(ctx context.Context, registrations []*eth2api.VersionedSignedValidatorRegistration) error {

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -94,6 +94,11 @@ func defaultHTTPMock() Mock {
 				Value:    "16",
 			},
 			{
+				Endpoint: "/eth/v1/config/spec",
+				Key:      "SECONDS_PER_SLOT",
+				Value:    "12",
+			},
+			{
 				Endpoint: "/eth/v1/beacon/genesis",
 				Key:      "genesis_time",
 				Value:    strconv.FormatInt(genesis.Unix(), 10),

--- a/testutil/beaconmock/headproducer.go
+++ b/testutil/beaconmock/headproducer.go
@@ -51,10 +51,11 @@ type headProducer struct {
 // Start starts the internal slot ticker that updates head.
 func (p *headProducer) Start(httpMock HTTPMock) error {
 	ctx := context.Background()
-	genesisTime, err := httpMock.GenesisTime(ctx)
+	genesis, err := httpMock.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {
 		return err
 	}
+	genesisTime := genesis.Data.GenesisTime
 
 	eth2Resp, err := httpMock.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -621,7 +621,16 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 			return nil
 		},
 		SlotsPerEpochFunc: func(ctx context.Context) (uint64, error) {
-			return httpMock.SlotsPerEpoch(ctx)
+			respSpec, err := httpMock.Spec(ctx, &eth2api.SpecOpts{})
+			if err != nil {
+				return 0, errors.Wrap(err, "getting spec")
+			}
+			slotsPerEpoch, ok := respSpec.Data["SLOTS_PER_EPOCH"].(uint64)
+			if !ok {
+				return 0, errors.New("fetch slots per epoch")
+			}
+
+			return slotsPerEpoch, nil
 		},
 		SubmitProposalPreparationsFunc: func(context.Context, []*eth2v1.ProposalPreparation) error {
 			return nil

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -597,8 +597,13 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		SubmitVoluntaryExitFunc: func(context.Context, *eth2p0.SignedVoluntaryExit) error {
 			return nil
 		},
-		GenesisTimeFunc: func(ctx context.Context) (time.Time, error) {
-			return httpMock.GenesisTime(ctx)
+		GenesisFunc: func(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2v1.Genesis, error) {
+			resp, err := httpMock.Genesis(ctx, opts)
+			if err != nil {
+				return nil, err
+			}
+
+			return resp.Data, nil
 		},
 		NodeSyncingFunc: func(ctx context.Context, opts *eth2api.NodeSyncingOpts) (*eth2v1.SyncState, error) {
 			resp, err := httpMock.NodeSyncing(ctx, opts)

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -37,7 +37,6 @@ type HTTPMock interface {
 	eth2client.ForkProvider
 	eth2client.ForkScheduleProvider
 	eth2client.GenesisProvider
-	eth2client.GenesisTimeProvider
 	eth2client.NodeSyncingProvider
 	eth2client.NodeVersionProvider
 	eth2client.SlotDurationProvider

--- a/testutil/beaconmock/server_test.go
+++ b/testutil/beaconmock/server_test.go
@@ -55,10 +55,6 @@ func TestGenesisTimeOverride(t *testing.T) {
 	genesisResp, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	require.NoError(t, err)
 	require.Equal(t, t0, genesisResp.Data.GenesisTime)
-
-	genesisTime, err := eth2Cl.GenesisTime(ctx)
-	require.NoError(t, err)
-	require.Equal(t, t0, genesisTime)
 }
 
 func TestSlotsPerEpochOverride(t *testing.T) {
@@ -134,7 +130,8 @@ func TestDefaultOverrides(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, 16, slotsPerEpoch)
 
-	genesis, err := bmock.GenesisTime(ctx)
+	genesis, err := bmock.Genesis(ctx, &eth2api.GenesisOpts{})
+	genesisTime := genesis.Data.GenesisTime
 	require.NoError(t, err)
-	require.Equal(t, "2022-03-01 00:00:00 +0000 UTC", genesis.UTC().String())
+	require.Equal(t, "2022-03-01 00:00:00 +0000 UTC", genesisTime.UTC().String())
 }

--- a/testutil/beaconmock/server_test.go
+++ b/testutil/beaconmock/server_test.go
@@ -90,7 +90,7 @@ func TestSlotsDurationOverride(t *testing.T) {
 	actual, ok := eth2Resp.Data["SECONDS_PER_SLOT"].(time.Duration)
 	require.True(t, ok)
 	require.NoError(t, err)
-	require.EqualValues(t, expect, actual)
+	require.Equal(t, expect, actual)
 
 	specResp, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	require.NoError(t, err)

--- a/testutil/compose/auto.go
+++ b/testutil/compose/auto.go
@@ -289,7 +289,7 @@ func newLogWriter(logFile string) (io.WriteCloser, func() error, error) {
 	}
 
 	// Preparing log file.
-	file, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644) //nolint:nosnakecase
+	file, err := os.OpenFile(logFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "open log file")
 	}

--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -29,6 +29,9 @@ import (
 	"text/template"
 	"time"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+
 	"github.com/obolnetwork/charon/app/errors"
 	applog "github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/version"
@@ -274,7 +277,7 @@ func tplDataFromPRs(prs []pullRequest, gitRange string, issueData func(int) (str
 
 		cat := cats[issue.Category]
 		cat.Name = issue.Category
-		cat.Label = strings.Title(issue.Category)
+		cat.Label = cases.Title(language.English).String(issue.Category)
 		cat.Issues = append(cat.Issues, issue)
 		cats[issue.Category] = cat
 	}

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -145,6 +145,8 @@ func TestSimnetDuties(t *testing.T) {
 				}
 			case vcVmock:
 				args.VMocks = true
+			case vcUnknown:
+				panic("unknown VC")
 			}
 
 			if test.scheduledType != core.DutyAttester {

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -146,7 +146,6 @@ func TestSimnetDuties(t *testing.T) {
 			case vcVmock:
 				args.VMocks = true
 			case vcUnknown:
-				panic("unknown VC")
 			}
 
 			if test.scheduledType != core.DutyAttester {

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -144,6 +144,8 @@ func TestSimnetDuties(t *testing.T) {
 				}
 			} else if test.vcType == vcVmock {
 				args.VMocks = true
+			case vcUnknown:
+				panic("unknown VC")
 			}
 
 			if test.scheduledType != core.DutyAttester {

--- a/testutil/integration/simnet_test.go
+++ b/testutil/integration/simnet_test.go
@@ -138,14 +138,13 @@ func TestSimnetDuties(t *testing.T) {
 			args.BuilderAPI = test.builderAPI
 			args.VoluntaryExit = test.exit
 
-			if test.vcType == vcTeku {
+			switch test.vcType {
+			case vcTeku:
 				for i := range args.N {
 					args = startTeku(t, args, i)
 				}
-			} else if test.vcType == vcVmock {
+			case vcVmock:
 				args.VMocks = true
-			case vcUnknown:
-				panic("unknown VC")
 			}
 
 			if test.scheduledType != core.DutyAttester {

--- a/testutil/validatormock/propose.go
+++ b/testutil/validatormock/propose.go
@@ -42,10 +42,15 @@ func ProposeBlock(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc
 		return err
 	}
 
-	slotsPerEpoch, err := eth2Cl.SlotsPerEpoch(ctx)
+	respSpec, err := eth2Cl.Spec(ctx, &eth2api.SpecOpts{})
 	if err != nil {
 		return err
 	}
+	slotsPerEpoch, ok := respSpec.Data["SLOTS_PER_EPOCH"].(uint64)
+	if !ok {
+		return errors.New("fetch slots per epoch")
+	}
+
 	epoch := eth2p0.Epoch(uint64(slot) / slotsPerEpoch)
 
 	var indexes []eth2p0.ValidatorIndex

--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -190,9 +190,10 @@ func verifyBody(body string) error {
 
 			ticket := strings.TrimSpace(strings.TrimPrefix(line, ticketTag))
 
-			if ticket == "" {
+			switch ticket {
+			case "":
 				return errors.New("ticket tag empty")
-			} else if ticket == "#000" {
+			case "#000":
 				return errors.New("invalid #000 ticket")
 			}
 
@@ -224,9 +225,10 @@ func verifyBody(body string) error {
 
 			flag := strings.TrimSpace(strings.TrimPrefix(line, featureTag))
 
-			if flag == "" {
+			switch flag {
+			case "":
 				return errors.New("feature_flag tag empty")
-			} else if flag == "?" {
+			case "?":
 				return errors.New("invalid ? feature_flag")
 			}
 


### PR DESCRIPTION
- bump go to v1.24
- bump linter from v1 to v2
- some autoformatting of yaml files
- linting
  - swap deprecated functions
  - accommodate new linters
  - remove unused linters

category: misc
ticket: #3596 
