### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -814,11 +814,7 @@ func calculateTrackerDelay(ctx context.Context, cl eth2wrap.Client, now time.Tim
 	maxDelayTimeSlot := currentSlot + uint64(maxDelayTime/slotDuration) + 1
 	minDelaySlot := currentSlot + minDelaySlots
 
-	if maxDelayTimeSlot < minDelaySlot {
-		return minDelaySlot, nil
-	}
-
-	return maxDelayTimeSlot, nil
+	return max(minDelaySlot, maxDelayTimeSlot), nil
 }
 
 // eth2PubKeys returns a list of BLS pubkeys of validators in the cluster lock.


### PR DESCRIPTION


In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

