### PR TITLE
*: fix PRs parsing

### DIFF
--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -329,7 +329,7 @@ func selectCategory(current, candidate string) string {
 // parsePRs returns parsed PRs by query the git logs for the provided range.
 func parsePRs(gitRange string) ([]pullRequest, error) {
 	// Custom json encoding of git log output.
-	const format = `--pretty=format:{…commit…: …%h…,…body…: …%b…,…subject…: …%s…,…author…: …%aE…}†`
+	const format = `--pretty=format:{¬commit¬: ¬%h¬,¬body¬: ¬%b¬,¬subject¬: ¬%s¬,¬author¬: ¬%aE¬}†`
 
 	b, err := exec.Command("git", "log", format, gitRange).CombinedOutput()
 	if err != nil {
@@ -344,8 +344,9 @@ func parsePRs(gitRange string) ([]pullRequest, error) {
 	out = strings.ReplaceAll(out, `\"`, `‰`)        // Hide already escaped quotes
 	out = strings.ReplaceAll(out, `"`, `\"`)        // Escape double quotes
 	out = strings.ReplaceAll(out, `‰`, `\"`)        // Unhide already escaped quotes
-	out = strings.ReplaceAll(out, `…`, `"`)         // Replace field separator
+	out = strings.ReplaceAll(out, `¬`, `"`)         // Replace field separator
 	out = strings.ReplaceAll(out, "`\\`", "`\\\\`") // Edge case in which backticks are used in issue/PR names
+	out = strings.ReplaceAll(out, `\[`, `\\[`)      // Edge case with invalid escape character
 
 	var logs []log
 	if err := json.Unmarshal([]byte(out), &logs); err != nil {


### PR DESCRIPTION
Two commits were crashing our parsing logic in `genchangelog`:
- https://github.com/ObolNetwork/charon/commit/82c9ee4135442aacb07a9dded5ffc104e560edc0 - body contains a character which was our field separator leading to broken parsing.
- https://github.com/ObolNetwork/charon/commit/c3caee9a38e90d7734c83db5ec65b82a31b2a724 - body contains a sequence of characters which our logic didn't correctly escape, specifically the sequence `\[!WARNING]\` contains a `\[` which must be escaped to `\\[` 

category: bug
ticket: none
