### PR TITLE
*: new default partial deposits

### DIFF
--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -227,7 +227,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	}
 
 	if len(depositAmounts) == 0 {
-		depositAmounts = deposit.DefaultDepositAmounts()
+		depositAmounts = deposit.DefaultDepositAmounts(conf.Compounding)
 	}
 
 	if len(secrets) == 0 {

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -372,7 +372,7 @@ func testCreateCluster(t *testing.T, conf clusterConfig, def cluster.Definition,
 		vals := make(map[string]struct{})
 		amounts := deposit.DedupAmounts(deposit.EthsToGweis(conf.DepositAmounts))
 		if len(amounts) == 0 {
-			amounts = deposit.DefaultDepositAmounts()
+			amounts = deposit.DefaultDepositAmounts(conf.Compounding)
 		}
 		for _, val := range lock.Validators {
 			vals[val.PublicKeyHex()] = struct{}{}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -253,7 +253,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	depositAmounts := def.DepositAmounts
 	if len(depositAmounts) == 0 {
 		if cluster.SupportPartialDeposits(def.Version) {
-			depositAmounts = deposit.DefaultDepositAmounts()
+			depositAmounts = deposit.DefaultDepositAmounts(def.Compounding)
 		} else {
 			depositAmounts = []eth2p0.Gwei{deposit.DefaultDepositAmount}
 		}

--- a/dkg/dkg_test.go
+++ b/dkg/dkg_test.go
@@ -418,7 +418,7 @@ func verifyDistValidators(t *testing.T, lock cluster.Lock, def cluster.Definitio
 			if !cluster.SupportPartialDeposits(def.Version) {
 				depositAmounts = []eth2p0.Gwei{deposit.DefaultDepositAmount}
 			} else {
-				depositAmounts = deposit.DefaultDepositAmounts()
+				depositAmounts = deposit.DefaultDepositAmounts(def.Compounding)
 			}
 		}
 		require.Len(t, val.PartialDepositData, len(depositAmounts))

--- a/eth2util/deposit/deposit.go
+++ b/eth2util/deposit/deposit.go
@@ -291,8 +291,14 @@ func DedupAmounts(amounts []eth2p0.Gwei) []eth2p0.Gwei {
 	return result
 }
 
-// DefaultDepositAmounts returns the default deposit amounts: 1ETH and 32ETH.
-func DefaultDepositAmounts() []eth2p0.Gwei {
+// DefaultDepositAmounts returns the default deposit amounts:
+// --compounding=false: [1,32] ETH,
+// --compounding=true: [1,8,32,256] ETH.
+func DefaultDepositAmounts(compounding bool) []eth2p0.Gwei {
+	if compounding {
+		return []eth2p0.Gwei{MinDepositAmount, 8 * OneEthInGwei, 32 * OneEthInGwei, 256 * OneEthInGwei}
+	}
+
 	return []eth2p0.Gwei{MinDepositAmount, DefaultDepositAmount}
 }
 

--- a/eth2util/deposit/deposit_test.go
+++ b/eth2util/deposit/deposit_test.go
@@ -155,11 +155,20 @@ func TestVerifyDepositAmounts(t *testing.T) {
 }
 
 func TestDefaultDepositAmounts(t *testing.T) {
-	amounts := deposit.DefaultDepositAmounts()
+	amounts := deposit.DefaultDepositAmounts(false)
 
 	require.Equal(t, []eth2p0.Gwei{
 		deposit.MinDepositAmount,
 		deposit.DefaultDepositAmount,
+	}, amounts)
+
+	amounts = deposit.DefaultDepositAmounts(true)
+
+	require.Equal(t, []eth2p0.Gwei{
+		deposit.MinDepositAmount,
+		8 * deposit.OneEthInGwei,
+		32 * deposit.OneEthInGwei,
+		256 * deposit.OneEthInGwei,
 	}, amounts)
 }
 


### PR DESCRIPTION
New default partial deposits `[1,8,32,256]` when `--compounding` flag is enabled. Otherwise, the default values are `[1,32]`.

category: feature
ticket: #3640 
