### PR TITLE
*: fix validator cache behavior

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -456,7 +456,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	// Setup validator cache, refreshing it every epoch.
 	valCache := eth2wrap.NewValidatorCache(eth2Cl, eth2Pubkeys)
-	eth2Cl.SetValidatorCache(valCache.Get)
+	eth2Cl.SetValidatorCache(valCache.GetByHead)
 
 	firstValCacheRefresh := true
 	refreshedBySlot := true

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -92,7 +92,7 @@ func (c *ValidatorCache) cached() (CompleteValidators, bool) {
 }
 
 // Get returns the cached active validators, cached complete Validators response, or fetches them if not available populating the cache.
-func (c *ValidatorCache) Get(ctx context.Context) (ActiveValidators, CompleteValidators, error) {
+func (c *ValidatorCache) GetByHead(ctx context.Context) (ActiveValidators, CompleteValidators, error) {
 	completeCached, completeOk := c.cached()
 	activeCached, activeOk := c.activeCached()
 

--- a/app/eth2wrap/valcache.go
+++ b/app/eth2wrap/valcache.go
@@ -6,20 +6,12 @@ import (
 	"context"
 	"strconv"
 	"sync"
-	"time"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
-	"github.com/obolnetwork/charon/app/log"
-	"github.com/obolnetwork/charon/app/z"
-)
-
-const (
-	maxRetries = 20
-	retryDelay = 100 * time.Millisecond
 )
 
 // ActiveValidators is a map of active validator indices to pubkeys.
@@ -143,32 +135,27 @@ func (c *ValidatorCache) Get(ctx context.Context) (ActiveValidators, CompleteVal
 }
 
 // GetBySlot fetches active and complete validator by slot populating the cache.
-func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveValidators, CompleteValidators, error) {
+// If it fails to fetch by slot, it falls back to head state and retries to fetch by slot next slot.
+func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveValidators, CompleteValidators, bool, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+
+	refreshedBySlot := true
 
 	opts := &eth2api.ValidatorsOpts{
 		State:   strconv.FormatUint(slot, 10),
 		PubKeys: c.pubkeys,
 	}
 
-	var eth2Resp *eth2api.Response[map[eth2p0.ValidatorIndex]*eth2v1.Validator]
-	var err error
-
-	for retryCount := 0; retryCount < maxRetries; retryCount++ {
-		eth2Resp, err = c.eth2Cl.Validators(ctx, opts)
-		if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-			break
-		}
-
-		sleepDuration := retryDelay * time.Duration(retryCount+1)
-		time.Sleep(sleepDuration)
-
-		log.Info(ctx, "Retrying fetching validators by slot", z.U64("slot", slot), z.Int("retryCount", retryCount+1), z.Err(err))
-	}
-
+	eth2Resp, err := c.eth2Cl.Validators(ctx, opts)
 	if err != nil {
-		return nil, nil, wrapError(ctx, err, "Failed to fetch validators by slot after maximum retries")
+		// Failed to fetch by slot, fall back to head state
+		refreshedBySlot = false
+		opts.State = "head"
+		eth2Resp, err = c.eth2Cl.Validators(ctx, opts)
+		if err != nil {
+			return nil, nil, refreshedBySlot, err
+		}
 	}
 
 	complete := eth2Resp.Data
@@ -176,7 +163,7 @@ func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveVali
 	active := make(ActiveValidators)
 	for _, val := range complete {
 		if val == nil || val.Validator == nil {
-			return nil, nil, errors.New("validator data cannot be nil")
+			return nil, nil, refreshedBySlot, errors.New("validator data cannot be nil")
 		}
 
 		if !val.Status.IsActive() {
@@ -189,5 +176,5 @@ func (c *ValidatorCache) GetBySlot(ctx context.Context, slot uint64) (ActiveVali
 	c.active = active
 	c.complete = complete
 
-	return active, complete, nil
+	return active, complete, refreshedBySlot, nil
 }

--- a/app/eth2wrap/valcache_test.go
+++ b/app/eth2wrap/valcache_test.go
@@ -59,14 +59,14 @@ func TestValidatorCache(t *testing.T) {
 	ctx := context.Background()
 
 	// Check cache is populated.
-	actual, complete, err := valCache.Get(ctx)
+	actual, complete, err := valCache.GetByHead(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 1, queried)
 	require.Equal(t, completeExpected, complete)
 
 	// Check cache is used.
-	actual, complete, err = valCache.Get(ctx)
+	actual, complete, err = valCache.GetByHead(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 1, queried)
@@ -76,14 +76,14 @@ func TestValidatorCache(t *testing.T) {
 	valCache.Trim()
 
 	// Check cache is populated again.
-	actual, complete, err = valCache.Get(ctx)
+	actual, complete, err = valCache.GetByHead(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 2, queried)
 	require.Equal(t, completeExpected, complete)
 
 	// Check cache is used again.
-	actual, complete, err = valCache.Get(ctx)
+	actual, complete, err = valCache.GetByHead(ctx)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 	require.Equal(t, 2, queried)

--- a/app/vmock.go
+++ b/app/vmock.go
@@ -96,7 +96,7 @@ func newVMockEth2Provider(conf Config, pubshares []eth2p0.BLSPubKey) func() (eth
 
 			cached = eth2wrap.AdaptEth2HTTP(eth2Http, nil, timeout)
 			valCache := eth2wrap.NewValidatorCache(cached, pubshares)
-			cached.SetValidatorCache(valCache.Get)
+			cached.SetValidatorCache(valCache.GetByHead)
 
 			break
 		}


### PR DESCRIPTION
Validator cache is refreshed at the start of the epoch. Previous behavior would request too many times causing issues with beacon node and had no fallback in case of complete failure.

This PR fixes this behavior according to what's described in ticket.

category: bug
ticket: #3636
