### PR TITLE
*: improving spans

### DIFF
--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -391,6 +391,8 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 	)
 
 	_, span = tracer.Start(ctx, "qbft.runInstance")
+	span.SetAttributes(attribute.String("duty", duty.Type.String()))
+
 	defer func() {
 		if err != nil && !isContextErr(err) {
 			span.RecordError(err)

--- a/core/parsigdb/memory.go
+++ b/core/parsigdb/memory.go
@@ -92,10 +92,6 @@ func (db *MemDB) StoreExternal(ctx context.Context, duty core.Duty, signedSet co
 			continue
 		}
 
-		log.Debug(ctx, "Partial signed data stored",
-			z.Int("count", len(sigs)),
-			z.Any("pubkey", pubkey))
-
 		// Check if sufficient matching partial signed data has been received.
 		psigs, ok, err := getThresholdMatching(duty.Type, sigs, db.threshold)
 		if err != nil {

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
+	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -72,73 +73,88 @@ func WithTracing() WireOption {
 			ctx, span := tracer.Start(parent, "core/fetcher.Fetch")
 			defer span.End()
 
-			return clone.FetcherFetch(ctx, duty, set)
+			return withSpanStatus(span, clone.FetcherFetch(ctx, duty, set))
 		}
 		w.ConsensusParticipate = func(parent context.Context, duty Duty) error {
 			ctx, span := tracer.Start(parent, "core/consensus.Participate")
 			defer span.End()
 
-			return clone.ConsensusParticipate(ctx, duty)
+			return withSpanStatus(span, clone.ConsensusParticipate(ctx, duty))
 		}
 		w.ConsensusPropose = func(parent context.Context, duty Duty, set UnsignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/consensus.Propose")
 			defer span.End()
 
-			return clone.ConsensusPropose(ctx, duty, set)
+			return withSpanStatus(span, clone.ConsensusPropose(ctx, duty, set))
 		}
 		w.DutyDBStore = func(parent context.Context, duty Duty, set UnsignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/dutydb.Store")
 			defer span.End()
 
-			return clone.DutyDBStore(ctx, duty, set)
+			return withSpanStatus(span, clone.DutyDBStore(ctx, duty, set))
 		}
 		w.DutyDBAwaitProposal = func(parent context.Context, slot uint64) (*eth2api.VersionedProposal, error) {
 			ctx, span := tracer.Start(parent, "core/dutydb.AwaitProposal")
 			defer span.End()
 
-			return clone.DutyDBAwaitProposal(ctx, slot)
+			vp, err := clone.DutyDBAwaitProposal(ctx, slot)
+
+			return vp, withSpanStatus(span, err)
 		}
 		w.ParSigDBStoreInternal = func(parent context.Context, duty Duty, set ParSignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/parsigdb.StoreInternal")
 			defer span.End()
 
-			return clone.ParSigDBStoreInternal(ctx, duty, set)
+			return withSpanStatus(span, clone.ParSigDBStoreInternal(ctx, duty, set))
 		}
 		w.ParSigDBStoreExternal = func(parent context.Context, duty Duty, set ParSignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/parsigdb.StoreExternal")
 			defer span.End()
 
-			return clone.ParSigDBStoreExternal(ctx, duty, set)
+			return withSpanStatus(span, clone.ParSigDBStoreExternal(ctx, duty, set))
 		}
 		w.ParSigExBroadcast = func(parent context.Context, duty Duty, set ParSignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/parsigex.Broadcast")
 			defer span.End()
 
-			return clone.ParSigExBroadcast(ctx, duty, set)
+			return withSpanStatus(span, clone.ParSigExBroadcast(ctx, duty, set))
 		}
 		w.SigAggAggregate = func(parent context.Context, duty Duty, set map[PubKey][]ParSignedData) error {
 			ctx, span := tracer.Start(parent, "core/sigagg.Aggregate")
 			defer span.End()
 
-			return clone.SigAggAggregate(ctx, duty, set)
+			return withSpanStatus(span, clone.SigAggAggregate(ctx, duty, set))
 		}
 		w.AggSigDBStore = func(parent context.Context, duty Duty, set SignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/aggsigdb.Store")
 			defer span.End()
 
-			return clone.AggSigDBStore(ctx, duty, set)
+			return withSpanStatus(span, clone.AggSigDBStore(ctx, duty, set))
 		}
 		w.AggSigDBAwait = func(parent context.Context, duty Duty, key PubKey) (SignedData, error) {
 			ctx, span := tracer.Start(parent, "core/aggsigdb.Await")
 			defer span.End()
 
-			return clone.AggSigDBAwait(ctx, duty, key)
+			sd, err := clone.AggSigDBAwait(ctx, duty, key)
+
+			return sd, withSpanStatus(span, err)
 		}
 		w.BroadcasterBroadcast = func(parent context.Context, duty Duty, set SignedDataSet) error {
 			ctx, span := tracer.Start(parent, "core/broadcaster.Broadcast")
 			defer span.End()
 
-			return clone.BroadcasterBroadcast(ctx, duty, set)
+			return withSpanStatus(span, clone.BroadcasterBroadcast(ctx, duty, set))
 		}
 	}
+}
+
+func withSpanStatus(span trace.Span, err error) error {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	} else {
+		span.SetStatus(codes.Ok, "")
+	}
+
+	return err
 }

--- a/core/tracing.go
+++ b/core/tracing.go
@@ -12,6 +12,7 @@ import (
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/tracer"
 )
 
@@ -149,7 +150,7 @@ func WithTracing() WireOption {
 }
 
 func withSpanStatus(span trace.Span, err error) error {
-	if err != nil {
+	if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 	} else {


### PR DESCRIPTION
Improved tracing spans data: added status codes, recording errors, etc. This is in particular useful with spanmetrics connector and raw traces rendering with grafana, as it gives more context. This barely increases network traffic, because we only track spans for Propose duty.

Fixed a bug in QBFT that prevented QBFT instance to stop promptly upon Decide. The instance was eventually terminating after the timeout - 60s, but this retained unnecessary memory and system handles. Now this finished QBFT protocol as soon as Decided is triggered. Also, this resulted in proper tracing span duration evaluation.

category: refactor
ticket: none
