### PR TITLE
*: fix PRs parsing

### DIFF
--- a/testutil/genchangelog/main.go
+++ b/testutil/genchangelog/main.go
@@ -345,11 +345,11 @@ func parsePRs(gitRange string) ([]pullRequest, error) {
 	out = strings.ReplaceAll(out, "\n", `\n`)       // Escape new lines
 	out = strings.ReplaceAll(out, "\t", `\t`)       // Escape tabs
 	out = strings.ReplaceAll(out, `\"`, `‰`)        // Hide already escaped quotes
+	out = strings.ReplaceAll(out, `\`, `\\`)        // Escape backslashes
 	out = strings.ReplaceAll(out, `"`, `\"`)        // Escape double quotes
 	out = strings.ReplaceAll(out, `‰`, `\"`)        // Unhide already escaped quotes
 	out = strings.ReplaceAll(out, `¬`, `"`)         // Replace field separator
 	out = strings.ReplaceAll(out, "`\\`", "`\\\\`") // Edge case in which backticks are used in issue/PR names
-	out = strings.ReplaceAll(out, `\[`, `\\[`)      // Edge case with invalid escape character
 
 	var logs []log
 	if err := json.Unmarshal([]byte(out), &logs); err != nil {


### PR DESCRIPTION
One commit was crashing our parsing logic in `genchangelog`:
- https://github.com/ObolNetwork/charon/commit/9c4122b33dd4b123b420e0911f140c5647fddc8a - body contains `\\[` which would turn into `\\\[` which is not valid json

In the future, we should consider moving away from manually escaping characters to avoid these types of issues.

category: bug
ticket: none

