### PR TITLE
app: combined service.name

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -182,8 +182,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	clusterHash := cluster.GetInitialMutationHash()
 	core.SetClusterHash(clusterHash)
 
-	tracingNamespace := hex.EncodeToString(clusterHash)
-	if err := wireTracing(life, conf, tracingNamespace); err != nil {
+	if err := wireTracing(life, conf, clusterHash); err != nil {
 		return err
 	}
 
@@ -1074,11 +1073,11 @@ func wireVAPIRouter(ctx context.Context, life *lifecycle.Manager, vapiAddr strin
 }
 
 // wireTracing constructs the global tracer and registers it with the life cycle manager.
-func wireTracing(life *lifecycle.Manager, conf Config, clusterHash string) error {
+func wireTracing(life *lifecycle.Manager, conf Config, clusterHash []byte) error {
 	stopTracer, err := tracer.Init(
 		tracer.WithOTLPTracer(conf.OTLPAddress),
 		tracer.WithServiceName(conf.OTLPServiceName),
-		tracer.WithNamespaceName(clusterHash),
+		tracer.WithNamespaceName(hex7(clusterHash)),
 	)
 	if err != nil {
 		return errors.Wrap(err, "init tracing")


### PR DESCRIPTION
Tempo does not support indexing on `service.namespace` attribute which we use to reflect the cluster hash.
Therefore, Grafana Explore does not render a filter for this attribute.
To improve usability and querying performance, we combine 7-characters cluster hash and service name (node name): `{resource.service.name="fc7fc15/kurtosis-node1"}`. Such the combined service name would be pretty unique across all clusters and will simplify the search.

category: misc
ticket: none