### PR TITLE
*: added verify-lock command

### DIFF
--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -5,6 +5,7 @@ package cluster
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"time"
 
@@ -500,7 +501,8 @@ func (d Definition) VerifyHashes() error {
 	}
 
 	if !bytes.Equal(d.DefinitionHash, defHash[:]) {
-		return errors.New("invalid definition hash")
+		errStr := fmt.Sprintf("invalid definition hash: expected %x, actual %x", d.DefinitionHash, defHash[:])
+		return errors.New(errStr)
 	}
 
 	return nil

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -64,6 +64,7 @@ func New() *cobra.Command {
 			newBcastFullExitCmd(runBcastFullExit),
 			newFetchExitCmd(runFetchExit),
 		),
+		newVerifyLockCmd(runVerifyLockCmd),
 		newUnsafeCmd(newRunCmd(app.Run, true)),
 	)
 }

--- a/cmd/verify_lock.go
+++ b/cmd/verify_lock.go
@@ -1,0 +1,65 @@
+// Copyright © 2022-2024 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"encoding/hex"
+	"fmt"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/cluster/manifest"
+)
+
+func newVerifyLockCmd(runFunc func(io.Writer, string)) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "verify-lock <cluster-lock.json>",
+		Short: "Verify cluster-lock.json file and exit",
+		Long:  "Verify cluster-lock.json file and exit",
+		Run: func(cmd *cobra.Command, args []string) { //nolint:revive // keep args variable name for clarity
+			if len(args) != 1 {
+				cmd.Printf("Usage: %s\n", cmd.UseLine())
+			} else {
+				runFunc(cmd.OutOrStdout(), args[0])
+			}
+		},
+	}
+
+	return cmd
+}
+
+func runVerifyLockCmd(out io.Writer, clusterLockFilePath string) {
+	_, _ = fmt.Fprintf(out, "Reading cluster lock file: %s\n", clusterLockFilePath)
+
+	verifyLock := func(lock cluster.Lock) error {
+		_, _ = fmt.Fprintf(out, "Cluster lock version: %s\n", lock.Version)
+		_, _ = fmt.Fprintf(out, "Expected cluster lock hash: %s\n", hex.EncodeToString(lock.LockHash))
+		_, _ = fmt.Fprintf(out, "Expected cluster config hash: %s\n", hex.EncodeToString(lock.ConfigHash))
+		_, _ = fmt.Fprintf(out, "Expected cluster definition hash: %s\n", hex.EncodeToString(lock.DefinitionHash))
+
+		if err := lock.VerifyHashes(); err != nil {
+			_, _ = fmt.Fprintf(out, "Cluster lock hash verification failed: %+v\n", err)
+		} else {
+			_, _ = fmt.Fprintf(out, "Cluster lock hash verification succeeded\n")
+		}
+
+		if err := lock.VerifySignatures(); err != nil {
+			_, _ = fmt.Fprintf(out, "Cluster lock signature verification failed: %+v\n", err)
+		} else {
+			_, _ = fmt.Fprintf(out, "Cluster lock signature verification succeeded\n")
+		}
+
+		return nil
+	}
+
+	cluster, err := manifest.LoadCluster("", clusterLockFilePath, verifyLock)
+	if err != nil {
+		_, _ = fmt.Fprintf(out, "Failed to load cluster lock: %+v\n", err)
+		return
+	}
+
+	hash := cluster.GetLatestMutationHash()
+	_, _ = fmt.Fprintf(out, "Calculated cluster lock hash: %s\n", hex.EncodeToString(hash))
+}


### PR DESCRIPTION
Added `charon verify-lock <cluster-lock.json>` command to verify cluster lock file's integrity, hashes and signatures validity.

Sample output:
```
./charon verify-lock ~/Downloads/cluster-lock.json
Reading cluster lock file: ~/Downloads/cluster-lock.json
Cluster lock version: v1.10.0
Expected cluster lock hash: f9603e8461d30ca179f97424903a72747ef9376fa75072a10cba5e8f3afa4610
Expected cluster config hash: d415ca322bc01f4cebd3875b6f188398630a46553aabe474dd178c6b025ab2b4
Expected cluster definition hash: a2f03a8dfbac16a5c1885b9bfa0b1118fee68f5b4e9da65d37a5f7069d72c2a6
Cluster lock hash verification succeeded
Cluster lock signature verification succeeded
Calculated cluster lock hash: f9603e8461d30ca179f97424903a72747ef9376fa75072a10cba5e8f3afa4610
```

**We do not merge it and we do not release it. This is for certain clients experiencing issues with cluster-lock verification.**

category: feature
ticket: none
