### PR TITLE
testutil: use slices.Contains to simplify code

### DIFF
--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -165,17 +166,10 @@ func verifyBody(body string) error {
 			}
 
 			var (
-				ok     bool
 				allows = []string{"feature", "bug", "refactor", "docs", "test", "fixbuild", "misc"}
 			)
-			for _, allow := range allows {
-				if allow == cat {
-					ok = true
-					break
-				}
-			}
 
-			if !ok {
+			if !slices.Contains(allows, cat) {
 				return errors.New("invalid category", z.Str("category", cat), z.Any("allows", allows))
 			}
 


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.

category: refactor
ticket: none
