### PR TITLE
*: fixed build-release-binaries.xml

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -1,17 +1,12 @@
-name: Build and Release Binaries
-
 on:
-  workflow_run:
-    workflows: ["Publish Release"]
-    types:
-      - completed
-
+  push:
+    branches:
+      - main*
+    tags:
+      - 'v*'
+name: Build and Release Binaries
 jobs:
   build-binaries:
-    # Only run if the triggering workflow succeeded and it was triggered by a tag
-    if: >
-      github.event.workflow_run.conclusion == 'success' &&
-      startsWith(github.event.workflow_run.head_branch, 'refs/tags/v')
     runs-on: ubuntu-24.04
     name: Build Cross-Platform Binaries
     steps:


### PR DESCRIPTION
The previous condition failed to run this action during v1.4.0 release. Now copied the trigger `on` rule from another job that is known to run properly during a release.

category: fixbuild
ticket: none
