### PR TITLE
*: introduced duty submission deadline

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -441,7 +441,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 		return err
 	}
 
-	deadlineFunc, err := core.NewDutyDeadlineFunc(ctx, eth2Cl)
+	deadlineFunc, submitDeadlineFunc, err := core.NewDutyDeadlineFunc(ctx, eth2Cl)
 	if err != nil {
 		return err
 	}
@@ -570,6 +570,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	}
 
 	retryer := retry.New(deadlineFunc)
+	submitRetryer := retry.New(submitDeadlineFunc)
 
 	// Consensus
 	consensusController, err := consensus.NewConsensusController(
@@ -611,7 +612,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	opts := []core.WireOption{
 		core.WithTracing(),
 		core.WithTracking(track, inclusion),
-		core.WithAsyncRetry(retryer),
+		core.WithAsyncRetry(retryer, submitRetryer),
 	}
 	core.Wire(sched, fetch, coreConsensus, dutyDB, vapi, parSigDB, parSigEx, sigAgg, aggSigDB, broadcaster, opts...)
 

--- a/app/retry/retry_test.go
+++ b/app/retry/retry_test.go
@@ -108,7 +108,7 @@ func TestShutdown(t *testing.T) {
 	deadlineFunc, _, err := core.NewDutyDeadlineFunc(ctx, bmock)
 	require.NoError(t, err)
 
-	retryer := retry.New[core.Duty](deadlineFunc)
+	retryer := retry.New(deadlineFunc)
 
 	const n = 3
 	waiting := make(chan struct{}, n)

--- a/app/retry/retry_test.go
+++ b/app/retry/retry_test.go
@@ -105,7 +105,7 @@ func TestShutdown(t *testing.T) {
 	bmock, err := beaconmock.New()
 	require.NoError(t, err)
 
-	deadlineFunc, err := core.NewDutyDeadlineFunc(ctx, bmock)
+	deadlineFunc, _, err := core.NewDutyDeadlineFunc(ctx, bmock)
 	require.NoError(t, err)
 
 	retryer := retry.New[core.Duty](deadlineFunc)

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -202,7 +202,11 @@ func getCurrDuty(duties map[Duty]bool, deadlineFunc DeadlineFunc) (Duty, time.Ti
 	return currDuty, currDeadline
 }
 
-// NewDutyDeadlineFunc returns the function that provides duty deadlines or false if the duty never deadlines.
+// NewDutyDeadlineFunc returns two functions:
+// 1. dutyDeadline: Determines the deadline for a duty to be processed. If a duty never expires (e.g., exit or registration duties), it returns false.
+// 2. submitDutyDeadline: Determines the submission deadline for a duty, which varies based on the duty type.
+// For example, proposer duties have a submission deadline of 1/3 of the slot duration.
+// Both functions use the genesis time and slot duration to calculate deadlines.
 func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineFunc, SubmitDeadlineFunc, error) {
 	genesis, err := eth2Cl.Genesis(ctx, &eth2api.GenesisOpts{})
 	if err != nil {

--- a/core/retry.go
+++ b/core/retry.go
@@ -9,7 +9,7 @@ import (
 )
 
 // WithAsyncRetry wraps component input functions with the async Retryer adding robustness to network issues.
-func WithAsyncRetry(retryer *retry.Retryer[Duty]) WireOption {
+func WithAsyncRetry(retryer, submitRetryer *retry.Retryer[Duty]) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w
 		w.FetcherFetch = func(ctx context.Context, duty Duty, set DutyDefinitionSet) error {
@@ -42,7 +42,7 @@ func WithAsyncRetry(retryer *retry.Retryer[Duty]) WireOption {
 			return nil
 		}
 		w.BroadcasterBroadcast = func(ctx context.Context, duty Duty, set SignedDataSet) error {
-			go retryer.DoAsync(ctx, duty, "bcast", "broadcast", func(ctx context.Context) error {
+			go submitRetryer.DoAsync(ctx, duty, "bcast", "broadcast", func(ctx context.Context) error {
 				return clone.BroadcasterBroadcast(ctx, duty, set)
 			})
 

--- a/core/retry.go
+++ b/core/retry.go
@@ -9,6 +9,8 @@ import (
 )
 
 // WithAsyncRetry wraps component input functions with the async Retryer adding robustness to network issues.
+// The submitRetryer is dedicated to handling submission-related retries,
+// while the primary retryer is for all other functions.
 func WithAsyncRetry(retryer, submitRetryer *retry.Retryer[Duty]) WireOption {
 	return func(w *wireFuncs) {
 		clone := *w

--- a/core/retry_internal_test.go
+++ b/core/retry_internal_test.go
@@ -1,0 +1,97 @@
+// Copyright © 2022-2025 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package core
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/retry"
+)
+
+func TestWithAsyncRetry(t *testing.T) {
+	var retryer, submitRetryer *retry.Retryer[Duty]
+
+	retryer = retry.New(func(_ Duty) (time.Time, bool) {
+		// shall be in the future, allows for at least 2 retries
+		return time.Now().Add(3 * time.Second), true
+	})
+	submitRetryer = retry.New(func(_ Duty) (time.Time, bool) {
+		// shall allow for little time window, to not retry
+		return time.Now().Add(10 * time.Millisecond), true
+	})
+
+	var (
+		fetcherFetchCount         atomic.Int32
+		consensusParticipateCount atomic.Int32
+		consensusProposeCount     atomic.Int32
+		parSigExBroadcastCount    atomic.Int32
+		broadcasterBroadcastCount atomic.Int32
+	)
+
+	wireOption := WithAsyncRetry(retryer, submitRetryer)
+	var wf wireFuncs
+	wf.FetcherFetch = func(_ context.Context, _ Duty, _ DutyDefinitionSet) error {
+		fetcherFetchCount.Add(1)
+		return errors.New("retryable") // shall trigger a retry
+	}
+	wf.ConsensusParticipate = func(_ context.Context, _ Duty) error {
+		consensusParticipateCount.Add(1)
+		return errors.New("retryable") // shall trigger a retry
+	}
+	wf.ConsensusPropose = func(_ context.Context, _ Duty, _ UnsignedDataSet) error {
+		consensusProposeCount.Add(1)
+		return errors.New("retryable") // shall trigger a retry
+	}
+	wf.ParSigExBroadcast = func(_ context.Context, _ Duty, _ ParSignedDataSet) error {
+		parSigExBroadcastCount.Add(1)
+		return errors.New("retryable") // shall trigger a retry
+	}
+	wf.BroadcasterBroadcast = func(_ context.Context, _ Duty, _ SignedDataSet) error {
+		broadcasterBroadcastCount.Add(1)
+		return errors.New("retryable") // shall not trigger a retry due to late deadline
+	}
+	wireOption(&wf)
+
+	// Check that the functions are wrapped correctly
+	require.NotNil(t, wf.FetcherFetch)
+	require.NotNil(t, wf.ConsensusParticipate)
+	require.NotNil(t, wf.ConsensusPropose)
+	require.NotNil(t, wf.ParSigExBroadcast)
+	require.NotNil(t, wf.BroadcasterBroadcast)
+
+	duty := NewProposerDuty(1)
+
+	err := wf.BroadcasterBroadcast(t.Context(), duty, SignedDataSet{})
+	require.NoError(t, err)
+
+	err = wf.ParSigExBroadcast(t.Context(), duty, ParSignedDataSet{})
+	require.NoError(t, err)
+
+	err = wf.FetcherFetch(t.Context(), duty, DutyDefinitionSet{})
+	require.NoError(t, err)
+
+	err = wf.ConsensusParticipate(t.Context(), duty)
+	require.NoError(t, err)
+
+	err = wf.ConsensusPropose(t.Context(), duty, UnsignedDataSet{})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		// all functions except BroadcasterBroadcast should have been called at least 3 times
+		// BroadcasterBroadcast should have been called once (no retry attemptted)
+		return broadcasterBroadcastCount.Load() == 1 &&
+			parSigExBroadcastCount.Load() >= 3 &&
+			fetcherFetchCount.Load() >= 3 &&
+			consensusParticipateCount.Load() >= 3 &&
+			consensusProposeCount.Load() >= 3
+	}, 10*time.Second, 10*time.Millisecond)
+
+	retryer.Shutdown(t.Context())
+	submitRetryer.Shutdown(t.Context())
+}


### PR DESCRIPTION
The proposal to avoid hammering BNs when executing our standard retrying logic: for specific duties, we evaluate different deadlines specifically for submission (applied to bcast.Broadcast):

```
        case DutyProposer:
			end = start.Add(slotDuration / 3)
		case DutyAttester:
			end = start.Add(slotDuration * 2 / 3)
		case DutySyncMessage:
			end = start.Add(slotDuration * 2 / 3)
		case DutyAggregator:
			end = start.Add(slotDuration)
		case DutySyncContribution:
			end = start.Add(slotDuration)
```

for others, we remain the deadline intact.

category: feature
ticket: #3671