### PR TITLE
app: remove check for unexisting v2 endpoint

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -19,7 +19,6 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
-	eth2e "github.com/attestantio/go-eth2-client/spec/electra"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -402,57 +401,6 @@ func TestBlockAttestations(t *testing.T) {
 	resp, err = cl.BlockAttestations(context.Background(), "head")
 	require.NoError(t, err)
 	require.Empty(t, resp)
-}
-
-func TestBlockAttestationsV2(t *testing.T) {
-	electraAtt1 := testutil.RandomElectraAttestation()
-	electraAtt2 := testutil.RandomElectraAttestation()
-
-	tests := []struct {
-		version          string
-		attestations     []*eth2spec.VersionedAttestation
-		serverJSONStruct any
-		expErr           string
-	}{
-		{
-			version: "electra",
-			attestations: []*eth2spec.VersionedAttestation{
-				{Version: eth2spec.DataVersionElectra, Electra: electraAtt1},
-				{Version: eth2spec.DataVersionElectra, Electra: electraAtt2},
-			},
-			serverJSONStruct: struct{ Data []*eth2e.Attestation }{Data: []*eth2e.Attestation{electraAtt1, electraAtt2}},
-			expErr:           "",
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.version, func(t *testing.T) {
-			statusCode := http.StatusOK
-			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				require.Equal(t, http.MethodGet, r.Method)
-				require.Equal(t, "/eth/v2/beacon/blocks/head/attestations", r.URL.Path)
-				b, err := json.Marshal(test.serverJSONStruct)
-				require.NoError(t, err)
-
-				w.Header().Add("Eth-Consensus-Version", test.version)
-				w.WriteHeader(statusCode)
-				_, _ = w.Write(b)
-			}))
-
-			cl := eth2wrap.NewHTTPAdapterForT(t, srv.URL, nil, time.Hour)
-			resp, err := cl.BlockAttestationsV2(context.Background(), "head")
-			if test.expErr != "" {
-				require.ErrorContains(t, err, test.expErr)
-			} else {
-				require.NoError(t, err)
-			}
-			require.Equal(t, test.attestations, resp)
-
-			statusCode = http.StatusNotFound
-			resp, err = cl.BlockAttestationsV2(context.Background(), "head")
-			require.ErrorContains(t, err, eth2wrap.ErrEndpointNotFound.Error())
-			require.Empty(t, resp)
-		})
-	}
 }
 
 // TestOneError tests the case where one of the servers returns errors.

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -12,7 +12,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -227,15 +226,7 @@ func (h *httpAdapter) BlockAttestationsV2(ctx context.Context, stateID string) (
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, errors.Wrap(err, ErrEndpointNotFound.Error(), z.Int("status", resp.StatusCode))
-		}
-		if strings.Contains(string(respBody), "Block not found") {
-			return nil, nil // No block for slot, so no attestations.
-		}
-
-		return nil, errors.Wrap(err, ErrEndpointNotFound.Error(), z.Int("status", resp.StatusCode))
+		return nil, nil // No block for slot, so no attestations.
 	} else if resp.StatusCode != http.StatusOK {
 		return nil, errors.New("request block attestations failed", z.Int("status", resp.StatusCode))
 	}


### PR DESCRIPTION
Before pectra we've checked if v2 endpoint exist or not. We expect post-pectra this endpoint to always exist and we default only to non-existing block, as before.

category: misc
ticket: none