### PR TITLE
core: fix incompatibility between v1.3/4.1 and v1.3/4.2

### DIFF
--- a/core/ssz_test.go
+++ b/core/ssz_test.go
@@ -457,3 +457,22 @@ func TestV3ProposalSSZSerialisation(t *testing.T) {
 		})
 	}
 }
+
+func TestValIdxVersionedAttestation(t *testing.T) {
+	f := testutil.NewEth2Fuzzer(t, 0)
+
+	val1, val2 := new(core.VersionedAttestation), new(core.VersionedAttestation)
+
+	f.Fuzz(val1)
+
+	// Assert that we can successfully unmarshal attestation without ValidatorIndex.
+	val1.ValidatorIndex = nil
+
+	b, err := val1.MarshalSSZ()
+	testutil.RequireNoError(t, err)
+
+	err = val2.UnmarshalSSZ(b)
+	testutil.RequireNoError(t, err)
+
+	require.Equal(t, val1, val2)
+}


### PR DESCRIPTION
Previously I've introduced SSZ marshaling of the validator index. In the rush, I didn't take into consideration that adding the marshaling to the new version will break compatibility with the previous version.

category: bug
ticket: none