### PR TITLE
core: fix incompatibility between v1.3.1 and v1.3.2

### DIFF
--- a/core/ssz_test.go
+++ b/core/ssz_test.go
@@ -457,3 +457,22 @@ func TestV3ProposalSSZSerialisation(t *testing.T) {
 		})
 	}
 }
+
+func TestValIdxVersionedAttestation(t *testing.T) {
+	f := testutil.NewEth2Fuzzer(t, 0)
+
+	val1, val2 := new(core.VersionedAttestation), new(core.VersionedAttestation)
+
+	f.Fuzz(val1)
+
+	// Assert that we can successfully unmarshal attestation without ValidatorIndex.
+	val1.ValidatorIndex = nil
+
+	b, err := val1.MarshalSSZ()
+	testutil.RequireNoError(t, err)
+
+	err = val2.UnmarshalSSZ(b)
+	testutil.RequireNoError(t, err)
+
+	require.Equal(t, val1, val2)
+}

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -429,6 +429,10 @@ func checkAttestationV2Inclusion(sub submission, block blockV2) (bool, error) {
 		return false, nil
 	}
 
+	if subData.ValidatorIndex == nil {
+		return false, errors.New("no validator index in attestation")
+	}
+
 	var attesterDutyData *eth2v1.AttesterDuty
 	for _, ad := range block.AttDuties {
 		if *subData.ValidatorIndex == ad.ValidatorIndex {


### PR DESCRIPTION
Previously I've introduced SSZ marshaling of the validator index. In the rush, I didn't take into consideration that adding the marshaling to the new version will break compatibility with the previous version.

category: bug
ticket: none
