### PR TITLE
app: create tracer only when configured

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -1078,7 +1078,12 @@ func wireVAPIRouter(ctx context.Context, life *lifecycle.Manager, vapiAddr strin
 }
 
 // wireTracing constructs the global tracer and registers it with the life cycle manager.
+// If OTLPAddress is not configured, no tracer is created.
 func wireTracing(life *lifecycle.Manager, conf Config, clusterHash []byte) error {
+	if conf.OTLPAddress == "" {
+		return nil
+	}
+
 	stopTracer, err := tracer.Init(
 		tracer.WithOTLPTracer(conf.OTLPAddress),
 		tracer.WithServiceName(conf.OTLPServiceName),


### PR DESCRIPTION
The tracer client has been created even though it was not configured by the client, which resulted in unwanted error messages:
```
traces export: failed to exit idle mode: dns resolver: missing address
```

This fix avoids tracing initialization if OTLP address it not configured.

category: bug
ticket: none
