### PR TITLE
tracker: check for available validator index in inclusions

### DIFF
--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -436,6 +436,10 @@ func checkAttestationV2Inclusion(sub submission, block blockV2) (bool, error) {
 		return false, nil
 	}
 
+	if subData.ValidatorIndex == nil {
+		return false, errors.New("no validator index in attestation")
+	}
+
 	var attesterDutyData *eth2v1.AttesterDuty
 	for _, ad := range block.AttDuties {
 		if *subData.ValidatorIndex == ad.ValidatorIndex {


### PR DESCRIPTION
As now it is possible validator indices to be nil, because of previously introduced bug, double check if it is nil or not.

Validator index can be nil only if charon has received a partially signed attestation object from a peer on version v1.3.0, v1.3.1, v1.4.0 and v1.4.1, before it received it from its own VC.

This will result in charon not being able to check for inclusion.

category: bug
ticket: none
