### PR TITLE
cluster: add WithForkVersion to definition

### DIFF
--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -39,6 +39,13 @@ func WithVersion(version string) func(*Definition) {
 	}
 }
 
+// WithForkVersion returns an option to set a non-default fork version in a new definition.
+func WithForkVersion(forkVersion []byte) func(*Definition) {
+	return func(d *Definition) {
+		d.ForkVersion = forkVersion
+	}
+}
+
 // WithDKGAlgorithm returns an option to set a non-default DKG algorithm in a new definition.
 func WithDKGAlgorithm(algorithm string) func(*Definition) {
 	return func(d *Definition) {

--- a/testutil/verifypr/verify.go
+++ b/testutil/verifypr/verify.go
@@ -165,9 +165,7 @@ func verifyBody(body string) error {
 				return errors.New("category tag empty")
 			}
 
-			var (
-				allows = []string{"feature", "bug", "refactor", "docs", "test", "fixbuild", "misc"}
-			)
+			allows := []string{"feature", "bug", "refactor", "docs", "test", "fixbuild", "misc"}
 
 			if !slices.Contains(allows, cat) {
 				return errors.New("invalid category", z.Str("category", cat), z.Any("allows", allows))


### PR DESCRIPTION
We have hardcoded fork version inside `NewForT` utility function used to create lock and definition for testing.

A useful option to adjust that.

category: feature
ticket: none

