### PR TITLE
*: custom duty deadlines

### DIFF
--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -20,10 +20,19 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/expbackoff"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/tracer"
 	"github.com/obolnetwork/charon/app/z"
 )
+
+// Derived from expbackoff.DefaultConfig, but MaxDelay is 12s.
+var backoffConfig = expbackoff.Config{
+	BaseDelay:  1.0 * time.Second,
+	Multiplier: 1.6,
+	Jitter:     0.2,
+	MaxDelay:   12 * time.Second,
+}
 
 // New returns a new Retryer instance.
 func New[T any](timeoutFunc func(T) (time.Time, bool)) *Retryer[T] {
@@ -37,11 +46,10 @@ func New[T any](timeoutFunc func(T) (time.Time, bool)) *Retryer[T] {
 		return context.WithDeadline(ctx, timeout)
 	}
 
-	// backoffProvider is a naive constant 1s backoff function.
-	backoffProvider := func() func() <-chan time.Time {
-		return func() <-chan time.Time {
-			const backoff = time.Second
-			return time.After(backoff)
+	backoffProvider := func() func(int) <-chan time.Time {
+		return func(iteration int) <-chan time.Time {
+			delay := delayForIteration(iteration)
+			return time.After(delay)
 		}
 	}
 
@@ -52,14 +60,28 @@ func New[T any](timeoutFunc func(T) (time.Time, bool)) *Retryer[T] {
 func NewForT[T any](
 	_ *testing.T,
 	ctxTimeoutFunc func(context.Context, T) (context.Context, context.CancelFunc),
-	backoffProvider func() func() <-chan time.Time,
+	backoffProvider func() func(int) <-chan time.Time,
 ) *Retryer[T] {
 	return newInternal(ctxTimeoutFunc, backoffProvider)
 }
 
+// delayForIteration returns the delay for the given iteration:
+// 1s, 1s, 1s, 1s, 1.6s, 2.56s, 4.09s, 6.55s, 10.48s, 12s, 12s, 12s, 12s.
+func delayForIteration(iteration int) time.Duration {
+	const linearBackoffIterations = 3
+	var delay time.Duration
+	if iteration < linearBackoffIterations {
+		delay = time.Second
+	} else {
+		delay = expbackoff.Backoff(backoffConfig, iteration-linearBackoffIterations)
+	}
+
+	return delay
+}
+
 func newInternal[T any](
 	ctxTimeoutFunc func(context.Context, T) (context.Context, context.CancelFunc),
-	backoffProvider func() func() <-chan time.Time,
+	backoffProvider func() func(int) <-chan time.Time,
 ) *Retryer[T] {
 	// Create a fresh context used as parent of all async contexts
 	ctx, cancel := context.WithCancel(context.Background())
@@ -80,7 +102,7 @@ type Retryer[T any] struct {
 	asyncCtx        context.Context
 	asyncCancel     context.CancelFunc
 	ctxTimeoutFunc  func(context.Context, T) (context.Context, context.CancelFunc)
-	backoffProvider func() func() <-chan time.Time
+	backoffProvider func() func(int) <-chan time.Time
 
 	mu       sync.Mutex
 	shutdown chan struct{}
@@ -139,7 +161,7 @@ func (r *Retryer[T]) DoAsync(parent context.Context, t T, topic, name string, fn
 		if ctx.Err() == nil {
 			log.Warn(ctx, "Temporary failure (will retry) calling "+label, err)
 			select {
-			case <-backoffFunc():
+			case <-backoffFunc(i):
 			case <-ctx.Done():
 			case <-r.shutdown:
 				return

--- a/app/retry/retry.go
+++ b/app/retry/retry.go
@@ -28,9 +28,9 @@ import (
 
 // Derived from expbackoff.DefaultConfig, but MaxDelay is 12s.
 var backoffConfig = expbackoff.Config{
-	BaseDelay:  1.0 * time.Second,
+	BaseDelay:  250 * time.Millisecond,
 	Multiplier: 1.6,
-	Jitter:     0.2,
+	Jitter:     0.1,
 	MaxDelay:   12 * time.Second,
 }
 
@@ -66,17 +66,9 @@ func NewForT[T any](
 }
 
 // delayForIteration returns the delay for the given iteration:
-// 1s, 1s, 1s, 1s, 1.6s, 2.56s, 4.09s, 6.55s, 10.48s, 12s, 12s, 12s, 12s.
+// 250ms, 400ms, 640ms, 1s, 1.6s, 2.56s, 4.096s, 6.5536s, 10.48576s, 12s
 func delayForIteration(iteration int) time.Duration {
-	const linearBackoffIterations = 3
-	var delay time.Duration
-	if iteration < linearBackoffIterations {
-		delay = time.Second
-	} else {
-		delay = expbackoff.Backoff(backoffConfig, iteration-linearBackoffIterations)
-	}
-
-	return delay
+	return expbackoff.Backoff(backoffConfig, iteration)
 }
 
 func newInternal[T any](

--- a/app/retry/retry_internal_test.go
+++ b/app/retry/retry_internal_test.go
@@ -1,0 +1,26 @@
+// Copyright © 2022-2025 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package retry
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/expbackoff"
+)
+
+func TestDelayForIteration(t *testing.T) {
+	for i := 0; i < 13; i++ {
+		delay := delayForIteration(i)
+
+		if i < 3 {
+			require.Equal(t, time.Second, delay)
+		} else {
+			backoff := expbackoff.Backoff(backoffConfig, i-3)
+			deltaWithJitter := float64(backoff) * (1 + backoffConfig.Jitter)
+			require.InDelta(t, backoff, delay, deltaWithJitter)
+		}
+	}
+}

--- a/app/retry/retry_internal_test.go
+++ b/app/retry/retry_internal_test.go
@@ -4,7 +4,6 @@ package retry
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -14,13 +13,9 @@ import (
 func TestDelayForIteration(t *testing.T) {
 	for i := 0; i < 13; i++ {
 		delay := delayForIteration(i)
-
-		if i < 3 {
-			require.Equal(t, time.Second, delay)
-		} else {
-			backoff := expbackoff.Backoff(backoffConfig, i-3)
-			deltaWithJitter := float64(backoff) * (1 + backoffConfig.Jitter)
-			require.InDelta(t, backoff, delay, deltaWithJitter)
-		}
+		t.Log(delay)
+		backoff := expbackoff.Backoff(backoffConfig, i)
+		deltaWithJitter := float64(backoff) * (1 + backoffConfig.Jitter)
+		require.InDelta(t, backoff, delay, deltaWithJitter)
 	}
 }

--- a/app/retry/retry_test.go
+++ b/app/retry/retry_test.go
@@ -75,8 +75,8 @@ func TestRetryer(t *testing.T) {
 			}
 
 			var backoffCount int
-			backoffProvider := func() func() <-chan time.Time {
-				return func() <-chan time.Time {
+			backoffProvider := func() func(int) <-chan time.Time {
+				return func(int) <-chan time.Time {
 					backoffCount++
 					if backoffCount >= test.TimeoutCount {
 						cancel()

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -210,6 +210,7 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 		case DutyExit, DutyBuilderRegistration:
 			// Do not timeout exit or registration duties.
 			return time.Time{}, false
+		default:
 		}
 
 		var (

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -221,12 +221,17 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 
 		switch duty.Type {
 		case DutyProposer:
-			duration = slotDuration / 3
+			duration = 1 / 3 * slotDuration
 		case DutyAttester, DutyAggregator, DutyPrepareAggregator:
+			// Even though attestations and aggregations are acceptable even after 2 slots, the rewards are heavily diminished.
 			duration = 2 * slotDuration
 		case DutySyncMessage:
-			duration = 2 * slotDuration / 3
+			duration = 2 / 3 * slotDuration
+		case DutySyncContribution, DutyPrepareSyncContribution:
+			duration = slotDuration
 		case DutyRandao:
+			// Randao should be accepted as long as it is not after the proposer's slot.
+			// However, given how cheap the operation is, the beacon node failing to provide it for 2 slots signals that there is something wrong with the beacon node itself.
 			duration = 2 * slotDuration
 		default:
 			duration = slotDuration

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -95,19 +95,13 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 		)
 
 		switch duty.Type {
-		case DutyProposer:
+		case DutyProposer, DutyRandao, DutySyncMessage:
 			duration = slotDuration / 3
 		case DutyAttester, DutyAggregator, DutyPrepareAggregator:
 			// Even though attestations and aggregations are acceptable even after 2 slots, the rewards are heavily diminished.
 			duration = 2 * slotDuration
-		case DutySyncMessage:
-			duration = 2 * slotDuration / 3
 		case DutySyncContribution, DutyPrepareSyncContribution:
 			duration = slotDuration
-		case DutyRandao:
-			// Randao should be accepted as long as it is not after the proposer's slot.
-			// However, given how cheap the operation is, the beacon node failing to provide it for 2 slots signals that there is something wrong with the beacon node itself.
-			duration = 2 * slotDuration
 		default:
 			duration = slotDuration
 		}

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -221,12 +221,12 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 
 		switch duty.Type {
 		case DutyProposer:
-			duration = 1 / 3 * slotDuration
+			duration = slotDuration / 3
 		case DutyAttester, DutyAggregator, DutyPrepareAggregator:
 			// Even though attestations and aggregations are acceptable even after 2 slots, the rewards are heavily diminished.
 			duration = 2 * slotDuration
 		case DutySyncMessage:
-			duration = 2 / 3 * slotDuration
+			duration = 2 * slotDuration / 3
 		case DutySyncContribution, DutyPrepareSyncContribution:
 			duration = slotDuration
 		case DutyRandao:

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -224,8 +224,10 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 			duration = slotDuration / 3
 		case DutyAttester, DutyAggregator, DutyPrepareAggregator:
 			duration = 2 * slotDuration
-		case DutySyncMessage, DutySyncContribution:
+		case DutySyncMessage:
 			duration = 2 * slotDuration / 3
+		case DutyRandao:
+			duration = 2 * slotDuration
 		default:
 			duration = slotDuration
 		}

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -95,13 +95,13 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 		)
 
 		switch duty.Type {
-		case DutyProposer, DutyRandao, DutySyncMessage:
+		case DutyProposer, DutyRandao:
 			duration = slotDuration / 3
+		case DutySyncMessage:
+			duration = 2 * slotDuration / 3
 		case DutyAttester, DutyAggregator, DutyPrepareAggregator:
 			// Even though attestations and aggregations are acceptable even after 2 slots, the rewards are heavily diminished.
 			duration = 2 * slotDuration
-		case DutySyncContribution, DutyPrepareSyncContribution:
-			duration = slotDuration
 		default:
 			duration = slotDuration
 		}

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -137,7 +137,7 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 		},
 		{
 			duty:             core.NewSyncMessageDuty(currentSlot),
-			expectedDuration: 2*slotDuration/3 + margin,
+			expectedDuration: slotDuration/3 + margin,
 		},
 		{
 			duty:             core.NewSyncContributionDuty(currentSlot),
@@ -145,7 +145,7 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 		},
 		{
 			duty:             core.NewRandaoDuty(currentSlot),
-			expectedDuration: 2*slotDuration + margin,
+			expectedDuration: slotDuration/3 + margin,
 		},
 		{
 			duty:             core.NewInfoSyncDuty(currentSlot),

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -137,7 +137,7 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 		},
 		{
 			duty:             core.NewSyncMessageDuty(currentSlot),
-			expectedDuration: slotDuration/3 + margin,
+			expectedDuration: 2*slotDuration/3 + margin,
 		},
 		{
 			duty:             core.NewSyncContributionDuty(currentSlot),

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -141,11 +141,11 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 		},
 		{
 			duty:             core.NewSyncContributionDuty(currentSlot),
-			expectedDuration: 2*slotDuration/3 + margin,
+			expectedDuration: slotDuration + margin,
 		},
 		{
 			duty:             core.NewRandaoDuty(currentSlot),
-			expectedDuration: slotDuration + margin,
+			expectedDuration: 2*slotDuration + margin,
 		},
 		{
 			duty:             core.NewInfoSyncDuty(currentSlot),

--- a/testutil/integration/infosync_test.go
+++ b/testutil/integration/infosync_test.go
@@ -30,7 +30,7 @@ import (
 func TestInfoSync(t *testing.T) {
 	skipIfDisabled(t)
 
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 
 	const n = 3
 	seed := 0
@@ -38,7 +38,7 @@ func TestInfoSync(t *testing.T) {
 	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, seed, random)
 
 	asserter := &priorityAsserter{
-		asserter: asserter{Timeout: time.Second * 15},
+		asserter: asserter{Timeout: time.Second * 10},
 		N:        n,
 	}
 

--- a/testutil/integration/infosync_test.go
+++ b/testutil/integration/infosync_test.go
@@ -30,7 +30,7 @@ import (
 func TestInfoSync(t *testing.T) {
 	skipIfDisabled(t)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 
 	const n = 3
 	seed := 0
@@ -38,7 +38,7 @@ func TestInfoSync(t *testing.T) {
 	lock, p2pKeys, _ := cluster.NewForT(t, 1, n, n, seed, random)
 
 	asserter := &priorityAsserter{
-		asserter: asserter{Timeout: time.Second * 10},
+		asserter: asserter{Timeout: time.Second * 15},
 		N:        n,
 	}
 


### PR DESCRIPTION
New custom duty deadlines in according with the design doc (proposal):

```
		{
			duty:             core.NewProposerDuty(currentSlot),
			expectedDuration: slotDuration/3 + margin,
		},
		{
			duty:             core.NewAttesterDuty(currentSlot),
			expectedDuration: 2*slotDuration + margin,
		},
		{
			duty:             core.NewAggregatorDuty(currentSlot),
			expectedDuration: 2*slotDuration + margin,
		},
		{
			duty:             core.NewPrepareAggregatorDuty(currentSlot),
			expectedDuration: 2*slotDuration + margin,
		},
		{
			duty:             core.NewSyncMessageDuty(currentSlot),
			expectedDuration: 2*slotDuration/3 + margin,
		},
		{
			duty:             core.NewSyncContributionDuty(currentSlot),
			expectedDuration: slotDuration + margin,
		},
		{
			duty:             core.NewRandaoDuty(currentSlot),
			expectedDuration: slotDuration/3 + margin,
		},
		{
			duty:             core.NewInfoSyncDuty(currentSlot),
			expectedDuration: slotDuration + margin,
		},
		{
			duty:             core.NewPrepareSyncContributionDuty(currentSlot),
			expectedDuration: slotDuration + margin,
		},
```

category: feature
ticket: #3671

