### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/app/log/loki/client.go
+++ b/app/log/loki/client.go
@@ -13,6 +13,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"maps"
 	"net/http"
 	"time"
 
@@ -182,9 +183,7 @@ func (c *Client) labels() map[string]string {
 	}
 
 	kvs, _ := c.moreLabelsFunc()
-	for k, v := range kvs {
-		labels[k] = v
-	}
+	maps.Copy(labels, kvs)
 
 	return labels
 }

--- a/app/promauto/promauto_test.go
+++ b/app/promauto/promauto_test.go
@@ -3,6 +3,7 @@
 package promauto_test
 
 import (
+	"maps"
 	"testing"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -35,9 +36,7 @@ func TestWrapRegisterer(t *testing.T) {
 		// All metrics contain own and registered labels.
 		for _, metric := range metricFam.GetMetric() {
 			notFound := make(prometheus.Labels)
-			for k, v := range labels {
-				notFound[k] = v
-			}
+			maps.Copy(notFound, labels)
 			for _, label := range metric.GetLabel() {
 				v, ok := notFound[label.GetName()]
 				if !ok {


### PR DESCRIPTION
use maps.Copy for cleaner map handling
