### PR TITLE
core/validatorapi: add encoding verification per endpoint

### DIFF
--- a/core/validatorapi/eth2types.go
+++ b/core/validatorapi/eth2types.go
@@ -146,3 +146,31 @@ type nodeVersionResponse struct {
 		Version string `json:"version"`
 	} `json:"data"`
 }
+
+// SignedValidatorRegistrations defines the request body to the submit validator registration endpoint.
+// See: https://ethereum.github.io/beacon-APIs/#/Validator/registerValidator
+// Implements the ssz.Unmarshal interface
+type signedValidatorRegistrations struct {
+	Registrations []*eth2v1.SignedValidatorRegistration
+}
+
+// UnmarshalSSZ unmarshals an array of eth2v1.SignedValidatorRegistration SSZ marshaled objects
+func (s *signedValidatorRegistrations) UnmarshalSSZ(buf []byte) error {
+	const sszObjectSize = 180
+	
+	if len(buf)%sszObjectSize != 0 {
+		return errors.New("invalid buffer size")
+	}
+	for offset := 0; offset < len(buf); offset +=sszObjectSize {
+		registration := new(eth2v1.SignedValidatorRegistration)
+		registration.UnmarshalSSZ(buf[offset : offset+sszObjectSize])
+		s.Registrations = append(s.Registrations, registration)
+	}
+
+	return nil
+}
+
+// UnmarshalJSON unmarshals an array of eth2v1.SignedValidatorRegistration JSON marshaled objects
+func (s *signedValidatorRegistrations) UnmarshalJSON(buf []byte) error {
+	return json.Unmarshal(buf, &s.Registrations)
+}


### PR DESCRIPTION
Add encoding verification per endpoint to only allow expected encodings and reject others with http status code 415.
Fix bug related to unmarshaling SSZ request body

category: feature
ticket: none
