### PR TITLE
*: check for attestation inclusion only under feature flag

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -24,6 +24,7 @@ type Client interface {
 	eth2exp.SyncCommitteeSelectionAggregator
 	eth2exp.ProposerConfigProvider
 	BlockAttestationsProvider
+	BlockProvider
 	BeaconStateCommitteesProvider
 	NodePeerCountProvider
 
@@ -134,10 +135,11 @@ func (m multi) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 	return res0, err
 }
 
-// AggregateAttestation fetches the aggregate attestation for the given options to v2 beacon node endpoint.
+// AggregateAttestation fetches the aggregate attestation for the given options.
 func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
-	const label = "aggregate_attestation_v2"
+	const label = "aggregate_attestation"
 	defer latency(ctx, label, false)()
+	defer incRequest(label)
 
 	res0, err := provide(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) (*api.Response[*spec.VersionedAttestation], error) {
@@ -154,10 +156,11 @@ func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 	return res0, err
 }
 
-// SubmitAggregateAttestations submits aggregate attestations to v2 beacon node endpoint..
+// SubmitAggregateAttestations submits aggregate attestations.
 func (m multi) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
-	const label = "submit_aggregate_attestations_v2"
+	const label = "submit_aggregate_attestations"
 	defer latency(ctx, label, false)()
+	defer incRequest(label)
 
 	err := submit(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) error {
@@ -195,10 +198,11 @@ func (m multi) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 	return res0, err
 }
 
-// SubmitAttestations submits attestations on v2 BN endpoint.
+// SubmitAttestations submits attestations.
 func (m multi) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
-	const label = "submit_attestations_v2"
+	const label = "submit_attestations"
 	defer latency(ctx, label, false)()
+	defer incRequest(label)
 
 	err := submit(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) error {
@@ -786,7 +790,7 @@ func (l *lazy) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 	return cl.SignedBeaconBlock(ctx, opts)
 }
 
-// AggregateAttestation fetches the aggregate attestation for the given options to v2 beacon node endpoint.
+// AggregateAttestation fetches the aggregate attestation for the given options.
 func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (res0 *api.Response[*spec.VersionedAttestation], err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
@@ -796,7 +800,7 @@ func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 	return cl.AggregateAttestation(ctx, opts)
 }
 
-// SubmitAggregateAttestations submits aggregate attestations to v2 beacon node endpoint..
+// SubmitAggregateAttestations submits aggregate attestations.
 func (l *lazy) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) (err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
@@ -816,7 +820,7 @@ func (l *lazy) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 	return cl.AttestationData(ctx, opts)
 }
 
-// SubmitAttestations submits attestations on v2 BN endpoint.
+// SubmitAttestations submits attestations.
 func (l *lazy) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) (err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -51,6 +51,7 @@ type Client interface {
     eth2exp.SyncCommitteeSelectionAggregator
     eth2exp.ProposerConfigProvider
     BlockAttestationsProvider
+		BlockProvider
     BeaconStateCommitteesProvider
     NodePeerCountProvider
 

--- a/app/eth2wrap/httpwrap.go
+++ b/app/eth2wrap/httpwrap.go
@@ -37,6 +37,13 @@ type BlockAttestationsProvider interface {
 	BlockAttestations(ctx context.Context, stateID string) ([]*spec.VersionedAttestation, error)
 }
 
+// BlockProvider is the interface for providing block details.
+// It is a standard beacon API endpoint not implemented by eth2client.
+// See https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2.
+type BlockProvider interface {
+	Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error)
+}
+
 // BeaconStateCommitteesProvider is the interface for providing committees for given slot.
 // It is a standard beacon API endpoint not implemented by eth2client.
 // See https://ethereum.github.io/beacon-APIs/#/Beacon/getEpochCommittees.
@@ -272,6 +279,38 @@ func (h *httpAdapter) BlockAttestations(ctx context.Context, stateID string) ([]
 	}
 
 	return res, nil
+}
+
+// Block returns the block details.
+// See https://ethereum.github.io/beacon-APIs/#/Beacon/getBlockV2.
+func (h *httpAdapter) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	path := "/eth/v2/beacon/blocks/" + stateID
+	ctx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+
+	resp, err := httpGetRaw(ctx, h.address, path, h.headers, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "request block")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, nil //nolint:nilnil // No block for slot.
+	} else if resp.StatusCode != http.StatusOK {
+		return nil, errors.New("request block failed", z.Int("status", resp.StatusCode))
+	}
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "request block attestations body")
+	}
+
+	res := spec.VersionedSignedBeaconBlock{}
+	if err := json.Unmarshal(respBody, &res); err != nil {
+		return nil, errors.Wrap(err, "failed to parse block response")
+	}
+
+	return &res, nil
 }
 
 // BeaconStateCommittees returns the attestations included in the requested block.

--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -202,6 +202,15 @@ func (l *lazy) BlockAttestations(ctx context.Context, stateID string) ([]*spec.V
 	return cl.BlockAttestations(ctx, stateID)
 }
 
+func (l *lazy) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	cl, err := l.getOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.Block(ctx, stateID)
+}
+
 func (l *lazy) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {

--- a/app/eth2wrap/mocks/client.go
+++ b/app/eth2wrap/mocks/client.go
@@ -290,6 +290,36 @@ func (_m *Client) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*st
 	return r0, r1
 }
 
+// Block provides a mock function with given fields: ctx, stateID
+func (_m *Client) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	ret := _m.Called(ctx, stateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Block")
+	}
+
+	var r0 *spec.VersionedSignedBeaconBlock
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*spec.VersionedSignedBeaconBlock, error)); ok {
+		return rf(ctx, stateID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *spec.VersionedSignedBeaconBlock); ok {
+		r0 = rf(ctx, stateID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*spec.VersionedSignedBeaconBlock)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, stateID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // BlockAttestations provides a mock function with given fields: ctx, stateID
 func (_m *Client) BlockAttestations(ctx context.Context, stateID string) ([]*spec.VersionedAttestation, error) {
 	ret := _m.Called(ctx, stateID)

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -202,6 +202,25 @@ func (m multi) BlockAttestations(ctx context.Context, stateID string) ([]*spec.V
 	return res, err
 }
 
+func (m multi) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	const label = "block_v2"
+	defer latency(ctx, label, false)()
+	defer incRequest(label)
+
+	res, err := provide(ctx, m.clients, m.fallbacks,
+		func(ctx context.Context, args provideArgs) (*spec.VersionedSignedBeaconBlock, error) {
+			return args.client.Block(ctx, stateID)
+		},
+		nil, m.selector,
+	)
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return res, err
+}
+
 func (m multi) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {
 	const label = "beacon_state_committees"
 	defer latency(ctx, label, false)()

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -52,6 +52,11 @@ const (
 
 	// SSEReorgDuties enables Scheduler to refresh duties when reorg occurs.
 	SSEReorgDuties Feature = "sse_reorg_duties"
+
+	// AttestationInclusion enables tracking of on-chain inclusion for attestations.
+	// Previously this was the default behaviour, however, tracking on-chain inclusions post-electra is costly.
+	// The extra load that Charon puts the beacon node is deemed so high that it can throttle the completion of other duties.
+	AttestationInclusion Feature = "attestation_inclusion"
 )
 
 var (
@@ -65,6 +70,7 @@ var (
 		GnosisBlockHotfix:    statusAlpha,
 		Linear:               statusAlpha,
 		SSEReorgDuties:       statusAlpha,
+		AttestationInclusion: statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/app/featureset/featureset_internal_test.go
+++ b/app/featureset/featureset_internal_test.go
@@ -18,6 +18,7 @@ func TestAllFeatureStatus(t *testing.T) {
 		GnosisBlockHotfix,
 		Linear,
 		SSEReorgDuties,
+		AttestationInclusion,
 	}
 
 	for _, feature := range features {

--- a/core/bcast/metrics.go
+++ b/core/bcast/metrics.go
@@ -23,7 +23,7 @@ var (
 		Namespace: "core",
 		Subsystem: "bcast",
 		Name:      "broadcast_delay_seconds",
-		Help:      "Duty broadcast delay from start of slot in seconds by type",
+		Help:      "Duty broadcast delay since the expected duty submission in seconds by type",
 		Buckets:   []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60},
 	}, []string{"duty"})
 

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -93,7 +93,7 @@ var (
 		Namespace: "core",
 		Subsystem: "tracker",
 		Name:      "inclusion_delay",
-		Help:      "Cluster's average attestation inclusion delay in slots",
+		Help:      "Cluster's average attestation inclusion delay in slots. Available only when attestation_inclusion feature flag is enabled.",
 	})
 
 	inclusionMisses = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -206,7 +206,7 @@ func dutyFailedStep(es []event) (bool, step, error) {
 
 // lastStep returns the last step of the duty which is either bcast or chainInclusion.
 func lastStep(dutyType core.DutyType) step {
-	if inclSupported[dutyType] {
+	if inclSupported()[dutyType] {
 		return chainInclusion
 	}
 

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -342,9 +342,9 @@ func TestAnalyseDutyFailed(t *testing.T) {
 			attDuty = core.NewAttesterDuty(uint64(1))
 		)
 
-		require.Equal(t, chainInclusion, lastStep(attDuty.Type))
+		require.Equal(t, bcast, lastStep(attDuty.Type))
 
-		for step := fetcher; step < sentinel; step++ {
+		for step := fetcher; step < chainInclusion; step++ {
 			events[attDuty] = append(events[attDuty], event{step: step, duty: attDuty})
 		}
 
@@ -377,7 +377,7 @@ func TestAnalyseDutyFailed(t *testing.T) {
 
 func TestDutyFailedStep(t *testing.T) {
 	var events []event
-	for step := fetcher; step < sentinel; step++ {
+	for step := fetcher; step < chainInclusion; step++ {
 		events = append(events, event{step: step, duty: core.NewAttesterDuty(0)})
 	}
 
@@ -1182,7 +1182,7 @@ func TestDutyFailedMultipleEvents(t *testing.T) {
 	duty := core.NewAttesterDuty(123)
 	testErr := errors.New("test error")
 	var events []event
-	for step := fetcher; step < sentinel; step++ {
+	for step := fetcher; step < chainInclusion; step++ {
 		for range 5 {
 			events = append(events, event{step: step, duty: duty, stepErr: testErr})
 		}
@@ -1191,11 +1191,11 @@ func TestDutyFailedMultipleEvents(t *testing.T) {
 	// Failed at last step.
 	failed, step, err := dutyFailedStep(events)
 	require.True(t, failed)
-	require.Equal(t, chainInclusion, step)
+	require.Equal(t, bcast, step)
 	require.ErrorIs(t, err, testErr)
 
 	// No Failure.
-	for step := fetcher; step < sentinel; step++ {
+	for step := fetcher; step < chainInclusion; step++ {
 		events = append(events, event{step: step, duty: duty})
 	}
 	failed, step, err = dutyFailedStep(events)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -65,7 +65,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `core_tracker_expect_duties_total` | Counter | Total number of expected duties (failed + success) by type | `duty` |
 | `core_tracker_failed_duties_total` | Counter | Total number of failed duties by type | `duty` |
 | `core_tracker_failed_duty_reasons_total` | Counter | Total number of failed duties by type and reason code | `duty, reason` |
-| `core_tracker_inclusion_delay` | Gauge | Cluster`s average attestation inclusion delay in slots |  |
+| `core_tracker_inclusion_delay` | Gauge | Cluster`s average attestation inclusion delay in slots. Available only when attestation_inclusion feature flag is enabled. |  |
 | `core_tracker_inclusion_missed_total` | Counter | Total number of broadcast duties never included in any block by type | `duty` |
 | `core_tracker_inconsistent_parsigs_total` | Counter | Total number of duties that contained inconsistent partial signed data by duty type | `duty` |
 | `core_tracker_participation` | Gauge | Set to 1 if peer participated successfully for the given duty or else 0 | `duty, peer` |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,7 +44,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `cluster_operators` | Gauge | Number of operators in the cluster lock |  |
 | `cluster_threshold` | Gauge | Aggregation threshold in the cluster lock |  |
 | `cluster_validators` | Gauge | Number of validators in the cluster lock |  |
-| `core_bcast_broadcast_delay_seconds` | Histogram | Duty broadcast delay from start of slot in seconds by type | `duty` |
+| `core_bcast_broadcast_delay_seconds` | Histogram | Duty broadcast delay since the expected duty submission in seconds by type | `duty` |
 | `core_bcast_broadcast_total` | Counter | The total count of successfully broadcast duties by type | `duty` |
 | `core_bcast_recast_errors_total` | Counter | The total count of failed recasted registrations by source; `pregen` vs `downstream` | `source` |
 | `core_bcast_recast_registration_total` | Counter | The total number of unique validator registration stored in recaster per pubkey | `pubkey` |

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -133,6 +133,7 @@ type Mock struct {
 	AttestationDataFunc                    func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
 	AttesterDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
 	BlockAttestationsFunc                  func(ctx context.Context, stateID string) ([]*eth2spec.VersionedAttestation, error)
+	BlockFunc                              func(ctx context.Context, stateID string) (*eth2spec.VersionedSignedBeaconBlock, error)
 	BeaconStateCommitteesFunc              func(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error)
 	NodePeerCountFunc                      func(ctx context.Context) (int, error)
 	ProposalFunc                           func(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error)
@@ -296,6 +297,10 @@ func (m Mock) Genesis(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.
 
 func (m Mock) BlockAttestations(ctx context.Context, stateID string) ([]*eth2spec.VersionedAttestation, error) {
 	return m.BlockAttestationsFunc(ctx, stateID)
+}
+
+func (m Mock) Block(ctx context.Context, stateID string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+	return m.BlockFunc(ctx, stateID)
 }
 
 func (m Mock) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {

--- a/testutil/beaconmock/beaconmock_fuzz.go
+++ b/testutil/beaconmock/beaconmock_fuzz.go
@@ -182,5 +182,12 @@ func WithBeaconMockFuzzer() Option {
 
 			return atts, nil
 		}
+
+		mock.BlockFunc = func(context.Context, string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+			var block *eth2spec.VersionedSignedBeaconBlock
+			fuzz.New().Fuzz(&block)
+
+			return block, nil
+		}
 	}
 }

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -546,6 +546,9 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		BlockAttestationsFunc: func(context.Context, string) ([]*eth2spec.VersionedAttestation, error) {
 			return []*eth2spec.VersionedAttestation{}, nil
 		},
+		BlockFunc: func(context.Context, string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+			return &eth2spec.VersionedSignedBeaconBlock{}, nil
+		},
 		NodePeerCountFunc: func(context.Context) (int, error) {
 			return 80, nil
 		},


### PR DESCRIPTION
Previously was checked only the slot of the first attestation in a block, which caused some attestations submitted wrongly deemed as not included on-chain.

~TODO: Still to be tested on a Hoodi cluster before merging.~
After testing on Hoodi this seems to add A LOT of load on the beacon node. I have introduced caching of the state, but even that is putting a lot of stress. Calling for state on each slot is expensive. Sometimes those requests timeout and we again fail to check the attestation, as we don't have the data from the BN.

~I personally am in favour of removing the attestations for the on-chain inclusion tracking or delegating the whole on-chain inclusion tracking to a separate BN.~

It has been agreed to change the default scenario to not tracking attestations and aggregations, but still provide a feature flag for people that are willing to put the BN under high load to track those.

category: feature
ticket: none
feature_flag: attestation_inclusion
