### PR TITLE
CI: migrate workflows to golangci-lint-action v8

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-go
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v8
         with:
           version: v2.0.1
       - name: notify failure


### PR DESCRIPTION
Maintenance update: switch all jobs to golangci-lint-action@v8 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v8.0.0 release](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0).