### PR TITLE
core/scheduler: bugfix

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -5,7 +5,6 @@ package scheduler
 import (
 	"context"
 	"math"
-	"runtime"
 	"sort"
 	"sync"
 	"testing"
@@ -180,7 +179,7 @@ func (s *Scheduler) GetDutyDefinition(ctx context.Context, duty core.Duty) (core
 		if ctx.Err() != nil {
 			return nil, errors.Wrap(ctx.Err(), "context cancelled while waiting for epoch to resolve")
 		}
-		runtime.Gosched()
+		time.Sleep(100 * time.Millisecond)
 	}
 
 	if !s.isEpochResolved(epoch) {

--- a/core/scheduler/scheduler_internal_test.go
+++ b/core/scheduler/scheduler_internal_test.go
@@ -127,3 +127,15 @@ func TestResolveSyncCommDuties(t *testing.T) {
 		SlotsPerEpoch: 1,
 	}, schedVals), "invalid sync committee duty pubkey")
 }
+
+func TestResolvingEpoch(t *testing.T) {
+	sched, _ := setupScheduler(t)
+
+	sched.setResolvingEpoch(10)
+	require.True(t, sched.isResolvingEpoch(10))
+	require.False(t, sched.isResolvingEpoch(11))
+
+	sched.setResolvingEpoch(11)
+	require.False(t, sched.isResolvingEpoch(10))
+	require.True(t, sched.isResolvingEpoch(11))
+}


### PR DESCRIPTION
Bugfix is to address the following edge case:
- Scheduler is fetching/resolving duties for a slot.
- GetDutyDefinition is called for the same slot at the same time (from VAPI).
- This resulted in failed VAPI request, because the epoch in question did not appear "resolved".

The fix will cause GetDutyDefinition to wait if Scheduler is in process of resolving duties for the requested epoch. This would prevent VAPI request to fail, but apparently it will delay the request by the time needed to complete all duties resolution.

category: bug
ticket: none