### PR TITLE
*: remove attestation and aggregation on-chain tracking

### DIFF
--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -24,6 +24,7 @@ type Client interface {
 	eth2exp.SyncCommitteeSelectionAggregator
 	eth2exp.ProposerConfigProvider
 	BlockAttestationsProvider
+	BlockProvider
 	BeaconStateCommitteesProvider
 	NodePeerCountProvider
 
@@ -134,10 +135,11 @@ func (m multi) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 	return res0, err
 }
 
-// AggregateAttestation fetches the aggregate attestation for the given options to v2 beacon node endpoint.
+// AggregateAttestation fetches the aggregate attestation for the given options.
 func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (*api.Response[*spec.VersionedAttestation], error) {
-	const label = "aggregate_attestation_v2"
+	const label = "aggregate_attestation"
 	defer latency(ctx, label, false)()
+	defer incRequest(label)
 
 	res0, err := provide(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) (*api.Response[*spec.VersionedAttestation], error) {
@@ -154,10 +156,11 @@ func (m multi) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 	return res0, err
 }
 
-// SubmitAggregateAttestations submits aggregate attestations to v2 beacon node endpoint..
+// SubmitAggregateAttestations submits aggregate attestations.
 func (m multi) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) error {
-	const label = "submit_aggregate_attestations_v2"
+	const label = "submit_aggregate_attestations"
 	defer latency(ctx, label, false)()
+	defer incRequest(label)
 
 	err := submit(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) error {
@@ -195,10 +198,11 @@ func (m multi) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 	return res0, err
 }
 
-// SubmitAttestations submits attestations on v2 BN endpoint.
+// SubmitAttestations submits attestations.
 func (m multi) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) error {
-	const label = "submit_attestations_v2"
+	const label = "submit_attestations"
 	defer latency(ctx, label, false)()
+	defer incRequest(label)
 
 	err := submit(ctx, m.clients, m.fallbacks,
 		func(ctx context.Context, args provideArgs) error {
@@ -786,7 +790,7 @@ func (l *lazy) SignedBeaconBlock(ctx context.Context, opts *api.SignedBeaconBloc
 	return cl.SignedBeaconBlock(ctx, opts)
 }
 
-// AggregateAttestation fetches the aggregate attestation for the given options to v2 beacon node endpoint.
+// AggregateAttestation fetches the aggregate attestation for the given options.
 func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAttestationOpts) (res0 *api.Response[*spec.VersionedAttestation], err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
@@ -796,7 +800,7 @@ func (l *lazy) AggregateAttestation(ctx context.Context, opts *api.AggregateAtte
 	return cl.AggregateAttestation(ctx, opts)
 }
 
-// SubmitAggregateAttestations submits aggregate attestations to v2 beacon node endpoint..
+// SubmitAggregateAttestations submits aggregate attestations.
 func (l *lazy) SubmitAggregateAttestations(ctx context.Context, opts *api.SubmitAggregateAttestationsOpts) (err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {
@@ -816,7 +820,7 @@ func (l *lazy) AttestationData(ctx context.Context, opts *api.AttestationDataOpt
 	return cl.AttestationData(ctx, opts)
 }
 
-// SubmitAttestations submits attestations on v2 BN endpoint.
+// SubmitAttestations submits attestations.
 func (l *lazy) SubmitAttestations(ctx context.Context, opts *api.SubmitAttestationsOpts) (err error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -51,6 +51,7 @@ type Client interface {
     eth2exp.SyncCommitteeSelectionAggregator
     eth2exp.ProposerConfigProvider
     BlockAttestationsProvider
+    BlockProvider
     BeaconStateCommitteesProvider
     NodePeerCountProvider
 

--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -202,6 +202,15 @@ func (l *lazy) BlockAttestations(ctx context.Context, stateID string) ([]*spec.V
 	return cl.BlockAttestations(ctx, stateID)
 }
 
+func (l *lazy) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	cl, err := l.getOrCreateClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return cl.Block(ctx, stateID)
+}
+
 func (l *lazy) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {
 	cl, err := l.getOrCreateClient(ctx)
 	if err != nil {

--- a/app/eth2wrap/mocks/client.go
+++ b/app/eth2wrap/mocks/client.go
@@ -290,6 +290,36 @@ func (_m *Client) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*st
 	return r0, r1
 }
 
+// Block provides a mock function with given fields: ctx, stateID
+func (_m *Client) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	ret := _m.Called(ctx, stateID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Block")
+	}
+
+	var r0 *spec.VersionedSignedBeaconBlock
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*spec.VersionedSignedBeaconBlock, error)); ok {
+		return rf(ctx, stateID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *spec.VersionedSignedBeaconBlock); ok {
+		r0 = rf(ctx, stateID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*spec.VersionedSignedBeaconBlock)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, stateID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // BlockAttestations provides a mock function with given fields: ctx, stateID
 func (_m *Client) BlockAttestations(ctx context.Context, stateID string) ([]*spec.VersionedAttestation, error) {
 	ret := _m.Called(ctx, stateID)

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -202,6 +202,25 @@ func (m multi) BlockAttestations(ctx context.Context, stateID string) ([]*spec.V
 	return res, err
 }
 
+func (m multi) Block(ctx context.Context, stateID string) (*spec.VersionedSignedBeaconBlock, error) {
+	const label = "block_v2"
+	defer latency(ctx, label, false)()
+	defer incRequest(label)
+
+	res, err := provide(ctx, m.clients, m.fallbacks,
+		func(ctx context.Context, args provideArgs) (*spec.VersionedSignedBeaconBlock, error) {
+			return args.client.Block(ctx, stateID)
+		},
+		nil, m.selector,
+	)
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return res, err
+}
+
 func (m multi) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {
 	const label = "beacon_state_committees"
 	defer latency(ctx, label, false)()

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -38,7 +38,7 @@ func New(ctx context.Context, eth2Cl eth2wrap.Client) (Broadcaster, error) {
 
 type Broadcaster struct {
 	eth2Cl    eth2wrap.Client
-	delayFunc func(slot uint64) time.Duration
+	delayFunc func(slot uint64, duty core.DutyType) time.Duration
 }
 
 // Broadcast broadcasts the aggregated signed duty data object to the beacon-node.
@@ -46,7 +46,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 	ctx = log.WithTopic(ctx, "bcast")
 	defer func() {
 		if err == nil {
-			instrumentDuty(duty, b.delayFunc(duty.Slot))
+			instrumentDuty(duty, b.delayFunc(duty.Slot, duty.Type))
 		}
 	}()
 
@@ -152,7 +152,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 		}
 
 		log.Info(ctx, "Successfully submitted v2 attestations to beacon node",
-			z.Any("delay", b.delayFunc(duty.Slot)),
+			z.Any("delay", b.delayFunc(duty.Slot, core.DutyAttester)),
 		)
 
 		return nil
@@ -191,7 +191,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 
 		if err == nil {
 			log.Info(ctx, "Successfully submitted block proposal to beacon node",
-				z.Any("delay", b.delayFunc(duty.Slot)),
+				z.Any("delay", b.delayFunc(duty.Slot, core.DutyProposer)),
 				z.Any("pubkey", pubkey),
 				z.Bool("blinded", block.Blinded),
 			)
@@ -219,7 +219,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 		err = b.eth2Cl.SubmitValidatorRegistrations(ctx, registrations)
 		if err == nil {
 			log.Info(ctx, "Successfully submitted validator registrations to beacon node",
-				z.Any("delay", b.delayFunc(duty.Slot)),
+				z.Any("delay", b.delayFunc(duty.Slot, core.DutyBuilderRegistration)),
 			)
 		}
 
@@ -236,7 +236,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 			err = b.eth2Cl.SubmitVoluntaryExit(ctx, &exit.SignedVoluntaryExit)
 			if err == nil {
 				log.Info(ctx, "Successfully submitted voluntary exit to beacon node",
-					z.Any("delay", b.delayFunc(duty.Slot)),
+					z.Any("delay", b.delayFunc(duty.Slot, core.DutyExit)),
 					z.Any("pubkey", pubkey),
 				)
 			}
@@ -261,7 +261,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 		}
 
 		log.Info(ctx, "Successfully submitted v2 attestation aggregations to beacon node",
-			z.Any("delay", b.delayFunc(duty.Slot)))
+			z.Any("delay", b.delayFunc(duty.Slot, core.DutyAggregator)))
 
 		return nil
 	case core.DutySyncMessage:
@@ -273,7 +273,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 		err = b.eth2Cl.SubmitSyncCommitteeMessages(ctx, msgs)
 		if err == nil {
 			log.Info(ctx, "Successfully submitted sync committee messages to beacon node",
-				z.Any("delay", b.delayFunc(duty.Slot)))
+				z.Any("delay", b.delayFunc(duty.Slot, core.DutySyncMessage)))
 		}
 
 		return err
@@ -289,7 +289,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 		err = b.eth2Cl.SubmitSyncCommitteeContributions(ctx, contributions)
 		if err == nil {
 			log.Info(ctx, "Successfully submitted sync committee contributions to beacon node",
-				z.Any("delay", b.delayFunc(duty.Slot)))
+				z.Any("delay", b.delayFunc(duty.Slot, core.DutySyncContribution)))
 		}
 
 		return err
@@ -385,8 +385,8 @@ func setToAttestations(set core.SignedDataSet) ([]*eth2spec.VersionedAttestation
 	return resp, nil
 }
 
-// newDelayFunc returns a function that calculates the delay since the start of a slot.
-func newDelayFunc(ctx context.Context, eth2Cl eth2wrap.Client) (func(slot uint64) time.Duration, error) {
+// newDelayFunc returns a function that calculates the delay since the expected duty submission.
+func newDelayFunc(ctx context.Context, eth2Cl eth2wrap.Client) (func(slot uint64, duty core.DutyType) time.Duration, error) {
 	genesisTime, err := eth2wrap.FetchGenesisTime(ctx, eth2Cl)
 	if err != nil {
 		return nil, err
@@ -396,9 +396,17 @@ func newDelayFunc(ctx context.Context, eth2Cl eth2wrap.Client) (func(slot uint64
 		return nil, err
 	}
 
-	return func(slot uint64) time.Duration {
+	return func(slot uint64, duty core.DutyType) time.Duration {
 		slotStart := genesisTime.Add(slotDuration * time.Duration(slot))
-		return time.Since(slotStart)
+		expectedSubmission := slotStart
+		if duty == core.DutyAttester {
+			expectedSubmission = slotStart.Add(slotDuration * 1 / 3)
+		}
+		if duty == core.DutyAggregator || duty == core.DutySyncContribution {
+			expectedSubmission = slotStart.Add(slotDuration * 2 / 3)
+		}
+
+		return time.Since(expectedSubmission)
 	}, nil
 }
 

--- a/core/bcast/metrics.go
+++ b/core/bcast/metrics.go
@@ -23,7 +23,7 @@ var (
 		Namespace: "core",
 		Subsystem: "bcast",
 		Name:      "broadcast_delay_seconds",
-		Help:      "Duty broadcast delay from start of slot in seconds by type",
+		Help:      "Duty broadcast delay since the expected duty submission in seconds by type",
 		Buckets:   []float64{.05, .1, .25, .5, 1, 2.5, 5, 10, 20, 30, 60},
 	}, []string{"duty"})
 

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -5,23 +5,15 @@ package tracker
 import (
 	"context"
 	"fmt"
-	"maps"
 	"strconv"
 	"sync"
 	"time"
-
-	eth2api "github.com/attestantio/go-eth2-client/api"
-	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
-	eth2spec "github.com/attestantio/go-eth2-client/spec"
-	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/core"
-	"github.com/obolnetwork/charon/eth2util/statecomm"
 )
 
 const (
@@ -45,25 +37,10 @@ type subkey struct {
 
 // submission represents a duty submitted to the beacon node/chain.
 type submission struct {
-	Duty        core.Duty
-	Pubkey      core.PubKey
-	Data        core.SignedData
-	AttDataRoot eth2p0.Root
-	Delay       time.Duration
-}
-
-// block is a simplified block with its attestations.
-type block struct {
-	Slot                   uint64
-	AttDuties              []*eth2v1.AttesterDuty
-	AttestationsByDataRoot map[eth2p0.Root]*eth2spec.VersionedAttestation
-	BeaconCommitees        []*statecomm.StateCommittee
-}
-
-// attCommittee is a versioned attestation with its aggregation bits mapped to the respective beacon committee
-type attCommittee struct {
-	Attestation           *eth2spec.VersionedAttestation
-	CommitteeAggregations map[eth2p0.CommitteeIndex]bitfield.Bitlist
+	Duty   core.Duty
+	Pubkey core.PubKey
+	Data   core.SignedData
+	Delay  time.Duration
 }
 
 // trackerInclFunc defines the tracker callback for the inclusion checker.
@@ -71,10 +48,7 @@ type trackerInclFunc func(core.Duty, core.PubKey, core.SignedData, error)
 
 // inclSupported defines duty types for which inclusion checks are supported.
 var inclSupported = map[core.DutyType]bool{
-	core.DutyAttester:   true,
-	core.DutyAggregator: true,
-	core.DutyProposer:   true,
-	// TODO(corver) Add support for sync committee and exit duties
+	core.DutyProposer: true,
 }
 
 // inclusionCore tracks the inclusion of submitted duties.
@@ -85,7 +59,6 @@ type inclusionCore struct {
 
 	trackerInclFunc trackerInclFunc
 	missedFunc      func(context.Context, submission)
-	attIncludedFunc func(context.Context, submission, block)
 }
 
 // Submitted is called when a duty is submitted to the beacon node.
@@ -95,95 +68,45 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 		return nil
 	}
 
-	var attRoot eth2p0.Root
+	var (
+		block core.VersionedSignedProposal
+		ok    bool
+	)
 
-	if duty.Type == core.DutyAttester {
-		att, ok := data.(core.VersionedAttestation)
-		if ok {
-			attData, err := att.Data()
-			if err != nil {
-				return errors.Wrap(err, "get attestation data")
-			}
-			attRoot, err = attData.HashTreeRoot()
-			if err != nil {
-				return errors.Wrap(err, "hash attestation")
-			}
-		} else {
-			att, ok := data.(core.Attestation)
-			if !ok {
-				return errors.New("invalid attestation")
-			}
-			attRoot, err = att.Data.HashTreeRoot()
-			if err != nil {
-				return errors.Wrap(err, "hash attestation")
-			}
-		}
+	block, ok = data.(core.VersionedSignedProposal)
+	if !ok {
+		return errors.New("invalid block")
 	}
 
-	if duty.Type == core.DutyAggregator {
-		agg, ok := data.(core.VersionedSignedAggregateAndProof)
-		if ok {
-			attRoot, err = agg.Data().HashTreeRoot()
-			if err != nil {
-				return errors.Wrap(err, "hash aggregate")
-			}
-		} else {
-			agg, ok := data.(core.SignedAggregateAndProof)
-			if !ok {
-				return errors.New("invalid aggregate and proof")
-			}
-			attRoot, err = agg.Message.Aggregate.Data.HashTreeRoot()
-			if err != nil {
-				return errors.Wrap(err, "hash aggregate")
-			}
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.New("could not determine if proposal was synthetic or not",
+				z.Str("proposal", fmt.Sprintf("%+v", block)),
+				z.Bool("blinded", block.Blinded),
+			)
 		}
-	}
+	}()
 
-	if duty.Type == core.DutyProposer {
-		var (
-			block core.VersionedSignedProposal
-			ok    bool
-		)
-
-		block, ok = data.(core.VersionedSignedProposal)
-		if !ok {
-			return errors.New("invalid block")
+	//nolint: gocritic // Prefer clearer separation of blinded <-> unblinded.
+	if block.Blinded {
+		blinded, err := block.ToBlinded()
+		if err != nil {
+			return errors.Wrap(err, "expected blinded proposal")
 		}
 
-		defer func() {
-			if r := recover(); r != nil {
-				err = errors.New("could not determine if proposal was synthetic or not",
-					z.Str("proposal", fmt.Sprintf("%+v", block)),
-					z.Bool("blinded", block.Blinded),
-				)
-			}
-		}()
+		if eth2wrap.IsSyntheticBlindedBlock(&blinded) {
+			// Report inclusion for synthetic blocks as it is already included on-chain.
+			i.trackerInclFunc(duty, pubkey, data, nil)
 
-		//nolint: gocritic // Prefer clearer separation of blinded <-> unblinded.
-		if block.Blinded {
-			blinded, err := block.ToBlinded()
-			if err != nil {
-				return errors.Wrap(err, "expected blinded proposal")
-			}
-
-			if eth2wrap.IsSyntheticBlindedBlock(&blinded) {
-				// Report inclusion for synthetic blocks as it is already included on-chain.
-				i.trackerInclFunc(duty, pubkey, data, nil)
-
-				return nil
-			}
-		} else {
-			if eth2wrap.IsSyntheticProposal(&block.VersionedSignedProposal) {
-				// Report inclusion for synthetic blocks as it is already included on-chain.
-				i.trackerInclFunc(duty, pubkey, data, nil)
-
-				return nil
-			}
+			return nil
 		}
-	}
+	} else {
+		if eth2wrap.IsSyntheticProposal(&block.VersionedSignedProposal) {
+			// Report inclusion for synthetic blocks as it is already included on-chain.
+			i.trackerInclFunc(duty, pubkey, data, nil)
 
-	if duty.Type == core.DutyBuilderProposer {
-		return core.ErrDeprecatedDutyBuilderProposer
+			return nil
+		}
 	}
 
 	i.mu.Lock()
@@ -191,11 +114,10 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 
 	key := subkey{Duty: duty, Pubkey: pubkey}
 	i.submissions[key] = submission{
-		Duty:        duty,
-		Pubkey:      pubkey,
-		Data:        data,
-		AttDataRoot: attRoot,
-		Delay:       delay,
+		Duty:   duty,
+		Pubkey: pubkey,
+		Data:   data,
+		Delay:  delay,
 	}
 
 	return err
@@ -222,37 +144,14 @@ func (i *inclusionCore) Trim(ctx context.Context, slot uint64) {
 }
 
 // CheckBlock checks whether the block includes any of the submitted duties.
-func (i *inclusionCore) CheckBlock(ctx context.Context, block block) {
+func (i *inclusionCore) CheckBlock(ctx context.Context, slot uint64, found bool) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 
 	for key, sub := range i.submissions {
 		switch sub.Duty.Type {
-		case core.DutyAttester:
-			ok, err := checkAttestationInclusion(sub, block)
-			if err != nil {
-				log.Warn(ctx, "Failed to check attestation inclusion", err)
-			} else if !ok {
-				continue
-			}
-
-			// Report inclusion and trim
-			i.attIncludedFunc(ctx, sub, block)
-			i.trackerInclFunc(sub.Duty, sub.Pubkey, sub.Data, nil)
-			delete(i.submissions, key)
-		case core.DutyAggregator:
-			ok, err := checkAggregationInclusion(sub, block)
-			if err != nil {
-				log.Warn(ctx, "Failed to check aggregate inclusion", err)
-			} else if !ok {
-				continue
-			}
-			// Report inclusion and trim
-			i.attIncludedFunc(ctx, sub, block)
-			i.trackerInclFunc(sub.Duty, sub.Pubkey, sub.Data, nil)
-			delete(i.submissions, key)
 		case core.DutyProposer:
-			if sub.Duty.Slot != block.Slot {
+			if sub.Duty.Slot != slot {
 				continue
 			}
 
@@ -262,16 +161,20 @@ func (i *inclusionCore) CheckBlock(ctx context.Context, block block) {
 				continue
 			}
 
-			msg := "Broadcasted block included on-chain"
-			if proposal.Blinded {
-				msg = "Broadcasted blinded block included on-chain"
+			if found {
+				var msg string
+				msg = "Broadcasted block included on-chain"
+				if proposal.Blinded {
+					msg = "Broadcasted blinded block included on-chain"
+				}
+				log.Info(ctx, msg,
+					z.U64("block_slot", slot),
+					z.Any("pubkey", sub.Pubkey),
+					z.Any("broadcast_delay", sub.Delay),
+				)
+			} else {
+				i.missedFunc(ctx, sub)
 			}
-
-			log.Info(ctx, msg,
-				z.U64("block_slot", block.Slot),
-				z.Any("pubkey", sub.Pubkey),
-				z.Any("broadcast_delay", sub.Delay),
-			)
 
 			// Just report block inclusions to tracker and trim
 			i.trackerInclFunc(sub.Duty, sub.Pubkey, sub.Data, nil)
@@ -282,121 +185,11 @@ func (i *inclusionCore) CheckBlock(ctx context.Context, block block) {
 	}
 }
 
-// checkAggregationInclusion checks whether the aggregation is included in the block.
-func checkAggregationInclusion(sub submission, block block) (bool, error) {
-	att, ok := block.AttestationsByDataRoot[sub.AttDataRoot]
-	if !ok {
-		return false, nil
-	}
-
-	attAggregationBits, err := att.AggregationBits()
-	if err != nil {
-		return false, errors.Wrap(err, "get attestation aggregation bits")
-	}
-	signedAggAndProof, ok := sub.Data.(core.VersionedSignedAggregateAndProof)
-	if !ok {
-		return false, errors.New("parse VersionedSignedAggregateAndProof")
-	}
-
-	subBits := signedAggAndProof.AggregationBits()
-	ok, err = attAggregationBits.Contains(subBits)
-	if err != nil {
-		return false, errors.Wrap(err, "check aggregation bits",
-			z.U64("block_bits", attAggregationBits.Len()),
-			z.U64("sub_bits", subBits.Len()),
-		)
-	}
-
-	return ok, nil
-}
-
-// checkAttestationInclusion checks whether the attestation is included in the block.
-func checkAttestationInclusion(sub submission, block block) (bool, error) {
-	subData, ok := sub.Data.(core.VersionedAttestation)
-	if !ok {
-		return false, errors.New("not an attestation block data")
-	}
-
-	att, ok := block.AttestationsByDataRoot[sub.AttDataRoot]
-	if !ok {
-		return false, nil
-	}
-
-	switch subData.Version {
-	case eth2spec.DataVersionPhase0, eth2spec.DataVersionAltair, eth2spec.DataVersionBellatrix, eth2spec.DataVersionCapella, eth2spec.DataVersionDeneb:
-		subBits, err := subData.AggregationBits()
-		if err != nil {
-			return false, errors.Wrap(err, "fetch submission aggregation bits from phase0 attestation")
-		}
-		attAggBits, err := att.AggregationBits()
-		if err != nil {
-			return false, errors.Wrap(err, "fetch attestation aggregation bits from phase0 attestation")
-		}
-		ok, err := attAggBits.Contains(subBits)
-		if err != nil {
-			return false, errors.Wrap(err, "check phase0 aggregation bits",
-				z.U64("block_bits", attAggBits.Len()),
-				z.U64("sub_bits", subBits.Len()),
-			)
-		}
-
-		return ok, nil
-	case eth2spec.DataVersionElectra:
-		if subData.ValidatorIndex == nil {
-			return false, errors.New("no validator index in electra attestation")
-		}
-
-		var attesterDutyData *eth2v1.AttesterDuty
-		for _, ad := range block.AttDuties {
-			if *subData.ValidatorIndex == ad.ValidatorIndex {
-				attesterDutyData = ad
-				break
-			}
-		}
-
-		if attesterDutyData == nil {
-			return false, errors.New("no attester duty data found in electra attestation")
-		}
-
-		attAggBits, err := att.AggregationBits()
-		if err != nil {
-			return false, errors.Wrap(err, "get attestation aggregation bits from phase0 attestation")
-		}
-
-		subCommIdx, err := subData.CommitteeIndex()
-		if err != nil {
-			return false, errors.Wrap(err, "get committee index from phase0 attestation")
-		}
-
-		// Calculate the length of validators of committees before the committee index of the submitted attestation.
-		previousCommsValidatorsLen := 0
-		for idx := range subCommIdx {
-			previousCommsValidatorsLen += len(block.BeaconCommitees[idx].Validators)
-		}
-
-		// Previous committees validators length + validator index in attestation committee gives the index of the attestation in the full agreggation bits bitlist.
-		return attAggBits.BitAt(uint64(previousCommsValidatorsLen) + attesterDutyData.ValidatorCommitteeIndex), nil
-	default:
-		return false, errors.New("unknown version", z.Str("version", subData.Version.String()))
-	}
-}
-
 // reportMissed reports duties that were broadcast but never included on chain.
 func reportMissed(ctx context.Context, sub submission) {
 	inclusionMisses.WithLabelValues(sub.Duty.Type.String()).Inc()
 
 	switch sub.Duty.Type {
-	case core.DutyAttester, core.DutyAggregator:
-		msg := "Broadcasted attestation never included on-chain"
-		if sub.Duty.Type == core.DutyAggregator {
-			msg = "Broadcasted attestation aggregate never included on-chain"
-		}
-
-		log.Warn(ctx, msg, nil,
-			z.Any("pubkey", sub.Pubkey),
-			z.U64("attestation_slot", sub.Duty.Slot),
-			z.Any("broadcast_delay", sub.Delay),
-		)
 	case core.DutyProposer:
 		proposal, ok := sub.Data.(core.VersionedSignedProposal)
 		if !ok {
@@ -418,36 +211,6 @@ func reportMissed(ctx context.Context, sub submission) {
 	}
 }
 
-// reportAttInclusion reports attestations that were included in a block.
-func reportAttInclusion(ctx context.Context, sub submission, block block) {
-	att, ok := block.AttestationsByDataRoot[sub.AttDataRoot]
-	if !ok {
-		return
-	}
-	attData, err := att.Data()
-	if err != nil {
-		return
-	}
-	attSlot := uint64(attData.Slot)
-	blockSlot := block.Slot
-	inclDelay := block.Slot - attSlot
-
-	msg := "Broadcasted attestation included on-chain"
-	if sub.Duty.Type == core.DutyAggregator {
-		msg = "Broadcasted attestation aggregate included on-chain"
-	}
-
-	log.Info(ctx, msg,
-		z.U64("block_slot", blockSlot),
-		z.U64("attestation_slot", attSlot),
-		z.Any("pubkey", sub.Pubkey),
-		z.U64("inclusion_delay", inclDelay),
-		z.Any("broadcast_delay", sub.Delay),
-	)
-
-	inclusionDelay.Set(float64(blockSlot - attSlot))
-}
-
 // NewInclusion returns a new InclusionChecker.
 func NewInclusion(ctx context.Context, eth2Cl eth2wrap.Client, trackerInclFunc trackerInclFunc) (*InclusionChecker, error) {
 	genesisTime, err := eth2wrap.FetchGenesisTime(ctx, eth2Cl)
@@ -460,7 +223,6 @@ func NewInclusion(ctx context.Context, eth2Cl eth2wrap.Client, trackerInclFunc t
 	}
 
 	inclCore := &inclusionCore{
-		attIncludedFunc: reportAttInclusion,
 		missedFunc:      reportMissed,
 		trackerInclFunc: trackerInclFunc,
 		submissions:     make(map[subkey]submission),
@@ -481,7 +243,7 @@ type InclusionChecker struct {
 	slotDuration   time.Duration
 	eth2Cl         eth2wrap.Client
 	core           *inclusionCore
-	checkBlockFunc func(context.Context, block) // Alises for testing
+	checkBlockFunc func(ctx context.Context, slot uint64, found bool) // Alises for testing
 }
 
 // Submitted is called when a duty has been submitted.
@@ -503,14 +265,7 @@ func (a *InclusionChecker) Run(ctx context.Context) {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
 
-	_, slotsPerEpoch, err := eth2wrap.FetchSlotsConfig(ctx, a.eth2Cl)
-	if err != nil {
-		log.Warn(ctx, "Failed to fetch eth2 spec and start inclusion checker", err)
-		return
-	}
-
 	var checkedSlot uint64
-	var attesterDuties []*eth2v1.AttesterDuty
 
 	for {
 		select {
@@ -521,41 +276,7 @@ func (a *InclusionChecker) Run(ctx context.Context) {
 			if checkedSlot == slot {
 				continue
 			}
-			epoch := eth2p0.Epoch(slot) / eth2p0.Epoch(slotsPerEpoch)
-			indices := []eth2p0.ValidatorIndex{}
-			a.core.mu.Lock()
-			subs := maps.Clone(a.core.submissions)
-			a.core.mu.Unlock()
-			for _, s := range subs {
-				att, ok := s.Data.(core.VersionedAttestation)
-				if !ok {
-					continue
-				}
-				if att.ValidatorIndex == nil {
-					continue
-				}
-				indices = append(indices, *att.ValidatorIndex)
-			}
-
-			// check if there are pending unchecked submissions are made
-			if len(indices) == 0 {
-				attesterDuties = []*eth2v1.AttesterDuty{}
-			} else {
-				// TODO: This can be optimised by not calling attester duties on every slot, in the case of small clusters, where there are <32 validators per cluster.
-				opts := &eth2api.AttesterDutiesOpts{
-					Epoch:   epoch,
-					Indices: indices,
-				}
-				resp, err := a.eth2Cl.AttesterDuties(ctx, opts)
-				if err != nil {
-					log.Warn(ctx, "Failed to fetch attester duties for epoch", err, z.U64("epoch", uint64(epoch)), z.Any("indices", indices))
-					attesterDuties = []*eth2v1.AttesterDuty{}
-				} else {
-					attesterDuties = resp.Data
-				}
-			}
-
-			if err := a.checkBlock(ctx, slot, attesterDuties); err != nil {
+			if err := a.checkBlock(ctx, slot); err != nil {
 				log.Warn(ctx, "Failed to check inclusion", err, z.U64("slot", slot))
 				continue
 			}
@@ -566,293 +287,19 @@ func (a *InclusionChecker) Run(ctx context.Context) {
 	}
 }
 
-func (a *InclusionChecker) checkBlock(ctx context.Context, slot uint64, attDuties []*eth2v1.AttesterDuty) error {
-	atts, err := a.eth2Cl.BlockAttestations(ctx, strconv.FormatUint(slot, 10))
-	if err != nil {
-		return err
-	} else if len(atts) == 0 {
-		return nil // No block for this slot
-	}
-
-	// Get the slot for which the attestations in the current slot are.
-	// This is usually the previous slot, except when the previous is a missed proposal.
-	attestation0Data, err := atts[0].Data()
+func (a *InclusionChecker) checkBlock(ctx context.Context, slot uint64) error {
+	block, err := a.eth2Cl.Block(ctx, strconv.FormatUint(slot, 10))
 	if err != nil {
 		return err
 	}
-	attestedSlot := attestation0Data.Slot
-
-	// Get the beacon committee for the above mentioned slot.
-	committeesForState, err := a.eth2Cl.BeaconStateCommittees(ctx, uint64(attestedSlot))
-	if err != nil {
-		return err
-	}
-
-	// Map attestations by data root, merging duplicates' aggregation bits.
-	attsCommitteesMap := make(map[eth2p0.Root]*attCommittee)
-	for _, att := range atts {
-		if att == nil {
-			return errors.New("invalid attestation")
-		}
-
-		attData, err := att.Data()
-		if err != nil {
-			return errors.Wrap(err, "invalid attestation data")
-		}
-		if attData.Target == nil || attData.Source == nil {
-			return errors.New("invalid attestation data checkpoint")
-		}
-
-		root, err := attData.HashTreeRoot()
-		if err != nil {
-			return errors.Wrap(err, "hash attestation")
-		}
-
-		// Zero signature since it isn't used and wouldn't be valid after merging anyway.
-		err = setAttestationSignature(*att, eth2p0.BLSSignature{})
-		if err != nil {
-			return err
-		}
-
-		attCommittee := &attCommittee{
-			Attestation: att,
-		}
-		committeeAggregations, err := conjugateAggregationBits(attCommittee, attsCommitteesMap, root, committeesForState)
-		if err != nil {
-			return err
-		}
-		attCommittee.CommitteeAggregations = committeeAggregations
-		attsCommitteesMap[root] = attCommittee
-	}
-
-	attsMap := make(map[eth2p0.Root]*eth2spec.VersionedAttestation)
-	for root, att := range attsCommitteesMap {
-		unwrapedAtt := att.Attestation
-		if att.CommitteeAggregations != nil {
-			aggBits := bitfield.Bitlist{}
-			for _, commBits := range att.CommitteeAggregations {
-				aggBits = append(aggBits, commBits...)
-			}
-			err = setAttestationAggregationBits(*unwrapedAtt, aggBits)
-			if err != nil {
-				return err
-			}
-		}
-		attsMap[root] = unwrapedAtt
-	}
-
-	a.checkBlockFunc(ctx, block{Slot: slot, AttDuties: attDuties, AttestationsByDataRoot: attsMap, BeaconCommitees: committeesForState})
-
-	return nil
-}
-
-func setAttestationSignature(att eth2spec.VersionedAttestation, sig eth2p0.BLSSignature) error {
-	switch att.Version {
-	case eth2spec.DataVersionPhase0:
-		if att.Phase0 == nil {
-			return errors.New("no Phase0 attestation")
-		}
-		att.Phase0.Signature = sig
-
-		return nil
-	case eth2spec.DataVersionAltair:
-		if att.Altair == nil {
-			return errors.New("no Altair attestation")
-		}
-		att.Altair.Signature = sig
-
-		return nil
-	case eth2spec.DataVersionBellatrix:
-		if att.Bellatrix == nil {
-			return errors.New("no Bellatrix attestation")
-		}
-		att.Bellatrix.Signature = sig
-
-		return nil
-	case eth2spec.DataVersionCapella:
-		if att.Capella == nil {
-			return errors.New("no Capella attestation")
-		}
-		att.Capella.Signature = sig
-
-		return nil
-	case eth2spec.DataVersionDeneb:
-		if att.Deneb == nil {
-			return errors.New("no Deneb attestation")
-		}
-		att.Deneb.Signature = sig
-
-		return nil
-	case eth2spec.DataVersionElectra:
-		if att.Electra == nil {
-			return errors.New("no Electra attestation")
-		}
-		att.Electra.Signature = sig
-
-		return nil
-	default:
-		return errors.New("unknown attestation version", z.Str("version", att.Version.String()))
-	}
-}
-
-func setAttestationAggregationBits(att eth2spec.VersionedAttestation, bits bitfield.Bitlist) error {
-	switch att.Version {
-	case eth2spec.DataVersionPhase0:
-		if att.Phase0 == nil {
-			return errors.New("no Phase0 attestation")
-		}
-		att.Phase0.AggregationBits = bits
-
-		return nil
-	case eth2spec.DataVersionAltair:
-		if att.Altair == nil {
-			return errors.New("no Altair attestation")
-		}
-		att.Altair.AggregationBits = bits
-
-		return nil
-	case eth2spec.DataVersionBellatrix:
-		if att.Bellatrix == nil {
-			return errors.New("no Bellatrix attestation")
-		}
-		att.Bellatrix.AggregationBits = bits
-
-		return nil
-	case eth2spec.DataVersionCapella:
-		if att.Capella == nil {
-			return errors.New("no Capella attestation")
-		}
-		att.Capella.AggregationBits = bits
-
-		return nil
-	case eth2spec.DataVersionDeneb:
-		if att.Deneb == nil {
-			return errors.New("no Deneb attestation")
-		}
-		att.Deneb.AggregationBits = bits
-
-		return nil
-	case eth2spec.DataVersionElectra:
-		if att.Electra == nil {
-			return errors.New("no Electra attestation")
-		}
-		att.Electra.AggregationBits = bits
-
-		return nil
-	default:
-		return errors.New("unknown attestation version", z.Str("version", att.Version.String()))
-	}
-}
-
-func conjugateAggregationBits(att *attCommittee, attsMap map[eth2p0.Root]*attCommittee, root eth2p0.Root, committeesForState []*statecomm.StateCommittee) (map[eth2p0.CommitteeIndex]bitfield.Bitlist, error) {
-	switch att.Attestation.Version {
-	case eth2spec.DataVersionPhase0:
-		if att.Attestation.Phase0 == nil {
-			return nil, errors.New("no Phase0 attestation")
-		}
-
-		return nil, conjugateAggregationBitsPhase0(att, attsMap, root)
-	case eth2spec.DataVersionAltair:
-		if att.Attestation.Altair == nil {
-			return nil, errors.New("no Altair attestation")
-		}
-
-		return nil, conjugateAggregationBitsPhase0(att, attsMap, root)
-	case eth2spec.DataVersionBellatrix:
-		if att.Attestation.Bellatrix == nil {
-			return nil, errors.New("no Bellatrix attestation")
-		}
-
-		return nil, conjugateAggregationBitsPhase0(att, attsMap, root)
-	case eth2spec.DataVersionCapella:
-		if att.Attestation.Capella == nil {
-			return nil, errors.New("no Capella attestation")
-		}
-
-		return nil, conjugateAggregationBitsPhase0(att, attsMap, root)
-	case eth2spec.DataVersionDeneb:
-		if att.Attestation.Deneb == nil {
-			return nil, errors.New("no Deneb attestation")
-		}
-
-		return nil, conjugateAggregationBitsPhase0(att, attsMap, root)
-	case eth2spec.DataVersionElectra:
-		if att.Attestation.Electra == nil {
-			return nil, errors.New("no Electra attestation")
-		}
-
-		return conjugateAggregationBitsElectra(att, attsMap, root, committeesForState)
-	default:
-		return nil, errors.New("unknown attestation version", z.Str("version", att.Attestation.Version.String()))
-	}
-}
-
-func conjugateAggregationBitsPhase0(att *attCommittee, attsMap map[eth2p0.Root]*attCommittee, root eth2p0.Root) error {
-	attAggregationBits, err := att.Attestation.AggregationBits()
-	if err != nil {
-		return errors.Wrap(err, "get attestation aggregation bits")
-	}
-
-	if exist, ok := attsMap[root]; ok {
-		existAttAggregationBits, err := exist.Attestation.AggregationBits()
-		if err != nil {
-			return errors.Wrap(err, "get attestation aggregation bits")
-		}
-		// Merge duplicate attestations (only aggregation bits).
-		bits, err := attAggregationBits.Or(existAttAggregationBits)
-		if err != nil {
-			return errors.Wrap(err, "merge attestation aggregation bits")
-		}
-		err = setAttestationAggregationBits(*att.Attestation, bits)
-		if err != nil {
-			return errors.Wrap(err, "set attestation aggregation bits")
-		}
-	}
-
-	return nil
-}
-
-func conjugateAggregationBitsElectra(att *attCommittee, attsMap map[eth2p0.Root]*attCommittee, root eth2p0.Root, committeesForState []*statecomm.StateCommittee) (map[eth2p0.CommitteeIndex]bitfield.Bitlist, error) {
-	fullAttestationAggregationBits, err := att.Attestation.AggregationBits()
-	if err != nil {
-		return nil, err
-	}
-	committeeBits, err := att.Attestation.CommitteeBits()
-	if err != nil {
-		return nil, err
-	}
-
-	var updated map[eth2p0.CommitteeIndex]bitfield.Bitlist
-	if exist, ok := attsMap[root]; ok {
-		updated = updateAggregationBits(committeeBits, exist.CommitteeAggregations, fullAttestationAggregationBits)
+	var found bool
+	if block != nil {
+		found = true
 	} else {
-		// Create new empty map of committee indices and aggregations per committee.
-		attsAggBits := make(map[eth2p0.CommitteeIndex]bitfield.Bitlist)
-		// Create a 0'ed bitlist of aggregations of size the amount of validators for all committees.
-		for _, comm := range committeesForState {
-			attsAggBits[comm.Index] = bitfield.NewBitlist(uint64(len(comm.Validators)))
-		}
-
-		updated = updateAggregationBits(committeeBits, attsAggBits, fullAttestationAggregationBits)
+		found = false
 	}
 
-	return updated, nil
-}
+	a.checkBlockFunc(ctx, slot, found)
 
-func updateAggregationBits(committeeBits bitfield.Bitvector64, committeeAggregation map[eth2p0.CommitteeIndex]bitfield.Bitlist, fullAttestationAggregationBits bitfield.Bitlist) map[eth2p0.CommitteeIndex]bitfield.Bitlist {
-	offset := uint64(0)
-	// Iterate over all committees that attested in the current attestation object.
-	for _, committeeIndex := range committeeBits.BitIndices() {
-		validatorsInCommittee := committeeAggregation[eth2p0.CommitteeIndex(committeeIndex)].Len()
-		// Iterate over all validators in the committee.
-		for idx := range validatorsInCommittee {
-			// Update the existing map if the said validator attested.
-			if fullAttestationAggregationBits.BitAt(offset + idx) {
-				committeeAggregation[eth2p0.CommitteeIndex(committeeIndex)].SetBitAt(idx, fullAttestationAggregationBits.BitAt(offset+idx))
-			}
-		}
-		offset += validatorsInCommittee
-	}
-
-	return committeeAggregation
+	return nil
 }

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -4,302 +4,104 @@ package tracker
 
 import (
 	"context"
-	"math/rand"
-	"slices"
 	"testing"
 
-	eth2spec "github.com/attestantio/go-eth2-client/spec"
-	"github.com/attestantio/go-eth2-client/spec/electra"
-	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/stretchr/testify/require"
 
-	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/core"
-	"github.com/obolnetwork/charon/eth2util/statecomm"
 	"github.com/obolnetwork/charon/testutil"
-	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
-func TestDuplicateAttData(t *testing.T) {
-	ctx := context.Background()
-
-	tests := []struct {
-		name                      string
-		attData                   *eth2p0.AttestationData
-		attestationsFunc          func(*eth2p0.AttestationData, bitfield.Bitlist, bitfield.Bitlist, bitfield.Bitlist) []*eth2spec.VersionedAttestation
-		beaconStateCommitteesFunc func(*eth2p0.AttestationData) []*statecomm.StateCommittee
-	}{
-		{
-			name:    "phase0",
-			attData: testutil.RandomAttestationDataPhase0(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionPhase0, Phase0: &eth2p0.Attestation{AggregationBits: aggBits1, Data: attData}},
-					{Version: eth2spec.DataVersionPhase0, Phase0: &eth2p0.Attestation{AggregationBits: aggBits2, Data: attData}},
-					{Version: eth2spec.DataVersionPhase0, Phase0: &eth2p0.Attestation{AggregationBits: aggBits3, Data: attData}},
-				}
+func TestBlockInclusion(t *testing.T) {
+	t.Run("block found", func(t *testing.T) {
+		var missed []core.Duty
+		incl := &inclusionCore{
+			missedFunc: func(ctx context.Context, sub submission) {
+				missed = append(missed, sub.Duty)
 			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: attData.Index, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1}},
-				}
+			trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
+			submissions:     make(map[subkey]submission),
+		}
+
+		block := testutil.RandomElectraVersionedSignedProposal()
+		blockSlot, err := block.Slot()
+		require.NoError(t, err)
+		blockDuty := core.NewProposerDuty(uint64(blockSlot))
+		coreBlock, err := core.NewVersionedSignedProposal(block)
+		require.NoError(t, err)
+		err = incl.Submitted(blockDuty, "", coreBlock, 0)
+		require.NoError(t, err)
+
+		incl.CheckBlock(context.Background(), blockDuty.Slot, true)
+		require.Empty(t, missed)
+	})
+
+	t.Run("block not found", func(t *testing.T) {
+		var missed []core.Duty
+		incl := &inclusionCore{
+			missedFunc: func(ctx context.Context, sub submission) {
+				missed = append(missed, sub.Duty)
 			},
-		},
-		{
-			name:    "altair",
-			attData: testutil.RandomAttestationDataPhase0(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionAltair, Altair: &eth2p0.Attestation{AggregationBits: aggBits1, Data: attData}},
-					{Version: eth2spec.DataVersionAltair, Altair: &eth2p0.Attestation{AggregationBits: aggBits2, Data: attData}},
-					{Version: eth2spec.DataVersionAltair, Altair: &eth2p0.Attestation{AggregationBits: aggBits3, Data: attData}},
-				}
+			trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
+			submissions:     make(map[subkey]submission),
+		}
+
+		block := testutil.RandomElectraVersionedSignedProposal()
+		blockSlot, err := block.Slot()
+		require.NoError(t, err)
+		blockDuty := core.NewProposerDuty(uint64(blockSlot))
+		coreBlock, err := core.NewVersionedSignedProposal(block)
+		require.NoError(t, err)
+		err = incl.Submitted(blockDuty, "", coreBlock, 0)
+		require.NoError(t, err)
+
+		incl.CheckBlock(context.Background(), blockDuty.Slot, false)
+		require.Len(t, missed, 1)
+	})
+
+	t.Run("received block not found in submissions", func(t *testing.T) {
+		var missed []core.Duty
+		incl := &inclusionCore{
+			missedFunc: func(ctx context.Context, sub submission) {
+				missed = append(missed, sub.Duty)
 			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: attData.Index, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1}},
-				}
+			trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
+			submissions:     make(map[subkey]submission),
+		}
+
+		block := testutil.RandomElectraVersionedSignedProposal()
+		blockSlot, err := block.Slot()
+		require.NoError(t, err)
+		blockDuty := core.NewProposerDuty(uint64(blockSlot))
+		coreBlock, err := core.NewVersionedSignedProposal(block)
+		require.NoError(t, err)
+		err = incl.Submitted(blockDuty, "", coreBlock, 0)
+		require.NoError(t, err)
+
+		incl.CheckBlock(context.Background(), blockDuty.Slot+1, true)
+		require.Empty(t, missed)
+	})
+
+	t.Run("received block is nil and not found in submissions", func(t *testing.T) {
+		var missed []core.Duty
+		incl := &inclusionCore{
+			missedFunc: func(ctx context.Context, sub submission) {
+				missed = append(missed, sub.Duty)
 			},
-		},
-		{
-			name:    "bellatrix",
-			attData: testutil.RandomAttestationDataPhase0(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionBellatrix, Bellatrix: &eth2p0.Attestation{AggregationBits: aggBits1, Data: attData}},
-					{Version: eth2spec.DataVersionBellatrix, Bellatrix: &eth2p0.Attestation{AggregationBits: aggBits2, Data: attData}},
-					{Version: eth2spec.DataVersionBellatrix, Bellatrix: &eth2p0.Attestation{AggregationBits: aggBits3, Data: attData}},
-				}
-			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: attData.Index, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1}},
-				}
-			},
-		},
-		{
-			name:    "capella",
-			attData: testutil.RandomAttestationDataPhase0(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionCapella, Capella: &eth2p0.Attestation{AggregationBits: aggBits1, Data: attData}},
-					{Version: eth2spec.DataVersionCapella, Capella: &eth2p0.Attestation{AggregationBits: aggBits2, Data: attData}},
-					{Version: eth2spec.DataVersionCapella, Capella: &eth2p0.Attestation{AggregationBits: aggBits3, Data: attData}},
-				}
-			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: attData.Index, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1}},
-				}
-			},
-		},
-		{
-			name:    "deneb",
-			attData: testutil.RandomAttestationDataPhase0(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionDeneb, Deneb: &eth2p0.Attestation{AggregationBits: aggBits1, Data: attData}},
-					{Version: eth2spec.DataVersionDeneb, Deneb: &eth2p0.Attestation{AggregationBits: aggBits2, Data: attData}},
-					{Version: eth2spec.DataVersionDeneb, Deneb: &eth2p0.Attestation{AggregationBits: aggBits3, Data: attData}},
-				}
-			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: attData.Index, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1}},
-				}
-			},
-		},
-		{
-			name:    "electra",
-			attData: testutil.RandomAttestationDataElectra(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				zeroComm := bitfield.NewBitvector64()
-				zeroComm.SetBitAt(0, true)
-				oneComm := bitfield.NewBitvector64()
-				oneComm.SetBitAt(1, true)
-				twoComm := bitfield.NewBitvector64()
-				twoComm.SetBitAt(2, true)
+			trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
+			submissions:     make(map[subkey]submission),
+		}
 
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionElectra, Electra: &electra.Attestation{AggregationBits: aggBits1, Data: attData, CommitteeBits: zeroComm}},
-					{Version: eth2spec.DataVersionElectra, Electra: &electra.Attestation{AggregationBits: aggBits2, Data: attData, CommitteeBits: oneComm}},
-					{Version: eth2spec.DataVersionElectra, Electra: &electra.Attestation{AggregationBits: aggBits3, Data: attData, CommitteeBits: twoComm}},
-				}
-			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: 0, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1, 2}},
-					{Index: 1, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1, 2}},
-					{Index: 2, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1, 2}},
-				}
-			},
-		},
-		{
-			name:    "electra - multiple committies per attestation",
-			attData: testutil.RandomAttestationDataElectra(),
-			attestationsFunc: func(attData *eth2p0.AttestationData, aggBits1 bitfield.Bitlist, aggBits2 bitfield.Bitlist, aggBits3 bitfield.Bitlist) []*eth2spec.VersionedAttestation {
-				zeroTwoComm := bitfield.NewBitvector64()
-				zeroTwoComm.SetBitAt(0, true)
-				zeroTwoComm.SetBitAt(2, true)
-				oneComm := bitfield.NewBitvector64()
-				oneComm.SetBitAt(1, true)
-				complexAttestationAggBits := slices.Concat(aggBits1, aggBits2)
+		block := testutil.RandomElectraVersionedSignedProposal()
+		blockSlot, err := block.Slot()
+		require.NoError(t, err)
+		blockDuty := core.NewProposerDuty(uint64(blockSlot))
+		coreBlock, err := core.NewVersionedSignedProposal(block)
+		require.NoError(t, err)
+		err = incl.Submitted(blockDuty, "", coreBlock, 0)
+		require.NoError(t, err)
 
-				return []*eth2spec.VersionedAttestation{
-					{Version: eth2spec.DataVersionElectra, Electra: &electra.Attestation{AggregationBits: complexAttestationAggBits, Data: attData, CommitteeBits: zeroTwoComm}},
-					{Version: eth2spec.DataVersionElectra, Electra: &electra.Attestation{AggregationBits: aggBits2, Data: attData, CommitteeBits: oneComm}},
-				}
-			},
-			beaconStateCommitteesFunc: func(attData *eth2p0.AttestationData) []*statecomm.StateCommittee {
-				return []*statecomm.StateCommittee{
-					{Index: 0, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1, 2}},
-					{Index: 1, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1, 2}},
-					{Index: 2, Slot: attData.Slot, Validators: []eth2p0.ValidatorIndex{0, 1, 2}},
-				}
-			},
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			bmock, err := beaconmock.New()
-			require.NoError(t, err)
-
-			// Mock 3 attestations, with same data but different aggregation bits.
-			attData := test.attData
-			aggBits1 := testutil.RandomBitList(8)
-			aggBits2 := testutil.RandomBitList(8)
-			aggBits3 := testutil.RandomBitList(8)
-
-			bmock.BlockAttestationsFunc = func(_ context.Context, _ string) ([]*eth2spec.VersionedAttestation, error) {
-				return test.attestationsFunc(attData, aggBits1, aggBits2, aggBits3), nil
-			}
-
-			bmock.BeaconStateCommitteesFunc = func(_ context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {
-				return test.beaconStateCommitteesFunc(attData), nil
-			}
-
-			noopTrackerInclFunc := func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {}
-
-			incl, err := NewInclusion(ctx, bmock, noopTrackerInclFunc)
-			require.NoError(t, err)
-
-			done := make(chan struct{})
-			attDataRoot, err := attData.HashTreeRoot()
-			require.NoError(t, err)
-
-			// Assert that the block to check contains all bitlists above.
-			incl.checkBlockFunc = func(ctx context.Context, block block) {
-				require.Len(t, block.AttestationsByDataRoot, 1)
-				att, ok := block.AttestationsByDataRoot[attDataRoot]
-				require.True(t, ok)
-
-				aggBits1, err := att.AggregationBits()
-				require.NoError(t, err)
-				ok, err = aggBits1.Contains(aggBits1)
-				require.NoError(t, err)
-				require.True(t, ok)
-
-				aggBits2, err := att.AggregationBits()
-				require.NoError(t, err)
-				ok, err = aggBits2.Contains(aggBits2)
-				require.NoError(t, err)
-				require.True(t, ok)
-
-				aggBits3, err := att.AggregationBits()
-				require.NoError(t, err)
-				ok, err = aggBits3.Contains(aggBits3)
-				require.NoError(t, err)
-				require.True(t, ok)
-
-				close(done)
-			}
-
-			err = incl.checkBlock(ctx, uint64(attData.Slot), nil)
-			require.NoError(t, err)
-
-			<-done
-		})
-	}
-}
-
-func TestInclusion(t *testing.T) {
-	//  Setup inclusion with a mock missedFunc and attIncludedFunc
-	var missed, included []core.Duty
-	incl := &inclusionCore{
-		missedFunc: func(ctx context.Context, sub submission) {
-			missed = append(missed, sub.Duty)
-		},
-		attIncludedFunc: func(ctx context.Context, sub submission, block block) {
-			included = append(included, sub.Duty)
-		},
-		trackerInclFunc: func(duty core.Duty, key core.PubKey, data core.SignedData, err error) {},
-		submissions:     make(map[subkey]submission),
-	}
-
-	// Create some duties
-	att1 := testutil.RandomDenebVersionedAttestation()
-	att1Duty := core.NewAttesterDuty(uint64(att1.Deneb.Data.Slot))
-
-	agg2 := testutil.RandomDenebVersionedSignedAggregateAndProof()
-	agg2Duty := core.NewAggregatorDuty(uint64(agg2.Deneb.Message.Aggregate.Data.Slot))
-
-	att3 := testutil.RandomPhase0Attestation()
-	att3Duty := core.NewAttesterDuty(uint64(att3.Data.Slot))
-
-	block4 := testutil.RandomDenebVersionedSignedProposal()
-	block4Duty := core.NewProposerDuty(uint64(block4.Deneb.SignedBlock.Message.Slot))
-
-	block5 := testutil.RandomDenebVersionedSignedBlindedProposal()
-	block5.DenebBlinded.Message.Body.Graffiti = eth2wrap.GetSyntheticGraffiti() // Ignored, not included or missed.
-	block5Duty := core.Duty{
-		Slot: uint64(block5.DenebBlinded.Message.Slot),
-		Type: core.DutyBuilderProposer,
-	}
-
-	// Submit all duties
-	err := incl.Submitted(att1Duty, "", core.NewAttestation(att1.Deneb), 0)
-	require.NoError(t, err)
-	err = incl.Submitted(agg2Duty, "", core.NewSignedAggregateAndProof(agg2.Deneb), 0)
-	require.NoError(t, err)
-	err = incl.Submitted(att3Duty, "", core.NewAttestation(att3), 0)
-	require.NoError(t, err)
-
-	coreBlock4, err := core.NewVersionedSignedProposal(block4)
-	require.NoError(t, err)
-	err = incl.Submitted(block4Duty, "", coreBlock4, 0)
-	require.NoError(t, err)
-	err = incl.Submitted(block5Duty, "", block5, 0)
-	require.NoError(t, err)
-
-	// Create a mock block with the 1st and 2nd attestations.
-	att1Root, err := att1.Deneb.Data.HashTreeRoot()
-	require.NoError(t, err)
-	att2Root, err := agg2.Deneb.Message.Aggregate.Data.HashTreeRoot()
-	require.NoError(t, err)
-	// Add some random aggregation bits to the attestation
-	addRandomBits(att1.Deneb.AggregationBits)
-	addRandomBits(agg2.Deneb.Message.Aggregate.AggregationBits)
-
-	block := block{
-		Slot: block4Duty.Slot,
-		AttestationsByDataRoot: map[eth2p0.Root]*eth2spec.VersionedAttestation{
-			att1Root: att1,
-			att2Root: {Deneb: agg2.Deneb.Message.Aggregate},
-		},
-	}
-
-	// Check the block
-	incl.CheckBlock(context.Background(), block)
-
-	// Assert that the 1st and 2nd duty was included
-	duties := []core.Duty{att1Duty, agg2Duty, att3Duty}
-	require.ElementsMatch(t, included, duties)
-}
-
-func addRandomBits(list bitfield.Bitlist) {
-	for range rand.Intn(4) {
-		list.SetBitAt(uint64(rand.Intn(int(list.Len()))), true)
-	}
+		incl.CheckBlock(context.Background(), blockDuty.Slot+1, false)
+		require.Empty(t, missed)
+	})
 }

--- a/core/tracker/metrics.go
+++ b/core/tracker/metrics.go
@@ -89,13 +89,6 @@ var (
 		Help:      "Total number of duties that contained inconsistent partial signed data by duty type",
 	}, []string{"duty"})
 
-	inclusionDelay = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: "core",
-		Subsystem: "tracker",
-		Name:      "inclusion_delay",
-		Help:      "Cluster's average attestation inclusion delay in slots",
-	})
-
 	inclusionMisses = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "core",
 		Subsystem: "tracker",

--- a/core/tracker/tracker_internal_test.go
+++ b/core/tracker/tracker_internal_test.go
@@ -342,9 +342,9 @@ func TestAnalyseDutyFailed(t *testing.T) {
 			attDuty = core.NewAttesterDuty(uint64(1))
 		)
 
-		require.Equal(t, chainInclusion, lastStep(attDuty.Type))
+		require.Equal(t, bcast, lastStep(attDuty.Type))
 
-		for step := fetcher; step < sentinel; step++ {
+		for step := fetcher; step < chainInclusion; step++ {
 			events[attDuty] = append(events[attDuty], event{step: step, duty: attDuty})
 		}
 
@@ -377,7 +377,7 @@ func TestAnalyseDutyFailed(t *testing.T) {
 
 func TestDutyFailedStep(t *testing.T) {
 	var events []event
-	for step := fetcher; step < sentinel; step++ {
+	for step := fetcher; step < chainInclusion; step++ {
 		events = append(events, event{step: step, duty: core.NewAttesterDuty(0)})
 	}
 
@@ -1182,7 +1182,7 @@ func TestDutyFailedMultipleEvents(t *testing.T) {
 	duty := core.NewAttesterDuty(123)
 	testErr := errors.New("test error")
 	var events []event
-	for step := fetcher; step < sentinel; step++ {
+	for step := fetcher; step < chainInclusion; step++ {
 		for range 5 {
 			events = append(events, event{step: step, duty: duty, stepErr: testErr})
 		}
@@ -1191,11 +1191,11 @@ func TestDutyFailedMultipleEvents(t *testing.T) {
 	// Failed at last step.
 	failed, step, err := dutyFailedStep(events)
 	require.True(t, failed)
-	require.Equal(t, chainInclusion, step)
+	require.Equal(t, bcast, step)
 	require.ErrorIs(t, err, testErr)
 
 	// No Failure.
-	for step := fetcher; step < sentinel; step++ {
+	for step := fetcher; step < chainInclusion; step++ {
 		events = append(events, event{step: step, duty: duty})
 	}
 	failed, step, err = dutyFailedStep(events)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -44,7 +44,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `cluster_operators` | Gauge | Number of operators in the cluster lock |  |
 | `cluster_threshold` | Gauge | Aggregation threshold in the cluster lock |  |
 | `cluster_validators` | Gauge | Number of validators in the cluster lock |  |
-| `core_bcast_broadcast_delay_seconds` | Histogram | Duty broadcast delay from start of slot in seconds by type | `duty` |
+| `core_bcast_broadcast_delay_seconds` | Histogram | Duty broadcast delay since the expected duty submission in seconds by type | `duty` |
 | `core_bcast_broadcast_total` | Counter | The total count of successfully broadcast duties by type | `duty` |
 | `core_bcast_recast_errors_total` | Counter | The total count of failed recasted registrations by source; `pregen` vs `downstream` | `source` |
 | `core_bcast_recast_registration_total` | Counter | The total number of unique validator registration stored in recaster per pubkey | `pubkey` |
@@ -65,7 +65,6 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `core_tracker_expect_duties_total` | Counter | Total number of expected duties (failed + success) by type | `duty` |
 | `core_tracker_failed_duties_total` | Counter | Total number of failed duties by type | `duty` |
 | `core_tracker_failed_duty_reasons_total` | Counter | Total number of failed duties by type and reason code | `duty, reason` |
-| `core_tracker_inclusion_delay` | Gauge | Cluster`s average attestation inclusion delay in slots |  |
 | `core_tracker_inclusion_missed_total` | Counter | Total number of broadcast duties never included in any block by type | `duty` |
 | `core_tracker_inconsistent_parsigs_total` | Counter | Total number of duties that contained inconsistent partial signed data by duty type | `duty` |
 | `core_tracker_participation` | Gauge | Set to 1 if peer participated successfully for the given duty or else 0 | `duty, peer` |

--- a/testutil/beaconmock/beaconmock.go
+++ b/testutil/beaconmock/beaconmock.go
@@ -133,6 +133,7 @@ type Mock struct {
 	AttestationDataFunc                    func(context.Context, eth2p0.Slot, eth2p0.CommitteeIndex) (*eth2p0.AttestationData, error)
 	AttesterDutiesFunc                     func(context.Context, eth2p0.Epoch, []eth2p0.ValidatorIndex) ([]*eth2v1.AttesterDuty, error)
 	BlockAttestationsFunc                  func(ctx context.Context, stateID string) ([]*eth2spec.VersionedAttestation, error)
+	BlockFunc                              func(ctx context.Context, stateID string) (*eth2spec.VersionedSignedBeaconBlock, error)
 	BeaconStateCommitteesFunc              func(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error)
 	NodePeerCountFunc                      func(ctx context.Context) (int, error)
 	ProposalFunc                           func(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.VersionedProposal, error)
@@ -296,6 +297,10 @@ func (m Mock) Genesis(ctx context.Context, opts *eth2api.GenesisOpts) (*eth2api.
 
 func (m Mock) BlockAttestations(ctx context.Context, stateID string) ([]*eth2spec.VersionedAttestation, error) {
 	return m.BlockAttestationsFunc(ctx, stateID)
+}
+
+func (m Mock) Block(ctx context.Context, stateID string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+	return m.BlockFunc(ctx, stateID)
 }
 
 func (m Mock) BeaconStateCommittees(ctx context.Context, slot uint64) ([]*statecomm.StateCommittee, error) {

--- a/testutil/beaconmock/beaconmock_fuzz.go
+++ b/testutil/beaconmock/beaconmock_fuzz.go
@@ -182,5 +182,12 @@ func WithBeaconMockFuzzer() Option {
 
 			return atts, nil
 		}
+
+		mock.BlockFunc = func(context.Context, string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+			var block *eth2spec.VersionedSignedBeaconBlock
+			fuzz.New().Fuzz(&block)
+
+			return block, nil
+		}
 	}
 }

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -546,6 +546,9 @@ func defaultMock(httpMock HTTPMock, httpServer *http.Server, clock clockwork.Clo
 		BlockAttestationsFunc: func(context.Context, string) ([]*eth2spec.VersionedAttestation, error) {
 			return []*eth2spec.VersionedAttestation{}, nil
 		},
+		BlockFunc: func(context.Context, string) (*eth2spec.VersionedSignedBeaconBlock, error) {
+			return &eth2spec.VersionedSignedBeaconBlock{}, nil
+		},
 		NodePeerCountFunc: func(context.Context) (int, error) {
 			return 80, nil
 		},


### PR DESCRIPTION
After attempts to fix inclusion checker for attestations in #3740, it became apparent that doing that successfully for electra attestations we will put the beacon node through quite a lot of load. So much, that it becomes contra-productive to check for attestation inclusions, as it will start hurting cluster's performance.

Here attestations and aggregations are removed from the on-chain inclusion checking. The metric for broadcasting delay is tweaked a bit to be more representative for the duties. 

category: refactor
ticket: none