### PR TITLE
*: changed golang image for arm64 build

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -44,7 +44,7 @@ jobs:
       run: |
         docker run --rm --platform linux/arm64 \
           -v "$(pwd)":/workspace -w /workspace \
-          golang:${{ steps.setup-go.outputs.go-version }}-bookworm \
+          golang:${{ steps.setup-go.outputs.go-version }} \
           bash -c "
             set -euo pipefail
             set -x


### PR DESCRIPTION
The -bookworm build only offers amd64 arch, so this change uses multi-arch image.

category: fixbuild
ticket: none
