### PR TITLE
cmd: change exit sign default epoch from 162304 to 194048

### DIFF
--- a/app/obolapi/exit_test.go
+++ b/app/obolapi/exit_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/obolnetwork/charon/testutil/obolapimock"
 )
 
-const exitEpoch = eth2p0.Epoch(162304)
+const exitEpoch = eth2p0.Epoch(194048)
 
 func TestAPIFlow(t *testing.T) {
 	kn := 4

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -160,7 +160,7 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 		case validatorPubkey:
 			cmd.Flags().StringVar(&config.ValidatorPubkey, validatorPubkey.String(), "", maybeRequired("Public key of the validator to exit, must be present in the cluster lock manifest. If --validator-index is also provided, validator liveliness won't be checked on the beacon chain."))
 		case exitEpoch:
-			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 162304, maybeRequired("Exit epoch at which the validator will exit, must be the same across all the partial exits."))
+			cmd.Flags().Uint64Var(&config.ExitEpoch, exitEpoch.String(), 194048, maybeRequired("Exit epoch at which the validator will exit, must be the same across all the partial exits."))
 		case exitFromFile:
 			cmd.Flags().StringVar(&config.ExitFromFilePath, exitFromFile.String(), "", maybeRequired("Retrieves a signed exit message from a pre-prepared file instead of --publish-address."))
 		case exitFromDir:


### PR DESCRIPTION
Bump default epoch to the Shapella fork epoch.

category: feature
ticket: none
