### PR TITLE
core: increased duty timeout margin

### DIFF
--- a/core/deadline.go
+++ b/core/deadline.go
@@ -19,7 +19,7 @@ import (
 const (
 	// marginFactor defines the fraction of the slot duration to use as a margin.
 	// This is to consider network delays and other factors that may affect the timing.
-	marginFactor = 24
+	marginFactor = 12
 )
 
 // DeadlineFunc is a function that returns the deadline for a duty.

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -94,7 +94,7 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 	slotDuration, _, err := eth2wrap.FetchSlotsConfig(t.Context(), bmock)
 	require.NoError(t, err)
 
-	margin := slotDuration / 24
+	margin := slotDuration / 12
 	currentSlot := uint64(time.Since(genesisTime) / slotDuration)
 	now := genesisTime.Add(time.Duration(currentSlot) * slotDuration)
 


### PR DESCRIPTION
For Teku VC we observed all duties were timed out due to insufficient duty timeout.
This change increases duty timeout margin from 0.5s to 1s (marginFactor=12) for Ethereum spec.
Having tested this change with Kurtosis, all duties appear to be working fine.
Note that Teku VC is the only VC type that needed this adjustment.

category: bug
ticket: none
