### PR TITLE
app: changed sse-head-delay buckets

### DIFF
--- a/app/sse/metrics.go
+++ b/app/sse/metrics.go
@@ -21,7 +21,7 @@ var (
 		Subsystem: "beacon_node",
 		Name:      "sse_head_delay",
 		Help:      "Delay in seconds between slot start and head update, supplied by beacon node's SSE endpoint. Values between 8s and 12s for Ethereum mainnet are considered safe.",
-		Buckets:   []float64{8, 9, 10, 11, 12, 14, 16, 20},
+		Buckets:   []float64{4, 6, 8, 10, 12, 16, 20},
 	}, []string{"addr"})
 
 	sseChainReorgDepthHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
Changed `sse_head_delay` metric buckets to `[4,6,8,10,12,16,20]`.

category: refactor
ticket: none

