### PR TITLE
utils: remove fulu from fork schedule

### DIFF
--- a/app/eth2wrap/utils.go
+++ b/app/eth2wrap/utils.go
@@ -28,7 +28,7 @@ const (
 	Capella
 	Deneb
 	Electra
-	Fulu
+	// Fulu
 )
 
 func (f Fork) String() string {
@@ -41,7 +41,7 @@ var forkLabels = map[Fork]string{
 	Capella:   "CAPELLA",
 	Deneb:     "DENEB",
 	Electra:   "ELECTRA",
-	Fulu:      "FULU",
+	// Fulu:      "FULU",
 }
 
 var (

--- a/app/eth2wrap/utils_test.go
+++ b/app/eth2wrap/utils_test.go
@@ -53,15 +53,15 @@ func TestFetchForkConfig(t *testing.T) {
 	require.NoError(t, err)
 	eVersion, err := hex.DecodeString("60000910")
 	require.NoError(t, err)
-	fVersion, err := hex.DecodeString("70000910")
-	require.NoError(t, err)
+	// fVersion, err := hex.DecodeString("70000910")
+	// require.NoError(t, err)
 	ffs := eth2wrap.ForkForkSchedule{
 		eth2wrap.Altair:    eth2wrap.ForkSchedule{Epoch: 0, Version: [4]byte(aVersion)},
 		eth2wrap.Bellatrix: eth2wrap.ForkSchedule{Epoch: 0, Version: [4]byte(bVersion)},
 		eth2wrap.Capella:   eth2wrap.ForkSchedule{Epoch: 0, Version: [4]byte(cVersion)},
 		eth2wrap.Deneb:     eth2wrap.ForkSchedule{Epoch: 0, Version: [4]byte(dVersion)},
 		eth2wrap.Electra:   eth2wrap.ForkSchedule{Epoch: 2048, Version: [4]byte(eVersion)},
-		eth2wrap.Fulu:      eth2wrap.ForkSchedule{Epoch: 18446744073709551615, Version: [4]byte(fVersion)},
+		// eth2wrap.Fulu:      eth2wrap.ForkSchedule{Epoch: 18446744073709551615, Version: [4]byte(fVersion)},
 	}
 
 	// Matching beaconmock/static.json


### PR DESCRIPTION
All clients support fulu in their config now, except Grandine. This results in Grandine crashing when we want to fetch Fulu from its config.

category: bug
ticket: none
