### PR TITLE
core: fix some function names in comment

### DIFF
--- a/core/scheduler/scheduler.go
+++ b/core/scheduler/scheduler.go
@@ -408,7 +408,7 @@ func (s *Scheduler) resolveAttDuties(ctx context.Context, slot core.Slot, vals v
 	return nil
 }
 
-// resolveProposerDuties resolves proposer duties for the given validators.
+// resolveProDuties resolves proposer duties for the given validators.
 func (s *Scheduler) resolveProDuties(ctx context.Context, slot core.Slot, vals validators) error {
 	opts := &eth2api.ProposerDutiesOpts{
 		Epoch:   eth2p0.Epoch(slot.Epoch()),

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -1207,7 +1207,7 @@ type SyncCommitteeSelection struct {
 	eth2exp.SyncCommitteeSelection
 }
 
-// MessageRoots returns the signing roots for the provided SyncCommitteeSelection.
+// MessageRoot returns the signing roots for the provided SyncCommitteeSelection.
 // Refer https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#syncaggregatorselectiondata
 func (s SyncCommitteeSelection) MessageRoot() ([32]byte, error) {
 	data := altair.SyncAggregatorSelectionData{
@@ -1784,7 +1784,7 @@ type SyncContributionAndProof struct {
 	altair.ContributionAndProof
 }
 
-// MessageRoots returns the signing roots for the provided SyncContributionAndProof.
+// MessageRoot returns the signing roots for the provided SyncContributionAndProof.
 // Refer: https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#aggregation-selection.
 func (s SyncContributionAndProof) MessageRoot() ([32]byte, error) {
 	data := altair.SyncAggregatorSelectionData{
@@ -1876,7 +1876,7 @@ type SignedSyncContributionAndProof struct {
 	altair.SignedContributionAndProof
 }
 
-// MessageRoots returns the signing roots for the provided SignedSyncContributionAndProof.
+// MessageRoot returns the signing roots for the provided SignedSyncContributionAndProof.
 // Refer get_contribution_and_proof_signature from https://github.com/ethereum/consensus-specs/blob/dev/specs/altair/validator.md#broadcast-sync-committee-contribution.
 func (s SignedSyncContributionAndProof) MessageRoot() ([32]byte, error) {
 	return s.Message.HashTreeRoot()

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -1924,7 +1924,7 @@ func testRawRouter(t *testing.T, handler testHandler, callback func(context.Cont
 	testRawRouterEx(t, handler, callback, true)
 }
 
-// testRawRouterEX is a helper function same as testRawRouter() but accepts GetBuilderAPIFlagFunc.
+// testRawRouterEx is a helper function same as testRawRouter() but accepts GetBuilderAPIFlagFunc.
 func testRawRouterEx(t *testing.T, handler testHandler, callback func(context.Context, string), builderEnabled bool) {
 	t.Helper()
 


### PR DESCRIPTION
Fixed some function names in comment.

category: refactor
ticket: none