### PR TITLE
*: delete partial exits

### DIFF
--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -118,8 +118,6 @@ func httpGet(ctx context.Context, url *url.URL, headers map[string]string) (io.R
 		return nil, errors.Wrap(err, "new GET request with ctx")
 	}
 
-	req.Header.Add("Content-Type", "application/json")
-
 	for key, val := range headers {
 		req.Header.Set(key, val)
 	}
@@ -150,7 +148,6 @@ func httpDelete(ctx context.Context, url *url.URL, headers map[string]string) er
 	if err != nil {
 		return errors.Wrap(err, "new DELETE request with ctx")
 	}
-	req.Header.Add("Content-Type", "application/json")
 
 	for key, val := range headers {
 		req.Header.Set(key, val)
@@ -160,6 +157,7 @@ func httpDelete(ctx context.Context, url *url.URL, headers map[string]string) er
 	if err != nil {
 		return errors.Wrap(err, "call DELETE endpoint")
 	}
+	defer res.Body.Close()
 
 	if res.StatusCode/100 != 2 {
 		if res.StatusCode == http.StatusNotFound {

--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -144,3 +144,30 @@ func httpGet(ctx context.Context, url *url.URL, headers map[string]string) (io.R
 
 	return res.Body, nil
 }
+
+func httpDelete(ctx context.Context, url *url.URL, headers map[string]string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, url.String(), nil)
+	if err != nil {
+		return errors.Wrap(err, "new DELETE request with ctx")
+	}
+	req.Header.Add("Content-Type", "application/json")
+
+	for key, val := range headers {
+		req.Header.Set(key, val)
+	}
+
+	res, err := new(http.Client).Do(req)
+	if err != nil {
+		return errors.Wrap(err, "call DELETE endpoint")
+	}
+
+	if res.StatusCode/100 != 2 {
+		if res.StatusCode == http.StatusNotFound {
+			return ErrNoExit
+		}
+
+		return errors.New("http DELETE failed", z.Int("status", res.StatusCode))
+	}
+
+	return nil
+}

--- a/app/obolapi/api_internal_test.go
+++ b/app/obolapi/api_internal_test.go
@@ -120,7 +120,6 @@ func TestHttpGet(t *testing.T) {
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.URL.Path, "/get-request")
 				require.Equal(t, r.Method, http.MethodGet)
-				require.Equal(t, r.Header.Get("Content-Type"), "application/json")
 				w.WriteHeader(http.StatusOK)
 			})),
 			expectedError: "",
@@ -132,7 +131,6 @@ func TestHttpGet(t *testing.T) {
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.URL.Path, "/get-request")
 				require.Equal(t, r.Method, http.MethodGet)
-				require.Equal(t, r.Header.Get("Content-Type"), "application/json")
 				require.Equal(t, r.Header.Get("test_header_key"), "test_header_value") //nolint:canonicalheader
 
 				w.WriteHeader(http.StatusOK)
@@ -149,7 +147,6 @@ func TestHttpGet(t *testing.T) {
 			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				require.Equal(t, r.URL.Path, "/get-request")
 				require.Equal(t, r.Method, http.MethodGet)
-				require.Equal(t, r.Header.Get("Content-Type"), "application/json")
 
 				w.WriteHeader(http.StatusBadRequest)
 				_, err := w.Write([]byte(`"Bad Request response"`))

--- a/app/obolapi/exit.go
+++ b/app/obolapi/exit.go
@@ -231,8 +231,6 @@ func (c Client) DeletePartialExit(ctx context.Context, valPubkey string, lockHas
 
 	path := deletePartialExitURL(valPubkey, "0x"+hex.EncodeToString(lockHash), shareIndex)
 
-	fmt.Println("path")
-	fmt.Println(path)
 	u, err := url.ParseRequestURI(c.baseURL)
 	if err != nil {
 		return errors.Wrap(err, "bad Obol API url")

--- a/app/obolapi/exit.go
+++ b/app/obolapi/exit.go
@@ -23,33 +23,32 @@ import (
 )
 
 const (
-	lockHashPath     = "{lock_hash}"
-	valPubkeyPath    = "{validator_pubkey}"
-	shareIndexPath   = "{share_index}"
-	fullExitBaseTmpl = "/exp/exit"
-	fullExitEndTmp   = "/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
+	lockHashPath   = "{lock_hash}"
+	valPubkeyPath  = "{validator_pubkey}"
+	shareIndexPath = "{share_index}"
 
-	partialExitTmpl = "/exp/partial_exits/" + lockHashPath
-	fullExitTmpl    = fullExitBaseTmpl + fullExitEndTmp
+	submitPartialExitTmpl = "/exp/partial_exits/" + lockHashPath
+	deletePartialExitTmpl = "/exp/partial_exits/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
+	fetchFullExitTmpl     = "/exp/exit/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
 )
 
 var ErrNoExit = errors.New("no exit for the given validator public key")
-
-// partialExitURL returns the partial exit Obol API URL for a given lock hash.
-func partialExitURL(lockHash string) string {
-	return strings.NewReplacer(
-		lockHashPath,
-		lockHash,
-	).Replace(partialExitTmpl)
-}
 
 // bearerString returns the bearer token authentication string given a token.
 func bearerString(data []byte) string {
 	return fmt.Sprintf("Bearer %#x", data)
 }
 
-// fullExitURL returns the full exit Obol API URL for a given validator public key.
-func fullExitURL(valPubkey, lockHash string, shareIndex uint64) string {
+// submitPartialExitURL returns the partial exit Obol API URL for a given lock hash.
+func submitPartialExitURL(lockHash string) string {
+	return strings.NewReplacer(
+		lockHashPath,
+		lockHash,
+	).Replace(submitPartialExitTmpl)
+}
+
+// deletePartialExitURL returns the full exit Obol API URL for a given validator public key.
+func deletePartialExitURL(valPubkey, lockHash string, shareIndex uint64) string {
 	return strings.NewReplacer(
 		valPubkeyPath,
 		valPubkey,
@@ -57,7 +56,19 @@ func fullExitURL(valPubkey, lockHash string, shareIndex uint64) string {
 		lockHash,
 		shareIndexPath,
 		strconv.FormatUint(shareIndex, 10),
-	).Replace(fullExitTmpl)
+	).Replace(deletePartialExitTmpl)
+}
+
+// fetchFullExitURL returns the full exit Obol API URL for a given validator public key.
+func fetchFullExitURL(valPubkey, lockHash string, shareIndex uint64) string {
+	return strings.NewReplacer(
+		valPubkeyPath,
+		valPubkey,
+		lockHashPath,
+		lockHash,
+		shareIndexPath,
+		strconv.FormatUint(shareIndex, 10),
+	).Replace(fetchFullExitTmpl)
 }
 
 // PostPartialExits POSTs the set of msg's to the Obol API, for a given lock hash.
@@ -65,7 +76,7 @@ func fullExitURL(valPubkey, lockHash string, shareIndex uint64) string {
 func (c Client) PostPartialExits(ctx context.Context, lockHash []byte, shareIndex uint64, identityKey *k1.PrivateKey, exitBlobs ...ExitBlob) error {
 	lockHashStr := "0x" + hex.EncodeToString(lockHash)
 
-	path := partialExitURL(lockHashStr)
+	path := submitPartialExitURL(lockHashStr)
 
 	u, err := url.ParseRequestURI(c.baseURL)
 	if err != nil {
@@ -121,7 +132,7 @@ func (c Client) GetFullExit(ctx context.Context, valPubkey string, lockHash []by
 		return ExitBlob{}, errors.Wrap(err, "validator pubkey to bytes")
 	}
 
-	path := fullExitURL(valPubkey, "0x"+hex.EncodeToString(lockHash), shareIndex)
+	path := fetchFullExitURL(valPubkey, "0x"+hex.EncodeToString(lockHash), shareIndex)
 
 	u, err := url.ParseRequestURI(c.baseURL)
 	if err != nil {
@@ -208,4 +219,51 @@ func (c Client) GetFullExit(ctx context.Context, valPubkey string, lockHash []by
 			Signature: eth2p0.BLSSignature(fullSig),
 		},
 	}, nil
+}
+
+// DeletePartialExit deletes the partial exit message for a given validator public key, lock hash and share index.
+// It respects the timeout specified in the Client instance.
+func (c Client) DeletePartialExit(ctx context.Context, valPubkey string, lockHash []byte, shareIndex uint64, identityKey *k1.PrivateKey) error {
+	valPubkeyBytes, err := from0x(valPubkey, 48) // public key is 48 bytes long
+	if err != nil {
+		return errors.Wrap(err, "validator pubkey to bytes")
+	}
+
+	path := deletePartialExitURL(valPubkey, "0x"+hex.EncodeToString(lockHash), shareIndex)
+
+	fmt.Println("path")
+	fmt.Println(path)
+	u, err := url.ParseRequestURI(c.baseURL)
+	if err != nil {
+		return errors.Wrap(err, "bad Obol API url")
+	}
+
+	u.Path = path
+
+	ctx, cancel := context.WithTimeout(ctx, c.reqTimeout)
+	defer cancel()
+
+	exitAuthData := FullExitAuthBlob{
+		LockHash:        lockHash,
+		ValidatorPubkey: valPubkeyBytes,
+		ShareIndex:      shareIndex,
+	}
+
+	exitAuthDataRoot, err := exitAuthData.HashTreeRoot()
+	if err != nil {
+		return errors.Wrap(err, "exit auth data root")
+	}
+
+	// sign the lockHash *bytes* with identity key
+	lockHashSignature, err := k1util.Sign(identityKey, exitAuthDataRoot[:])
+	if err != nil {
+		return errors.Wrap(err, "k1 sign")
+	}
+
+	err = httpDelete(ctx, u, map[string]string{"Authorization": bearerString(lockHashSignature)})
+	if err != nil {
+		return errors.Wrap(err, "http Obol API DELETE request")
+	}
+
+	return nil
 }

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -63,6 +63,7 @@ func New() *cobra.Command {
 			newSignPartialExitCmd(runSignPartialExit),
 			newBcastFullExitCmd(runBcastFullExit),
 			newFetchExitCmd(runFetchExit),
+			newDeleteExitCmd(runDeleteExit),
 		),
 		newUnsafeCmd(newRunCmd(app.Run, true)),
 	)

--- a/cmd/exit_delete.go
+++ b/cmd/exit_delete.go
@@ -118,7 +118,6 @@ func runDeleteExit(ctx context.Context, config exitConfig) error {
 
 				return errors.Wrap(err, "delete partial exits for all validators from public key")
 			}
-
 		}
 	} else {
 		validator := core.PubKey(config.ValidatorPubkey)

--- a/cmd/exit_delete.go
+++ b/cmd/exit_delete.go
@@ -1,0 +1,140 @@
+// Copyright © 2022-2025 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	libp2plog "github.com/ipfs/go-log/v2"
+	"github.com/spf13/cobra"
+
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/k1util"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/obolapi"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/keystore"
+)
+
+func newDeleteExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Command {
+	var config exitConfig
+
+	cmd := &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a signed exit message from the remote API",
+		Long:  `Deletes a partially signed exit message for a given validator from the remote API.`,
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if err := log.InitLogger(config.Log); err != nil {
+				return err
+			}
+			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+
+			printFlags(cmd.Context(), cmd.Flags())
+
+			return runFunc(cmd.Context(), config)
+		},
+	}
+
+	bindExitFlags(cmd, &config, []exitCLIFlag{
+		{publishAddress, false},
+		{privateKeyPath, false},
+		{lockFilePath, false},
+		{validatorPubkey, false},
+		{all, false},
+		{publishTimeout, false},
+		{testnetName, false},
+		{testnetForkVersion, false},
+		{testnetChainID, false},
+		{testnetGenesisTimestamp, false},
+		{testnetCapellaHardFork, false},
+	})
+
+	bindLogFlags(cmd.Flags(), &config.Log)
+
+	wrapPreRunE(cmd, func(cmd *cobra.Command, _ []string) error {
+		valPubkPresent := cmd.Flags().Lookup(validatorPubkey.String()).Changed
+
+		if !valPubkPresent && !config.All {
+			//nolint:revive,perfsprint // we use our own version of the errors package; keep consistency with other checks.
+			return errors.New(fmt.Sprintf("%s must be specified when exiting single validator.", validatorPubkey.String()))
+		}
+
+		if config.All && valPubkPresent {
+			//nolint:revive // we use our own version of the errors package.
+			return errors.New(fmt.Sprintf("%s should not be specified when %s is, as it is obsolete and misleading.", validatorPubkey.String(), all.String()))
+		}
+
+		return nil
+	})
+
+	return cmd
+}
+
+func runDeleteExit(ctx context.Context, config exitConfig) error {
+	// Check if custom testnet configuration is provided.
+	if config.testnetConfig.IsNonZero() {
+		// Add testnet config to supported networks.
+		eth2util.AddTestNetwork(config.testnetConfig)
+	}
+
+	identityKey, err := k1util.Load(config.PrivateKeyPath)
+	if err != nil {
+		return errors.Wrap(err, "load identity key", z.Str("private_key_path", config.PrivateKeyPath))
+	}
+
+	cl, err := loadClusterManifest("", config.LockFilePath)
+	if err != nil {
+		return errors.Wrap(err, "load cluster lock", z.Str("lock_file_path", config.LockFilePath))
+	}
+
+	oAPI, err := obolapi.New(config.PublishAddress, obolapi.WithTimeout(config.PublishTimeout))
+	if err != nil {
+		return errors.Wrap(err, "create Obol API client", z.Str("publish_address", config.PublishAddress))
+	}
+
+	shareIdx, err := keystore.ShareIdxForCluster(cl, *identityKey.PubKey())
+	if err != nil {
+		return errors.Wrap(err, "determine operator index from cluster lock for supplied identity key")
+	}
+
+	if config.All {
+		for _, validator := range cl.GetValidators() {
+			validatorPubKeyHex := fmt.Sprintf("0x%x", validator.GetPublicKey())
+
+			valCtx := log.WithCtx(ctx, z.Str("validator", validatorPubKeyHex))
+
+			log.Info(ctx, "Deleting partial exit message")
+
+			err := oAPI.DeletePartialExit(valCtx, validatorPubKeyHex, cl.GetInitialMutationHash(), shareIdx, identityKey)
+			if err != nil {
+				if errors.Is(err, obolapi.ErrNoExit) {
+					log.Warn(ctx, fmt.Sprintf("partial exit data from Obol API for validator %v not available (exit may not have been submitted)", validatorPubKeyHex), nil)
+					continue
+				}
+
+				return errors.Wrap(err, "delete partial exits for all validators from public key")
+			}
+
+		}
+	} else {
+		validator := core.PubKey(config.ValidatorPubkey)
+		if _, err := validator.Bytes(); err != nil {
+			return errors.Wrap(err, "convert validator pubkey to bytes", z.Str("validator_public_key", config.ValidatorPubkey))
+		}
+
+		ctx = log.WithCtx(ctx, z.Str("validator", validator.String()))
+
+		log.Info(ctx, "Deleting partial exit message")
+
+		err := oAPI.DeletePartialExit(ctx, config.ValidatorPubkey, cl.GetInitialMutationHash(), shareIdx, identityKey)
+		if err != nil {
+			return errors.Wrap(err, "delete partial exit data from Obol API", z.Str("validator_public_key", config.ValidatorPubkey))
+		}
+	}
+
+	return nil
+}

--- a/cmd/exit_delete_internal_test.go
+++ b/cmd/exit_delete_internal_test.go
@@ -37,6 +37,7 @@ func Test_runDeleteExit(t *testing.T) {
 
 func testRunDeleteExitFullFlow(t *testing.T, all bool) {
 	t.Helper()
+
 	ctx := context.Background()
 
 	valAmt := 100
@@ -84,6 +85,7 @@ func testRunDeleteExitFullFlow(t *testing.T, all bool) {
 		beaconmock.WithValidatorSet(validatorSet),
 	)
 	require.NoError(t, err)
+
 	defer func() {
 		require.NoError(t, beaconMock.Close())
 	}()
@@ -93,7 +95,9 @@ func testRunDeleteExitFullFlow(t *testing.T, all bool) {
 
 	handler, addLockFiles := obolapimock.MockServer(false, eth2Cl)
 	srv := httptest.NewServer(handler)
+
 	addLockFiles(lock)
+
 	defer srv.Close()
 
 	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)

--- a/cmd/exit_delete_internal_test.go
+++ b/cmd/exit_delete_internal_test.go
@@ -1,0 +1,177 @@
+// Copyright © 2022-2025 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/tbls"
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
+	"github.com/obolnetwork/charon/testutil/obolapimock"
+)
+
+func Test_runDeleteExit(t *testing.T) {
+	t.Parallel()
+	t.Run("full flow", func(t *testing.T) {
+		t.Parallel()
+		testRunDeleteExitFullFlow(t, false)
+	})
+	t.Run("full flow all", func(t *testing.T) {
+		t.Parallel()
+		testRunDeleteExitFullFlow(t, true)
+	})
+}
+
+func testRunDeleteExitFullFlow(t *testing.T, all bool) {
+	t.Helper()
+	ctx := context.Background()
+
+	valAmt := 100
+	operatorAmt := 4
+
+	random := rand.New(rand.NewSource(int64(0)))
+
+	lock, enrs, keyShares := cluster.NewForT(
+		t,
+		valAmt,
+		operatorAmt,
+		operatorAmt,
+		0,
+		random,
+	)
+
+	root := t.TempDir()
+
+	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
+
+	for opIdx := range operatorAmt {
+		for _, share := range keyShares {
+			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
+		}
+	}
+
+	mBytes, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	validatorSet := beaconmock.ValidatorSet{}
+
+	for idx, v := range lock.Validators {
+		validatorSet[eth2p0.ValidatorIndex(idx)] = &eth2v1.Validator{
+			Index:   eth2p0.ValidatorIndex(idx),
+			Balance: 42,
+			Status:  eth2v1.ValidatorStateActiveOngoing,
+			Validator: &eth2p0.Validator{
+				PublicKey:             eth2p0.BLSPubKey(v.PubKey),
+				WithdrawalCredentials: testutil.RandomBytes32(),
+			},
+		}
+	}
+
+	beaconMock, err := beaconmock.New(
+		beaconmock.WithValidatorSet(validatorSet),
+	)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, beaconMock.Close())
+	}()
+
+	eth2Cl, err := eth2Client(ctx, []string{}, map[string]string{}, []string{beaconMock.Address()}, 10*time.Second, [4]byte(lock.ForkVersion))
+	require.NoError(t, err)
+
+	handler, addLockFiles := obolapimock.MockServer(false, eth2Cl)
+	srv := httptest.NewServer(handler)
+	addLockFiles(lock)
+	defer srv.Close()
+
+	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, mBytes)
+
+	idx := 1
+	baseDir := filepath.Join(root, fmt.Sprintf("op%d", idx))
+
+	config := exitConfig{
+		BeaconNodeEndpoints: []string{beaconMock.Address()},
+		ValidatorPubkey:     lock.Validators[0].PublicKeyHex(),
+		PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+		ValidatorKeysDir:    filepath.Join(baseDir, "validator_keys"),
+		LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+		PublishAddress:      srv.URL,
+		ExitEpoch:           194048,
+		BeaconNodeTimeout:   30 * time.Second,
+		PublishTimeout:      10 * time.Second,
+		All:                 all,
+	}
+
+	require.NoError(t, runSignPartialExit(ctx, config), "operator index: %v", idx)
+
+	require.NoError(t, runDeleteExit(ctx, config))
+}
+
+func TestExitDeleteCLI(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectedErr string
+		flags       []string
+	}{
+		{
+			name:        "no validator public key and not all",
+			expectedErr: "validator-public-key must be specified when exiting single validator.",
+			flags: []string{
+				"--publish-address=test",
+				"--private-key-file=test",
+				"--lock-file=test",
+				"--publish-timeout=1ms",
+				"--all=false",
+				"--testnet-name=test",
+				"--testnet-fork-version=test",
+				"--testnet-chain-id=1",
+				"--testnet-genesis-timestamp=1",
+				"--testnet-capella-hard-fork=test",
+			},
+		},
+		{
+			name:        "validator public key and all",
+			expectedErr: "validator-public-key should not be specified when all is, as it is obsolete and misleading.",
+			flags: []string{
+				"--publish-address=test",
+				"--private-key-file=test",
+				"--lock-file=test",
+				"--validator-public-key=test",
+				"--publish-timeout=1ms",
+				"--all=true",
+				"--testnet-name=test",
+				"--testnet-fork-version=test",
+				"--testnet-chain-id=1",
+				"--testnet-genesis-timestamp=1",
+				"--testnet-capella-hard-fork=test",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cmd := newExitCmd(newDeleteExitCmd(runDeleteExit))
+			cmd.SetArgs(append([]string{"delete"}, test.flags...))
+
+			err := cmd.Execute()
+			if test.expectedErr != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, test.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -205,6 +205,7 @@ func (f *Fetcher) fetchAggregatorData(ctx context.Context, slot uint64, defSet c
 			pt.addNotSelected(pubkey.String())
 			continue
 		}
+
 		pt.addResolved(pubkey.String())
 
 		aggAtt, ok := aggAttByCommIdx[attDef.CommitteeIndex]
@@ -365,6 +366,7 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 			// This could happen if the beacon node didn't subscribe to the correct subnet.
 			return core.UnsignedDataSet{}, errors.New("sync committee contribution not found by root (retryable)", z.U64("subcommidx", subcommIdx), z.Hex("root", blockRoot[:]))
 		}
+
 		pt.addResolved(pubkey.String())
 
 		resp[pubkey] = core.SyncContribution{
@@ -442,6 +444,7 @@ func (pt *pubkeysTracker) log(ctx context.Context) {
 		s := strings.Join(pt.notSelectedPubKeys, ",")
 		log.Debug(ctx, pt.title+": not selected pubkeys", z.Str("pubkeys", s))
 	}
+
 	if len(pt.resolvedPubKeys) > 0 {
 		s := strings.Join(pt.resolvedPubKeys, ",")
 		log.Info(ctx, pt.title+": resolved pubkeys", z.Str("pubkeys", s))

--- a/testutil/obolapimock/obolapi_exit.go
+++ b/testutil/obolapimock/obolapi_exit.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -29,13 +30,16 @@ import (
 )
 
 const (
-	lockHashPath     = "{lock_hash}"
-	valPubkeyPath    = "{validator_pubkey}"
-	shareIndexPath   = "{share_index}"
-	fullExitBaseTmpl = "/exp/exit"
-	fullExitEndTmp   = "/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
+	lockHashPath   = "{lock_hash}"
+	valPubkeyPath  = "{validator_pubkey}"
+	shareIndexPath = "{share_index}"
 
-	partialExitTmpl = "/exp/partial_exits/" + lockHashPath
+	expPartialExits = "/exp/partial_exits"
+	expExit         = "/exp/exit"
+
+	submitPartialExitTmpl = "/" + lockHashPath
+	deletePartialExitTmpl = "/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
+	fetchFullExitTmpl     = "/" + lockHashPath + "/" + shareIndexPath + "/" + valPubkeyPath
 )
 
 type contextKey string
@@ -92,7 +96,7 @@ func (ts *testServer) addLockFiles(lock cluster.Lock) {
 	ts.lockFiles["0x"+hex.EncodeToString(lock.LockHash)] = lock
 }
 
-func (ts *testServer) HandlePartialExit(writer http.ResponseWriter, request *http.Request) {
+func (ts *testServer) HandleSubmitPartialExit(writer http.ResponseWriter, request *http.Request) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 
@@ -185,7 +189,7 @@ func (ts *testServer) HandlePartialExit(writer http.ResponseWriter, request *htt
 	writer.WriteHeader(http.StatusCreated)
 }
 
-func (ts *testServer) HandleFullExit(writer http.ResponseWriter, request *http.Request) {
+func (ts *testServer) HandleGetFullExit(writer http.ResponseWriter, request *http.Request) {
 	ts.lock.Lock()
 	defer ts.lock.Unlock()
 
@@ -282,6 +286,91 @@ func (ts *testServer) HandleFullExit(writer http.ResponseWriter, request *http.R
 	}
 }
 
+func (ts *testServer) HandleDeletePartialExit(writer http.ResponseWriter, request *http.Request) {
+	ts.lock.Lock()
+	defer ts.lock.Unlock()
+
+	authToken, ok := request.Context().Value(tokenContextKey).([]byte)
+	if !ok {
+		log.Error(request.Context(), "received context without token, that's impossible!", nil)
+		return
+	}
+
+	vars := mux.Vars(request)
+
+	valPubkey := vars[cleanTmpl(valPubkeyPath)]
+	lockHash := vars[cleanTmpl(lockHashPath)]
+	shareIndexStr := vars[cleanTmpl(shareIndexPath)]
+	shareIndex, err := strconv.ParseUint(shareIndexStr, 10, 64)
+	if err != nil {
+		writeErr(writer, http.StatusBadRequest, "malformed share index")
+		return
+	}
+
+	valPubkeyBytes, err := from0x(valPubkey, 48)
+	if err != nil {
+		writeErr(writer, http.StatusBadRequest, "invalid public key")
+		return
+	}
+
+	lockHashBytes, err := from0x(lockHash, 32)
+	if err != nil {
+		writeErr(writer, http.StatusBadRequest, "invalid lock hash")
+		return
+	}
+
+	lock, ok := ts.lockFiles[lockHash]
+	if !ok {
+		writeErr(writer, http.StatusNotFound, "lock not found")
+		return
+	}
+
+	partialExits, ok := ts.partialExits[valPubkey]
+	if !ok {
+		writeErr(writer, http.StatusNotFound, "validator not found")
+		return
+	}
+
+	// check that data has been signed with ShareIdx-th identity key
+	if shareIndex == 0 || shareIndex > uint64(len(lock.Operators)) {
+		writeErr(writer, http.StatusBadRequest, "invalid share index")
+		return
+	}
+
+	exitAuthData := obolapi.FullExitAuthBlob{
+		LockHash:        lockHashBytes,
+		ValidatorPubkey: valPubkeyBytes,
+		ShareIndex:      shareIndex,
+	}
+
+	exitAuthDataRoot, err := exitAuthData.HashTreeRoot()
+	if err != nil {
+		writeErr(writer, http.StatusInternalServerError, "cannot calculate exit auth data root")
+		return
+	}
+
+	if err := verifyIdentitySignature(lock.Operators[shareIndex-1], authToken, exitAuthDataRoot[:]); err != nil {
+		writeErr(writer, http.StatusBadRequest, "cannot verify signature: "+err.Error())
+		return
+	}
+
+	found := false
+	for idx, pExit := range partialExits {
+		if pExit.shareIdx == shareIndex {
+			partialExits = slices.Delete(partialExits, idx, idx+1)
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		writeErr(writer, http.StatusNotFound, "share index not found for validator")
+		return
+	}
+
+	ts.partialExits[valPubkey] = partialExits
+}
+
 func (ts *testServer) partialExitsMatch(newOne obolapi.ExitBlob) bool {
 	// get the last one
 	exitsLen := len(ts.partialExits[newOne.PublicKey])
@@ -331,11 +420,15 @@ func MockServer(dropOnePsig bool, beacon eth2wrap.Client) (http.Handler, func(lo
 
 	router := mux.NewRouter()
 
-	full := router.PathPrefix(fullExitBaseTmpl).Subrouter()
-	full.Use(authMiddleware)
-	full.HandleFunc(fullExitEndTmp, ts.HandleFullExit).Methods(http.MethodGet)
+	getFull := router.PathPrefix(expExit).Subrouter()
+	getFull.Use(authMiddleware)
+	getFull.HandleFunc(fetchFullExitTmpl, ts.HandleGetFullExit).Methods(http.MethodGet)
 
-	router.HandleFunc(partialExitTmpl, ts.HandlePartialExit).Methods(http.MethodPost)
+	deletePartial := router.PathPrefix(expPartialExits).Subrouter()
+	deletePartial.Use(authMiddleware)
+	deletePartial.HandleFunc(deletePartialExitTmpl, ts.HandleDeletePartialExit).Methods(http.MethodDelete)
+
+	router.HandleFunc(expPartialExits+submitPartialExitTmpl, ts.HandleSubmitPartialExit).Methods(http.MethodPost)
 
 	return router, ts.addLockFiles
 }

--- a/testutil/obolapimock/obolapi_exit.go
+++ b/testutil/obolapimock/obolapi_exit.go
@@ -301,6 +301,7 @@ func (ts *testServer) HandleDeletePartialExit(writer http.ResponseWriter, reques
 	valPubkey := vars[cleanTmpl(valPubkeyPath)]
 	lockHash := vars[cleanTmpl(lockHashPath)]
 	shareIndexStr := vars[cleanTmpl(shareIndexPath)]
+
 	shareIndex, err := strconv.ParseUint(shareIndexStr, 10, 64)
 	if err != nil {
 		writeErr(writer, http.StatusBadRequest, "malformed share index")
@@ -355,10 +356,12 @@ func (ts *testServer) HandleDeletePartialExit(writer http.ResponseWriter, reques
 	}
 
 	found := false
+
 	for idx, pExit := range partialExits {
 		if pExit.shareIdx == shareIndex {
 			partialExits = slices.Delete(partialExits, idx, idx+1)
 			found = true
+
 			break
 		}
 	}


### PR DESCRIPTION
Delete partial exits from Obol API.

N.B.: The endpoint is `/exp/exit/{lockHash}/{shareIndex}/{valPubkey}`, while it should be `/exp/partial_exits/{lockHash}/{shareIndex}/{valPubkey}`. I've talked with Launchpad to change it, but in the meantime I submit the PR as it is currently.

category: feature
ticket: #3798 

