### PR TITLE
*: use maps.Copy for cleaner map handling

### DIFF
--- a/core/consensus/qbft/transport.go
+++ b/core/consensus/qbft/transport.go
@@ -4,6 +4,7 @@ package qbft
 
 import (
 	"context"
+	"maps"
 	"sync"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -54,9 +55,7 @@ func (t *transport) setValues(msg Msg) {
 	t.valueMu.Lock()
 	defer t.valueMu.Unlock()
 
-	for k, v := range msg.Values() {
-		t.values[k] = v
-	}
+	maps.Copy(t.values, msg.Values())
 }
 
 // getValue returns the value by its hash.

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -5,6 +5,7 @@ package validatorapi
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/big"
 	"runtime"
 	"strconv"
@@ -1228,9 +1229,7 @@ func (c Component) Validators(ctx context.Context, opts *eth2api.ValidatorsOpts)
 			return nil, errors.Wrap(err, "fetching non-cached validators from BN")
 		}
 
-		for idx, val := range eth2Resp.Data {
-			ret[idx] = val
-		}
+		maps.Copy(ret, eth2Resp.Data)
 	} else {
 		log.Debug(ctx, "All validators requested were cached", z.Int("amount_requested", len(opts.PubKeys)))
 	}

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -4,6 +4,7 @@ package dkg
 
 import (
 	"context"
+	"maps"
 	"slices"
 	"sync"
 	"time"
@@ -153,9 +154,7 @@ func (e *exchanger) pushPsigs(ctx context.Context, duty core.Duty, set map[core.
 	}
 
 	ret := make(map[core.PubKey][]core.ParSignedData)
-	for k, v := range data {
-		ret[k] = v
-	}
+	maps.Copy(ret, data)
 
 	e.sigData.lock.Unlock()
 

--- a/testutil/beaconmock/server.go
+++ b/testutil/beaconmock/server.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	_ "embed"
 	"encoding/json"
+	"maps"
 	"net"
 	"net/http"
 	"os"
@@ -109,9 +110,7 @@ func newHTTPServer(addr string, optionalHandlers map[string]http.HandlerFunc, ov
 		},
 	}
 
-	for path, handler := range optionalHandlers {
-		endpoints[path] = handler
-	}
+	maps.Copy(endpoints, optionalHandlers)
 
 	r := mux.NewRouter()
 


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.



category: refactor
ticket: none
