### PR TITLE
core/tracker: trim state committees

### DIFF
--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -230,6 +230,15 @@ func (i *inclusionCore) Trim(ctx context.Context, slot uint64) {
 
 		delete(i.submissions, key)
 	}
+
+	// Trim state committees
+	for key := range i.stateCommittees {
+		if uint64(key) > slot {
+			continue
+		}
+
+		delete(i.stateCommittees, key)
+	}
 }
 
 // CheckBlock checks whether the block includes any of the submitted duties.


### PR DESCRIPTION
Under specific circumstances of attestation tracking feature flag being enabled AND block not being processed correctly (could be of multiple reasons), state committees were not cleaned up.

Include trimming of state committees alongside with submissions.

category: bug 
ticket: #3863 

