### PR TITLE
app/eth2wrap: improve fallback logic and metric

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -147,7 +147,7 @@ func TestMulti(t *testing.T) {
 
 func TestFallback(t *testing.T) {
 	returnValue := &eth2v1.PeerCount{Connected: 42}
-	closedErr := errors.New("error")
+	closedErr := errors.New("context deadline exceeded")
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
Restrict fallback beacon node calls to timeout or syncing issues instead of retrying on any error.
Prevent `usingFallback` metric flickering by setting gauge according to request response from primary beacon node.

category: refactor
ticket: #3869 
