### PR TITLE
core/tracker: fix tracker inclusion after PR clash

### DIFF
--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -231,12 +231,12 @@ func (i *inclusionCore) Trim(ctx context.Context, slot uint64) {
 	}
 
 	// Trim state committees
-	for key := range i.stateCommittees {
+	for key := range i.beaconCommittees {
 		if uint64(key) > slot {
 			continue
 		}
 
-		delete(i.stateCommittees, key)
+		delete(i.beaconCommittees, key)
 	}
 }
 


### PR DESCRIPTION
Merged #3862 and forgot to rebase. #3867 renamed one of the variables which I forgot to update in #3862.

category: bug
ticket: none

