### PR TITLE
cmd: add hostname verification

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,12 +5,12 @@ package cmd
 import (
 	"context"
 	"net/url"
-	"strings"
 	"time"
 
 	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/net/idna"
 
 	"github.com/obolnetwork/charon/app"
 	"github.com/obolnetwork/charon/app/errors"
@@ -175,8 +175,8 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
-		if _, found := strings.CutPrefix(config.ExternalHost, "--"); found {
-			return errors.New("external hostname can not start with '--'", z.Str("hostname", config.ExternalHost))
+		if _, err := idna.Lookup.ToASCII(config.ExternalHost); err != nil {
+			return errors.Wrap(err, "invalid hostname", z.Str("hostname", config.ExternalHost))
 		}
 
 		for _, relay := range config.Relays {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"context"
 	"net/url"
+	"strings"
 	"time"
 
 	libp2plog "github.com/ipfs/go-log/v2"
@@ -174,6 +175,10 @@ func bindP2PFlags(cmd *cobra.Command, config *p2p.Config) {
 	cmd.Flags().BoolVar(&config.DisableReuseport, "p2p-disable-reuseport", false, "Disables TCP port reuse for outgoing libp2p connections.")
 
 	wrapPreRunE(cmd, func(cmd *cobra.Command, args []string) error { //nolint:revive // keep args variable name for clarity
+		if _, found := strings.CutPrefix(config.ExternalHost, "--"); found {
+			return errors.New("external hostname can not start with '--'", z.Str("hostname", config.ExternalHost))
+		}
+
 		for _, relay := range config.Relays {
 			u, err := url.Parse(relay)
 			if err != nil {

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -140,6 +140,11 @@ func TestBindRunFlagsValidation(t *testing.T) {
 			Name: "valid vc tls cert and key files",
 			Args: slice("run", "--beacon-node-endpoints", "http://beacon.node", "--vc-tls-cert-file", certFile.Name(), "--vc-tls-key-file", keyFile.Name()),
 		},
+		{
+			Name: "invalid hostname",
+			Args: slice("run", "--beacon-node-endpoints", "http://beacon.node", "--p2p-external-hostname", "--p2p-tcp-address"),
+			Err:  "external hostname can not start with '--'",
+		},
 	}
 
 	for _, test := range tests {

--- a/cmd/run_internal_test.go
+++ b/cmd/run_internal_test.go
@@ -143,7 +143,7 @@ func TestBindRunFlagsValidation(t *testing.T) {
 		{
 			Name: "invalid hostname",
 			Args: slice("run", "--beacon-node-endpoints", "http://beacon.node", "--p2p-external-hostname", "--p2p-tcp-address"),
-			Err:  "external hostname can not start with '--'",
+			Err:  "invalid hostname",
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	go.uber.org/goleak v1.3.0
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.40.0
+	golang.org/x/net v0.42.0
 	golang.org/x/sync v0.16.0
 	golang.org/x/term v0.33.0
 	golang.org/x/text v0.28.0
@@ -277,7 +278,6 @@ require (
 	go.uber.org/zap/exp v0.3.0 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/mod v0.26.0 // indirect
-	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect


### PR DESCRIPTION
Add external hostname verification to prevent users from passing `--p2p-external-hostname` with empty value followed by another flag.

category: feature
ticket: none
