### PR TITLE
dkg: add zipped flag

### DIFF
--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -998,9 +998,13 @@ func TestZipping(t *testing.T) {
 	}
 
 	conf.ClusterDir = t.TempDir()
+	backupDir := t.TempDir()
 
 	var buf bytes.Buffer
 	require.NoError(t, runCreateCluster(ctx, &buf, conf))
+
+	// Backup cluster dir since bundleOutput is destructive
+	require.NoError(t, os.CopyFS(backupDir, os.DirFS(conf.ClusterDir)))
 
 	require.NoError(t, bundleOutput(conf.ClusterDir, conf.NumNodes))
 
@@ -1011,7 +1015,7 @@ func TestZipping(t *testing.T) {
 	require.NoError(t, err)
 
 	// Walk both directories and compare files
-	err = filepath.Walk(conf.ClusterDir, func(path string, info os.FileInfo, err error) error {
+	err = filepath.Walk(backupDir, func(path string, info os.FileInfo, err error) error {
 		require.NoError(t, err)
 
 		// Get the corresponding file in the unzipped directory

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -48,6 +48,7 @@ this command at the same time.`,
 	bindEth1Flag(cmd.Flags(), &config.ExecutionEngineAddr)
 
 	cmd.Flags().DurationVar(&config.Timeout, "timeout", 1*time.Minute, "Timeout for the DKG process, should be increased if DKG times out.")
+	cmd.Flags().BoolVar(&config.Zipped, "zipped", false, "Create a tar archive compressed with gzip of the target directory after creation.")
 
 	return cmd
 }


### PR DESCRIPTION
Add `zipped` flag to `charon dkg` command to create a gzip tarball file of the output files of DKG.
It will compress/archive the contents of `dataDir` into a file named `dkg.tar.gz` and delete the original files.

category: feature
ticket: none
