### PR TITLE
core/consensus: add peer name to initial QBFT log

### DIFF
--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -370,6 +370,7 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 	defer cancel()
 
 	log.Debug(ctx, "QBFT consensus instance starting",
+		z.Any("peer", p2p.PeerName(c.p2pNode.ID())),
 		z.Any("peers", c.peerLabels),
 		z.Any("timer", string(roundTimer.Type())),
 	)

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -520,6 +520,7 @@ func TestInstanceIO_MaybeStart(t *testing.T) {
 		p2pKey := testutil.GenerateInsecureK1Key(t, 0)
 		c.pubkeys = make(map[int64]*k1.PublicKey)
 		c.pubkeys[0] = p2pKey.PubKey()
+		c.p2pNode = testutil.CreateHost(t, testutil.AvailableAddr(t))
 
 		duty := core.Duty{Slot: 42, Type: 1}
 		msg := &pbv1.QBFTConsensusMsg{


### PR DESCRIPTION
Add `peer` label to initial QBFT log 

category: feature
ticket: #3919 
