### PR TITLE
dutydb: check only source and target for commidx 0

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -698,6 +698,7 @@ func RegisterConnectionLogger(ctx context.Context, p2pNode host.Host, peerIDs []
 					} else {
 						relayConnTypeGauge.WithLabelValues(peerName, cKey.Type, cKey.Protocol).Set(float64(count))
 					}
+
 					existing[peerName+":"+cKey.Type] = true
 				}
 


### PR DESCRIPTION
When we fetch attestation data with the fetcher, we are doing this in a loop, which takes variable amount of time, based on the beacon node's performance. If the beacon node is underperforming it might be that in the middle of this loop it receives a new block. This will result some attestation datas having the up to date head, while others have an old head.

In a good scenario of well performing beacon node, the heads will be the same and the `value` and `attData.Data` will be equal. However, in the scenario explained above, their head will missmatch, resulting in inequality.

That's why we are checking here only if source and target missmatch.

category: bug
ticket: none

