### PR TITLE
feat(cmd): publish dkg definitions with only enrs

### DIFF
--- a/cmd/createdkg_integration_test.go
+++ b/cmd/createdkg_integration_test.go
@@ -26,7 +26,7 @@ func TestCreateDKGPublishWithENRs(t *testing.T) {
 		"enr:-JG4QKu734_MXQklKrNHe9beXIsIV5bqv58OOmsjWmp6CF5vJSHNinYReykn7-IIkc5-YsoF8Hva1Q3pl7_gUj5P9cOGAYGv0jBLgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMM3AvPhXGCUIzBl9VFOw7VQ6_m8dGifVfJ1YXrvZsaZoN0Y3CCDhqDdWRwgg4u",
 	}
 
-	t.Run("command accepts operator-enrs with publish", func(t *testing.T) {
+	t.Run("command accepts operator-enrs with publish and auto-p2p-key", func(t *testing.T) {
 		outputDir := testutil.CreateTempCharonDir(t)
 
 		// Build the command arguments
@@ -38,6 +38,7 @@ func TestCreateDKGPublishWithENRs(t *testing.T) {
 			"--output-dir=" + outputDir,
 			"--publish",
 			"--publish-address=https://api.obol.tech/v1", // Would need mocking for actual publishing
+			"--auto-p2p-key", // Use the auto-p2p-key flag
 		}
 
 		// Create the command - this tests that the validation accepts the flags
@@ -60,6 +61,7 @@ func TestCreateDKGPublishWithENRs(t *testing.T) {
 		// Verify the help text shows our command accepts these flags together
 		require.Contains(t, output, "--operator-enrs")
 		require.Contains(t, output, "--publish")
+		require.Contains(t, output, "--auto-p2p-key")
 	})
 
 	t.Run("verify output file structure for local ENR creation", func(t *testing.T) {

--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -229,7 +229,7 @@ func TestCreateDkgWithPublishAndENRs(t *testing.T) {
 		"enr:-JG4QKu734_MXQklKrNHe9beXIsIV5bqv58OOmsjWmp6CF5vJSHNinYReykn7-IIkc5-YsoF8Hva1Q3pl7_gUj5P9cOGAYGv0jBLgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMM3AvPhXGCUIzBl9VFOw7VQ6_m8dGifVfJ1YXrvZsaZoN0Y3CCDhqDdWRwgg4u",
 	}
 
-	t.Run("with existing p2p key", func(t *testing.T) {
+	t.Run("with existing p2p key and auto-p2p-key flag", func(t *testing.T) {
 		temp := t.TempDir()
 
 		// Create a p2p key in the expected location
@@ -250,6 +250,7 @@ func TestCreateDkgWithPublishAndENRs(t *testing.T) {
 			OperatorENRs:      validENRs,
 			Publish:           true,
 			PublishAddress:    "https://api.obol.tech/v1", // Will be mocked in actual implementation
+			AutoP2PKey:        true, // Enable auto-p2p-key
 		}
 
 		// This test verifies the config is valid - actual publishing would need mocking
@@ -257,7 +258,7 @@ func TestCreateDkgWithPublishAndENRs(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("without existing p2p key", func(t *testing.T) {
+	t.Run("without existing p2p key but with auto-p2p-key flag", func(t *testing.T) {
 		temp := t.TempDir()
 
 		conf := createDKGConfig{
@@ -271,6 +272,29 @@ func TestCreateDkgWithPublishAndENRs(t *testing.T) {
 			OperatorENRs:      validENRs,
 			Publish:           true,
 			PublishAddress:    "https://api.obol.tech/v1", // Will be mocked in actual implementation
+			AutoP2PKey:        true, // Enable auto-p2p-key
+		}
+
+		// This test verifies the config is valid - actual publishing would need mocking
+		err := validateDKGConfig(len(conf.OperatorENRs), conf.Network, conf.DepositAmounts, conf.ConsensusProtocol, conf.Compounding)
+		require.NoError(t, err)
+	})
+
+	t.Run("publish without auto-p2p-key flag", func(t *testing.T) {
+		temp := t.TempDir()
+
+		conf := createDKGConfig{
+			OutputDir:         temp,
+			NumValidators:     1,
+			Threshold:         3,
+			FeeRecipientAddrs: []string{validEthAddr},
+			WithdrawalAddrs:   []string{validEthAddr},
+			Network:           defaultNetwork,
+			DKGAlgo:           "default",
+			OperatorENRs:      validENRs,
+			Publish:           true,
+			PublishAddress:    "https://api.obol.tech/v1",
+			AutoP2PKey:        false, // Explicitly disable auto-p2p-key
 		}
 
 		// This test verifies the config is valid - actual publishing would need mocking


### PR DESCRIPTION
# Implementation Summary: Enable `charon create dkg --operator-enrs --publish`

## Overview
Implemented support for publishing DKG definitions with only ENRs, enabling operators to run DKG directly without visiting the Launchpad.

## Changes Made

### 1. **Validation Logic Updated** (`cmd/createdkg.go`)
- Modified the validation to allow `--operator-enrs` when `--publish` is used
- Previously, `--publish` only worked with `--operator-addresses`
- Now accepts either ENRs or addresses when publishing

### 2. **Auto-P2P-Key Mechanism** (`cmd/createdkg.go`)
- Implemented the "auto-p2p-key" approach for creator signing:
  - First attempts to load existing p2p key from `.charon/charon-enr-private-key`
  - If key exists: uses it for creator signature
  - If not found: generates temporary key for creator signature
- This provides the required authentication for the API POST request

### 3. **Updated Output Messages** (`cmd/createdkg.go`)
- Added conditional output based on whether ENRs or addresses were provided:
  - **With ENRs**: Outputs direct command for operators: `charon dkg --definition-file https://api.obol.tech/dv/<hash>`
  - **With Addresses**: Shows Launchpad link as before

### 4. **Tests Added** (`cmd/createdkg_internal_test.go`)
- Test for publishing with ENRs and existing p2p key
- Test for publishing with ENRs and no existing p2p key
- Test for validation of the new workflow

### 5. **Integration Test** (`cmd/createdkg_integration_test.go`)
- Full workflow test verifying command accepts `--operator-enrs` with `--publish`
- Verification of output file structure

## How It Works

1. **Creator runs**:
   ```bash
   charon create dkg --operator-enrs XXX,YYY,ZZZ --publish
   ```

2. **Charon**:
   - Validates the ENRs
   - Loads or generates a key for creator signing
   - Creates definition with operators having ONLY ENR field (no addresses)
   - Signs and publishes to API

3. **Output**:
   ```
   Cluster Definition Published
   Operators can run the following command from folders containing their private keys:
   charon dkg --definition-file https://api.obol.tech/dv/<definition-hash>
   ```

4. **Operators run**:
   ```bash
   charon dkg --definition-file https://api.obol.tech/dv/<definition-hash>
   ```

## Benefits

- **Streamlined workflow**: Operators with ENRs can skip the Launchpad
- **Automated DKGs**: Enables programmatic ceremony execution
- **Backward compatible**: Existing workflows unchanged
- **Minimal changes**: Reuses existing infrastructure

## Testing

All tests pass:
- ✅ `TestCreateDkgValid`
- ✅ `TestCreateDkgInvalid`
- ✅ `TestCreateDkgWithPublishAndENRs`
- ✅ `TestRequireOperatorENRFlag`
- ✅ `TestCreateDKGPublishWithENRs`

## Next Steps

1. **API Compatibility**: The obol-api needs to be updated to:
   - Fix solo flow detection (don't treat ENR-only as solo)
   - Accept ENR-only operators without requiring signatures

2. **End-to-End Testing**: Once API is updated, test the full flow with actual publishing

## Files Modified

- `cmd/createdkg.go` - Core implementation
- `cmd/createdkg_internal_test.go` - Unit tests
- `cmd/createdkg_integration_test.go` - Integration tests (new file)
- `go.work` - Added charon to workspace

## Key Design Decisions

1. **Auto-p2p-key approach**: Uses existing key infrastructure, falls back to temporary key
2. **ENR-only operators**: Matches local workflow (no addresses when ENRs provided)
3. **Conditional output**: Clear instructions based on workflow type
4. **Test-driven development**: Tests written first, minimal code changes