### PR TITLE
*: attestations data fetch only committee index 0

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -553,7 +553,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 
 	electraSlot := eth2p0.Slot(uint64(forkSchedule[eth2wrap.Electra].Epoch) * slotsPerEpoch)
 
-	fetch, err := fetcher.New(eth2Cl, feeRecipientFunc, conf.BuilderAPI, graffitiBuilder, electraSlot)
+	fetch, err := fetcher.New(eth2Cl, feeRecipientFunc, conf.BuilderAPI, graffitiBuilder, electraSlot, featureset.Enabled(featureset.FetchOnlyCommIdx0))
 	if err != nil {
 		return err
 	}

--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -63,6 +63,9 @@ const (
 
 	// QUIC enables the QUIC transport protocol in libp2p.
 	QUIC = "quic"
+
+	// FetchOnlyCommIdx0 enables querying the beacon node for attestation data only for committee index 0.
+	FetchOnlyCommIdx0 = "fetch_only_commidx_0"
 )
 
 var (
@@ -79,6 +82,7 @@ var (
 		AttestationInclusion: statusAlpha,
 		ProposalTimeout:      statusAlpha,
 		QUIC:                 statusAlpha,
+		FetchOnlyCommIdx0:    statusAlpha,
 		// Add all features and there status here.
 	}
 

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -553,7 +553,7 @@ func TestFetchSyncContribution(t *testing.T) {
 func mustCreateFetcher(t *testing.T, bmock beaconmock.Mock) *fetcher.Fetcher {
 	t.Helper()
 
-	fetch, err := fetcher.New(bmock, nil, true, &fetcher.GraffitiBuilder{}, 5)
+	fetch, err := fetcher.New(bmock, nil, true, &fetcher.GraffitiBuilder{}, 5, false)
 	require.NoError(t, err)
 
 	return fetch
@@ -564,7 +564,7 @@ func mustCreateFetcherWithAddressAndGraffiti(t *testing.T, bmock beaconmock.Mock
 
 	fetch, err := fetcher.New(bmock, func(core.PubKey) string {
 		return addr
-	}, true, graffitiBuilder, 5)
+	}, true, graffitiBuilder, 5, false)
 	require.NoError(t, err)
 
 	return fetch


### PR DESCRIPTION
Add feature flag to query the BN only for committee index 0 on attestation data request.

Charon nodes with VC versions greater or equal to the ones mentioned in the issue here can add it to reduce load to their BNs and potentially improve their cluster performance.

category: feature
ticket: #3980 
feature_flag: fetch_only_commidx_0
