### PR TITLE
docs: fix some a/an issues

### DIFF
--- a/app/eth2wrap/eth2wrap_test.go
+++ b/app/eth2wrap/eth2wrap_test.go
@@ -414,7 +414,7 @@ func TestOneError(t *testing.T) {
 func TestOneTimeout(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	// Start an timeout server.
+	// Start a timeout server.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		<-ctx.Done()
 	}))

--- a/tbls/tbls.go
+++ b/tbls/tbls.go
@@ -29,7 +29,7 @@ type Implementation interface {
 	// GenerateSecretKey generates a secret key and returns its compressed serialized representation.
 	GenerateSecretKey() (PrivateKey, error)
 
-	// GenerateInsecureKey generates a insecure deterministic secret key using the provided random number generator
+	// GenerateInsecureKey generates an insecure deterministic secret key using the provided random number generator
 	// and returns its compressed serialized representation.
 	GenerateInsecureKey(t *testing.T, random io.Reader) (PrivateKey, error)
 
@@ -81,7 +81,7 @@ func GenerateSecretKey() (PrivateKey, error) {
 	return impl.GenerateSecretKey()
 }
 
-// GenerateInsecureKey generates a insecure deterministic secret key using the provided random number generator
+// GenerateInsecureKey generates an insecure deterministic secret key using the provided random number generator
 // and returns its compressed serialized representation.
 func GenerateInsecureKey(t *testing.T, random io.Reader) (PrivateKey, error) {
 	t.Helper()

--- a/testutil/obolapimock/obolapi_exit.go
+++ b/testutil/obolapimock/obolapi_exit.go
@@ -410,7 +410,7 @@ func cleanTmpl(tmpl string) string {
 		"").Replace(tmpl)
 }
 
-// MockServer returns a Obol API mock test server.
+// MockServer returns an Obol API mock test server.
 // It returns a http.Handler to be served over HTTP, and a function to add cluster lock files to its database.
 func MockServer(dropOnePsig bool, beacon eth2wrap.Client) (http.Handler, func(lock cluster.Lock)) {
 	ts := testServer{


### PR DESCRIPTION
Fix typos in `app/eth2wrap/eth2wrap_test.go`, `tbls/tbls.go`, `testutil/obolapimock/obolapi_exit.go` and improves language.

category: docs
ticket: none