### PR TITLE
qbft: move chain split check to preprepare round

### DIFF
--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -724,6 +724,9 @@ func TestDuplicatePrePreparesRules(t *testing.T) {
 
 		require.Fail(t, "unexpected round", "round=%d", round)
 	}
+	def.Compare = func(ctx context.Context, qcommit Msg[int64, int64, int64], inputValueSourceCh <-chan int64, inputValueSource int64, returnErr chan error, returnValue chan int64) {
+		returnErr <- nil
+	}
 
 	rChan := make(chan Msg[int64, int64, int64], 2)
 	rChan <- newPreprepare(1)


### PR DESCRIPTION
It's safer to do the chain split check in the pre-prepare round.

WIP: still testing

category: feature
ticket: none
feature_flag: chain_split_halt
