### PR TITLE
app/sse: fix bucket delay values

### DIFF
--- a/app/sse/listener.go
+++ b/app/sse/listener.go
@@ -214,7 +214,7 @@ func (p *listener) handleBlockGossipEvent(ctx context.Context, event *event, add
 		z.Str("delay", delay.String()),
 		z.Str("block", blockGossip.Block))
 
-	sseBlockGossipHistogram.WithLabelValues(addr).Observe(float64(delay))
+	sseBlockGossipHistogram.WithLabelValues(addr).Observe(delay.Seconds())
 
 	return nil
 }
@@ -245,7 +245,7 @@ func (p *listener) handleBlockEvent(ctx context.Context, event *event, addr stri
 		z.Str("delay", delay.String()),
 		z.Str("block", block.Block))
 
-	sseBlockHistogram.WithLabelValues(addr).Observe(float64(delay))
+	sseBlockHistogram.WithLabelValues(addr).Observe(delay.Seconds())
 
 	return nil
 }


### PR DESCRIPTION
Delay event values were being passed as `float64(delay)` instead of `delay.Seconds()` which causes Prometheus to store them incorrectly.

category: bug 
ticket: none

