### PR TITLE
cmd: use WaitGroup.Go to simplify code

### DIFF
--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -484,12 +484,10 @@ func beaconPingLoadTest(ctx context.Context, conf *testBeaconConfig, target stri
 	for pingCtx.Err() == nil {
 		select {
 		case <-ticker.C:
-			wg.Add(1)
 
-			go func() {
+			wg.Go(func() {
 				pingBeaconContinuously(pingCtx, target, testResCh)
-				wg.Done()
-			}()
+			})
 		case <-pingCtx.Done():
 		}
 	}

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -451,12 +451,10 @@ func peerPingLoadTest(ctx context.Context, conf *testPeersConfig, p2pNode host.H
 	for pingCtx.Err() == nil {
 		select {
 		case <-ticker.C:
-			wg.Add(1)
 
-			go func() {
+			wg.Go(func() {
 				pingPeerContinuously(pingCtx, p2pNode, peer, testResCh)
-				wg.Done()
-			}()
+			})
 		case <-pingCtx.Done():
 		}
 	}

--- a/cmd/testvalidator.go
+++ b/cmd/testvalidator.go
@@ -245,12 +245,10 @@ func validatorPingLoadTest(ctx context.Context, conf *testValidatorConfig) testR
 	for pingCtx.Err() == nil {
 		select {
 		case <-ticker.C:
-			wg.Add(1)
 
-			go func() {
+			wg.Go(func() {
 				pingValidatorContinuously(pingCtx, conf.APIAddress, testResCh)
-				wg.Done()
-			}()
+			})
 		case <-pingCtx.Done():
 		}
 	}


### PR DESCRIPTION
use WaitGroup.Go to simplify code. More info: https://github.com/golang/go/issues/63796

category: refactor
ticket: none

