### PR TITLE
*: replace sort.Slice with slices.Sort for natural ordering

### DIFF
--- a/cmd/testbeacon.go
+++ b/cmd/testbeacon.go
@@ -14,7 +14,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -1829,9 +1828,7 @@ func generateSimulationValues(s []time.Duration, endpoint string) SimulationValu
 
 	sorted := make([]time.Duration, len(s))
 	copy(sorted, s)
-	sort.Slice(sorted, func(i, j int) bool {
-		return sorted[i] < sorted[j]
-	})
+	slices.Sort(sorted)
 	minVal := sorted[0]
 	maxVal := sorted[len(s)-1]
 	medianVal := sorted[len(s)/2]

--- a/core/consensus/qbft/strategysim_internal_test.go
+++ b/core/consensus/qbft/strategysim_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"math/rand"
 	"os"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -759,9 +760,7 @@ func quorumDecidedDuration(results []result) time.Duration {
 		panic("not enough durations")
 	}
 
-	sort.Slice(durations, func(i, j int) bool {
-		return durations[i] < durations[j]
-	})
+	slices.Sort(durations)
 
 	return durations[q-1]
 }

--- a/testutil/beaconmock/options.go
+++ b/testutil/beaconmock/options.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"net/http"
 	"slices"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -368,9 +367,7 @@ func WithDeterministicProposerDuties(factor int) Option {
 
 			valIdxs := vals.Indices()
 
-			sort.Slice(valIdxs, func(i, j int) bool {
-				return valIdxs[i] < valIdxs[j]
-			})
+			slices.Sort(valIdxs)
 
 			slotsPerEpoch, err := mock.SlotsPerEpoch(ctx)
 			if err != nil {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/slices#Sort) added in the go1.21 standard library, which can make the code more concise and easy to read.

category: refactor
ticket: none
