### PR TITLE
app: skip warn for unknown git hash

### DIFF
--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -218,8 +218,8 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			p.nicknamesMu.Unlock()
 
 			// Validator git hash with regex.
-			if !gitHashMatch.MatchString(resp.GetGitHash()) {
-				log.Warn(ctx, "Invalid peer git hash", nil, z.Str("peer", name))
+			if !gitHashMatch.MatchString(resp.GetGitHash()) && resp.GetGitHash() != version.Unknown {
+				log.Warn(ctx, "Invalid peer git hash", nil, z.Str("peer", name), z.Str("peer_git_hash", resp.GetGitHash()))
 				return
 			}
 

--- a/app/version/version.go
+++ b/app/version/version.go
@@ -28,6 +28,10 @@ var (
 	vcsTime     = ""
 )
 
+const (
+	Unknown = "unknown"
+)
+
 // Supported returns the supported minor versions in order of precedence.
 func Supported() []SemVer {
 	return []SemVer{
@@ -49,7 +53,7 @@ func GitCommit() (hash string, timestamp string) {
 		return vcsRevision, vcsTime
 	}
 
-	hash, timestamp = "unknown", "unknown"
+	hash, timestamp = Unknown, Unknown
 	hashLen := 7
 
 	info, ok := debug.ReadBuildInfo()


### PR DESCRIPTION
Improved behavior for older builds having `unknown` git hash:
- to not warn aggressively, we can still show `unknown` in grafana 
- to not break metric submission flow

category: bug
ticket: #4001