### PR TITLE
eth2util/rlp: fixed wrong condition

### DIFF
--- a/eth2util/rlp/rlp.go
+++ b/eth2util/rlp/rlp.go
@@ -168,7 +168,7 @@ func toBigEndian(i int) []byte {
 
 // fromBigEndian returns the integer encoded as big endian at the provided byte slice offset and length.
 func fromBigEndian(b []byte, offset int, length int) (int, error) {
-	if offset >= len(b) || offset+length >= len(b) {
+	if offset >= len(b) || offset+length > len(b) {
 		return 0, errors.New("input too short")
 	}
 


### PR DESCRIPTION
Fixed wrong condition in https://github.com/ObolNetwork/charon/blob/552b290f6cf595bca2aca542feaf010b1f0c4c09/eth2util/rlp/rlp.go#L170

category: bug
ticket: none
