### PR TITLE
cluster: fix incorrect function name in comment

### DIFF
--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -211,7 +211,7 @@ func TestDefinitionVerify(t *testing.T) {
 	})
 }
 
-// randomOperator returns a random ETH1 private key and populated creator struct (excluding config signature).
+// randomCreator returns a random ETH1 private key and populated creator struct (excluding config signature).
 func randomCreator(t *testing.T) (*k1.PrivateKey, Creator) {
 	t.Helper()
 


### PR DESCRIPTION
fix incorrect function name in comment

category: docs 
ticket: none

