### PR TITLE
*: tag-minor-release-candidate gh action

### DIFF
--- a/.github/workflows/tag-minor-release-candidate.yml
+++ b/.github/workflows/tag-minor-release-candidate.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: 1. Checkout Repository
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0 # Required to get all tags and branches
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
           git fetch --all
 
           # Find all minor release branches matching pattern main-vX.Y
-          RELEASE_BRANCHES=$(git branch -r | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
+          RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
 
           if [[ -z "$RELEASE_BRANCHES" ]]; then
             echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
@@ -116,7 +116,7 @@ jobs:
           ### Next Steps
           1. The docker image will be automatically built with tag \`${{ steps.latest_rc.outputs.NEW_TAG }}\`
           2. Test the release candidate thoroughly (Kurtosis, Hoodi environments, etc.)
-          3. If successful, proceed with "Tag Minor Full Release" workflow
+          3. If successful, proceed with "Prepare Minor Full Release" workflow
           4. If fixes needed:
              - Merge fixes to \`main\` branch
              - Cherry-pick fixes to \`${{ steps.find_branch.outputs.RELEASE_BRANCH }}\`


### PR DESCRIPTION
Introduces `tag-minor-release-candidate.yml` GH action.
This action finds the latest release branch (ideally, created from `bump-minor-version.yml` #4084) such as `main-vX.Y`, creates a version prefix `vX.Y.0`, finds the latest release candidate for this version such as `vX.Y.0-rcZ` and creates/pushes a new release candidate tag `vX.Y.0-rc(Z+1)`.

category: misc
ticket: #3933
