### PR TITLE
*: handing 409 for obol api post

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,3 +159,4 @@ changelog.md
 .claude/
 .charon**
 .anthropic/
+.serena/

--- a/app/obolapi/api.go
+++ b/app/obolapi/api.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 )
@@ -106,7 +107,11 @@ func httpPost(ctx context.Context, url *url.URL, body []byte, headers map[string
 			return errors.Wrap(err, "read POST response", z.Int("status", res.StatusCode))
 		}
 
-		return errors.New("http POST failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
+		if res.StatusCode != http.StatusConflict {
+			return errors.New("http POST failed", z.Int("status", res.StatusCode), z.Str("body", string(data)))
+		}
+
+		log.Info(ctx, "Duplicate request ignored by Obol API. Likely another node submitted the same data already.", z.Int("status", res.StatusCode), z.Str("body", string(data)))
 	}
 
 	return nil

--- a/app/obolapi/api_internal_test.go
+++ b/app/obolapi/api_internal_test.go
@@ -89,6 +89,22 @@ func TestHttpPost(t *testing.T) {
 			})),
 			expectedError: "POST failed",
 		},
+		{
+			name:     "status code 409 Conflict (duplicate ignored)",
+			body:     nil,
+			headers:  nil,
+			endpoint: "/post-request",
+			server: httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.Equal(t, r.URL.Path, "/post-request")
+				require.Equal(t, r.Method, http.MethodPost)
+				require.Equal(t, r.Header.Get("Content-Type"), "application/json")
+
+				w.WriteHeader(http.StatusConflict)
+				_, err := w.Write([]byte(`"Duplicate request"`))
+				require.NoError(t, err)
+			})),
+			expectedError: "",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Handling 409 status code for Obol API's HTTP POST requests, e.g. when DKG is publishing the lock file.

category: refactor
ticket: #4107 