### PR TITLE
core: fix incorrect struct name in comment

### DIFF
--- a/core/deadline.go
+++ b/core/deadline.go
@@ -39,7 +39,7 @@ type Deadliner interface {
 	C() <-chan Duty
 }
 
-// deadlinerInput represents the input to inputChan.
+// deadlineInput represents the input to inputChan.
 type deadlineInput struct {
 	duty    Duty
 	success chan<- bool


### PR DESCRIPTION
 fix incorrect struct name in comment

category: docs
ticket: none

