### PR TITLE
*: add check-latest to setup-go

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -12,7 +12,7 @@ runs:
       id: setup-go
       uses: actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c # v6
       with:
-        check-lastest: true
+        check-latest: true
         go-version: "1.25"
 
     - name: Verify setup


### PR DESCRIPTION
Fix `govulncheck` errors by adding `check-latest` to `setup-go`.

category: misc
ticket: none
