### PR TITLE
core/fetcher: update blinded gauge metric values

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -305,10 +305,10 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot uint64, defSet cor
 			return nil, errors.Wrap(err, "new proposal")
 		}
 
-		// Track whether the fetched proposal is blinded (built by MEV builder, 2) or local (built by beacon node, 1)
-		blinded := 1.0
+		// Track whether the fetched proposal is blinded (built by MEV builder, 1) or local (built by beacon node, 2)
+		blinded := 2.0
 		if proposal.Blinded {
-			blinded = 2.0
+			blinded = 1.0
 		}
 
 		proposalBlindedGauge.Set(blinded)

--- a/core/fetcher/metrics.go
+++ b/core/fetcher/metrics.go
@@ -12,5 +12,5 @@ var proposalBlindedGauge = promauto.NewGauge(prometheus.GaugeOpts{
 	Namespace: "core",
 	Subsystem: "fetcher",
 	Name:      "proposal_blinded",
-	Help:      "Whether the fetched proposal was blinded (2) or local (1)",
+	Help:      "Whether the fetched proposal was blinded (1) or local (2)",
 })

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,7 +54,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `core_consensus_duration_seconds` | Histogram | Duration of the consensus process by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_consensus_error_total` | Counter | Total count of consensus errors by protocol | `protocol` |
 | `core_consensus_timeout_total` | Counter | Total count of consensus timeouts by protocol, duty, and timer | `protocol, duty, timer` |
-| `core_fetcher_proposal_blinded` | Gauge | Whether the fetched proposal was blinded (2) or local (1) |  |
+| `core_fetcher_proposal_blinded` | Gauge | Whether the fetched proposal was blinded (1) or local (2) |  |
 | `core_parsigdb_exit_total` | Counter | Total number of partially signed voluntary exits per public key | `pubkey` |
 | `core_scheduler_current_epoch` | Gauge | The current epoch |  |
 | `core_scheduler_current_slot` | Gauge | The current slot |  |


### PR DESCRIPTION
Previously `core_fetcher_proposal_blinded` had values 0 (local) or 1 (blinded). This is problematic because the default value for the gauge is also zero so when a node starts/restarts it reports a 0 value before fetching any block which makes monitoring more complicated.

This updates the values to be 2 (local) and 1 (blinded)

category: bug
ticket: none
