### PR TITLE
github: remove annotation from tagging in pipelines

### DIFF
--- a/.github/workflows/tag-minor-full-release.yml
+++ b/.github/workflows/tag-minor-full-release.yml
@@ -130,7 +130,7 @@ jobs:
           TAG_VERSION="${{ steps.version.outputs.TAG_VERSION }}"
           RELEASE_BRANCH="${{ steps.find_branch.outputs.RELEASE_BRANCH }}"
 
-          # Create annotated tag
+          # Create tag
           git tag "${TAG_VERSION}" -m "Release ${TAG_VERSION}"
 
           # Push tag to remote

--- a/.github/workflows/tag-minor-release-candidate.yml
+++ b/.github/workflows/tag-minor-release-candidate.yml
@@ -108,7 +108,7 @@ jobs:
         run: |
           NEW_TAG="${{ steps.latest_rc.outputs.NEW_TAG }}"
 
-          # Create annotated tag
+          # Create tag
           git tag "$NEW_TAG" -m "Release candidate $NEW_TAG"
 
           # Push tag

--- a/.github/workflows/tag-patch-full-release.yml
+++ b/.github/workflows/tag-patch-full-release.yml
@@ -162,7 +162,7 @@ jobs:
           TAG_VERSION="${{ steps.find_patch.outputs.TAG_VERSION }}"
           RELEASE_BRANCH="${{ steps.find_branch.outputs.RELEASE_BRANCH }}"
 
-          # Create annotated tag
+          # Create tag
           git tag "${TAG_VERSION}" -m "Release ${TAG_VERSION}"
 
           # Push tag to remote

--- a/.github/workflows/tag-patch-release-candidate.yml
+++ b/.github/workflows/tag-patch-release-candidate.yml
@@ -141,7 +141,7 @@ jobs:
         run: |
           NEW_TAG="${{ steps.latest_rc.outputs.NEW_TAG }}"
 
-          # Create annotated tag
+          # Create tag
           git tag "$NEW_TAG" -m "Release candidate $NEW_TAG"
 
           # Push tag


### PR DESCRIPTION
If tags are annotated the other pipelines are running the flow for a branch and not a tag. Hence, they are not creating a `v.X.Y.Z` image, but are reading the tag from the `version.go`.

category: bug
ticket: none
