### PR TITLE
chore: update copyright year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -11,7 +11,7 @@ Licensor:             Obol GmbH.
 
 Licensed Work:        Charon, the Distributed Validator Client.
                       The Licensed Work is
-                      © 2022-2025 Obol Labs, Inc.
+                      © 2022-2026 Obol Labs, Inc.
 
 Additional Use Grant: Any uses listed and defined at
                       charon-additional-use-grants.obol.eth.


### PR DESCRIPTION
## Summary
Updated copyright year in LICENSE file(s).

**Before:** 2025
**After:** 2026

Routine maintenance to keep copyright notices up to date.