### PR TITLE
core: reset vc agent gauge

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -398,6 +398,7 @@ func wrap(endpoint string, handler handlerFunc, encodings []contentType) http.Ha
 
 		userAgent := r.Header.Get("User-Agent")
 		if userAgent != "" {
+			vcUserAgentGauge.Reset()
 			vcUserAgentGauge.WithLabelValues(userAgent).Set(1)
 		}
 


### PR DESCRIPTION
Just resetting vc agent gauge to not report multiple versions.

category: bug
ticket: #4198
