### PR TITLE
*: edit commands publishing lock

### DIFF
--- a/cmd/edit_addoperators.go
+++ b/cmd/edit_addoperators.go
@@ -56,6 +56,7 @@ func newAddOperatorsCmd(runFunc func(context.Context, dkg.AddOperatorsConfig, dk
 	bindLogFlags(cmd.Flags(), &dkgConfig.Log)
 	bindEth1Flag(cmd.Flags(), &dkgConfig.ExecutionEngineAddr)
 	bindShutdownDelayFlag(cmd.Flags(), &dkgConfig.ShutdownDelay)
+	bindPublishFlags(cmd.Flags(), &dkgConfig)
 
 	return cmd
 }

--- a/cmd/edit_addvalidators.go
+++ b/cmd/edit_addvalidators.go
@@ -77,6 +77,7 @@ func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) erro
 	bindLogFlags(cmd.Flags(), &config.DKG.Log)
 	bindShutdownDelayFlag(cmd.Flags(), &config.DKG.ShutdownDelay)
 	bindEth1Flag(cmd.Flags(), &config.DKG.ExecutionEngineAddr)
+	bindPublishFlags(cmd.Flags(), &config.DKG)
 	cmd.Flags().DurationVar(&config.DKG.Timeout, "timeout", 1*time.Minute, "Timeout for the command, should be increased if the command times out.")
 
 	// Bind `create dkg` flags.

--- a/cmd/edit_recreateprivatekeys.go
+++ b/cmd/edit_recreateprivatekeys.go
@@ -47,6 +47,7 @@ func newRecreatePrivateKeysCmd(runFunc func(context.Context, dkg.ReshareConfig) 
 	bindLogFlags(cmd.Flags(), &config.DKGConfig.Log)
 	bindEth1Flag(cmd.Flags(), &config.DKGConfig.ExecutionEngineAddr)
 	bindShutdownDelayFlag(cmd.Flags(), &config.DKGConfig.ShutdownDelay)
+	bindPublishFlags(cmd.Flags(), &config.DKGConfig)
 
 	return cmd
 }

--- a/cmd/edit_removeoperators.go
+++ b/cmd/edit_removeoperators.go
@@ -54,6 +54,7 @@ func newRemoveOperatorsCmd(runFunc func(context.Context, dkg.RemoveOperatorsConf
 	bindLogFlags(cmd.Flags(), &dkgConfig.Log)
 	bindEth1Flag(cmd.Flags(), &dkgConfig.ExecutionEngineAddr)
 	bindShutdownDelayFlag(cmd.Flags(), &dkgConfig.ShutdownDelay)
+	bindPublishFlags(cmd.Flags(), &dkgConfig)
 
 	return cmd
 }

--- a/cmd/edit_replaceoperator.go
+++ b/cmd/edit_replaceoperator.go
@@ -55,6 +55,7 @@ func newReplaceOperatorCmd(runFunc func(context.Context, dkg.ReplaceOperatorConf
 	bindLogFlags(cmd.Flags(), &dkgConfig.Log)
 	bindEth1Flag(cmd.Flags(), &dkgConfig.ExecutionEngineAddr)
 	bindShutdownDelayFlag(cmd.Flags(), &dkgConfig.ShutdownDelay)
+	bindPublishFlags(cmd.Flags(), &dkgConfig)
 
 	return cmd
 }

--- a/dkg/protocolsteps.go
+++ b/dkg/protocolsteps.go
@@ -187,6 +187,14 @@ func (s *writeArtifactsProtocolStep) Run(ctx context.Context, pctx *ProtocolCont
 
 	log.Info(ctx, "Stored artifacts", z.Str("output_dir", s.outputDir))
 
+	if pctx.Config.Publish {
+		if _, err := writeLockToAPI(ctx, pctx.Config.PublishAddr, *pctx.Lock, pctx.Config.PublishTimeout); err != nil {
+			return errors.Wrap(err, "publish lock to API")
+		}
+
+		log.Info(ctx, "The new cluster lock has been published to Obol API")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
All edit commands to support `--publish` flags same as `dkg` does.

category: feature
ticket: #4234
