### PR TITLE
cmd: create dkg with testnet

### DIFF
--- a/cmd/createdkg_internal_test.go
+++ b/cmd/createdkg_internal_test.go
@@ -198,23 +198,23 @@ func TestValidateWithdrawalAddr(t *testing.T) {
 func TestValidateDKGConfig(t *testing.T) {
 	t.Run("insufficient ENRs", func(t *testing.T) {
 		numOperators := 2
-		err := validateDKGConfig(numOperators, "", nil, "", false)
+		err := validateDKGConfig(numOperators, "", eth2util.Network{}, nil, "", false)
 		require.ErrorContains(t, err, "number of operators is below minimum")
 	})
 
 	t.Run("invalid network", func(t *testing.T) {
 		numOperators := 4
-		err := validateDKGConfig(numOperators, "cosmos", nil, "", false)
+		err := validateDKGConfig(numOperators, "cosmos", eth2util.Network{}, nil, "", false)
 		require.ErrorContains(t, err, "unsupported network")
 	})
 
 	t.Run("wrong deposit amounts sum", func(t *testing.T) {
-		err := validateDKGConfig(4, "goerli", []int{8, 16}, "", false)
+		err := validateDKGConfig(4, "goerli", eth2util.Network{}, []int{8, 16}, "", false)
 		require.ErrorContains(t, err, "sum of partial deposit amounts must be at least 32ETH, repetition is allowed")
 	})
 
 	t.Run("unsupported consensus protocol", func(t *testing.T) {
-		err := validateDKGConfig(4, "goerli", nil, "unreal", false)
+		err := validateDKGConfig(4, "goerli", eth2util.Network{}, nil, "unreal", false)
 		require.ErrorContains(t, err, "unsupported consensus protocol")
 	})
 }


### PR DESCRIPTION
`charon create dkg` supporting testnet flags same as `charon create cluster` does.
Also, set default network to `mainnet` for `charon create cluster` for consistency with dkg.

category: feature
ticket: #4052
