### PR TITLE
dkg: nodesigs peer idx check

### DIFF
--- a/dkg/nodesigs.go
+++ b/dkg/nodesigs.go
@@ -118,7 +118,7 @@ func (n *nodeSigBcast) setSig(sig []byte, slot int) {
 }
 
 // broadcastCallback is the default bcast.Callback for nodeSigBcast.
-func (n *nodeSigBcast) broadcastCallback(ctx context.Context, _ peer.ID, _ string, msg proto.Message) error {
+func (n *nodeSigBcast) broadcastCallback(ctx context.Context, senderID peer.ID, _ string, msg proto.Message) error {
 	nodeSig, ok := msg.(*dkgpb.MsgNodeSig)
 	if !ok {
 		return errors.New("invalid node sig type")
@@ -136,6 +136,11 @@ func (n *nodeSigBcast) broadcastCallback(ctx context.Context, _ peer.ID, _ strin
 
 	if (msgPeerIdx == n.nodeIdx.PeerIdx) || (msgPeerIdx < 0 || msgPeerIdx >= len(n.peers)) {
 		return errors.New("invalid peer index")
+	}
+
+	// Verify that the actual sender's peer ID matches the claimed peer index
+	if n.peers[msgPeerIdx].ID != senderID {
+		return errors.New("sender peer ID does not match claimed peer index")
 	}
 
 	lockHash, err := n.lockHash(ctx)

--- a/dkg/nodesigs_internal_test.go
+++ b/dkg/nodesigs_internal_test.go
@@ -227,6 +227,24 @@ func TestSigsCallbacks(t *testing.T) {
 		require.ErrorContains(t, err, "invalid node sig type")
 	})
 
+	t.Run("sender peer ID mismatch", func(t *testing.T) {
+		ns.lockHashData = bytes.Repeat([]byte{42}, 32)
+
+		msg := &dkgpb.MsgNodeSig{
+			Signature: bytes.Repeat([]byte{42}, 65),
+			PeerIndex: uint32(2), // Claims to be from peer 2
+		}
+
+		// But actually sent by peer 1
+		err := ns.broadcastCallback(context.Background(),
+			peers[1],
+			"",
+			msg,
+		)
+
+		require.ErrorContains(t, err, "sender peer ID does not match claimed peer index")
+	})
+
 	t.Run("signature verification failed", func(t *testing.T) {
 		ns.lockHashData = bytes.Repeat([]byte{42}, 32)
 
@@ -236,7 +254,7 @@ func TestSigsCallbacks(t *testing.T) {
 		}
 
 		err := ns.broadcastCallback(context.Background(),
-			peers[0],
+			peers[2],
 			"",
 			msg,
 		)
@@ -251,7 +269,7 @@ func TestSigsCallbacks(t *testing.T) {
 		}
 
 		err := ns.broadcastCallback(context.Background(),
-			peers[0],
+			peers[2],
 			"",
 			msg,
 		)


### PR DESCRIPTION
Verify that the actual sender's peer ID matches the claimed peer index in nodesigs.

category: refactor
ticket: none
