### PR TITLE
*: fetching lock via http

### DIFF
--- a/cluster/load.go
+++ b/cluster/load.go
@@ -5,7 +5,11 @@ package cluster
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
 	"os"
+	"time"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth1wrap"
@@ -22,15 +26,16 @@ func LoadClusterLockAndVerify(ctx context.Context, lockFilePath string) (*Lock, 
 }
 
 // LoadClusterLock loads and verifies the cluster lock.
-func LoadClusterLock(ctx context.Context, lockFilePath string, noVerify bool, eth1Cl eth1wrap.EthClientRunner) (*Lock, error) {
-	b, err := os.ReadFile(lockFilePath)
+// The lockFilePathOrURL can be either a local file path or an HTTP/HTTPS URL.
+func LoadClusterLock(ctx context.Context, lockFilePathOrURL string, noVerify bool, eth1Cl eth1wrap.EthClientRunner) (*Lock, error) {
+	b, err := loadClusterLockBytes(ctx, lockFilePathOrURL)
 	if err != nil {
-		return nil, errors.Wrap(err, "read cluster-lock.json", z.Str("path", lockFilePath))
+		return nil, err
 	}
 
 	var lock Lock
 	if err := json.Unmarshal(b, &lock); err != nil {
-		return nil, errors.Wrap(err, "unmarshal cluster-lock.json", z.Str("path", lockFilePath))
+		return nil, errors.Wrap(err, "unmarshal cluster-lock.json", z.Str("path", lockFilePathOrURL))
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -49,4 +54,65 @@ func LoadClusterLock(ctx context.Context, lockFilePath string, noVerify bool, et
 	}
 
 	return &lock, nil
+}
+
+// loadClusterLockBytes loads the cluster lock bytes from either a local file path or an HTTP/HTTPS URL.
+func loadClusterLockBytes(ctx context.Context, pathOrURL string) ([]byte, error) {
+	if IsURL(pathOrURL) {
+		parsedURL, err := url.ParseRequestURI(pathOrURL)
+		if err != nil {
+			return nil, errors.Wrap(err, "parse cluster lock URL", z.Str("url", pathOrURL))
+		}
+
+		if parsedURL.Scheme != "https" {
+			log.Warn(ctx, "Fetching cluster lock file over insecure HTTP connection", nil, z.Str("url", pathOrURL))
+		}
+
+		return fetchClusterLockBytes(ctx, pathOrURL)
+	}
+
+	b, err := os.ReadFile(pathOrURL)
+	if err != nil {
+		return nil, errors.Wrap(err, "read cluster-lock.json from disk", z.Str("path", pathOrURL))
+	}
+
+	return b, nil
+}
+
+// fetchClusterLockBytes fetches cluster lock file bytes from a remote URL.
+func fetchClusterLockBytes(ctx context.Context, url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "create http request")
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "fetch cluster-lock.json from URL")
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		return nil, errors.New("http error fetching cluster-lock.json", z.Int("status_code", resp.StatusCode))
+	}
+
+	buf, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "read response body")
+	}
+
+	return buf, nil
+}
+
+// IsURL returns true if the given string is a valid HTTP or HTTPS URL.
+func IsURL(s string) bool {
+	parsedURL, err := url.ParseRequestURI(s)
+	if err != nil {
+		return false
+	}
+
+	return parsedURL.Host != "" && (parsedURL.Scheme == "http" || parsedURL.Scheme == "https")
 }

--- a/cluster/load_internal_test.go
+++ b/cluster/load_internal_test.go
@@ -1,0 +1,199 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package cluster
+
+import (
+	"context"
+	"encoding/json"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsURL(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "HTTPS URL",
+			input: "https://example.com/cluster-lock.json",
+			want:  true,
+		},
+		{
+			name:  "HTTP URL",
+			input: "http://example.com/cluster-lock.json",
+			want:  true,
+		},
+		{
+			name:  "HTTPS URL with port",
+			input: "https://example.com:8080/path/to/lock.json",
+			want:  true,
+		},
+		{
+			name:  "Local file path",
+			input: "/path/to/cluster-lock.json",
+			want:  false,
+		},
+		{
+			name:  "Relative file path",
+			input: "./cluster-lock.json",
+			want:  false,
+		},
+		{
+			name:  "Windows-style path",
+			input: "C:\\path\\to\\cluster-lock.json",
+			want:  false,
+		},
+		{
+			name:  "Empty string",
+			input: "",
+			want:  false,
+		},
+		{
+			name:  "FTP URL (not supported)",
+			input: "ftp://example.com/file.json",
+			want:  false,
+		},
+		{
+			name:  "File URL scheme (not supported)",
+			input: "file:///path/to/file.json",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsURL(tt.input)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestFetchClusterLockBytes(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := NewForT(t, 1, 2, 3, seed, random)
+
+	validLockBytes, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch strings.TrimSpace(r.URL.Path) {
+		case "/valid":
+			_, _ = w.Write(validLockBytes)
+		case "/notfound":
+			w.WriteHeader(http.StatusNotFound)
+		case "/error":
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name    string
+		url     string
+		wantErr string
+	}{
+		{
+			name:    "Fetch valid lock",
+			url:     server.URL + "/valid",
+			wantErr: "",
+		},
+		{
+			name:    "HTTP 404 error",
+			url:     server.URL + "/notfound",
+			wantErr: "http error",
+		},
+		{
+			name:    "HTTP 500 error",
+			url:     server.URL + "/error",
+			wantErr: "http error",
+		},
+		{
+			name:    "Invalid URL",
+			url:     "http://invalid.invalid.invalid/lock.json",
+			wantErr: "fetch cluster-lock.json from URL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fetchClusterLockBytes(context.Background(), tt.url)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, validLockBytes, got)
+		})
+	}
+}
+
+func TestLoadClusterLockBytes(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := NewForT(t, 1, 2, 3, seed, random)
+
+	validLockBytes, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	// Create a temporary file with valid lock content
+	tmpDir := t.TempDir()
+	tmpFile := filepath.Join(tmpDir, "cluster-lock.json")
+	err = os.WriteFile(tmpFile, validLockBytes, 0o644)
+	require.NoError(t, err)
+
+	// Create HTTP server
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(validLockBytes)
+	}))
+	defer server.Close()
+
+	tests := []struct {
+		name      string
+		pathOrURL string
+		wantErr   string
+	}{
+		{
+			name:      "Load from local file",
+			pathOrURL: tmpFile,
+			wantErr:   "",
+		},
+		{
+			name:      "Load from HTTP URL",
+			pathOrURL: server.URL + "/lock.json",
+			wantErr:   "",
+		},
+		{
+			name:      "Non-existent local file",
+			pathOrURL: filepath.Join(tmpDir, "nonexistent.json"),
+			wantErr:   "read cluster-lock.json from disk",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := loadClusterLockBytes(context.Background(), tt.pathOrURL)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, validLockBytes, got)
+		})
+	}
+}

--- a/cmd/depositfetch_internal_test.go
+++ b/cmd/depositfetch_internal_test.go
@@ -111,7 +111,7 @@ func TestDepositFetchCLI(t *testing.T) {
 	}{
 		{
 			name:        "correct flags",
-			expectedErr: "read cluster-lock.json: open test: no such file or directory",
+			expectedErr: "read cluster-lock.json from disk: open test: no such file or directory",
 			flags: []string{
 				"--validator-public-keys=test",
 				"--private-key-file=test",

--- a/cmd/edit_addoperators.go
+++ b/cmd/edit_addoperators.go
@@ -14,6 +14,7 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/dkg"
 	"github.com/obolnetwork/charon/eth2util/enr"
 )
@@ -41,7 +42,7 @@ func newAddOperatorsCmd(runFunc func(context.Context, dkg.AddOperatorsConfig, dk
 	}
 
 	cmd.Flags().StringVar(&config.PrivateKeyPath, "private-key-file", ".charon/charon-enr-private-key", "The path to the charon enr private key file. ")
-	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining the distributed validator cluster.")
+	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path or URL to the cluster lock file defining the distributed validator cluster.")
 	cmd.Flags().StringVar(&config.ValidatorKeysDir, "validator-keys-dir", ".charon/validator_keys", "Path to the directory containing the validator private key share files and passwords.")
 	cmd.Flags().StringVar(&config.OutputDir, "output-dir", "distributed_validator", "The destination folder for the new cluster data. Must be empty.")
 	cmd.Flags().StringSliceVar(&config.NewENRs, "new-operator-enrs", nil, "Comma-separated list of the new operators to be added (Charon ENR addresses).")
@@ -84,7 +85,7 @@ func validateAddOperatorsConfig(ctx context.Context, config *dkg.AddOperatorsCon
 		return errors.New("new-operator-enrs is required")
 	}
 
-	if !app.FileExists(config.LockFilePath) {
+	if !cluster.IsURL(config.LockFilePath) && !app.FileExists(config.LockFilePath) {
 		return errors.New("lock-file does not exist")
 	}
 

--- a/cmd/edit_addvalidators.go
+++ b/cmd/edit_addvalidators.go
@@ -64,7 +64,7 @@ func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) erro
 	// Bind `add-validator` flags.
 	cmd.Flags().IntVar(&config.NumValidators, "num-validators", 1, "The number of new validators to generate and add to the existing cluster.")
 	cmd.Flags().StringVar(&config.PrivateKeyPath, "private-key-file", ".charon/charon-enr-private-key", "The path to the charon enr private key file. ")
-	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining the distributed validator cluster.")
+	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path or URL to the cluster lock file defining the distributed validator cluster.")
 	cmd.Flags().StringVar(&config.ValidatorKeysDir, "validator-keys-dir", ".charon/validator_keys", "Path to the directory containing the validator private key share files and passwords.")
 	cmd.Flags().StringVar(&config.OutputDir, "output-dir", "distributed_validator", "The destination folder for the new (combined) cluster data. Must be empty.")
 	cmd.Flags().BoolVar(&config.Unverified, "unverified", false,
@@ -196,7 +196,7 @@ func validateConfig(ctx context.Context, config *addValidatorsConfig) (err error
 		return errors.New("private-key-file is required")
 	}
 
-	if !app.FileExists(config.LockFilePath) {
+	if !cluster.IsURL(config.LockFilePath) && !app.FileExists(config.LockFilePath) {
 		return errors.New("lock-file is required")
 	}
 

--- a/cmd/edit_removeoperators.go
+++ b/cmd/edit_removeoperators.go
@@ -41,7 +41,7 @@ func newRemoveOperatorsCmd(runFunc func(context.Context, dkg.RemoveOperatorsConf
 	}
 
 	cmd.Flags().StringVar(&config.PrivateKeyPath, "private-key-file", ".charon/charon-enr-private-key", "The path to the charon enr private key file. ")
-	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining the distributed validator cluster.")
+	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path or URL to the cluster lock file defining the distributed validator cluster.")
 	cmd.Flags().StringVar(&config.ValidatorKeysDir, "validator-keys-dir", ".charon/validator_keys", "Path to the directory containing the validator private key share files and passwords.")
 	cmd.Flags().StringVar(&config.OutputDir, "output-dir", "distributed_validator", "The destination folder for the new cluster data. Must be empty. Optional for removed operators.")
 	cmd.Flags().StringSliceVar(&config.RemovingENRs, "operator-enrs-to-remove", nil, "Comma-separated list of operators to be removed (Charon ENR addresses).")
@@ -82,7 +82,7 @@ func validateRemoveOperatorsConfig(ctx context.Context, config *dkg.RemoveOperat
 		return errors.New("operator-enrs-to-remove is required")
 	}
 
-	if !app.FileExists(config.LockFilePath) {
+	if !cluster.IsURL(config.LockFilePath) && !app.FileExists(config.LockFilePath) {
 		return errors.New("lock-file does not exist")
 	}
 

--- a/cmd/edit_replaceoperator.go
+++ b/cmd/edit_replaceoperator.go
@@ -43,7 +43,7 @@ func newReplaceOperatorCmd(runFunc func(context.Context, dkg.ReplaceOperatorConf
 	}
 
 	cmd.Flags().StringVar(&config.PrivateKeyPath, "private-key-file", ".charon/charon-enr-private-key", "The path to the charon enr private key file. ")
-	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path to the cluster lock file defining the distributed validator cluster.")
+	cmd.Flags().StringVar(&config.LockFilePath, "lock-file", ".charon/cluster-lock.json", "The path or URL to the cluster lock file defining the distributed validator cluster.")
 	cmd.Flags().StringVar(&config.ValidatorKeysDir, "validator-keys-dir", ".charon/validator_keys", "Path to the directory containing the validator private key share files and passwords.")
 	cmd.Flags().StringVar(&config.OutputDir, "output-dir", "distributed_validator", "The destination folder for the new cluster data. Must be empty.")
 	cmd.Flags().StringVar(&config.NewENR, "new-operator-enr", "", "The new operator to be added (Charon ENR address).")
@@ -95,7 +95,7 @@ func validateReplaceOperatorConfig(ctx context.Context, config *dkg.ReplaceOpera
 		return errors.New("old-operator-enr and new-operator-enr cannot be the same")
 	}
 
-	if !app.FileExists(config.LockFilePath) {
+	if !cluster.IsURL(config.LockFilePath) && !app.FileExists(config.LockFilePath) {
 		return errors.New("lock-file does not exist")
 	}
 

--- a/cmd/exit_list_internal_test.go
+++ b/cmd/exit_list_internal_test.go
@@ -210,7 +210,7 @@ func TestExitListCLI(t *testing.T) {
 	}{
 		{
 			name:        "check flags",
-			expectedErr: "read cluster-lock.json: open test: no such file or directory",
+			expectedErr: "read cluster-lock.json from disk: open test: no such file or directory",
 			flags: []string{
 				"--lock-file=test",
 				"--beacon-node-endpoints=test1,test2",


### PR DESCRIPTION
Cluster lock file can be fetched via http is a URL is provided.

category: feature
ticket: #4166

