### PR TITLE
*: add cluster definition v1.11

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -178,8 +178,13 @@ func Run(ctx context.Context, conf Config) (err error) {
 		eth2util.AddTestNetwork(conf.TestnetConfig)
 	}
 
+	// Start the eth1 client and wait for it to connect before loading the cluster lock, since lock
+	// signature verification may make ERC-1271 (e.g. Safe multisig) contract calls.
+	// Returns noop client when no endpoint is configured.
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(conf.ExecutionEngineAddr)
-	life.RegisterStart(lifecycle.AsyncAppCtx, lifecycle.StartEth1Client, lifecycle.HookFuncCtx(eth1Cl.Run))
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return err
+	}
 
 	lock, err := loadClusterLock(ctx, conf, eth1Cl)
 	if err != nil {

--- a/app/eth1wrap/eth1wrap_test.go
+++ b/app/eth1wrap/eth1wrap_test.go
@@ -343,3 +343,29 @@ func TestNoopClient(t *testing.T) {
 		require.ErrorIs(t, err, eth1wrap.ErrNoExecutionEngineAddr)
 	})
 }
+
+func TestWaitConnected(t *testing.T) {
+	t.Run("noop client returns immediately", func(t *testing.T) {
+		// No endpoint configured: nothing to wait for.
+		require.NoError(t, eth1wrap.WaitConnected(t.Context(), eth1wrap.NewDefaultEthClientRunner("")))
+	})
+
+	t.Run("unconnected client times out", func(t *testing.T) {
+		client := eth1wrap.NewEthClientRunner(
+			"http://localhost:0",
+			func(context.Context, string) (eth1wrap.EthClient, error) {
+				return mocks.NewEthClient(t), nil
+			},
+			func(string, eth1wrap.EthClient) (eth1wrap.Erc1271, error) {
+				return mocks.NewErc1271(t), nil
+			},
+		)
+
+		// Run is never started, so the client never connects. A short parent context bounds the wait.
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
+		defer cancel()
+
+		err := eth1wrap.WaitConnected(ctx, client)
+		require.ErrorIs(t, err, eth1wrap.ErrEthClientNotConnected)
+	})
+}

--- a/app/eth1wrap/runner.go
+++ b/app/eth1wrap/runner.go
@@ -5,6 +5,7 @@ package eth1wrap
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -12,7 +13,46 @@ import (
 	"github.com/obolnetwork/charon/app/errors"
 	erc1271 "github.com/obolnetwork/charon/app/eth1wrap/generated"
 	"github.com/obolnetwork/charon/app/expbackoff"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 )
+
+const defaultConnectTimeout = 10 * time.Second
+
+func RunAndWait(ctx context.Context, cl EthClientRunner) error {
+	go cl.Run(ctx)
+
+	return WaitConnected(ctx, cl)
+}
+
+func WaitConnected(ctx context.Context, cl EthClientRunner) error {
+	ctx, cancel := context.WithTimeout(ctx, defaultConnectTimeout)
+	defer cancel()
+
+	// Fast path: already connected, or a noop client with no endpoint and nothing to wait for.
+	if _, err := cl.ClientVersion(ctx); err == nil || errors.Is(err, ErrNoExecutionEngineAddr) {
+		return nil
+	}
+
+	log.Debug(ctx, "Waiting for execution client to connect")
+
+	start := time.Now()
+
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return errors.Wrap(ErrEthClientNotConnected, "wait for execution client to connect")
+		case <-ticker.C:
+			if _, err := cl.ClientVersion(ctx); err == nil || errors.Is(err, ErrNoExecutionEngineAddr) {
+				log.Debug(ctx, "Execution client connected", z.Str("waited", time.Since(start).String()))
+				return nil
+			}
+		}
+	}
+}
 
 //go:generate abigen --abi=build/IERC1271.abi --pkg=erc1271 --out=generated/erc1271.go
 

--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -3,13 +3,16 @@
 package cluster
 
 import (
+	"bytes"
 	"fmt"
 	"math/rand"
 	"testing"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/eth1wrap/mocks"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/testutil"
 )
@@ -208,6 +211,36 @@ func TestDefinitionVerify(t *testing.T) {
 
 		err = definition.VerifySignatures(nil)
 		require.NoError(t, err)
+	})
+}
+
+// TestVerifySignaturesSafeMultisig verifies that v1.11 routes concatenated Safe multisig
+// signatures (operators and creator) through the ERC-1271 smart-contract verification path.
+func TestVerifySignaturesSafeMultisig(t *testing.T) {
+	_, op0 := randomOperator(t)
+	_, op1 := randomOperator(t)
+	_, creator := randomCreator(t)
+
+	// Safe multisig signatures: concatenated 65-byte signatures (threshold=2).
+	multisig := bytes.Repeat([]byte{0x07}, 2*sszLenK1Sig)
+	op0.ConfigSignature, op0.ENRSignature = multisig, multisig
+	op1.ConfigSignature, op1.ENRSignature = multisig, multisig
+	creator.ConfigSignature = multisig
+
+	def := randomDefinition(t, creator, op0, op1, 30000000, WithVersion(v1_11))
+
+	t.Run("valid via ERC-1271", func(t *testing.T) {
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
+
+		require.NoError(t, def.VerifySignatures(eth1))
+	})
+
+	t.Run("invalid via ERC-1271", func(t *testing.T) {
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", mock.Anything, mock.Anything, mock.Anything).Return(false, nil)
+
+		require.ErrorContains(t, def.VerifySignatures(eth1), "invalid operator config signature")
 	})
 }
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -317,6 +317,85 @@ func TestDefinitionPeers(t *testing.T) {
 	}
 }
 
+// TestV1x11SafeSignatures tests that v1.11 supports variable-length signatures (Safe multisig).
+func TestV1x11SafeSignatures(t *testing.T) {
+	r := rand.New(rand.NewSource(1))
+
+	// Create 130-byte signatures (Safe threshold=2: 2 × 65 bytes)
+	safeSignature130 := make([]byte, 130)
+	_, _ = r.Read(safeSignature130)
+
+	// Create 195-byte signatures (Safe threshold=3: 3 × 65 bytes)
+	safeSignature195 := make([]byte, 195)
+	_, _ = r.Read(safeSignature195)
+
+	// Create 65-byte EOA signature
+	eoaSignature65 := testutil.RandomSecp256k1SignatureSeed(r)
+
+	_, enr1 := testutil.RandomENR(t, 1)
+	_, enr2 := testutil.RandomENR(t, 2)
+
+	def, err := cluster.NewDefinition(
+		"Safe multisig cluster",
+		1,
+		2,
+		[]string{testutil.RandomETHAddressSeed(r)},
+		[]string{testutil.RandomETHAddressSeed(r)},
+		eth2util.Sepolia.GenesisForkVersionHex,
+		cluster.Creator{
+			Address:         testutil.RandomETHAddressSeed(r),
+			ConfigSignature: safeSignature130, // Safe threshold=2
+		},
+		[]cluster.Operator{
+			{
+				Address:         testutil.RandomETHAddressSeed(r),
+				ENR:             enr1.String(),
+				ConfigSignature: safeSignature195, // Safe threshold=3
+				ENRSignature:    safeSignature130, // Safe threshold=2
+			},
+			{
+				Address:         testutil.RandomETHAddressSeed(r),
+				ENR:             enr2.String(),
+				ConfigSignature: eoaSignature65, // EOA (65 bytes)
+				ENRSignature:    eoaSignature65, // EOA (65 bytes)
+			},
+		},
+		[]int{32}, // Deposit amounts (32 ETH)
+		"abft",    // Consensus protocol
+		30000000,  // Target gas limit
+		false,     // Compounding
+		r,         // Random reader
+		func(d *cluster.Definition) {
+			d.Version = v1_11
+			d.Timestamp = "2024-01-01T00:00:00Z"
+		},
+	)
+	require.NoError(t, err)
+
+	// Test SetDefinitionHashes with variable-length signatures
+	defWithHashes, err := def.SetDefinitionHashes()
+	require.NoError(t, err, "SetDefinitionHashes should succeed with Safe signatures")
+	require.NotEmpty(t, defWithHashes.ConfigHash, "ConfigHash should be computed")
+	require.NotEmpty(t, defWithHashes.DefinitionHash, "DefinitionHash should be computed")
+
+	// Test JSON marshaling/unmarshaling
+	jsonBytes, err := json.Marshal(defWithHashes)
+	require.NoError(t, err, "JSON marshal should succeed")
+
+	var unmarshaled cluster.Definition
+	err = json.Unmarshal(jsonBytes, &unmarshaled)
+	require.NoError(t, err, "JSON unmarshal should succeed")
+
+	// Verify signatures are preserved
+	require.Equal(t, 130, len(unmarshaled.Creator.ConfigSignature), "Creator Safe signature length")
+	require.Equal(t, 195, len(unmarshaled.Operators[0].ConfigSignature), "Operator 0 config Safe signature length")
+	require.Equal(t, 130, len(unmarshaled.Operators[0].ENRSignature), "Operator 0 ENR Safe signature length")
+	require.Equal(t, 65, len(unmarshaled.Operators[1].ConfigSignature), "Operator 1 EOA signature length")
+
+	// Test VerifyHashes
+	require.NoError(t, defWithHashes.VerifyHashes(), "VerifyHashes should succeed")
+}
+
 func isAnyVersion(version string, list ...string) bool {
 	return slices.Contains(list, version)
 }

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -21,6 +21,7 @@ import (
 //go:generate go test . -v -update -clean
 
 const (
+	v1_11 = "v1.11.0"
 	v1_10 = "v1.10.0"
 	v1_9  = "v1.9.0"
 	v1_8  = "v1.8.0"
@@ -64,12 +65,12 @@ func TestEncode(t *testing.T) {
 			}
 
 			var partialAmounts []int
-			if isAnyVersion(version, v1_8, v1_9, v1_10) {
+			if isAnyVersion(version, v1_8, v1_9, v1_10, v1_11) {
 				partialAmounts = []int{16, 16}
 			}
 
 			targetGasLimit := uint(0)
-			if isAnyVersion(version, v1_10) {
+			if isAnyVersion(version, v1_10, v1_11) {
 				targetGasLimit = 30000000
 			}
 

--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -383,14 +383,15 @@ func TestV1x11SafeSignatures(t *testing.T) {
 	require.NoError(t, err, "JSON marshal should succeed")
 
 	var unmarshaled cluster.Definition
+
 	err = json.Unmarshal(jsonBytes, &unmarshaled)
 	require.NoError(t, err, "JSON unmarshal should succeed")
 
 	// Verify signatures are preserved
-	require.Equal(t, 130, len(unmarshaled.Creator.ConfigSignature), "Creator Safe signature length")
-	require.Equal(t, 195, len(unmarshaled.Operators[0].ConfigSignature), "Operator 0 config Safe signature length")
-	require.Equal(t, 130, len(unmarshaled.Operators[0].ENRSignature), "Operator 0 ENR Safe signature length")
-	require.Equal(t, 65, len(unmarshaled.Operators[1].ConfigSignature), "Operator 1 EOA signature length")
+	require.Len(t, unmarshaled.Creator.ConfigSignature, 130, "Creator Safe signature length")
+	require.Len(t, unmarshaled.Operators[0].ConfigSignature, 195, "Operator 0 config Safe signature length")
+	require.Len(t, unmarshaled.Operators[0].ENRSignature, 130, "Operator 0 ENR Safe signature length")
+	require.Len(t, unmarshaled.Operators[1].ConfigSignature, 65, "Operator 1 EOA signature length")
 
 	// Test VerifyHashes
 	require.NoError(t, defWithHashes.VerifyHashes(), "VerifyHashes should succeed")

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -318,41 +318,48 @@ func (d Definition) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 	return nil
 }
 
-// validateCreatorSignatureLength validates creator signature length for v1.11.0+.
+// validateCreatorSignatureLength validates the creator config signature length.
 func (d Definition) validateCreatorSignatureLength() error {
-	if !isAnyVersion(d.Version, v1_11) {
-		return nil // Skip validation for older versions
-	}
-
-	if err := validateSignatureLength(d.Creator.ConfigSignature, "creator config signature"); err != nil {
+	if err := validateSignatureLength(d.Version, d.Creator.ConfigSignature, "creator config signature"); err != nil {
 		return errors.Wrap(err, "invalid signature length", z.Str("address", d.Creator.Address))
 	}
 
 	return nil
 }
 
-// validateOperatorSignatureLengths validates a single operator's signature lengths for v1.11.0+.
+// validateOperatorSignatureLengths validates a single operator's signature lengths.
 func (d Definition) validateOperatorSignatureLengths(op Operator) error {
-	if !isAnyVersion(d.Version, v1_11) {
-		return nil // Skip validation for older versions
-	}
-
-	if err := validateSignatureLength(op.ConfigSignature, "operator config signature"); err != nil {
+	if err := validateSignatureLength(d.Version, op.ConfigSignature, "operator config signature"); err != nil {
 		return errors.Wrap(err, "invalid signature length", z.Str("address", op.Address))
 	}
 
-	if err := validateSignatureLength(op.ENRSignature, "operator enr signature"); err != nil {
+	if err := validateSignatureLength(d.Version, op.ENRSignature, "operator enr signature"); err != nil {
 		return errors.Wrap(err, "invalid signature length", z.Str("address", op.Address))
 	}
 
 	return nil
 }
 
-// validateSignatureLength validates that a signature is either empty or a multiple of 65 bytes.
-// Safe/Gnosis Safe multisig signatures are concatenated ECDSA signatures: threshold × 65 bytes.
-func validateSignatureLength(sig []byte, fieldName string) error {
+// validateSignatureLength validates a signature length for the given definition version.
+// An empty signature is always valid (unsigned operator/creator). Pre-v1.11 supports only a single
+// fixed 65-byte secp256k1 signature; v1.11+ also supports concatenated Safe multisig signatures,
+// which are a multiple of 65 bytes up to sszMaxK1Sigs signatures.
+func validateSignatureLength(version string, sig []byte, fieldName string) error {
 	if len(sig) == 0 {
-		return nil // Empty signatures are valid
+		return nil // Empty signatures are valid.
+	}
+
+	// Variable-length (Safe multisig) signatures are only represented by the v1.11 schema; earlier
+	// versions hash via fixed Bytes65 and must therefore be exactly one 65-byte signature.
+	if !isAnyVersion(version, v1_11) {
+		if len(sig) != sszLenK1Sig {
+			return errors.New("signature must be 65 bytes",
+				z.Str("field", fieldName),
+				z.Int("length", len(sig)),
+			)
+		}
+
+		return nil
 	}
 
 	if len(sig)%sszLenK1Sig != 0 {

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -355,11 +355,11 @@ func validateSignatureLength(sig []byte, fieldName string) error {
 		return nil // Empty signatures are valid
 	}
 
-	if len(sig)%65 != 0 {
+	if len(sig)%sszLenK1Sig != 0 {
 		return errors.New("signature must be multiple of 65 bytes",
 			z.Str("field", fieldName),
 			z.Int("length", len(sig)),
-			z.Int("remainder", len(sig)%65),
+			z.Int("remainder", len(sig)%sszLenK1Sig),
 		)
 	}
 

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -1187,7 +1187,8 @@ type definitionJSONv1x10to11 struct {
 // Note the following struct tag meanings:
 //   - json: json field name.
 //   - ssz: ssz equivalent. Either uint64 for numbers, BytesN for fixed length bytes, ByteList[MaxN]
-//     for variable length strings, or CompositeList[MaxN] for nested object arrays.
+//     for variable length strings, List[BytesN,MaxItems] for lists of fixed length byte arrays,
+//     or CompositeList[MaxN] for nested object arrays.
 //   - config_hash: field ordering when calculating config hash. Some fields are excluded indicated by `-`.
 //   - definition_hash: field ordering when calculating definition hash. Some fields are excluded indicated by `-`.
 type Creator struct {
@@ -1195,7 +1196,8 @@ type Creator struct {
 	Address string `config_hash:"0" definition_hash:"0" json:"address" ssz:"Bytes20"`
 
 	// ConfigSignature is an EIP712 signature of the config_hash using privkey corresponding to creator Ethereum Address.
-	ConfigSignature []byte `config_hash:"-" definition_hash:"1" json:"config_signature" ssz:"Bytes65"`
+	// It is a single 65-byte secp256k1 signature, or concatenated 65-byte signatures for Safe smart-contract multisigs.
+	ConfigSignature []byte `config_hash:"-" definition_hash:"1" json:"config_signature" ssz:"List[Bytes65,32]"`
 }
 
 // creatorJSON is the json formatter of Creator.

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -263,16 +263,11 @@ func (d Definition) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			return err
 		}
 
-		// Check that we have a valid config signature for each operator.
-		if ok, err := verifySig(o.Address, operatorConfigHashDigest, o.ConfigSignature); err != nil {
+		// Check that we have a valid config signature for each operator (EOA or ERC-1271).
+		if ok, err := verifySigOrERC1271(eth1, o.Address, operatorConfigHashDigest, o.ConfigSignature); err != nil {
 			return err
 		} else if !ok {
-			// Check ERC-1271 signature
-			if ok, err = eth1.VerifySmartContractBasedSignature(o.Address, [32]byte(operatorConfigHashDigest), o.ConfigSignature); err != nil {
-				return err
-			} else if !ok {
-				return errors.New("invalid operator config signature", z.Any("operator_address", o.Address))
-			}
+			return errors.New("invalid operator config signature", z.Any("operator_address", o.Address))
 		}
 
 		// Check that we have a valid enr signature for each operator.
@@ -281,15 +276,10 @@ func (d Definition) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			return err
 		}
 
-		if ok, err := verifySig(o.Address, enrDigest, o.ENRSignature); err != nil {
+		if ok, err := verifySigOrERC1271(eth1, o.Address, enrDigest, o.ENRSignature); err != nil {
 			return err
 		} else if !ok {
-			// Check ERC-1271 signature
-			if ok, err = eth1.VerifySmartContractBasedSignature(o.Address, [32]byte(enrDigest), o.ENRSignature); err != nil {
-				return err
-			} else if !ok {
-				return errors.New("invalid operator enr signature", z.Any("operator_address", o.Address))
-			}
+			return errors.New("invalid operator enr signature", z.Any("operator_address", o.Address))
 		}
 	}
 
@@ -318,7 +308,7 @@ func (d Definition) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			return err
 		}
 
-		if ok, err := verifySig(d.Creator.Address, creatorConfigHashDigest, d.Creator.ConfigSignature); err != nil {
+		if ok, err := verifySigOrERC1271(eth1, d.Creator.Address, creatorConfigHashDigest, d.Creator.ConfigSignature); err != nil {
 			return err
 		} else if !ok {
 			return errors.New("invalid creator config signature")
@@ -350,6 +340,7 @@ func (d Definition) validateOperatorSignatureLengths(op Operator) error {
 	if err := validateSignatureLength(op.ConfigSignature, "operator config signature"); err != nil {
 		return errors.Wrap(err, "invalid signature length", z.Str("address", op.Address))
 	}
+
 	if err := validateSignatureLength(op.ENRSignature, "operator enr signature"); err != nil {
 		return errors.Wrap(err, "invalid signature length", z.Str("address", op.Address))
 	}
@@ -372,12 +363,12 @@ func validateSignatureLength(sig []byte, fieldName string) error {
 		)
 	}
 
-	if len(sig) > sszMaxSignature {
+	if len(sig) > sszMaxK1Sigs*sszLenK1Sig {
 		return errors.New("signature exceeds maximum length",
 			z.Str("field", fieldName),
 			z.Int("length", len(sig)),
-			z.Int("max", sszMaxSignature),
-			z.Int("max_threshold", sszMaxSignature/65),
+			z.Int("max_len", sszMaxK1Sigs*sszLenK1Sig),
+			z.Int("max_threshold", sszMaxK1Sigs),
 		)
 	}
 

--- a/cluster/helpers.go
+++ b/cluster/helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth1wrap"
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/eth2util"
@@ -127,6 +128,33 @@ func verifySig(expectedAddr string, digest []byte, sig []byte) (bool, error) {
 	return expectedAddr == actualAddr, nil
 }
 
+// verifySigOrERC1271 verifies an EIP712 signature against addr, either as a standard 65-byte
+// EOA secp256k1 signature or, failing that, as an ERC-1271 smart-contract signature via the eth1 client.
+func verifySigOrERC1271(eth1 eth1wrap.EthClientRunner, addr string, digest, sig []byte) (bool, error) {
+	var (
+		eoaOK  bool
+		eoaErr error
+	)
+
+	if len(sig) == sszLenK1Sig {
+		eoaOK, eoaErr = verifySig(addr, digest, sig)
+		if eoaErr == nil && eoaOK {
+			return true, nil
+		}
+	}
+
+	if eth1 == nil {
+		return false, eoaErr
+	}
+
+	ok, err := eth1.VerifySmartContractBasedSignature(addr, [32]byte(digest), sig)
+	if errors.Is(err, eth1wrap.ErrNoExecutionEngineAddr) {
+		return false, eoaErr
+	}
+
+	return ok, err
+}
+
 // signCreator returns the definition with signed creator config hash.
 func signCreator(secret *k1.PrivateKey, def Definition) (Definition, error) {
 	var err error
@@ -225,6 +253,26 @@ func putByteList(h ssz.HashWalker, b []byte, limit int, field string) error {
 
 	h.AppendBytes32(b)
 	h.MerkleizeWithMixin(elemIndx, uint64(byteLen), uint64(limit+31)/32)
+
+	return nil
+}
+
+func putK1SigList(h ssz.HashWalker, sig []byte, maxAmountSigs int, field string) error {
+	if len(sig)%sszLenK1Sig != 0 {
+		return errors.New("signature not a multiple of 65 bytes", z.Str("field", field), z.Int("length", len(sig)))
+	}
+
+	num := uint64(len(sig) / sszLenK1Sig)
+	if num > uint64(maxAmountSigs) {
+		return errors.Wrap(ssz.ErrIncorrectListSize, "put k1 sig list", z.Str("field", field))
+	}
+
+	elemIndx := h.Index()
+	for i := 0; i < len(sig); i += sszLenK1Sig {
+		h.PutBytes(sig[i : i+sszLenK1Sig])
+	}
+
+	h.MerkleizeWithMixin(elemIndx, num, uint64(maxAmountSigs))
 
 	return nil
 }

--- a/cluster/helpers_internal_test.go
+++ b/cluster/helpers_internal_test.go
@@ -3,6 +3,7 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
 	crand "crypto/rand"
 	"encoding/hex"
@@ -18,8 +19,12 @@ import (
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	ssz "github.com/ferranbt/fastssz"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth1wrap"
+	"github.com/obolnetwork/charon/app/eth1wrap/mocks"
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/testutil"
@@ -300,6 +305,137 @@ func TestVerifySig(t *testing.T) {
 		require.NoError(t, err)
 		require.True(t, ok)
 	})
+}
+
+func TestVerifySigOrERC1271(t *testing.T) {
+	secret, err := k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	addr := eth2util.PublicKeyToAddress(secret.PubKey())
+	digest := testutil.RandomRoot()
+
+	eoaSig, err := k1util.Sign(secret, digest[:])
+	require.NoError(t, err)
+
+	// A Safe multisig signature is concatenated 65-byte signatures (threshold=2 here), opaque to the mock.
+	multisig := bytes.Repeat([]byte{0x42}, 2*sszLenK1Sig)
+
+	t.Run("valid EOA does not consult ERC-1271", func(t *testing.T) {
+		eth1 := mocks.NewEthClientRunner(t) // No expectations: panics if VerifySmartContractBasedSignature is called.
+
+		ok, err := verifySigOrERC1271(eth1, addr, digest[:], eoaSig)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("multisig routes to ERC-1271 valid", func(t *testing.T) {
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", addr, [32]byte(digest), multisig).Return(true, nil).Once()
+
+		ok, err := verifySigOrERC1271(eth1, addr, digest[:], multisig)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("multisig ERC-1271 invalid", func(t *testing.T) {
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", mock.Anything, mock.Anything, mock.Anything).Return(false, nil).Once()
+
+		ok, err := verifySigOrERC1271(eth1, addr, digest[:], multisig)
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("multisig ERC-1271 error propagates", func(t *testing.T) {
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", mock.Anything, mock.Anything, mock.Anything).
+			Return(false, errors.New("rpc down")).Once()
+
+		_, err := verifySigOrERC1271(eth1, addr, digest[:], multisig)
+		require.ErrorContains(t, err, "rpc down")
+	})
+
+	t.Run("65-byte non-matching EOA falls through to ERC-1271", func(t *testing.T) {
+		other, err := k1.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		wrongSig, err := k1util.Sign(other, digest[:]) // Valid 65-byte sig, but recovers to a different address.
+		require.NoError(t, err)
+
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", addr, [32]byte(digest), wrongSig).Return(true, nil).Once()
+
+		ok, err := verifySigOrERC1271(eth1, addr, digest[:], wrongSig)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("65-byte unrecoverable EOA falls through to ERC-1271", func(t *testing.T) {
+		// A single 65-byte Safe signature whose v-byte is not a valid EOA recovery id: verifySig
+		// errors, but it must still be offered to the ERC-1271 contract rather than rejected outright.
+		bad := make([]byte, sszLenK1Sig)
+		bad[64] = 200 // Invalid EOA recovery id.
+
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", addr, [32]byte(digest), bad).Return(true, nil).Once()
+
+		ok, err := verifySigOrERC1271(eth1, addr, digest[:], bad)
+		require.NoError(t, err)
+		require.True(t, ok)
+	})
+
+	t.Run("nil eth1 client does not panic", func(t *testing.T) {
+		// A failing EOA signature with no eth1 client cannot be checked via ERC-1271; it must
+		// report not-verified rather than panic.
+		ok, err := verifySigOrERC1271(nil, addr, digest[:], make([]byte, 2*sszLenK1Sig))
+		require.NoError(t, err)
+		require.False(t, ok)
+	})
+
+	t.Run("no eth1 endpoint reports EOA result not client error", func(t *testing.T) {
+		// A regular signer never configures an execution client. A failing EOA signature must report
+		// the plain verification result, not the (irrelevant) "endpoint not set" client error.
+		other, err := k1.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		wrongSig, err := k1util.Sign(other, digest[:]) // Valid 65-byte sig recovering to a different address.
+		require.NoError(t, err)
+
+		eth1 := mocks.NewEthClientRunner(t)
+		eth1.On("VerifySmartContractBasedSignature", mock.Anything, mock.Anything, mock.Anything).
+			Return(false, eth1wrap.ErrNoExecutionEngineAddr).Once()
+
+		ok, err := verifySigOrERC1271(eth1, addr, digest[:], wrongSig)
+		require.NoError(t, err) // EOA mismatch (no error), not the client error.
+		require.False(t, ok)
+	})
+}
+
+func TestValidateSignatureLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		length  int
+		wantErr string
+	}{
+		{name: "empty", length: 0},
+		{name: "single eoa", length: sszLenK1Sig},
+		{name: "safe threshold 2", length: 2 * sszLenK1Sig},
+		{name: "safe threshold 3", length: 3 * sszLenK1Sig},
+		{name: "max", length: sszMaxK1Sigs * sszLenK1Sig},
+		{name: "not multiple of 65", length: 100, wantErr: "multiple of 65 bytes"},
+		{name: "exceeds maximum", length: (sszMaxK1Sigs + 1) * sszLenK1Sig, wantErr: "exceeds maximum length"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateSignatureLength(make([]byte, tt.length), "test signature")
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
 }
 
 func TestFetchDefinition(t *testing.T) {

--- a/cluster/helpers_internal_test.go
+++ b/cluster/helpers_internal_test.go
@@ -414,21 +414,28 @@ func TestVerifySigOrERC1271(t *testing.T) {
 func TestValidateSignatureLength(t *testing.T) {
 	tests := []struct {
 		name    string
+		version string
 		length  int
 		wantErr string
 	}{
-		{name: "empty", length: 0},
-		{name: "single eoa", length: sszLenK1Sig},
-		{name: "safe threshold 2", length: 2 * sszLenK1Sig},
-		{name: "safe threshold 3", length: 3 * sszLenK1Sig},
-		{name: "max", length: sszMaxK1Sigs * sszLenK1Sig},
-		{name: "not multiple of 65", length: 100, wantErr: "multiple of 65 bytes"},
-		{name: "exceeds maximum", length: (sszMaxK1Sigs + 1) * sszLenK1Sig, wantErr: "exceeds maximum length"},
+		// v1.11+ allows a single signature or concatenated Safe multisig signatures (multiple of 65).
+		{name: "v1.11 empty", version: v1_11, length: 0},
+		{name: "v1.11 single eoa", version: v1_11, length: sszLenK1Sig},
+		{name: "v1.11 safe threshold 2", version: v1_11, length: 2 * sszLenK1Sig},
+		{name: "v1.11 safe threshold 3", version: v1_11, length: 3 * sszLenK1Sig},
+		{name: "v1.11 max", version: v1_11, length: sszMaxK1Sigs * sszLenK1Sig},
+		{name: "v1.11 not multiple of 65", version: v1_11, length: 100, wantErr: "multiple of 65 bytes"},
+		{name: "v1.11 exceeds maximum", version: v1_11, length: (sszMaxK1Sigs + 1) * sszLenK1Sig, wantErr: "exceeds maximum length"},
+		// Pre-v1.11 only allows a single fixed 65-byte signature (or empty); multisig is rejected.
+		{name: "v1.10 empty", version: v1_10, length: 0},
+		{name: "v1.10 single eoa", version: v1_10, length: sszLenK1Sig},
+		{name: "v1.10 multisig rejected", version: v1_10, length: 2 * sszLenK1Sig, wantErr: "signature must be 65 bytes"},
+		{name: "v1.10 not 65 rejected", version: v1_10, length: 100, wantErr: "signature must be 65 bytes"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateSignatureLength(make([]byte, tt.length), "test signature")
+			err := validateSignatureLength(tt.version, make([]byte, tt.length), "test signature")
 			if tt.wantErr == "" {
 				require.NoError(t, err)
 			} else {

--- a/cluster/load.go
+++ b/cluster/load.go
@@ -13,12 +13,15 @@ import (
 	"github.com/obolnetwork/charon/app/z"
 )
 
-// LoadClusterLockAndVerify loads and verifies the cluster lock. Suitable for cmd tools.
-// execEngineAddr is the execution client RPC endpoint used to verify ERC-1271 (e.g. Safe multisig)
-// cluster signatures; pass "" when none is configured (EOA-only clusters do not require it).
+// LoadClusterLockAndVerify loads and verifies the cluster lock.
+// execEngineAddr is the execution client RPC endpoint used to verify ERC-1271 (e.g. Safe multisig) cluster signatures;
+// pass "" when none is configured (EOA-only clusters do not require it).
 func LoadClusterLockAndVerify(ctx context.Context, lockFilePath, execEngineAddr string) (*Lock, error) {
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(execEngineAddr)
-	go eth1Cl.Run(ctx)
+
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return nil, err
+	}
 
 	return LoadClusterLock(ctx, lockFilePath, false, eth1Cl)
 }

--- a/cluster/load.go
+++ b/cluster/load.go
@@ -14,8 +14,10 @@ import (
 )
 
 // LoadClusterLockAndVerify loads and verifies the cluster lock. Suitable for cmd tools.
-func LoadClusterLockAndVerify(ctx context.Context, lockFilePath string) (*Lock, error) {
-	eth1Cl := eth1wrap.NewDefaultEthClientRunner("")
+// execEngineAddr is the execution client RPC endpoint used to verify ERC-1271 (e.g. Safe multisig)
+// cluster signatures; pass "" when none is configured (EOA-only clusters do not require it).
+func LoadClusterLockAndVerify(ctx context.Context, lockFilePath, execEngineAddr string) (*Lock, error) {
+	eth1Cl := eth1wrap.NewDefaultEthClientRunner(execEngineAddr)
 	go eth1Cl.Run(ctx)
 
 	return LoadClusterLock(ctx, lockFilePath, false, eth1Cl)

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -55,7 +55,7 @@ func (l Lock) MarshalJSON() ([]byte, error) {
 		return marshalLockV1x6(l, lockHash)
 	case isAnyVersion(l.Version, v1_7):
 		return marshalLockV1x7(l, lockHash)
-	case isAnyVersion(l.Version, v1_8, v1_9, v1_10):
+	case isAnyVersion(l.Version, v1_8, v1_9, v1_10, v1_11):
 		return marshalLockV1x8OrLater(l, lockHash)
 	default:
 		return nil, errors.New("unsupported version")
@@ -104,7 +104,7 @@ func (l *Lock) UnmarshalJSON(data []byte) error {
 		if err != nil {
 			return err
 		}
-	case isAnyVersion(version.Definition.Version, v1_8, v1_9, v1_10):
+	case isAnyVersion(version.Definition.Version, v1_8, v1_9, v1_10, v1_11):
 		lock, err = unmarshalLockV1x8OrLater(data)
 		if err != nil {
 			return err

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -21,10 +21,10 @@ type Operator struct {
 	ENR string `config_hash:"-" definition_hash:"1" json:"enr" ssz:"ByteList[1024]"`
 
 	// ConfigSignature is an EIP712 signature of the config_hash using privkey corresponding to operator Ethereum Address.
-	ConfigSignature []byte `config_hash:"-" definition_hash:"2" json:"config_signature" ssz:"Bytes65|ByteList[384]"`
+	ConfigSignature []byte `config_hash:"-" definition_hash:"2" json:"config_signature" ssz:"ByteList[384]"`
 
 	// ENRSignature is a EIP712 signature of the ENR by the Address, authorising the charon node to act on behalf of the operator in the cluster.
-	ENRSignature []byte `config_hash:"-" definition_hash:"3" json:"enr_signature" ssz:"Bytes65|ByteList[384]"`
+	ENRSignature []byte `config_hash:"-" definition_hash:"3" json:"enr_signature" ssz:"ByteList[384]"`
 }
 
 // operatorJSONv1x1 is the json formatter of Operator for versions v1.0.0 and v1.1.0.

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -21,10 +21,10 @@ type Operator struct {
 	ENR string `config_hash:"-" definition_hash:"1" json:"enr" ssz:"ByteList[1024]"`
 
 	// ConfigSignature is an EIP712 signature of the config_hash using privkey corresponding to operator Ethereum Address.
-	ConfigSignature []byte `config_hash:"-" definition_hash:"2" json:"config_signature" ssz:"Bytes65"`
+	ConfigSignature []byte `config_hash:"-" definition_hash:"2" json:"config_signature" ssz:"Bytes65|ByteList[384]"`
 
 	// ENRSignature is a EIP712 signature of the ENR by the Address, authorising the charon node to act on behalf of the operator in the cluster.
-	ENRSignature []byte `config_hash:"-" definition_hash:"3" json:"enr_signature" ssz:"Bytes65"`
+	ENRSignature []byte `config_hash:"-" definition_hash:"3" json:"enr_signature" ssz:"Bytes65|ByteList[384]"`
 }
 
 // operatorJSONv1x1 is the json formatter of Operator for versions v1.0.0 and v1.1.0.

--- a/cluster/operator.go
+++ b/cluster/operator.go
@@ -10,7 +10,8 @@ import (
 // Note the following struct tag meanings:
 //   - json: json field name.
 //   - ssz: ssz equivalent. Either uint64 for numbers, BytesN for fixed length bytes, ByteList[MaxN]
-//     for variable length strings, or CompositeList[MaxN] for nested object arrays.
+//     for variable length strings, List[BytesN,MaxItems] for lists of fixed length byte arrays,
+//     or CompositeList[MaxN] for nested object arrays.
 //   - config_hash: field ordering when calculating config hash. Some fields are excluded indicated by `-`.
 //   - definition_hash: field ordering when calculating definition hash. Some fields are excluded indicated by `-`.
 type Operator struct {
@@ -21,10 +22,12 @@ type Operator struct {
 	ENR string `config_hash:"-" definition_hash:"1" json:"enr" ssz:"ByteList[1024]"`
 
 	// ConfigSignature is an EIP712 signature of the config_hash using privkey corresponding to operator Ethereum Address.
-	ConfigSignature []byte `config_hash:"-" definition_hash:"2" json:"config_signature" ssz:"ByteList[384]"`
+	// It is a single 65-byte secp256k1 signature, or concatenated 65-byte signatures for Safe smart-contract multisigs.
+	ConfigSignature []byte `config_hash:"-" definition_hash:"2" json:"config_signature" ssz:"List[Bytes65,32]"`
 
 	// ENRSignature is a EIP712 signature of the ENR by the Address, authorising the charon node to act on behalf of the operator in the cluster.
-	ENRSignature []byte `config_hash:"-" definition_hash:"3" json:"enr_signature" ssz:"ByteList[384]"`
+	// It is a single 65-byte secp256k1 signature, or concatenated 65-byte signatures for Safe smart-contract multisigs.
+	ENRSignature []byte `config_hash:"-" definition_hash:"3" json:"enr_signature" ssz:"List[Bytes65,32]"`
 }
 
 // operatorJSONv1x1 is the json formatter of Operator for versions v1.0.0 and v1.1.0.

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -19,6 +19,7 @@ const (
 	sszMaxOperators      = 256
 	sszMaxValidators     = 65536
 	sszMaxDepositAmounts = 256
+	sszMaxSignature      = 384
 	sszLenForkVersion    = 4
 	sszLenK1Sig          = 65
 	sszLenBLSSig         = 96
@@ -42,6 +43,8 @@ func getDefinitionHashFunc(version string) (func(Definition, ssz.HashWalker, boo
 		return hashDefinitionV1x9, nil
 	case isAnyVersion(version, v1_10):
 		return hashDefinitionV1x10, nil
+	case isAnyVersion(version, v1_11):
+		return hashDefinitionV1x11, nil
 	default:
 		return nil, errors.New("unknown version", z.Str("version", version))
 	}
@@ -491,12 +494,160 @@ func hashDefinitionV1x10(d Definition, hh ssz.HashWalker, configOnly bool) error
 	})
 }
 
+// hashDefinitionV1x11 hashes the new definition.
+func hashDefinitionV1x11(d Definition, hh ssz.HashWalker, configOnly bool) error {
+	indx := hh.Index()
+
+	// Field (0) 'UUID' ByteList[64]
+	if err := putByteList(hh, []byte(d.UUID), sszMaxUUID, "uuid"); err != nil {
+		return err
+	}
+
+	// Field (1) 'Name' ByteList[256]
+	if err := putByteList(hh, []byte(d.Name), sszMaxName, "name"); err != nil {
+		return err
+	}
+
+	// Field (2) 'version' ByteList[16]
+	if err := putByteList(hh, []byte(d.Version), sszMaxVersion, "version"); err != nil {
+		return err
+	}
+
+	// Field (3) 'Timestamp' ByteList[32]
+	if err := putByteList(hh, []byte(d.Timestamp), sszMaxTimestamp, "timestamp"); err != nil {
+		return err
+	}
+
+	// Field (4) 'NumValidators' uint64
+	hh.PutUint64(uint64(d.NumValidators))
+
+	// Field (5) 'Threshold' uint64
+	hh.PutUint64(uint64(d.Threshold))
+
+	// Field (6) 'DKGAlgorithm' ByteList[32]
+	if err := putByteList(hh, []byte(d.DKGAlgorithm), sszMaxDKGAlgorithm, "dkg_algorithm"); err != nil {
+		return err
+	}
+
+	// Field (7) 'ForkVersion' Bytes4
+	if err := putBytesN(hh, d.ForkVersion, sszLenForkVersion); err != nil {
+		return err
+	}
+
+	// Field (8) 'Operators' CompositeList[256]
+	{
+		operatorsIdx := hh.Index()
+
+		num := uint64(len(d.Operators))
+		for _, o := range d.Operators {
+			operatorIdx := hh.Index()
+
+			// Field (0) 'Address' Bytes20
+			if err := putHexBytes20(hh, o.Address); err != nil {
+				return err
+			}
+
+			if !configOnly {
+				// Field (1) 'ENR' ByteList[1024]
+				if err := putByteList(hh, []byte(o.ENR), sszMaxENR, "enr"); err != nil {
+					return err
+				}
+
+				// Field (2) 'ConfigSignature' ByteList[384]
+				if err := putByteList(hh, o.ConfigSignature, sszMaxSignature, "config_signature"); err != nil {
+					return err
+				}
+
+				// Field (3) 'ENRSignature' ByteList[384]
+				if err := putByteList(hh, o.ENRSignature, sszMaxSignature, "enr_signature"); err != nil {
+					return err
+				}
+			}
+
+			hh.Merkleize(operatorIdx)
+		}
+
+		hh.MerkleizeWithMixin(operatorsIdx, num, sszMaxOperators)
+	}
+
+	// Field (9) 'Creator' Composite
+	{
+		creatorIdx := hh.Index()
+
+		// Field (0) 'Address' Bytes20
+		if err := putHexBytes20(hh, d.Creator.Address); err != nil {
+			return err
+		}
+
+		if !configOnly {
+			// Field (1) 'ConfigSignature' ByteList[384]
+			if err := putByteList(hh, d.Creator.ConfigSignature, sszMaxSignature, "creator_config_signature"); err != nil {
+				return err
+			}
+		}
+
+		hh.Merkleize(creatorIdx)
+	}
+
+	// Field (10) 'ValidatorAddresses' CompositeList[65536]
+	{
+		subIndx := hh.Index()
+
+		num := uint64(len(d.ValidatorAddresses))
+		for _, vAddr := range d.ValidatorAddresses {
+			vAddrIdx := hh.Index()
+
+			// Field (0) 'FeeRecipientAddress' Bytes20
+			if err := putHexBytes20(hh, vAddr.FeeRecipientAddress); err != nil {
+				return err
+			}
+
+			// Field (1) 'WithdrawalAddress' Bytes20
+			if err := putHexBytes20(hh, vAddr.WithdrawalAddress); err != nil {
+				return err
+			}
+
+			hh.Merkleize(vAddrIdx)
+		}
+
+		hh.MerkleizeWithMixin(subIndx, num, sszMaxValidators)
+	}
+
+	// Field (11) 'DepositAmounts' uint64[256]
+	hasher, ok := hh.(*ssz.Hasher)
+	if !ok {
+		return errors.New("invalid hasher type")
+	}
+
+	var amounts64 []uint64
+	for _, amount := range d.DepositAmounts {
+		amounts64 = append(amounts64, uint64(amount))
+	}
+
+	hasher.PutUint64Array(amounts64, sszMaxDepositAmounts)
+
+	// Field (12) 'ConsensusProtocol' ByteList[256]
+	if err := putByteList(hh, []byte(d.ConsensusProtocol), sszMaxName, "consensus_protocol"); err != nil {
+		return err
+	}
+
+	// Field (13) 'TargetGasLimit' uint64
+	hh.PutUint64(uint64(d.TargetGasLimit))
+
+	// Field (14) 'Compounding' bool
+	hh.PutBool(d.Compounding)
+
+	hh.Merkleize(indx)
+
+	return nil
+}
+
 // hashLock returns a lock hash.
 func hashLock(l Lock) ([32]byte, error) {
 	var hashFunc func(Lock, ssz.HashWalker) error
 	if isAnyVersion(l.Version, v1_0, v1_1, v1_2) {
 		hashFunc = hashLockLegacy
-	} else if isAnyVersion(l.Version, v1_3, v1_4, v1_5, v1_6, v1_7, v1_8, v1_9, v1_10) {
+	} else if isAnyVersion(l.Version, v1_3, v1_4, v1_5, v1_6, v1_7, v1_8, v1_9, v1_10, v1_11) {
 		hashFunc = hashLockV1x3orLater
 	} else {
 		return [32]byte{}, errors.New("unknown version")
@@ -561,7 +712,7 @@ func getValidatorHashFunc(version string) (func(DistValidator, ssz.HashWalker, s
 		return hashValidatorV1x3Or4, nil
 	} else if isAnyVersion(version, v1_5, v1_6, v1_7) {
 		return hashValidatorV1x5to7, nil
-	} else if isAnyVersion(version, v1_8, v1_9, v1_10) {
+	} else if isAnyVersion(version, v1_8, v1_9, v1_10, v1_11) {
 		return hashValidatorV1x8OrLater, nil
 	}
 
@@ -760,7 +911,7 @@ func getDepositDataHashFunc(version string) (func(DepositData, ssz.HashWalker) e
 		return func(DepositData, ssz.HashWalker) error { return nil }, nil
 	} else if isAnyVersion(version, v1_6) {
 		return hashDepositDataV1x6, nil
-	} else if isAnyVersion(version, v1_7, v1_8, v1_9, v1_10) {
+	} else if isAnyVersion(version, v1_7, v1_8, v1_9, v1_10, v1_11) {
 		return hashDepositDataV1x7OrLater, nil
 	}
 
@@ -772,7 +923,7 @@ func getRegistrationHashFunc(version string) (func(BuilderRegistration, ssz.Hash
 	if isAnyVersion(version, v1_0, v1_1, v1_2, v1_3, v1_4, v1_5, v1_6) {
 		// Noop hash function for v1.0 to v1.6 that do not support builder registration.
 		return func(BuilderRegistration, ssz.HashWalker) error { return nil }, nil
-	} else if isAnyVersion(version, v1_7, v1_8, v1_9, v1_10) {
+	} else if isAnyVersion(version, v1_7, v1_8, v1_9, v1_10, v1_11) {
 		return hashBuilderRegistration, nil
 	}
 

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -637,6 +637,11 @@ func hashDefinitionV1x11(d Definition, hh ssz.HashWalker, configOnly bool) error
 	// Field (14) 'Compounding' bool
 	hh.PutBool(d.Compounding)
 
+	// Field (15) 'ConfigHash' Bytes32 (only for full definition hash)
+	if !configOnly {
+		hh.PutBytes(d.ConfigHash[:])
+	}
+
 	hh.Merkleize(indx)
 
 	return nil

--- a/cluster/ssz.go
+++ b/cluster/ssz.go
@@ -19,7 +19,7 @@ const (
 	sszMaxOperators      = 256
 	sszMaxValidators     = 65536
 	sszMaxDepositAmounts = 256
-	sszMaxSignature      = 384
+	sszMaxK1Sigs         = 32
 	sszLenForkVersion    = 4
 	sszLenK1Sig          = 65
 	sszLenBLSSig         = 96
@@ -553,13 +553,13 @@ func hashDefinitionV1x11(d Definition, hh ssz.HashWalker, configOnly bool) error
 					return err
 				}
 
-				// Field (2) 'ConfigSignature' ByteList[384]
-				if err := putByteList(hh, o.ConfigSignature, sszMaxSignature, "config_signature"); err != nil {
+				// Field (2) 'ConfigSignature' List[Bytes65, 32]
+				if err := putK1SigList(hh, o.ConfigSignature, sszMaxK1Sigs, "config_signature"); err != nil {
 					return err
 				}
 
-				// Field (3) 'ENRSignature' ByteList[384]
-				if err := putByteList(hh, o.ENRSignature, sszMaxSignature, "enr_signature"); err != nil {
+				// Field (3) 'ENRSignature' List[Bytes65, 32]
+				if err := putK1SigList(hh, o.ENRSignature, sszMaxK1Sigs, "enr_signature"); err != nil {
 					return err
 				}
 			}
@@ -580,8 +580,8 @@ func hashDefinitionV1x11(d Definition, hh ssz.HashWalker, configOnly bool) error
 		}
 
 		if !configOnly {
-			// Field (1) 'ConfigSignature' ByteList[384]
-			if err := putByteList(hh, d.Creator.ConfigSignature, sszMaxSignature, "creator_config_signature"); err != nil {
+			// Field (1) 'ConfigSignature' List[Bytes65, 32]
+			if err := putK1SigList(hh, d.Creator.ConfigSignature, sszMaxK1Sigs, "creator_config_signature"); err != nil {
 				return err
 			}
 		}
@@ -639,7 +639,7 @@ func hashDefinitionV1x11(d Definition, hh ssz.HashWalker, configOnly bool) error
 
 	// Field (15) 'ConfigHash' Bytes32 (only for full definition hash)
 	if !configOnly {
-		hh.PutBytes(d.ConfigHash[:])
+		hh.PutBytes(d.ConfigHash)
 	}
 
 	hh.Merkleize(indx)

--- a/cluster/testdata/cluster_definition_v1_11_0.json
+++ b/cluster/testdata/cluster_definition_v1_11_0.json
@@ -43,5 +43,5 @@
  "target_gas_limit": 30000000,
  "compounding": false,
  "config_hash": "0x9f889a6e78ca1f4637fab903ccaef6919e70ff35bcc43022512dbb843232d575",
- "definition_hash": "0x21d6a14240b899aa12ffa630dad43f723d918cd1d3269a7c723e49fa438314e3"
+ "definition_hash": "0x3c2c092d9cda006262fc49ef5e8b889e410a4d7b7c215d3f6d90bf3ce3359639"
 }

--- a/cluster/testdata/cluster_definition_v1_11_0.json
+++ b/cluster/testdata/cluster_definition_v1_11_0.json
@@ -1,0 +1,47 @@
+{
+ "name": "test definition",
+ "creator": {
+  "address": "0x6325253fec448615bbda08313f6a8eb668d20bf5",
+  "config_signature": "0x844592d2572bcd0668d2d6c52f5054e2d0836bf84c7174cb7476364cc3dbd968b0f7172ed85794bb358b0c3b525da1786f9fff094279db1944ebd7a19d0f7bba1b"
+ },
+ "operators": [
+  {
+   "address": "0xe0255aa5b7d44bec40f84c892b9bffd43629b022",
+   "enr": "enr:-HW4QNHE5aL5CrfBtTF9Hi2VrssawbiC4xuTUzuk0Mu3wRQSL2mA-XQtlmSQ7brloyZAZKKagpag6KJHOa124gXyklOAgmlkgnY0iXNlY3AyNTZrMaECdAJRmH_MYH0n6WfA_wtyIp3jHSHnNAivFMYGZJlY9Hk",
+   "config_signature": "0x4294040374f6924b98cbf8713f8d962d7c8d019192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea6f5b3af6de0374366c4719e43a00",
+   "enr_signature": "0x067d89bc7f01f1f573981659a44ff17a4c7215a3b539eb1e5849c6077dbb5722f5717a289a266f97647981998ebea89c0b4b373970115e82ed6f4125c8fa73111b"
+  },
+  {
+   "address": "0xd7defa922daae7786667f7e936cd4f24abf7df86",
+   "enr": "enr:-HW4QHWdfdJ6sz5b0NUvnc8gVkv-uBLNhKmPK-uh2CzWzcnFP-TZZoGZkJj9Aavr47GinAQTrOTdvXKYe_0dkvkXnYmAgmlkgnY0iXNlY3AyNTZrMaECRm1_yuVj5csJoNGHC7WANEgEYXh5oUlJzyIoXxuuPyc",
+   "config_signature": "0xf4a8b0993ebdf8883a0ad8be9c3978b04883e56a156a8de563afa467d49dec6a40e9a1d007f033c2823061bdd0eaa59f8e4da6430105220d0b29688b734b8ea000",
+   "enr_signature": "0xca9936e8461f10d77c96ea80a7a665f606f6a63b7f3dfd2567c18979e4d60f26686d9bf2fb26c901ff354cde1607ee294b39f32b7c7822ba64f84ab43ca0c6e61b"
+  }
+ ],
+ "uuid": "0194FDC2-FA2F-4CC0-81D3-FF12045B73C8",
+ "version": "v1.11.0",
+ "timestamp": "2022-07-19T18:19:58+02:00",
+ "num_validators": 2,
+ "threshold": 3,
+ "validators": [
+  {
+   "fee_recipient_address": "0x52fdfc072182654f163f5f0f9a621d729566c74d",
+   "withdrawal_address": "0x81855ad8681d0d86d1e91e00167939cb6694d2c4"
+  },
+  {
+   "fee_recipient_address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
+   "withdrawal_address": "0x5fb90badb37c5821b6d95526a41a9504680b4e7c"
+  }
+ ],
+ "dkg_algorithm": "default",
+ "fork_version": "0x90000069",
+ "deposit_amounts": [
+  "16000000000",
+  "16000000000"
+ ],
+ "consensus_protocol": "abft",
+ "target_gas_limit": 30000000,
+ "compounding": false,
+ "config_hash": "0x9f889a6e78ca1f4637fab903ccaef6919e70ff35bcc43022512dbb843232d575",
+ "definition_hash": "0x21d6a14240b899aa12ffa630dad43f723d918cd1d3269a7c723e49fa438314e3"
+}

--- a/cluster/testdata/cluster_definition_v1_11_0.json
+++ b/cluster/testdata/cluster_definition_v1_11_0.json
@@ -43,5 +43,5 @@
  "target_gas_limit": 30000000,
  "compounding": false,
  "config_hash": "0x9f889a6e78ca1f4637fab903ccaef6919e70ff35bcc43022512dbb843232d575",
- "definition_hash": "0x3c2c092d9cda006262fc49ef5e8b889e410a4d7b7c215d3f6d90bf3ce3359639"
+ "definition_hash": "0x1d3f0ecd993b4dc1083fe39b3a5970f3f3824b82a63791a16e9d3e4e289ed9e4"
 }

--- a/cluster/testdata/cluster_lock_v1_11_0.json
+++ b/cluster/testdata/cluster_lock_v1_11_0.json
@@ -44,7 +44,7 @@
   "target_gas_limit": 30000000,
   "compounding": false,
   "config_hash": "0x9f889a6e78ca1f4637fab903ccaef6919e70ff35bcc43022512dbb843232d575",
-  "definition_hash": "0x21d6a14240b899aa12ffa630dad43f723d918cd1d3269a7c723e49fa438314e3"
+  "definition_hash": "0x3c2c092d9cda006262fc49ef5e8b889e410a4d7b7c215d3f6d90bf3ce3359639"
  },
  "distributed_validators": [
   {
@@ -109,7 +109,7 @@
   }
  ],
  "signature_aggregate": "0x1c1fd3be8990434179d3af4491a369012db92d184fc39d1734ff5716428953bb",
- "lock_hash": "0x44255a0ec5f8e81479be2cab94383912b9026908ccd64d334fbb629a6f77eeb2",
+ "lock_hash": "0x0b7de0e4590ef54d994ac294602caebb899922fbb8dbb54af60ed14b9d08166b",
  "node_signatures": [
   "0xfa3f85b8a62708caebbac880b5b89b93da53810164402104e648b6226a1b7802",
   "0x1851f5d9ac0f313a89ddfc454c5f8f72ac89b38b19f53784c19e9beac03c875a"

--- a/cluster/testdata/cluster_lock_v1_11_0.json
+++ b/cluster/testdata/cluster_lock_v1_11_0.json
@@ -1,0 +1,117 @@
+{
+ "cluster_definition": {
+  "name": "test definition",
+  "creator": {
+   "address": "0x6325253fec448615bbda08313f6a8eb668d20bf5",
+   "config_signature": "0x844592d2572bcd0668d2d6c52f5054e2d0836bf84c7174cb7476364cc3dbd968b0f7172ed85794bb358b0c3b525da1786f9fff094279db1944ebd7a19d0f7bba1b"
+  },
+  "operators": [
+   {
+    "address": "0xe0255aa5b7d44bec40f84c892b9bffd43629b022",
+    "enr": "enr:-HW4QNHE5aL5CrfBtTF9Hi2VrssawbiC4xuTUzuk0Mu3wRQSL2mA-XQtlmSQ7brloyZAZKKagpag6KJHOa124gXyklOAgmlkgnY0iXNlY3AyNTZrMaECdAJRmH_MYH0n6WfA_wtyIp3jHSHnNAivFMYGZJlY9Hk",
+    "config_signature": "0x4294040374f6924b98cbf8713f8d962d7c8d019192c24224e2cafccae3a61fb586b14323a6bc8f9e7df1d929333ff993933bea6f5b3af6de0374366c4719e43a00",
+    "enr_signature": "0x067d89bc7f01f1f573981659a44ff17a4c7215a3b539eb1e5849c6077dbb5722f5717a289a266f97647981998ebea89c0b4b373970115e82ed6f4125c8fa73111b"
+   },
+   {
+    "address": "0xd7defa922daae7786667f7e936cd4f24abf7df86",
+    "enr": "enr:-HW4QHWdfdJ6sz5b0NUvnc8gVkv-uBLNhKmPK-uh2CzWzcnFP-TZZoGZkJj9Aavr47GinAQTrOTdvXKYe_0dkvkXnYmAgmlkgnY0iXNlY3AyNTZrMaECRm1_yuVj5csJoNGHC7WANEgEYXh5oUlJzyIoXxuuPyc",
+    "config_signature": "0xf4a8b0993ebdf8883a0ad8be9c3978b04883e56a156a8de563afa467d49dec6a40e9a1d007f033c2823061bdd0eaa59f8e4da6430105220d0b29688b734b8ea000",
+    "enr_signature": "0xca9936e8461f10d77c96ea80a7a665f606f6a63b7f3dfd2567c18979e4d60f26686d9bf2fb26c901ff354cde1607ee294b39f32b7c7822ba64f84ab43ca0c6e61b"
+   }
+  ],
+  "uuid": "0194FDC2-FA2F-4CC0-81D3-FF12045B73C8",
+  "version": "v1.11.0",
+  "timestamp": "2022-07-19T18:19:58+02:00",
+  "num_validators": 2,
+  "threshold": 3,
+  "validators": [
+   {
+    "fee_recipient_address": "0x52fdfc072182654f163f5f0f9a621d729566c74d",
+    "withdrawal_address": "0x81855ad8681d0d86d1e91e00167939cb6694d2c4"
+   },
+   {
+    "fee_recipient_address": "0xeb9d18a44784045d87f3c67cf22746e995af5a25",
+    "withdrawal_address": "0x5fb90badb37c5821b6d95526a41a9504680b4e7c"
+   }
+  ],
+  "dkg_algorithm": "default",
+  "fork_version": "0x90000069",
+  "deposit_amounts": [
+   "16000000000",
+   "16000000000"
+  ],
+  "consensus_protocol": "abft",
+  "target_gas_limit": 30000000,
+  "compounding": false,
+  "config_hash": "0x9f889a6e78ca1f4637fab903ccaef6919e70ff35bcc43022512dbb843232d575",
+  "definition_hash": "0x21d6a14240b899aa12ffa630dad43f723d918cd1d3269a7c723e49fa438314e3"
+ },
+ "distributed_validators": [
+  {
+   "distributed_public_key": "0x6865fcf92b0c3a17c9028be9914eb7649c6c9347800979d1830356f2a54c3deab2a4b4475d63afbe8fb56987c77f5818",
+   "public_shares": [
+    "0x526f1814be823350eab13935f31d84484517e924aef78ae151c00755925836b7075885650c30ec29a3703934bf50a28d",
+    "0xa102975deda77e758579ea3dfe4136abf752b3b8271d03e944b3c9db366b75045f8efd69d22ae5411947cb553d769426"
+   ],
+   "builder_registration": {
+    "message": {
+     "fee_recipient": "0x9be1072fb63c35d6042c4160f38ee9e2a9f3fb4f",
+     "gas_limit": 30000000,
+     "timestamp": 1655733600,
+     "pubkey": "0x6865fcf92b0c3a17c9028be9914eb7649c6c9347800979d1830356f2a54c3deab2a4b4475d63afbe8fb56987c77f5818"
+    },
+    "signature": "0x15d9afbcbf7f7da41ab0408e3969c2e2cdcf233438bf1774ace7709a4f091e9a83fdeae0ec55eb233a9b5394cb3c7856b546d313c8a3b4c1c0e05447f4ba370eb36dbcfdec90b302dcdc3b9ef522e2a6f1ed0afec1f8e20faabedf6b162e717d"
+   },
+   "partial_deposit_data": [
+    {
+     "pubkey": "0x6865fcf92b0c3a17c9028be9914eb7649c6c9347800979d1830356f2a54c3deab2a4b4475d63afbe8fb56987c77f5818",
+     "withdrawal_credentials": "0x5abf44ccde263b5606633e2bf0006f28295d7d39069f01a239c4365854c3af7f",
+     "amount": "5159484672389300587",
+     "signature": "0x8d12f41257325fff332f7576b0620556304a3e3eae14c28d0cea39d2901a52720da85ca1e4b38eaf3f44c6c6ef8362f2f54fc00e09d6fc25640854c15dfcacaa8a2cecce5a3aba53ab705b18db94b4d338a5143e63408d8724b0cf3fae17a3f7"
+    },
+    {
+     "pubkey": "0x6865fcf92b0c3a17c9028be9914eb7649c6c9347800979d1830356f2a54c3deab2a4b4475d63afbe8fb56987c77f5818",
+     "withdrawal_credentials": "0xf08dfcbd02b80809398585928a0f7de50be1a6dc1d5768e8537988fddce562e9",
+     "amount": "634163968188082595",
+     "signature": "0xb948c918bbe5e60c5ead6fc7ae77ba1d259b188a4b21c86fbc23d728b45347eada650af24c56d0800a8691332088a805bd55c446e25eb07590bafcccbec6177536401d9a2b7f512b54bfc9d00532adf5aaa7c3a96bc59b489f77d9042c5bce26"
+    }
+   ]
+  },
+  {
+   "distributed_public_key": "0x3a748a58677a0c56348f8921a266b11d0f334c62fe52ba53af19779cb2948b6570ffa0b773963c130ad797ddeafe4e3a",
+   "public_shares": [
+    "0xd29b5125210f0ef1c314090f07c79a6f571c246f3e9ac0b7413ef110bd58b00ce73bff706f7ff4b6f44090a32711f320",
+    "0x8e4e4b89cb5165ce64002cbd9c2887aa113df2468928d5a23b9ca740f80c9382d9c6034ad2960c796503e1ce221725f5"
+   ],
+   "builder_registration": {
+    "message": {
+     "fee_recipient": "0x09277b92cef9046efa18500944cbe800a0b1527e",
+     "gas_limit": 30000000,
+     "timestamp": 1655733600,
+     "pubkey": "0x3a748a58677a0c56348f8921a266b11d0f334c62fe52ba53af19779cb2948b6570ffa0b773963c130ad797ddeafe4e3a"
+    },
+    "signature": "0x8857b799acb18e4affabe3037ffe7fa68aa8af5e39cc416e734d373c5ebebc9cdcc595bcce3c7bd3d8df93fab7e125ddebafe65a31bd5d41e2d2ce9c2b17892f0fea1931a290220777a93143dfdcbfa68406e877073ff08834e197a4034aa48a"
+   },
+   "partial_deposit_data": [
+    {
+     "pubkey": "0x3a748a58677a0c56348f8921a266b11d0f334c62fe52ba53af19779cb2948b6570ffa0b773963c130ad797ddeafe4e3a",
+     "withdrawal_credentials": "0x6c9fb03fc9228fbae88fd580663a0454b68312207f0a3b584c62316492b49753",
+     "amount": "5118991178208641749",
+     "signature": "0xb558250d8fb50e77f2bf4f0152e5d49435807f9d4b97be6fb77970466a5626fe33408cf9e88e2c797408a32d29416baf206a329cfffd4a75e498320982c85aad70384859c05a4b13a1d5b2f5bfef5a6ed92da482caa9568e5b6fe9d8a9ddd9eb"
+    },
+    {
+     "pubkey": "0x3a748a58677a0c56348f8921a266b11d0f334c62fe52ba53af19779cb2948b6570ffa0b773963c130ad797ddeafe4e3a",
+     "withdrawal_credentials": "0x5580ff560760fd36514ca197c875f1d02d9216eba7627e2398322eb5cf43d72b",
+     "amount": "395882274225087444",
+     "signature": "0xd2e5b887ad6eb82acd1c5b078143ee26a586ad23139d5041723470bf24a865837c9123461c41f5ff99aa99ce24eb4d788576e3336e65491622558fdf297b9fa007864bafd7cd4ca1b2fb5766ab431a032b72b9a7e937ed648d0801f29055d309"
+    }
+   ]
+  }
+ ],
+ "signature_aggregate": "0x1c1fd3be8990434179d3af4491a369012db92d184fc39d1734ff5716428953bb",
+ "lock_hash": "0x44255a0ec5f8e81479be2cab94383912b9026908ccd64d334fbb629a6f77eeb2",
+ "node_signatures": [
+  "0xfa3f85b8a62708caebbac880b5b89b93da53810164402104e648b6226a1b7802",
+  "0x1851f5d9ac0f313a89ddfc454c5f8f72ac89b38b19f53784c19e9beac03c875a"
+ ]
+}

--- a/cluster/testdata/cluster_lock_v1_11_0.json
+++ b/cluster/testdata/cluster_lock_v1_11_0.json
@@ -44,7 +44,7 @@
   "target_gas_limit": 30000000,
   "compounding": false,
   "config_hash": "0x9f889a6e78ca1f4637fab903ccaef6919e70ff35bcc43022512dbb843232d575",
-  "definition_hash": "0x3c2c092d9cda006262fc49ef5e8b889e410a4d7b7c215d3f6d90bf3ce3359639"
+  "definition_hash": "0x1d3f0ecd993b4dc1083fe39b3a5970f3f3824b82a63791a16e9d3e4e289ed9e4"
  },
  "distributed_validators": [
   {
@@ -109,7 +109,7 @@
   }
  ],
  "signature_aggregate": "0x1c1fd3be8990434179d3af4491a369012db92d184fc39d1734ff5716428953bb",
- "lock_hash": "0x0b7de0e4590ef54d994ac294602caebb899922fbb8dbb54af60ed14b9d08166b",
+ "lock_hash": "0xecb029e3f8fb17a280a8960718d21aef2506d861b8b1a0ca9a95d8ee15dae8e0",
  "node_signatures": [
   "0xfa3f85b8a62708caebbac880b5b89b93da53810164402104e648b6226a1b7802",
   "0x1851f5d9ac0f313a89ddfc454c5f8f72ac89b38b19f53784c19e9beac03c875a"

--- a/cluster/version.go
+++ b/cluster/version.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	currentVersion = v1_10
+	currentVersion = v1_11
 	dkgAlgo        = "default"
 
-	v1_10 = "v1.10.0" // Default
+	v1_11 = "v1.11.0" // Default
+	v1_10 = "v1.10.0"
 	v1_9  = "v1.9.0"
 	v1_8  = "v1.8.0"
 	v1_7  = "v1.7.0"
@@ -29,6 +30,7 @@ const (
 )
 
 var supportedVersions = map[string]bool{
+	v1_11: true,
 	v1_10: true,
 	v1_9:  true,
 	v1_8:  true,

--- a/cmd/combine/combine.go
+++ b/cmd/combine/combine.go
@@ -65,7 +65,9 @@ func Combine(ctx context.Context, inputDir, outputDir string, force, noverify bo
 	)
 
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(executionEngineAddr)
-	go eth1Cl.Run(ctx)
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return errors.Wrap(err, "eth1 client")
+	}
 
 	lock, possibleKeyPaths, err := loadManifest(ctx, inputDir, noverify, eth1Cl)
 	if err != nil {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -178,7 +178,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 
 	var def cluster.Definition
 	if conf.DefFile != "" { // Load definition from DefFile
-		def, err = loadDefinition(ctx, conf.DefFile)
+		def, err = loadDefinition(ctx, conf.DefFile, conf.ExecutionEngineAddr)
 		if err != nil {
 			return err
 		}
@@ -1070,7 +1070,7 @@ func aggSign(secrets [][]tbls.PrivateKey, message []byte) ([]byte, error) {
 
 // loadDefinition returns the cluster definition from disk or an HTTP URL. It also verifies signatures
 // and hashes before returning the definition.
-func loadDefinition(ctx context.Context, defFile string) (cluster.Definition, error) {
+func loadDefinition(ctx context.Context, defFile, execEngineAddr string) (cluster.Definition, error) {
 	var def cluster.Definition
 
 	// Fetch definition from network if URI is provided
@@ -1098,7 +1098,10 @@ func loadDefinition(ctx context.Context, defFile string) (cluster.Definition, er
 			z.Str("definition_hash", fmt.Sprintf("%#x", def.DefinitionHash)))
 	}
 
-	if err := def.VerifySignatures(nil); err != nil {
+	eth1Cl := eth1wrap.NewDefaultEthClientRunner(execEngineAddr)
+	go eth1Cl.Run(ctx)
+
+	if err := def.VerifySignatures(eth1Cl); err != nil {
 		return cluster.Definition{}, err
 	}
 

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -216,7 +216,9 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	// Get a cluster definition, either from a definition file or from the config.
 	if conf.DefFile != "" {
 		eth1Cl := eth1wrap.NewDefaultEthClientRunner(conf.ExecutionEngineAddr)
-		go eth1Cl.Run(ctx)
+		if err = eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+			return err
+		}
 
 		// Validate the provided definition.
 		err = validateDef(ctx, conf.InsecureKeys, conf.KeymanagerAddrs, def, eth1Cl)
@@ -1099,7 +1101,9 @@ func loadDefinition(ctx context.Context, defFile, execEngineAddr string) (cluste
 	}
 
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(execEngineAddr)
-	go eth1Cl.Run(ctx)
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return cluster.Definition{}, err
+	}
 
 	if err := def.VerifySignatures(eth1Cl); err != nil {
 		return cluster.Definition{}, err

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -41,11 +41,11 @@ const (
 
 func TestCreateCluster(t *testing.T) {
 	defPath := "../cluster/examples/cluster-definition-006.json"
-	def, err := loadDefinition(context.Background(), defPath)
+	def, err := loadDefinition(context.Background(), defPath, "")
 	require.NoError(t, err)
 
 	defPathTwoNodes := "../cluster/examples/cluster-definition-001.json"
-	defTwoNodes, err := loadDefinition(context.Background(), defPathTwoNodes)
+	defTwoNodes, err := loadDefinition(context.Background(), defPathTwoNodes, "")
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -462,7 +462,7 @@ func TestValidateDef(t *testing.T) {
 	require.NoError(t, err)
 
 	defPath := "../cluster/examples/cluster-definition-002.json"
-	remoteDef, err := loadDefinition(context.Background(), defPath)
+	remoteDef, err := loadDefinition(context.Background(), defPath, "")
 	require.NoError(t, err)
 
 	t.Run("zero address", func(t *testing.T) {

--- a/cmd/createdkg.go
+++ b/cmd/createdkg.go
@@ -246,7 +246,9 @@ func runCreateDKG(ctx context.Context, conf createDKGConfig) (err error) {
 	}
 
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(conf.ExecutionEngineAddr)
-	go eth1Cl.Run(ctx)
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return err
+	}
 
 	if !conf.Publish {
 		if err := def.VerifySignatures(eth1Cl); err != nil {

--- a/cmd/deposit.go
+++ b/cmd/deposit.go
@@ -17,6 +17,7 @@ type depositConfig struct {
 	ValidatorKeysDir    string
 	PublishAddress      string
 	PublishTimeout      time.Duration
+	ExecutionEngineAddr string
 	Log                 log.Config
 }
 
@@ -39,4 +40,5 @@ func bindDepositFlags(cmd *cobra.Command, config *depositConfig) {
 	cmd.Flags().StringVar(&config.LockFilePath, lockFilePath.String(), ".charon/cluster-lock.json", "Path to the cluster lock file defining the distributed validator cluster.")
 	cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech/v1", "The URL of the remote API.")
 	cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 5*time.Minute, "Timeout for publishing a signed deposit to the publish-address API.")
+	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API, used to verify ERC-1271 (e.g. Safe multisig) cluster signatures.")
 }

--- a/cmd/depositfetch.go
+++ b/cmd/depositfetch.go
@@ -57,7 +57,7 @@ func bindDepositFetchFlags(cmd *cobra.Command, config *depositFetchConfig) {
 }
 
 func runDepositFetch(ctx context.Context, config depositFetchConfig) error {
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/depositsign.go
+++ b/cmd/depositsign.go
@@ -68,7 +68,7 @@ func runDepositSign(ctx context.Context, config depositSignConfig) error {
 		return errors.Wrap(err, "load identity key", z.Str("private_key_path", config.PrivateKeyPath))
 	}
 
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/exit.go
+++ b/cmd/exit.go
@@ -27,6 +27,7 @@ type exitConfig struct {
 	PrivateKeyPath          string
 	ValidatorKeysDir        string
 	LockFilePath            string
+	ExecutionEngineAddr     string
 	PublishAddress          string
 	PublishTimeout          time.Duration
 	ExitEpoch               uint64
@@ -78,6 +79,7 @@ const (
 	testnetCapellaHardFork
 	beaconNodeHeaders
 	fallbackBeaconNodeAddrs
+	executionClientRPCEndpoint
 )
 
 func (ef exitFlag) String() string {
@@ -124,6 +126,8 @@ func (ef exitFlag) String() string {
 		return "beacon-node-headers"
 	case fallbackBeaconNodeAddrs:
 		return "fallback-beacon-node-endpoints"
+	case executionClientRPCEndpoint:
+		return "execution-client-rpc-endpoint"
 	default:
 		return "unknown"
 	}
@@ -190,6 +194,8 @@ func bindExitFlags(cmd *cobra.Command, config *exitConfig, flags []exitCLIFlag) 
 			cmd.Flags().StringSliceVar(&config.BeaconNodeHeaders, "beacon-node-headers", nil, "Comma separated list of headers formatted as header=value")
 		case fallbackBeaconNodeAddrs:
 			cmd.Flags().StringSliceVar(&config.FallbackBeaconNodeAddrs, "fallback-beacon-node-endpoints", nil, "A list of beacon nodes to use if the primary list are offline or unhealthy.")
+		case executionClientRPCEndpoint:
+			cmd.Flags().StringVar(&config.ExecutionEngineAddr, executionClientRPCEndpoint.String(), "", maybeRequired("The address of the execution engine JSON-RPC API, used to verify ERC-1271 (e.g. Safe multisig) cluster signatures."))
 		}
 
 		if f.required {

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -58,6 +58,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 		{publishAddress, false},
 		{privateKeyPath, false},
 		{lockFilePath, false},
+		{executionClientRPCEndpoint, false},
 		{validatorKeysDir, false},
 		{exitEpoch, false},
 		{validatorPubkey, false},
@@ -126,7 +127,7 @@ func runBcastFullExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "load identity key")
 	}
 
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/exit_delete.go
+++ b/cmd/exit_delete.go
@@ -45,6 +45,7 @@ func newDeleteExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Co
 		{publishAddress, false},
 		{privateKeyPath, false},
 		{lockFilePath, false},
+		{executionClientRPCEndpoint, false},
 		{validatorPubkey, false},
 		{all, false},
 		{publishTimeout, false},
@@ -88,7 +89,7 @@ func runDeleteExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "load identity key", z.Str("private_key_path", config.PrivateKeyPath))
 	}
 
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/exit_fetch.go
+++ b/cmd/exit_fetch.go
@@ -49,6 +49,7 @@ func newFetchExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Com
 		{publishAddress, false},
 		{privateKeyPath, false},
 		{lockFilePath, false},
+		{executionClientRPCEndpoint, false},
 		{validatorPubkey, false},
 		{all, false},
 		{fetchedExitPath, false},
@@ -108,7 +109,7 @@ func runFetchExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "load identity key", z.Str("private_key_path", config.PrivateKeyPath))
 	}
 
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/exit_list.go
+++ b/cmd/exit_list.go
@@ -44,6 +44,7 @@ func newListActiveValidatorsCmd(runFunc func(context.Context, exitConfig) error)
 
 	bindExitFlags(cmd, &config, []exitCLIFlag{
 		{lockFilePath, false},
+		{executionClientRPCEndpoint, false},
 		{beaconNodeEndpoints, true},
 		{beaconNodeTimeout, false},
 		{testnetName, false},
@@ -90,7 +91,7 @@ func runListActiveValidatorsCmd(ctx context.Context, config exitConfig) error {
 }
 
 func listActiveVals(ctx context.Context, config exitConfig) ([]string, error) {
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -49,6 +49,7 @@ func newSignPartialExitCmd(runFunc func(context.Context, exitConfig) error) *cob
 		{publishAddress, false},
 		{privateKeyPath, false},
 		{lockFilePath, false},
+		{executionClientRPCEndpoint, false},
 		{validatorKeysDir, false},
 		{exitEpoch, false},
 		{validatorPubkey, false},
@@ -108,7 +109,7 @@ func runSignPartialExit(ctx context.Context, config exitConfig) error {
 		return errors.Wrap(err, "load identity key", z.Str("private_key_path", config.PrivateKeyPath))
 	}
 
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/feerecipient.go
+++ b/cmd/feerecipient.go
@@ -17,6 +17,7 @@ type feerecipientConfig struct {
 	OverridesFilePath   string
 	PublishAddress      string
 	PublishTimeout      time.Duration
+	ExecutionEngineAddr string
 	Log                 log.Config
 }
 
@@ -35,4 +36,5 @@ func newFeeRecipientCmd(cmds ...*cobra.Command) *cobra.Command {
 func bindFeeRecipientRemoteAPIFlags(cmd *cobra.Command, config *feerecipientConfig) {
 	cmd.Flags().StringVar(&config.PublishAddress, publishAddress.String(), "https://api.obol.tech/v1", "The URL of the remote API.")
 	cmd.Flags().DurationVar(&config.PublishTimeout, publishTimeout.String(), 5*time.Minute, "Timeout for accessing the remote API.")
+	cmd.Flags().StringVar(&config.ExecutionEngineAddr, "execution-client-rpc-endpoint", "", "The address of the execution engine JSON-RPC API, used to verify ERC-1271 (e.g. Safe multisig) cluster signatures.")
 }

--- a/cmd/feerecipientfetch.go
+++ b/cmd/feerecipientfetch.go
@@ -99,7 +99,7 @@ func logValidatorStatus(ctx context.Context, pv app.ProcessedValidators) {
 }
 
 func runFeeRecipientFetch(ctx context.Context, config feerecipientFetchConfig) error {
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/feerecipientlist.go
+++ b/cmd/feerecipientlist.go
@@ -154,7 +154,7 @@ func entriesEquivalent(a, b registrationEntry) bool {
 }
 
 func runFeeRecipientList(ctx context.Context, config feerecipientListConfig) error {
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/feerecipientsign.go
+++ b/cmd/feerecipientsign.go
@@ -156,7 +156,7 @@ func runFeeRecipientSign(ctx context.Context, config feerecipientSignConfig) err
 		return errors.Wrap(err, "load identity key", z.Str("private_key_path", config.PrivateKeyPath))
 	}
 
-	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath)
+	cl, err := cluster.LoadClusterLockAndVerify(ctx, config.LockFilePath, config.ExecutionEngineAddr)
 	if err != nil {
 		return err
 	}

--- a/cmd/testpeers.go
+++ b/cmd/testpeers.go
@@ -678,7 +678,7 @@ func relayPingMeasureTest(ctx context.Context, _ *testPeersConfig, target string
 // helper functions
 
 func fetchPeersFromDefinition(ctx context.Context, path string) ([]string, error) {
-	def, err := loadDefinition(ctx, path)
+	def, err := loadDefinition(ctx, path, "")
 	if err != nil {
 		return nil, errors.Wrap(err, "read definition file", z.Str("path", path))
 	}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -162,7 +162,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 
 	// This DKG only supports a few specific config versions.
-	if def.Version != "v1.6.0" && def.Version != "v1.7.0" && def.Version != "v1.8.0" && def.Version != "v1.9.0" && def.Version != "v1.10.0" {
+	if def.Version != "v1.6.0" && def.Version != "v1.7.0" && def.Version != "v1.8.0" && def.Version != "v1.9.0" && def.Version != "v1.10.0" && def.Version != "v1.11.0" {
 		return errors.New("only v1.6.0 and newer cluster definition versions supported")
 	}
 

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -131,7 +131,9 @@ func Run(ctx context.Context, conf Config) (err error) {
 	version.LogInfo(ctx, "Charon DKG starting")
 
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(conf.ExecutionEngineAddr)
-	go eth1Cl.Run(ctx)
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return err
+	}
 
 	var (
 		def                  cluster.Definition

--- a/dkg/protocol.go
+++ b/dkg/protocol.go
@@ -117,7 +117,9 @@ func RunProtocol(ctx context.Context, protocol Protocol, lockFilePath, privateKe
 	}
 
 	protocolCtx.ETH1Client = eth1wrap.NewDefaultEthClientRunner(config.ExecutionEngineAddr)
-	go protocolCtx.ETH1Client.Run(ctx)
+	if err := eth1wrap.RunAndWait(ctx, protocolCtx.ETH1Client); err != nil {
+		return err
+	}
 
 	enrPrivateKey, err := LoadPrivKey(privateKeyPath)
 	if err != nil {
@@ -191,7 +193,9 @@ func LoadAndVerifyClusterLock(ctx context.Context, lockFilePath, executionEngine
 	defer cancel()
 
 	eth1Cl := eth1wrap.NewDefaultEthClientRunner(executionEngineAddr)
-	go eth1Cl.Run(ctx)
+	if err := eth1wrap.RunAndWait(ctx, eth1Cl); err != nil {
+		return nil, err
+	}
 
 	return cluster.LoadClusterLock(ctx, lockFilePath, noVerify, eth1Cl)
 }


### PR DESCRIPTION
New cluster definition `v1.11` to support variable-sized signatures.

category: feature
ticket: #4265

