### PR TITLE
app: promote fetch_only_commidx_0 feature flag to stable

### DIFF
--- a/app/featureset/featureset.go
+++ b/app/featureset/featureset.go
@@ -98,7 +98,7 @@ var (
 		AttestationInclusion:     statusAlpha,
 		ProposalTimeout:          statusAlpha,
 		QUIC:                     statusAlpha,
-		FetchOnlyCommIdx0:        statusAlpha,
+		FetchOnlyCommIdx0:        statusStable,
 		ChainSplitHalt:           statusAlpha,
 		FetchAttOnBlock:          statusAlpha,
 		FetchAttOnBlockWithDelay: statusAlpha,


### PR DESCRIPTION
With the newest lighthouse v8.1.0, now all VCs do query only commidx 0. Users running Lighthouse <v8.1.0 in their cluster can still disable it with `feature-set-disable=fetch_only_commidx_0` flag.

category: feature
ticket: none