### PR TITLE
dkg: bounds and shares checks

### DIFF
--- a/dkg/pedersen/reshare.go
+++ b/dkg/pedersen/reshare.go
@@ -23,7 +23,7 @@ import (
 )
 
 // RunReshareDKG runs the core reshare protocol for add/remove operators or just reshare.
-func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []share.Share) ([]share.Share, error) {
+func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []share.Share, expectedValidatorPubKeys []tbls.PublicKey) ([]share.Share, error) {
 	if config.Reshare == nil {
 		return nil, errors.New("reshare config is nil")
 	}
@@ -242,7 +242,13 @@ func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []s
 			reshareConfig.PublicCoeffs = nil
 		} else {
 			// This is a new node - restore public coefficients from exchanged public key shares
-			commits, err := restoreCommits(pubKeyShares, shareNum, config.Threshold)
+			// Validate that the recovered group public key matches the expected validator public key
+			var expectedPubKey *tbls.PublicKey
+			if shareNum < len(expectedValidatorPubKeys) {
+				expectedPubKey = &expectedValidatorPubKeys[shareNum]
+			}
+
+			commits, err := restoreCommits(pubKeyShares, shareNum, config.Threshold, expectedPubKey)
 			if err != nil {
 				return nil, errors.Wrap(err, "restore commits")
 			}
@@ -305,7 +311,8 @@ func broadcastNoneKey(ctx context.Context, config *Config, board *Board) error {
 
 // restoreCommitsFromPubShares recovers public polynomial commits from a map of public key shares.
 // The nodeIdx in the map is 0-indexed.
-func restoreCommitsFromPubShares(pubSharesBytes map[int][]byte, threshold int) ([]kyber.Point, error) {
+// If expectedValidatorPubKey is provided, validates that the recovered group public key matches.
+func restoreCommitsFromPubShares(pubSharesBytes map[int][]byte, threshold int, expectedValidatorPubKey *tbls.PublicKey) ([]kyber.Point, error) {
 	var (
 		suite          = kbls.NewBLS12381Suite()
 		kyberPubShares []*kshare.PubShare
@@ -331,6 +338,22 @@ func restoreCommitsFromPubShares(pubSharesBytes map[int][]byte, threshold int) (
 
 	_, commits := pubPoly.Info()
 
+	// Validate the recovered group public key against the expected validator public key.
+	if expectedValidatorPubKey != nil {
+		if len(commits) == 0 {
+			return nil, errors.New("no commits recovered")
+		}
+
+		recoveredPubKeyBytes, err := commits[0].MarshalBinary()
+		if err != nil {
+			return nil, errors.Wrap(err, "marshal recovered public key")
+		}
+
+		if !bytes.Equal(recoveredPubKeyBytes, expectedValidatorPubKey[:]) {
+			return nil, errors.New("recovered group public key does not match expected validator public key")
+		}
+	}
+
 	return commits, nil
 }
 
@@ -341,7 +364,7 @@ func restoreDistKeyShare(keyShare share.Share, threshold int, nodeIdx int) (*kdk
 		pubSharesBytes[shareIdx-1] = pks[:]
 	}
 
-	commits, err := restoreCommitsFromPubShares(pubSharesBytes, threshold)
+	commits, err := restoreCommitsFromPubShares(pubSharesBytes, threshold, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "restore commits")
 	}
@@ -376,14 +399,25 @@ func restoreDistKeyShare(keyShare share.Share, threshold int, nodeIdx int) (*kdk
 	return dks, nil
 }
 
-func restoreCommits(publicShares map[int][][]byte, shareNum, threshold int) ([]kyber.Point, error) {
+func restoreCommits(publicShares map[int][][]byte, shareNum, threshold int, expectedValidatorPubKey *tbls.PublicKey) ([]kyber.Point, error) {
+	// Validate that all nodes have sufficient shares before accessing
+	for nodeIdx, pks := range publicShares {
+		if shareNum >= len(pks) {
+			return nil, errors.New("insufficient public key shares from node",
+				z.Int("node_index", nodeIdx),
+				z.Int("share_num", shareNum),
+				z.Int("available_shares", len(pks)),
+			)
+		}
+	}
+
 	// Extract the specific share's public keys for all nodes
 	pubSharesBytes := make(map[int][]byte)
 	for nodeIdx, pks := range publicShares {
 		pubSharesBytes[nodeIdx] = pks[shareNum]
 	}
 
-	return restoreCommitsFromPubShares(pubSharesBytes, threshold)
+	return restoreCommitsFromPubShares(pubSharesBytes, threshold, expectedValidatorPubKey)
 }
 
 func generateNonce(nodes []kdkg.Node) ([]byte, error) {

--- a/dkg/pedersen/reshare_test.go
+++ b/dkg/pedersen/reshare_test.go
@@ -79,10 +79,20 @@ func TestRunReshare(t *testing.T) {
 
 	group, gctx := errgroup.WithContext(t.Context())
 
+	// Extract expected validator public keys from old shares
+	// All nodes should have the same validator public keys
+	var expectedValidatorPubKeys []tbls.PublicKey
+	if len(oldShares) > 0 && len(oldShares[0]) > 0 {
+		expectedValidatorPubKeys = make([]tbls.PublicKey, len(oldShares[0]))
+		for i, share := range oldShares[0] {
+			expectedValidatorPubKeys[i] = share.PubKey
+		}
+	}
+
 	for n := range nodes {
 		group.Go(func() error {
 			nodes[n].Config.Reshare = &pedersen.ReshareConfig{TotalShares: numVals, NewThreshold: threshold}
-			shares, err := pedersen.RunReshareDKG(gctx, nodes[n].Config, nodes[n].Board, oldShares[n])
+			shares, err := pedersen.RunReshareDKG(gctx, nodes[n].Config, nodes[n].Board, oldShares[n], expectedValidatorPubKeys)
 			nodes[n].Shares = shares
 
 			return err

--- a/dkg/protocolsteps.go
+++ b/dkg/protocolsteps.go
@@ -33,7 +33,18 @@ type reshareProtocolStep struct {
 }
 
 func (s *reshareProtocolStep) Run(ctx context.Context, pctx *ProtocolContext) error {
-	shares, err := pedersen.RunReshareDKG(ctx, s.config, s.board, pctx.Shares)
+	// Extract expected validator public keys from the cluster lock
+	expectedValidatorPubKeys := make([]tbls.PublicKey, len(pctx.Lock.Validators))
+	for i, validator := range pctx.Lock.Validators {
+		pubKey, err := validator.PublicKey()
+		if err != nil {
+			return errors.Wrap(err, "get validator public key", z.Int("validator_index", i))
+		}
+
+		expectedValidatorPubKeys[i] = pubKey
+	}
+
+	shares, err := pedersen.RunReshareDKG(ctx, s.config, s.board, pctx.Shares, expectedValidatorPubKeys)
 	if err != nil {
 		return err
 	}

--- a/dkg/protocolsteps_internal_test.go
+++ b/dkg/protocolsteps_internal_test.go
@@ -99,6 +99,16 @@ func TestReshareProtocolStep(t *testing.T) {
 
 	group, gctx := errgroup.WithContext(t.Context())
 
+	// Create a cluster lock with the expected validator public keys
+	lock := &cluster.Lock{
+		Validators: make([]cluster.DistValidator, numVals),
+	}
+	for i, pubKey := range oldPubKeys {
+		lock.Validators[i] = cluster.DistValidator{
+			PubKey: pedersen.MustDecodeHex(t, pubKey),
+		}
+	}
+
 	for n := range nodes {
 		group.Go(func() error {
 			nodes[n].Config.Reshare = &pedersen.ReshareConfig{TotalShares: numVals, NewThreshold: threshold}
@@ -109,6 +119,7 @@ func TestReshareProtocolStep(t *testing.T) {
 			}
 			pctx := &ProtocolContext{
 				Shares: oldShares[n],
+				Lock:   lock,
 			}
 
 			return step.Run(gctx, pctx)


### PR DESCRIPTION
Improves `reshare.go` checks:

1. ` restoreCommits` out-of-bounds checks for `shareNum`
2.  polynomial commitment validation during reshare (against expected validator pubkey)

category: refactor
ticket: none

