### PR TITLE
app: add HeadBlockNotFullyVerified condition fallback BN

### DIFF
--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -227,7 +227,7 @@ func isTimeoutError(err error) bool {
 // isSyncingError returns true if error message contains the word "syncing".
 func isSyncingError(err error) bool {
 	msg := err.Error()
-	return strings.Contains(msg, "syncing")
+	return strings.Contains(msg, "syncing") || strings.Contains(msg, "HeadBlockNotFullyVerified")
 }
 
 // isBadGateway returns true when the error indicates a connectivity or upstream gateway issue.


### PR DESCRIPTION
An operator had an issue where the EL is not synced, but the CL is. However, Charon did not fallback to its fallback BNs.

```
{"log":"04:15:15.014 ERRO fetcher    Permanent failure calling fetcher/fetch: fetch attester data: beacon api attestation_data: nok http response: GET failed with status 500: {\"code\":500,\"message\":\"UNHANDLED_ERROR: HeadBlockNotFullyVerified { beacon_block_root: 0x296d87292e7533cce4abfb1cd83e96bb5692d7f96498398109ccc653d125fc46, execution_status: Optimistic(0x8fc7a74d22d5272c2b938db92bbd7866a08cb4579d1523b26c281281eb5869d8) }\",\"stacktraces\":[]} {\"label\": \"attestation_data\", \"status_code\": 500, \"endpoint\": \"/eth/v1/validator/attestation_data\", \"method\": \"GET\", \"data\": \"{\\\"code\\\":500,\\\"message\\\":\\\"UNHANDLED_ERROR: HeadBlockNotFullyVerified { beacon_block_root: 0x296d87292e7533cce4abfb1cd83e96bb5692d7f96498398109ccc653d125fc46, execution_status: Optimistic(0x8fc7a74d22d5272c2b938db92bbd7866a08cb4579d1523b26c281281eb5869d8) }\\\",\\\"stacktraces\\\":[]}\", \"duty\": \"13728074/attester\"}\n","stream":"stderr","time":"2026-02-20T04:15:15.014464971Z"}
```

category: feature
ticket: none