### PR TITLE
github: change supported versions in different PR

### DIFF
--- a/.github/workflows/minor-release-step3.yml
+++ b/.github/workflows/minor-release-step3.yml
@@ -138,22 +138,9 @@ jobs:
             exit 1
           fi
 
-          # Add new version to the top of the Supported() list
-          # Find the line with "return []SemVer{" and add the new version on the next line
-          sed -i "/return \[\]SemVer{/a\\
-          \\t\\t{major: ${MAJOR}, minor: ${MINOR}}," "$VERSION_FILE"
-
-          # Verify the supported version was added
-          if ! grep -q "{major: ${MAJOR}, minor: ${MINOR}}" "$VERSION_FILE"; then
-            echo "::error::Failed to add version to Supported() in $VERSION_FILE"
-            exit 1
-          fi
-
           # Display the changes
           echo "::notice::Updated $VERSION_FILE:"
           grep "var version" "$VERSION_FILE"
-          echo "::notice::Added to Supported():"
-          grep -A 2 "return \[\]SemVer{" "$VERSION_FILE"
 
           echo "WORK_BRANCH=${WORK_BRANCH}" >> $GITHUB_OUTPUT
           echo "::notice::Prepared changes for: ${WORK_BRANCH}"
@@ -214,9 +201,22 @@ jobs:
             exit 1
           fi
 
+          # Add new version to the top of the Supported() list
+          # Find the line with "return []SemVer{" and add the new version on the next line
+          sed -i "/return \[\]SemVer{/a\\
+          \\t\\t{major: ${MAJOR}, minor: ${NEXT_MINOR}}," "$VERSION_FILE"
+
+          # Verify the supported version was added
+          if ! grep -q "{major: ${MAJOR}, minor: ${NEXT_MINOR}}" "$VERSION_FILE"; then
+            echo "::error::Failed to add version to Supported() in $VERSION_FILE"
+            exit 1
+          fi
+
           # Display the change
           echo "::notice::Updated $VERSION_FILE:"
           grep "var version" "$VERSION_FILE"
+          echo "::notice::Added to Supported():"
+          grep -A 2 "return \[\]SemVer{" "$VERSION_FILE"
 
           echo "DEV_WORK_BRANCH=${WORK_BRANCH}" >> $GITHUB_OUTPUT
           echo "::notice::Prepared changes for: ${WORK_BRANCH}"


### PR DESCRIPTION
During the latest release there was an issue with the 2 PRs created from this pipeline. The first PR that bumped the `v1.X-rc` to `v1.X` in the `main-v1.X` branch did change the supported versions by adding the same, so it became:
```
var version = "v1.X" <--- changed in the same PR from "v1.X-rc"
...
func Supported() []SemVer {
	return []SemVer{
		{major: 1, minor: X}, <--- newly added line
		{major: 1, minor: X},
		{major: 1, minor: X-1},
...
```

Instead, we want this in the second PR that bumps `v1.X-dev` to `v1.X+1-dev` in the `main` branch, so that i becomes

```
var version = "v1.X+1-dev" <--- changed in the same PR from "v1.X-dev"
...
func Supported() []SemVer {
	return []SemVer{
		{major: 1, minor: X+1}, <--- newly added line
		{major: 1, minor: X},
		{major: 1, minor: X-1},
...
```

Check those 2 PRs for more context:
https://github.com/ObolNetwork/charon/pull/4335
https://github.com/ObolNetwork/charon/pull/4336

category: bug
ticket: none
