### PR TITLE
*: group dependabot PRs by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
   ignore:
   - dependency-name: "github.com/herumi/bls-eth-go-binary"
     update-types: ["version-update:semver-major","version-update:semver-minor"]
+  groups:
+    go-dependencies:
+      patterns:
+        - "*"
 - package-ecosystem: "docker"
   directories:
     - "/"
@@ -16,3 +20,7 @@ updates:
     - "/testutil/compose/static/lighthouse/"
   schedule:
     interval: "daily"
+  groups:
+    docker-dependencies:
+      patterns:
+        - "*"


### PR DESCRIPTION
Group all Go module updates into a single PR and all Docker updates into a single PR, reducing daily PR noise from 5-10 individual PRs down to 2.

- `go-dependencies` group: all gomod updates in one PR
- `docker-dependencies` group: all Docker image updates in one PR

The `herumi/bls-eth-go-binary` ignore rule is preserved.

category: tidy
ticket: none