### PR TITLE
testutil/integration: fix nightly test

### DIFF
--- a/testutil/integration/nightly_dkg_test.go
+++ b/testutil/integration/nightly_dkg_test.go
@@ -9,7 +9,6 @@ import (
 	"math/rand"
 	"os"
 	"path"
-	"strings"
 	"testing"
 	"time"
 
@@ -173,8 +172,8 @@ func mimicDKGNode(parentCtx context.Context, t *testing.T, dkgConf dkg.Config, w
 			conf.DataDir = t.TempDir()
 
 			err := dkg.Run(ctx, conf)
-			if !strings.Contains(err.Error(), context.Canceled.Error()) {
-				panic("error is not of context canceled kind")
+			if err != nil && !errors.Is(err, context.Canceled) {
+				panic(fmt.Sprintf("error is not of context canceled kind: %v", err))
 			}
 		}(ctx)
 


### PR DESCRIPTION
## Summary
- Replace `strings.Contains(err.Error(), context.Canceled.Error())` with `errors.Is(err, context.Canceled)` to properly detect context cancellation through wrapped error chains
- Add nil error check to prevent panic when `dkg.Run` returns nil
- Include the actual error in the panic message for better debuggability

category: bug
ticket: none