### PR TITLE
app: improved feerecipient behavior

### DIFF
--- a/app/builderregistration.go
+++ b/app/builderregistration.go
@@ -228,12 +228,13 @@ func (s *builderRegistrationService) Run(ctx context.Context) {
 		if err != nil {
 			log.Warn(ctx, "Failed to create file watcher for builder registration overrides; file watching disabled", err)
 		} else {
-			defer watcher.Close()
-
 			dir := filepath.Dir(s.path)
 			if err := watcher.Add(dir); err != nil {
 				log.Warn(ctx, "Failed to watch directory for builder registration overrides; file watching disabled", err, z.Str("dir", dir))
+				watcher.Close()
 			} else {
+				defer watcher.Close()
+
 				fileEvents = watcher.Events
 				fileErrors = watcher.Errors
 			}

--- a/app/builderregistration.go
+++ b/app/builderregistration.go
@@ -226,19 +226,18 @@ func (s *builderRegistrationService) Run(ctx context.Context) {
 	if s.path != "" {
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
-			log.Error(ctx, "Failed to create file watcher for builder registration overrides", err)
-			return
-		}
-		defer watcher.Close()
+			log.Warn(ctx, "Failed to create file watcher for builder registration overrides; file watching disabled", err)
+		} else {
+			defer watcher.Close()
 
-		dir := filepath.Dir(s.path)
-		if err := watcher.Add(dir); err != nil {
-			log.Error(ctx, "Failed to watch directory for builder registration overrides", err, z.Str("dir", dir))
-			return
+			dir := filepath.Dir(s.path)
+			if err := watcher.Add(dir); err != nil {
+				log.Warn(ctx, "Failed to watch directory for builder registration overrides; file watching disabled", err, z.Str("dir", dir))
+			} else {
+				fileEvents = watcher.Events
+				fileErrors = watcher.Errors
+			}
 		}
-
-		fileEvents = watcher.Events
-		fileErrors = watcher.Errors
 	}
 
 	// Optional API fetch timer (nil channel if obolClient == nil).
@@ -252,6 +251,10 @@ func (s *builderRegistrationService) Run(ctx context.Context) {
 		defer fetchTimer.Stop()
 
 		fetchCh = fetchTimer.C
+	}
+
+	if fileEvents == nil && fetchCh == nil {
+		return
 	}
 
 	baseName := filepath.Base(s.path)

--- a/app/builderregistration_internal_test.go
+++ b/app/builderregistration_internal_test.go
@@ -218,6 +218,28 @@ func TestBuilderRegistrationService(t *testing.T) {
 		}
 	})
 
+	t.Run("missing directory returns without error", func(t *testing.T) {
+		// Path under a directory that does not exist. Watcher setup will fail,
+		// but with no API client configured, Run should return cleanly.
+		path := filepath.Join(t.TempDir(), "missing", "overrides.json")
+
+		svc, err := NewBuilderRegistrationService(ctx, path, eth2p0.Version{}, baseRegs, baseFeeRecipients, nil, nil)
+		require.NoError(t, err)
+
+		done := make(chan struct{})
+
+		go func() {
+			svc.Run(ctx)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+			t.Fatal("Run did not return when file watcher setup failed and no API client is configured")
+		}
+	})
+
 	t.Run("file watcher reloads on change", func(t *testing.T) {
 		dir := t.TempDir()
 		path := filepath.Join(dir, "overrides.json")


### PR DESCRIPTION
The builder registration service's `Run` loop aborts entirely if the fsnotify watcher cannot be created or the overrides directory does not exist. This also kills the periodic Obol API fetch, which is an independent source and should continue running.

Log these as warnings instead of errors and fall through with file watching disabled. The API fetch loop keeps running. If neither source is active after setup, return cleanly.

category: bug
ticket: none
