### PR TITLE
*: release actions improvements

### DIFF
--- a/.github/workflows/patch-release-step1.yml
+++ b/.github/workflows/patch-release-step1.yml
@@ -5,6 +5,12 @@ description: |
 
 on:
   workflow_dispatch:
+    inputs:
+      target_minor:
+        description: 'Target minor version to patch, e.g. v1.8. Leave empty to default to the latest released minor.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   create_patch_release_pr:
@@ -44,31 +50,49 @@ jobs:
           git fetch --all
           git fetch --tags
 
-          # Find all minor release branches matching pattern main-vX.Y
-          RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
+          TARGET_MINOR="${{ inputs.target_minor }}"
 
-          if [[ -z "$RELEASE_BRANCHES" ]]; then
-            echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
-            exit 1
-          fi
-
-          # Filter to branches whose minor has a released stable vX.Y.0 tag.
-          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
-          # targets the most recent fully-released minor.
-          RELEASE_BRANCH=""
-          while IFS= read -r candidate; do
-            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
-              CAND_MAJOR="${BASH_REMATCH[1]}"
-              CAND_MINOR="${BASH_REMATCH[2]}"
-              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
-                RELEASE_BRANCH="$candidate"
-              fi
+          if [[ -n "$TARGET_MINOR" ]]; then
+            # Opt-in: patch a specific (non-latest) minor.
+            if [[ ! "$TARGET_MINOR" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid target_minor format: '$TARGET_MINOR'. Expected 'vX.Y' (e.g. v1.8)"
+              exit 1
             fi
-          done <<< "$RELEASE_BRANCHES"
+            RELEASE_BRANCH="main-${TARGET_MINOR}"
+            if ! git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+              echo "::error::Release branch ${RELEASE_BRANCH} does not exist on origin"
+              exit 1
+            fi
+            if ! git tag -l "${TARGET_MINOR}.0" | grep -q .; then
+              echo "::error::Minor ${TARGET_MINOR} has not been released (tag ${TARGET_MINOR}.0 does not exist)"
+              exit 1
+            fi
+            echo "::notice::Using explicitly targeted minor: ${RELEASE_BRANCH}"
+          else
+            # Default: latest minor with a released stable vX.Y.0 tag.
+            # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3).
+            RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
 
-          if [[ -z "$RELEASE_BRANCH" ]]; then
-            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
-            exit 1
+            if [[ -z "$RELEASE_BRANCHES" ]]; then
+              echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
+              exit 1
+            fi
+
+            RELEASE_BRANCH=""
+            while IFS= read -r candidate; do
+              if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+                CAND_MAJOR="${BASH_REMATCH[1]}"
+                CAND_MINOR="${BASH_REMATCH[2]}"
+                if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                  RELEASE_BRANCH="$candidate"
+                fi
+              fi
+            done <<< "$RELEASE_BRANCHES"
+
+            if [[ -z "$RELEASE_BRANCH" ]]; then
+              echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+              exit 1
+            fi
           fi
 
           # Extract version from branch name (e.g., main-v1.8 -> 1.8)

--- a/.github/workflows/patch-release-step1.yml
+++ b/.github/workflows/patch-release-step1.yml
@@ -52,8 +52,24 @@ jobs:
             exit 1
           fi
 
-          # Get the latest release branch (last in sorted list)
-          RELEASE_BRANCH=$(echo "$RELEASE_BRANCHES" | tail -n 1)
+          # Filter to branches whose minor has a released stable vX.Y.0 tag.
+          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
+          # targets the most recent fully-released minor.
+          RELEASE_BRANCH=""
+          while IFS= read -r candidate; do
+            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+              CAND_MAJOR="${BASH_REMATCH[1]}"
+              CAND_MINOR="${BASH_REMATCH[2]}"
+              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                RELEASE_BRANCH="$candidate"
+              fi
+            fi
+          done <<< "$RELEASE_BRANCHES"
+
+          if [[ -z "$RELEASE_BRANCH" ]]; then
+            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+            exit 1
+          fi
 
           # Extract version from branch name (e.g., main-v1.8 -> 1.8)
           if [[ ! "$RELEASE_BRANCH" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then

--- a/.github/workflows/patch-release-step2.yml
+++ b/.github/workflows/patch-release-step2.yml
@@ -6,6 +6,12 @@ description: |
 
 on:
   workflow_dispatch:
+    inputs:
+      target_minor:
+        description: 'Target minor version to patch, e.g. v1.8. Leave empty to default to the latest released minor.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   tag_patch_release_candidate:
@@ -43,35 +49,53 @@ jobs:
           git fetch --all
           git fetch --tags
 
-          # Find all minor release branches matching pattern main-vX.Y
-          RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
+          TARGET_MINOR="${{ inputs.target_minor }}"
 
-          if [[ -z "$RELEASE_BRANCHES" ]]; then
-            echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
-            exit 1
-          fi
-
-          # Filter to branches whose minor has a released stable vX.Y.0 tag.
-          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
-          # targets the most recent fully-released minor.
-          RELEASE_BRANCH=""
-          while IFS= read -r candidate; do
-            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
-              CAND_MAJOR="${BASH_REMATCH[1]}"
-              CAND_MINOR="${BASH_REMATCH[2]}"
-              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
-                RELEASE_BRANCH="$candidate"
-              fi
+          if [[ -n "$TARGET_MINOR" ]]; then
+            # Opt-in: patch a specific (non-latest) minor.
+            if [[ ! "$TARGET_MINOR" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid target_minor format: '$TARGET_MINOR'. Expected 'vX.Y' (e.g. v1.8)"
+              exit 1
             fi
-          done <<< "$RELEASE_BRANCHES"
+            RELEASE_BRANCH="main-${TARGET_MINOR}"
+            if ! git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+              echo "::error::Release branch ${RELEASE_BRANCH} does not exist on origin"
+              exit 1
+            fi
+            if ! git tag -l "${TARGET_MINOR}.0" | grep -q .; then
+              echo "::error::Minor ${TARGET_MINOR} has not been released (tag ${TARGET_MINOR}.0 does not exist)"
+              exit 1
+            fi
+            echo "::notice::Using explicitly targeted minor: ${RELEASE_BRANCH}"
+          else
+            # Default: latest minor with a released stable vX.Y.0 tag.
+            # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3).
+            RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
 
-          if [[ -z "$RELEASE_BRANCH" ]]; then
-            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
-            exit 1
+            if [[ -z "$RELEASE_BRANCHES" ]]; then
+              echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
+              exit 1
+            fi
+
+            RELEASE_BRANCH=""
+            while IFS= read -r candidate; do
+              if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+                CAND_MAJOR="${BASH_REMATCH[1]}"
+                CAND_MINOR="${BASH_REMATCH[2]}"
+                if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                  RELEASE_BRANCH="$candidate"
+                fi
+              fi
+            done <<< "$RELEASE_BRANCHES"
+
+            if [[ -z "$RELEASE_BRANCH" ]]; then
+              echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+              exit 1
+            fi
           fi
 
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
-          echo "::notice::Found latest minor release branch: ${RELEASE_BRANCH}"
+          echo "::notice::Using minor release branch: ${RELEASE_BRANCH}"
 
           # Checkout the release branch
           git checkout "$RELEASE_BRANCH"

--- a/.github/workflows/patch-release-step2.yml
+++ b/.github/workflows/patch-release-step2.yml
@@ -39,8 +39,9 @@ jobs:
       - name: 3. Find Latest Release Branch
         id: find_branch
         run: |
-          # Fetch all remote branches
+          # Fetch all remote branches and tags
           git fetch --all
+          git fetch --tags
 
           # Find all minor release branches matching pattern main-vX.Y
           RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
@@ -50,8 +51,24 @@ jobs:
             exit 1
           fi
 
-          # Get the latest release branch (last in sorted list)
-          RELEASE_BRANCH=$(echo "$RELEASE_BRANCHES" | tail -n 1)
+          # Filter to branches whose minor has a released stable vX.Y.0 tag.
+          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
+          # targets the most recent fully-released minor.
+          RELEASE_BRANCH=""
+          while IFS= read -r candidate; do
+            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+              CAND_MAJOR="${BASH_REMATCH[1]}"
+              CAND_MINOR="${BASH_REMATCH[2]}"
+              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                RELEASE_BRANCH="$candidate"
+              fi
+            fi
+          done <<< "$RELEASE_BRANCHES"
+
+          if [[ -z "$RELEASE_BRANCH" ]]; then
+            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+            exit 1
+          fi
 
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "::notice::Found latest minor release branch: ${RELEASE_BRANCH}"

--- a/.github/workflows/patch-release-step3.yml
+++ b/.github/workflows/patch-release-step3.yml
@@ -4,6 +4,12 @@ description: |
 
 on:
   workflow_dispatch:
+    inputs:
+      target_minor:
+        description: 'Target minor version to patch, e.g. v1.8. Leave empty to default to the latest released minor.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   prepare_patch_full_release:
@@ -43,35 +49,53 @@ jobs:
           git fetch --all
           git fetch --tags
 
-          # Find all minor release branches matching pattern main-vX.Y
-          RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
+          TARGET_MINOR="${{ inputs.target_minor }}"
 
-          if [[ -z "$RELEASE_BRANCHES" ]]; then
-            echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
-            exit 1
-          fi
-
-          # Filter to branches whose minor has a released stable vX.Y.0 tag.
-          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
-          # targets the most recent fully-released minor.
-          RELEASE_BRANCH=""
-          while IFS= read -r candidate; do
-            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
-              CAND_MAJOR="${BASH_REMATCH[1]}"
-              CAND_MINOR="${BASH_REMATCH[2]}"
-              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
-                RELEASE_BRANCH="$candidate"
-              fi
+          if [[ -n "$TARGET_MINOR" ]]; then
+            # Opt-in: patch a specific (non-latest) minor.
+            if [[ ! "$TARGET_MINOR" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid target_minor format: '$TARGET_MINOR'. Expected 'vX.Y' (e.g. v1.8)"
+              exit 1
             fi
-          done <<< "$RELEASE_BRANCHES"
+            RELEASE_BRANCH="main-${TARGET_MINOR}"
+            if ! git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+              echo "::error::Release branch ${RELEASE_BRANCH} does not exist on origin"
+              exit 1
+            fi
+            if ! git tag -l "${TARGET_MINOR}.0" | grep -q .; then
+              echo "::error::Minor ${TARGET_MINOR} has not been released (tag ${TARGET_MINOR}.0 does not exist)"
+              exit 1
+            fi
+            echo "::notice::Using explicitly targeted minor: ${RELEASE_BRANCH}"
+          else
+            # Default: latest minor with a released stable vX.Y.0 tag.
+            # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3).
+            RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
 
-          if [[ -z "$RELEASE_BRANCH" ]]; then
-            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
-            exit 1
+            if [[ -z "$RELEASE_BRANCHES" ]]; then
+              echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
+              exit 1
+            fi
+
+            RELEASE_BRANCH=""
+            while IFS= read -r candidate; do
+              if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+                CAND_MAJOR="${BASH_REMATCH[1]}"
+                CAND_MINOR="${BASH_REMATCH[2]}"
+                if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                  RELEASE_BRANCH="$candidate"
+                fi
+              fi
+            done <<< "$RELEASE_BRANCHES"
+
+            if [[ -z "$RELEASE_BRANCH" ]]; then
+              echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+              exit 1
+            fi
           fi
 
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
-          echo "::notice::Found latest minor release branch: ${RELEASE_BRANCH}"
+          echo "::notice::Using minor release branch: ${RELEASE_BRANCH}"
 
       - name: 3. Extract Version from Branch Name
         id: version

--- a/.github/workflows/patch-release-step3.yml
+++ b/.github/workflows/patch-release-step3.yml
@@ -39,8 +39,9 @@ jobs:
       - name: 3. Find Latest Release Branch
         id: find_branch
         run: |
-          # Fetch all remote branches
+          # Fetch all remote branches and tags
           git fetch --all
+          git fetch --tags
 
           # Find all minor release branches matching pattern main-vX.Y
           RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
@@ -50,8 +51,24 @@ jobs:
             exit 1
           fi
 
-          # Get the latest release branch (last in sorted list)
-          RELEASE_BRANCH=$(echo "$RELEASE_BRANCHES" | tail -n 1)
+          # Filter to branches whose minor has a released stable vX.Y.0 tag.
+          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
+          # targets the most recent fully-released minor.
+          RELEASE_BRANCH=""
+          while IFS= read -r candidate; do
+            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+              CAND_MAJOR="${BASH_REMATCH[1]}"
+              CAND_MINOR="${BASH_REMATCH[2]}"
+              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                RELEASE_BRANCH="$candidate"
+              fi
+            fi
+          done <<< "$RELEASE_BRANCHES"
+
+          if [[ -z "$RELEASE_BRANCH" ]]; then
+            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+            exit 1
+          fi
 
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "::notice::Found latest minor release branch: ${RELEASE_BRANCH}"

--- a/.github/workflows/patch-release-step4.yml
+++ b/.github/workflows/patch-release-step4.yml
@@ -4,6 +4,12 @@ description: |
 
 on:
   workflow_dispatch:
+    inputs:
+      target_minor:
+        description: 'Target minor version to patch, e.g. v1.8. Leave empty to default to the latest released minor.'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   tag_patch_full_release:
@@ -54,35 +60,53 @@ jobs:
           git fetch --all
           git fetch --tags
 
-          # Find all minor release branches matching pattern main-vX.Y
-          RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
+          TARGET_MINOR="${{ inputs.target_minor }}"
 
-          if [[ -z "$RELEASE_BRANCHES" ]]; then
-            echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
-            exit 1
-          fi
-
-          # Filter to branches whose minor has a released stable vX.Y.0 tag.
-          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
-          # targets the most recent fully-released minor.
-          RELEASE_BRANCH=""
-          while IFS= read -r candidate; do
-            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
-              CAND_MAJOR="${BASH_REMATCH[1]}"
-              CAND_MINOR="${BASH_REMATCH[2]}"
-              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
-                RELEASE_BRANCH="$candidate"
-              fi
+          if [[ -n "$TARGET_MINOR" ]]; then
+            # Opt-in: patch a specific (non-latest) minor.
+            if [[ ! "$TARGET_MINOR" =~ ^v[0-9]+\.[0-9]+$ ]]; then
+              echo "::error::Invalid target_minor format: '$TARGET_MINOR'. Expected 'vX.Y' (e.g. v1.8)"
+              exit 1
             fi
-          done <<< "$RELEASE_BRANCHES"
+            RELEASE_BRANCH="main-${TARGET_MINOR}"
+            if ! git show-ref --verify --quiet "refs/remotes/origin/${RELEASE_BRANCH}"; then
+              echo "::error::Release branch ${RELEASE_BRANCH} does not exist on origin"
+              exit 1
+            fi
+            if ! git tag -l "${TARGET_MINOR}.0" | grep -q .; then
+              echo "::error::Minor ${TARGET_MINOR} has not been released (tag ${TARGET_MINOR}.0 does not exist)"
+              exit 1
+            fi
+            echo "::notice::Using explicitly targeted minor: ${RELEASE_BRANCH}"
+          else
+            # Default: latest minor with a released stable vX.Y.0 tag.
+            # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3).
+            RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
 
-          if [[ -z "$RELEASE_BRANCH" ]]; then
-            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
-            exit 1
+            if [[ -z "$RELEASE_BRANCHES" ]]; then
+              echo "::error::No minor release branches found matching pattern 'main-vX.Y'"
+              exit 1
+            fi
+
+            RELEASE_BRANCH=""
+            while IFS= read -r candidate; do
+              if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+                CAND_MAJOR="${BASH_REMATCH[1]}"
+                CAND_MINOR="${BASH_REMATCH[2]}"
+                if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                  RELEASE_BRANCH="$candidate"
+                fi
+              fi
+            done <<< "$RELEASE_BRANCHES"
+
+            if [[ -z "$RELEASE_BRANCH" ]]; then
+              echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+              exit 1
+            fi
           fi
 
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
-          echo "::notice::Found latest minor release branch: ${RELEASE_BRANCH}"
+          echo "::notice::Using minor release branch: ${RELEASE_BRANCH}"
 
       - name: 3. Extract Version from Branch Name
         id: version

--- a/.github/workflows/patch-release-step4.yml
+++ b/.github/workflows/patch-release-step4.yml
@@ -50,8 +50,9 @@ jobs:
       - name: 3. Find Latest Release Branch
         id: find_branch
         run: |
-          # Fetch all remote branches
+          # Fetch all remote branches and tags
           git fetch --all
+          git fetch --tags
 
           # Find all minor release branches matching pattern main-vX.Y
           RELEASE_BRANCHES=$(git branch -r --format='%(refname:short)' | grep -E 'origin/main-v[0-9]+\.[0-9]+$' | sed 's|origin/||' | sort -V)
@@ -61,8 +62,24 @@ jobs:
             exit 1
           fi
 
-          # Get the latest release branch (last in sorted list)
-          RELEASE_BRANCH=$(echo "$RELEASE_BRANCHES" | tail -n 1)
+          # Filter to branches whose minor has a released stable vX.Y.0 tag.
+          # Skips in-progress minors (RC-only, e.g. v1.10.0-rc3) so patching
+          # targets the most recent fully-released minor.
+          RELEASE_BRANCH=""
+          while IFS= read -r candidate; do
+            if [[ "$candidate" =~ ^main-v([0-9]+)\.([0-9]+)$ ]]; then
+              CAND_MAJOR="${BASH_REMATCH[1]}"
+              CAND_MINOR="${BASH_REMATCH[2]}"
+              if git tag -l "v${CAND_MAJOR}.${CAND_MINOR}.0" | grep -q .; then
+                RELEASE_BRANCH="$candidate"
+              fi
+            fi
+          done <<< "$RELEASE_BRANCHES"
+
+          if [[ -z "$RELEASE_BRANCH" ]]; then
+            echo "::error::No minor release branches with a stable vX.Y.0 tag found"
+            exit 1
+          fi
 
           echo "RELEASE_BRANCH=${RELEASE_BRANCH}" >> $GITHUB_OUTPUT
           echo "::notice::Found latest minor release branch: ${RELEASE_BRANCH}"


### PR DESCRIPTION
- Do not take into considerations RCs of minors when doing a new patch (i.e.: if there is v1.10.0-rc3, but no stable v1.10.0 and trigger the patch release pipelines, do not create v1.10.1-rc0, but rather v1.9.4-rc1)
- Add option to optionally tag patch of an old minor (i.e.: a vulnerability is found and we'd like to patch both v1.8 and v1.9)

category: feature
ticket: none

