### PR TITLE
core/validatorapi: fix SSE proxying

### DIFF
--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1656,7 +1656,7 @@ func eventsHandler(h Handler) http.HandlerFunc {
 		proxy := httputil.NewSingleHostReverseProxy(targetURL)
 		// NewSingleHostReverseProxy sets Director; ServeHTTP rejects proxies with
 		// both Director and Rewrite set, so clear it before installing Rewrite.
-		proxy.Director = nil
+		proxy.Director = nil //nolint:staticcheck
 		proxy.Rewrite = func(req *httputil.ProxyRequest) {
 			if targetURL.User != nil {
 				password, _ := targetURL.User.Password()

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -1654,17 +1654,17 @@ func eventsHandler(h Handler) http.HandlerFunc {
 		}
 
 		proxy := httputil.NewSingleHostReverseProxy(targetURL)
-
-		// Extend default proxy director with basic auth and host header
-		defaultDirector := proxy.Rewrite
+		// NewSingleHostReverseProxy sets Director; ServeHTTP rejects proxies with
+		// both Director and Rewrite set, so clear it before installing Rewrite.
+		proxy.Director = nil
 		proxy.Rewrite = func(req *httputil.ProxyRequest) {
 			if targetURL.User != nil {
 				password, _ := targetURL.User.Password()
 				req.Out.SetBasicAuth(targetURL.User.Username(), password)
 			}
 
+			req.SetURL(targetURL)
 			req.Out.Host = targetURL.Host
-			defaultDirector(req)
 
 			// Apply user provided beacon node headers
 			for k, v := range headers {

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"net/http/httputil"
@@ -135,7 +136,8 @@ func TestEventsHandlerProxy(t *testing.T) {
 	proxySrv := httptest.NewServer(router)
 	defer proxySrv.Close()
 
-	ctx, cancel := context.WithCancel(t.Context())
+	// Bound the request so a streaming regression (no flush, blocked read) fails fast.
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxySrv.URL+"/eth/v1/events?topics=head", nil)
@@ -147,7 +149,10 @@ func TestEventsHandlerProxy(t *testing.T) {
 	defer resp.Body.Close()
 
 	require.Equal(t, http.StatusOK, resp.StatusCode)
-	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	mediaType, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	require.NoError(t, err)
+	require.Equal(t, "text/event-stream", mediaType)
 
 	// Read one SSE frame to confirm streaming actually works end-to-end.
 	buf := make([]byte, 64)

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -104,6 +104,58 @@ func TestProxyShutdown(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestEventsHandlerProxy(t *testing.T) {
+	// Upstream "beacon node" that serves an SSE stream with one head event.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/eth/v1/events", r.URL.Path)
+		require.Equal(t, "head", r.URL.Query().Get("topics"))
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok)
+
+		_, err := io.WriteString(w, "event: head\ndata: {\"slot\":\"1\"}\n\n")
+		require.NoError(t, err)
+		flusher.Flush()
+
+		<-r.Context().Done()
+	}))
+	defer upstream.Close()
+
+	handler := testHandler{
+		AddressFunc: func() string { return upstream.URL },
+		HeadersFunc: func() map[string]string { return nil },
+	}
+
+	router, err := NewRouter(handler, true)
+	require.NoError(t, err)
+
+	proxySrv := httptest.NewServer(router)
+	defer proxySrv.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, proxySrv.URL+"/eth/v1/events?topics=head", nil)
+	require.NoError(t, err)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
+
+	// Read one SSE frame to confirm streaming actually works end-to-end.
+	buf := make([]byte, 64)
+	n, err := resp.Body.Read(buf)
+	require.NoError(t, err)
+	require.Contains(t, string(buf[:n]), "event: head")
+}
+
 func TestRouterIntegration(t *testing.T) {
 	beaconURL, ok := os.LookupEnv("BEACON_URL")
 	if !ok {


### PR DESCRIPTION
VC was receiving 502s on SSE

category: bug
ticket: none