### PR TITLE
cmd: surface remote state in list

### DIFF
--- a/cmd/feerecipientlist.go
+++ b/cmd/feerecipientlist.go
@@ -121,6 +121,22 @@ func resolveLatestRegistrations(cl cluster.Lock, overrides, remote map[string]re
 	return entries
 }
 
+// countRemoteOnly returns the number of resolved entries whose winning record
+// comes strictly from the remote API — neither the lock default nor the
+// overrides file carries an equivalent record. These are the only cases where
+// running fetch would add information the operator doesn't already have.
+func countRemoteOnly(entries []registrationEntry) int {
+	var n int
+
+	for _, e := range entries {
+		if len(e.Sources) == 1 && e.Sources[0] == sourceRemote {
+			n++
+		}
+	}
+
+	return n
+}
+
 // entriesEquivalent reports whether two candidate entries represent the same
 // record (same fee recipient, gas limit, and timestamp). Pubkey is keyed by
 // the caller so is not compared.
@@ -197,13 +213,7 @@ func runFeeRecipientList(ctx context.Context, config feerecipientListConfig) err
 		log.Info(ctx, "Validators unknown to remote API", z.Int("total", len(noReg)))
 	}
 
-	remoteOnly := 0
-
-	for _, e := range entries {
-		if slices.Contains(e.Sources, sourceRemote) && !slices.Contains(e.Sources, sourceOverrides) {
-			remoteOnly++
-		}
-	}
+	remoteOnly := countRemoteOnly(entries)
 
 	if remoteOnly > 0 {
 		log.Info(ctx, "Updated registrations are available. "+

--- a/cmd/feerecipientlist.go
+++ b/cmd/feerecipientlist.go
@@ -121,20 +121,21 @@ func resolveLatestRegistrations(cl cluster.Lock, overrides, remote map[string]re
 	return entries
 }
 
-// countRemoteOnly returns the number of resolved entries whose winning record
-// comes strictly from the remote API — neither the lock default nor the
-// overrides file carries an equivalent record. These are the only cases where
-// running fetch would add information the operator doesn't already have.
-func countRemoteOnly(entries []registrationEntry) int {
-	var n int
+// remoteOnlyPubkeys returns the pubkeys of resolved entries whose winning
+// record comes strictly from the remote API — neither the lock default nor
+// the overrides file carries an equivalent record. These are the only cases
+// where running fetch would add information the operator doesn't already
+// have.
+func remoteOnlyPubkeys(entries []registrationEntry) []string {
+	var pubkeys []string
 
 	for _, e := range entries {
 		if len(e.Sources) == 1 && e.Sources[0] == sourceRemote {
-			n++
+			pubkeys = append(pubkeys, e.Pubkey)
 		}
 	}
 
-	return n
+	return pubkeys
 }
 
 // entriesEquivalent reports whether two candidate entries represent the same
@@ -213,13 +214,13 @@ func runFeeRecipientList(ctx context.Context, config feerecipientListConfig) err
 		log.Info(ctx, "Validators unknown to remote API", z.Int("total", len(noReg)))
 	}
 
-	remoteOnly := countRemoteOnly(entries)
+	remoteOnly := remoteOnlyPubkeys(entries)
 
-	if remoteOnly > 0 {
+	if len(remoteOnly) > 0 {
 		log.Info(ctx, "Updated registrations are available. "+
 			"Use 'charon feerecipient fetch' to save them locally, "+
 			"or use 'charon run --fetch-feerecipient-updates' to have Charon check for updates daily.",
-			z.Int("total", remoteOnly),
+			z.Any("pubkeys", remoteOnly),
 		)
 	}
 

--- a/cmd/feerecipientlist.go
+++ b/cmd/feerecipientlist.go
@@ -13,15 +13,15 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app"
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/obolapi"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 )
 
 type feerecipientListConfig struct {
-	ValidatorPublicKeys []string
-	LockFilePath        string
-	OverridesFilePath   string
+	feerecipientConfig
 }
 
 func newFeeRecipientListCmd(runFunc func(context.Context, feerecipientListConfig) error) *cobra.Command {
@@ -30,7 +30,7 @@ func newFeeRecipientListCmd(runFunc func(context.Context, feerecipientListConfig
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "Display the latest builder registration details for each validator.",
-		Long:  "Displays the most recent builder registration for each validator, selecting the entry with the highest timestamp from either the cluster lock file or the overrides file.",
+		Long:  "Displays the most recent builder registration for each validator, selecting the entry with the highest timestamp from the cluster lock file, the overrides file, or the remote API.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runFunc(cmd.Context(), config)
@@ -41,6 +41,8 @@ func newFeeRecipientListCmd(runFunc func(context.Context, feerecipientListConfig
 	cmd.Flags().StringVar(&config.LockFilePath, lockFilePath.String(), ".charon/cluster-lock.json", "Path to the cluster lock file defining the distributed validator cluster.")
 	cmd.Flags().StringVar(&config.OverridesFilePath, "overrides-file", ".charon/builder_registrations_overrides.json", "Path to the builder registrations overrides file.")
 
+	bindFeeRecipientRemoteAPIFlags(cmd, &config.feerecipientConfig)
+
 	return cmd
 }
 
@@ -50,11 +52,20 @@ type registrationEntry struct {
 	FeeRecipient string
 	GasLimit     uint64
 	Timestamp    time.Time
+	// Sources lists the source names (lock, overrides, remote) whose record
+	// is equivalent to this winning entry, in canonical order.
+	Sources []string
 }
 
+const (
+	sourceLock      = "lock"
+	sourceOverrides = "overrides"
+	sourceRemote    = "remote"
+)
+
 // resolveLatestRegistrations returns the latest builder registration for each validator
-// by comparing timestamps from the cluster lock and overrides file.
-func resolveLatestRegistrations(cl cluster.Lock, overrides map[string]registrationEntry, pubkeyFilter map[string]struct{}) []registrationEntry {
+// by comparing timestamps from the cluster lock, overrides file, and remote API quorum map.
+func resolveLatestRegistrations(cl cluster.Lock, overrides, remote map[string]registrationEntry, pubkeyFilter map[string]struct{}) []registrationEntry {
 	var entries []registrationEntry
 
 	for _, dv := range cl.Validators {
@@ -67,27 +78,62 @@ func resolveLatestRegistrations(cl cluster.Lock, overrides map[string]registrati
 			}
 		}
 
-		feeRecipient := "0x" + hex.EncodeToString(dv.BuilderRegistration.Message.FeeRecipient)
-		gasLimit := uint64(dv.BuilderRegistration.Message.GasLimit)
-		timestamp := dv.BuilderRegistration.Message.Timestamp
+		lockEntry := registrationEntry{
+			FeeRecipient: "0x" + hex.EncodeToString(dv.BuilderRegistration.Message.FeeRecipient),
+			GasLimit:     uint64(dv.BuilderRegistration.Message.GasLimit),
+			Timestamp:    dv.BuilderRegistration.Message.Timestamp,
+		}
 
-		if override, ok := overrides[normalized]; ok {
-			if override.Timestamp.After(timestamp) {
-				feeRecipient = override.FeeRecipient
-				gasLimit = override.GasLimit
-				timestamp = override.Timestamp
-			}
+		override, hasOverride := overrides[normalized]
+		remoteEntry, hasRemote := remote[normalized]
+
+		winner := lockEntry
+		if hasOverride && override.Timestamp.After(winner.Timestamp) {
+			winner = override
+		}
+
+		if hasRemote && remoteEntry.Timestamp.After(winner.Timestamp) {
+			winner = remoteEntry
+		}
+
+		var sources []string
+		if entriesEquivalent(winner, lockEntry) {
+			sources = append(sources, sourceLock)
+		}
+
+		if hasOverride && entriesEquivalent(winner, override) {
+			sources = append(sources, sourceOverrides)
+		}
+
+		if hasRemote && entriesEquivalent(winner, remoteEntry) {
+			sources = append(sources, sourceRemote)
 		}
 
 		entries = append(entries, registrationEntry{
 			Pubkey:       pubkeyHex,
-			FeeRecipient: feeRecipient,
-			GasLimit:     gasLimit,
-			Timestamp:    timestamp,
+			FeeRecipient: winner.FeeRecipient,
+			GasLimit:     winner.GasLimit,
+			Timestamp:    winner.Timestamp,
+			Sources:      sources,
 		})
 	}
 
 	return entries
+}
+
+// entriesEquivalent reports whether two candidate entries represent the same
+// record (same fee recipient, gas limit, and timestamp). Pubkey is keyed by
+// the caller so is not compared.
+func entriesEquivalent(a, b registrationEntry) bool {
+	if a.GasLimit != b.GasLimit {
+		return false
+	}
+
+	if !a.Timestamp.Equal(b.Timestamp) {
+		return false
+	}
+
+	return strings.EqualFold(a.FeeRecipient, b.FeeRecipient)
 }
 
 func runFeeRecipientList(ctx context.Context, config feerecipientListConfig) error {
@@ -112,7 +158,14 @@ func runFeeRecipientList(ctx context.Context, config feerecipientListConfig) err
 		pubkeyFilter[normalizePubkey(pk)] = struct{}{}
 	}
 
-	entries := resolveLatestRegistrations(*cl, overrides, pubkeyFilter)
+	remote, incomplete, noReg, err := fetchRemoteQuorums(ctx, config, cl.LockHash)
+	if err != nil {
+		log.Warn(ctx, "Unable to fetch remote builder registrations; showing local data only", err)
+
+		remote, incomplete, noReg = nil, nil, nil
+	}
+
+	entries := resolveLatestRegistrations(*cl, overrides, remote, pubkeyFilter)
 
 	if len(entries) == 0 {
 		log.Info(ctx, "No builder registrations found", nil)
@@ -132,10 +185,71 @@ func runFeeRecipientList(ctx context.Context, config feerecipientListConfig) err
 			z.Str("fee_recipient", e.FeeRecipient),
 			z.U64("gas_limit", e.GasLimit),
 			z.I64("timestamp", e.Timestamp.Unix()),
+			z.Str("source", strings.Join(e.Sources, "+")),
+		)
+	}
+
+	if len(incomplete) > 0 {
+		log.Info(ctx, "Validators with partial builder registrations on remote", z.Int("total", len(incomplete)))
+	}
+
+	if len(noReg) > 0 {
+		log.Info(ctx, "Validators unknown to remote API", z.Int("total", len(noReg)))
+	}
+
+	remoteOnly := 0
+
+	for _, e := range entries {
+		if slices.Contains(e.Sources, sourceRemote) && !slices.Contains(e.Sources, sourceOverrides) {
+			remoteOnly++
+		}
+	}
+
+	if remoteOnly > 0 {
+		log.Info(ctx, "Updated registrations are available. "+
+			"Use 'charon feerecipient fetch' to save them locally, "+
+			"or use 'charon run --fetch-feerecipient-updates' to have Charon check for updates daily.",
+			z.Int("total", remoteOnly),
 		)
 	}
 
 	return nil
+}
+
+// fetchRemoteQuorums calls the Obol API and converts the response into a
+// pubkey-keyed quorum map plus the incomplete / no-registration pubkey
+// lists. Returns an error if the API is unreachable or the response can't
+// be processed; callers may choose to treat the error as soft.
+func fetchRemoteQuorums(ctx context.Context, config feerecipientListConfig, lockHash []byte) (remote map[string]registrationEntry, incomplete, noReg []string, err error) {
+	oAPI, err := obolapi.New(config.PublishAddress, obolapi.WithTimeout(config.PublishTimeout))
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "create Obol API client", z.Str("publish_address", config.PublishAddress))
+	}
+
+	resp, err := oAPI.PostFeeRecipientsFetch(ctx, lockHash, config.ValidatorPublicKeys)
+	if err != nil {
+		return nil, nil, nil, errors.Wrap(err, "fetch builder registrations from Obol API")
+	}
+
+	pv, err := app.ProcessValidators(resp.Validators)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	remote = make(map[string]registrationEntry, len(pv.QuorumMessages))
+	for pk, msg := range pv.QuorumMessages {
+		if msg == nil {
+			continue
+		}
+
+		remote[normalizePubkey(pk)] = registrationEntry{
+			FeeRecipient: msg.FeeRecipient.String(),
+			GasLimit:     msg.GasLimit,
+			Timestamp:    msg.Timestamp,
+		}
+	}
+
+	return remote, pv.Categories.Incomplete, pv.Categories.NoReg, nil
 }
 
 // loadOverrides reads the builder registrations overrides file and returns

--- a/cmd/feerecipientlist_internal_test.go
+++ b/cmd/feerecipientlist_internal_test.go
@@ -757,6 +757,40 @@ func TestFeeRecipientListIncompleteNoQuorum(t *testing.T) {
 	)
 }
 
+func TestCountRemoteOnly(t *testing.T) {
+	cases := []struct {
+		name    string
+		sources [][]string
+		want    int
+	}{
+		{"empty", nil, 0},
+		{"lock only", [][]string{{"lock"}}, 0},
+		{"overrides only", [][]string{{"overrides"}}, 0},
+		{"remote only", [][]string{{"remote"}}, 1},
+		{"lock+remote (remote matches lock default)", [][]string{{"lock", "remote"}}, 0},
+		{"overrides+remote (already synced)", [][]string{{"overrides", "remote"}}, 0},
+		{"lock+overrides+remote", [][]string{{"lock", "overrides", "remote"}}, 0},
+		{"mixed", [][]string{
+			{"lock"},
+			{"remote"},
+			{"lock", "remote"},
+			{"remote"},
+			{"overrides", "remote"},
+		}, 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			entries := make([]registrationEntry, len(tc.sources))
+			for i, s := range tc.sources {
+				entries[i] = registrationEntry{Sources: s}
+			}
+
+			require.Equal(t, tc.want, countRemoteOnly(entries))
+		})
+	}
+}
+
 // captureListLogs returns a context that routes charon logs into a buffer.
 // Tests read the buffer bytes (as text) to assert on log content. The buffer
 // uses logfmt formatting so tests can assert on "key=value" pairs.

--- a/cmd/feerecipientlist_internal_test.go
+++ b/cmd/feerecipientlist_internal_test.go
@@ -3,7 +3,6 @@
 package cmd
 
 import (
-	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -497,7 +496,8 @@ func TestFeeRecipientListFetchesRemote(t *testing.T) {
 }
 
 func TestFeeRecipientListRemoteOnlyTriggersSuggestion(t *testing.T) {
-	ctx, logs := captureListLogs(t, t.Context())
+	logs := initLogCapture(t)
+	ctx := t.Context()
 
 	valAmt := 4
 	operatorAmt := 4
@@ -566,7 +566,8 @@ func TestFeeRecipientListRemoteOnlyTriggersSuggestion(t *testing.T) {
 }
 
 func TestFeeRecipientListOverridesMatchRemote(t *testing.T) {
-	ctx, logs := captureListLogs(t, t.Context())
+	logs := initLogCapture(t)
+	ctx := t.Context()
 
 	valAmt := 4
 	operatorAmt := 4
@@ -647,7 +648,8 @@ func TestFeeRecipientListOverridesMatchRemote(t *testing.T) {
 }
 
 func TestFeeRecipientListRemoteUnreachable(t *testing.T) {
-	ctx, logs := captureListLogs(t, t.Context())
+	logs := initLogCapture(t)
+	ctx := t.Context()
 
 	valAmt := 4
 	operatorAmt := 4
@@ -685,7 +687,8 @@ func TestFeeRecipientListRemoteUnreachable(t *testing.T) {
 }
 
 func TestFeeRecipientListIncompleteNoQuorum(t *testing.T) {
-	ctx, logs := captureListLogs(t, t.Context())
+	logs := initLogCapture(t)
+	ctx := t.Context()
 
 	valAmt := 1
 	operatorAmt := 4
@@ -796,14 +799,15 @@ func TestRemoteOnlyPubkeys(t *testing.T) {
 	}
 }
 
-// captureListLogs returns a context that routes charon logs into a buffer.
-// Tests read the buffer bytes (as text) to assert on log content. The buffer
-// uses logfmt formatting so tests can assert on "key=value" pairs.
-func captureListLogs(t *testing.T, ctx context.Context) (context.Context, *zaptest.Buffer) {
+// initLogCapture points the process-global charon logger at a logfmt-encoded
+// buffer for the duration of the test and returns the buffer. Tests read the
+// buffer contents (as text) to assert on "key=value" pairs. Tests using this
+// helper must not run with t.Parallel(), since it mutates global state.
+func initLogCapture(t *testing.T) *zaptest.Buffer {
 	t.Helper()
 
 	buf := &zaptest.Buffer{}
 	log.InitLogfmtForT(t, buf)
 
-	return ctx, buf
+	return buf
 }

--- a/cmd/feerecipientlist_internal_test.go
+++ b/cmd/feerecipientlist_internal_test.go
@@ -757,36 +757,41 @@ func TestFeeRecipientListIncompleteNoQuorum(t *testing.T) {
 	)
 }
 
-func TestCountRemoteOnly(t *testing.T) {
+func TestRemoteOnlyPubkeys(t *testing.T) {
+	type entry struct {
+		pubkey  string
+		sources []string
+	}
+
 	cases := []struct {
 		name    string
-		sources [][]string
-		want    int
+		entries []entry
+		want    []string
 	}{
-		{"empty", nil, 0},
-		{"lock only", [][]string{{"lock"}}, 0},
-		{"overrides only", [][]string{{"overrides"}}, 0},
-		{"remote only", [][]string{{"remote"}}, 1},
-		{"lock+remote (remote matches lock default)", [][]string{{"lock", "remote"}}, 0},
-		{"overrides+remote (already synced)", [][]string{{"overrides", "remote"}}, 0},
-		{"lock+overrides+remote", [][]string{{"lock", "overrides", "remote"}}, 0},
-		{"mixed", [][]string{
-			{"lock"},
-			{"remote"},
-			{"lock", "remote"},
-			{"remote"},
-			{"overrides", "remote"},
-		}, 2},
+		{"empty", nil, nil},
+		{"lock only", []entry{{"pk1", []string{"lock"}}}, nil},
+		{"overrides only", []entry{{"pk1", []string{"overrides"}}}, nil},
+		{"remote only", []entry{{"pk1", []string{"remote"}}}, []string{"pk1"}},
+		{"lock+remote (remote matches lock default)", []entry{{"pk1", []string{"lock", "remote"}}}, nil},
+		{"overrides+remote (already synced)", []entry{{"pk1", []string{"overrides", "remote"}}}, nil},
+		{"lock+overrides+remote", []entry{{"pk1", []string{"lock", "overrides", "remote"}}}, nil},
+		{"mixed", []entry{
+			{"pk1", []string{"lock"}},
+			{"pk2", []string{"remote"}},
+			{"pk3", []string{"lock", "remote"}},
+			{"pk4", []string{"remote"}},
+			{"pk5", []string{"overrides", "remote"}},
+		}, []string{"pk2", "pk4"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			entries := make([]registrationEntry, len(tc.sources))
-			for i, s := range tc.sources {
-				entries[i] = registrationEntry{Sources: s}
+			entries := make([]registrationEntry, len(tc.entries))
+			for i, e := range tc.entries {
+				entries[i] = registrationEntry{Pubkey: e.pubkey, Sources: e.sources}
 			}
 
-			require.Equal(t, tc.want, countRemoteOnly(entries))
+			require.Equal(t, tc.want, remoteOnlyPubkeys(entries))
 		})
 	}
 }

--- a/cmd/feerecipientlist_internal_test.go
+++ b/cmd/feerecipientlist_internal_test.go
@@ -3,11 +3,16 @@
 package cmd
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math/rand"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -18,12 +23,16 @@ import (
 	"github.com/attestantio/go-eth2-client/spec/bellatrix"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util"
 	"github.com/obolnetwork/charon/eth2util/registration"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
+	"github.com/obolnetwork/charon/testutil/obolapimock"
 )
 
 func TestFeeRecipientListValid(t *testing.T) {
@@ -41,8 +50,12 @@ func TestFeeRecipientListValid(t *testing.T) {
 	require.NoError(t, os.WriteFile(lockFile, lockJSON, 0o644))
 
 	config := feerecipientListConfig{
-		LockFilePath:      lockFile,
-		OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      lockFile,
+			OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+			PublishAddress:    "http://127.0.0.1:0",
+			PublishTimeout:    500 * time.Millisecond,
+		},
 	}
 
 	require.NoError(t, runFeeRecipientList(t.Context(), config))
@@ -63,9 +76,13 @@ func TestFeeRecipientListWithFilter(t *testing.T) {
 	require.NoError(t, os.WriteFile(lockFile, lockJSON, 0o644))
 
 	config := feerecipientListConfig{
-		ValidatorPublicKeys: []string{lock.Validators[0].PublicKeyHex()},
-		LockFilePath:        lockFile,
-		OverridesFilePath:   filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+		feerecipientConfig: feerecipientConfig{
+			ValidatorPublicKeys: []string{lock.Validators[0].PublicKeyHex()},
+			LockFilePath:        lockFile,
+			OverridesFilePath:   filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+			PublishAddress:      "http://127.0.0.1:0",
+			PublishTimeout:      500 * time.Millisecond,
+		},
 	}
 
 	require.NoError(t, runFeeRecipientList(t.Context(), config))
@@ -86,9 +103,11 @@ func TestFeeRecipientListInvalidPubkey(t *testing.T) {
 	require.NoError(t, os.WriteFile(lockFile, lockJSON, 0o644))
 
 	config := feerecipientListConfig{
-		ValidatorPublicKeys: []string{"0x" + strings.Repeat("ab", 48)},
-		LockFilePath:        lockFile,
-		OverridesFilePath:   filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+		feerecipientConfig: feerecipientConfig{
+			ValidatorPublicKeys: []string{"0x" + strings.Repeat("ab", 48)},
+			LockFilePath:        lockFile,
+			OverridesFilePath:   filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+		},
 	}
 
 	err = runFeeRecipientList(t.Context(), config)
@@ -97,8 +116,10 @@ func TestFeeRecipientListInvalidPubkey(t *testing.T) {
 
 func TestFeeRecipientListInvalidLockFile(t *testing.T) {
 	config := feerecipientListConfig{
-		LockFilePath:      "nonexistent-lock.json",
-		OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      "nonexistent-lock.json",
+			OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+		},
 	}
 
 	err := runFeeRecipientList(t.Context(), config)
@@ -133,8 +154,12 @@ func TestFeeRecipientListWithOverrides(t *testing.T) {
 	require.NoError(t, os.WriteFile(overridesFile, overridesJSON, 0o644))
 
 	config := feerecipientListConfig{
-		LockFilePath:      lockFile,
-		OverridesFilePath: overridesFile,
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      lockFile,
+			OverridesFilePath: overridesFile,
+			PublishAddress:    "http://127.0.0.1:0",
+			PublishTimeout:    500 * time.Millisecond,
+		},
 	}
 
 	require.NoError(t, runFeeRecipientList(t.Context(), config))
@@ -201,12 +226,14 @@ func TestResolveLatestRegistrations(t *testing.T) {
 	normalizedPubkey := normalizePubkey(lock.Validators[0].PublicKeyHex())
 
 	t.Run("no overrides", func(t *testing.T) {
-		entries := resolveLatestRegistrations(lock, nil, nil)
+		entries := resolveLatestRegistrations(lock, nil, nil, nil)
 		require.Len(t, entries, 2)
 
 		require.Equal(t, lock.Validators[0].PublicKeyHex(), entries[0].Pubkey)
 		require.Equal(t, "0x"+hex.EncodeToString(lock.Validators[0].BuilderRegistration.Message.FeeRecipient), entries[0].FeeRecipient)
 		require.Equal(t, uint64(lock.Validators[0].BuilderRegistration.Message.GasLimit), entries[0].GasLimit)
+		require.Equal(t, []string{"lock"}, entries[0].Sources)
+		require.Equal(t, []string{"lock"}, entries[1].Sources)
 	})
 
 	t.Run("override with newer timestamp wins", func(t *testing.T) {
@@ -218,11 +245,13 @@ func TestResolveLatestRegistrations(t *testing.T) {
 			},
 		}
 
-		entries := resolveLatestRegistrations(lock, overrides, nil)
+		entries := resolveLatestRegistrations(lock, overrides, nil, nil)
 		require.Len(t, entries, 2)
 
 		require.Equal(t, "0x0000000000000000000000000000000000005678", entries[0].FeeRecipient)
 		require.Equal(t, uint64(99999), entries[0].GasLimit)
+		require.Equal(t, []string{"overrides"}, entries[0].Sources)
+		require.Equal(t, []string{"lock"}, entries[1].Sources)
 	})
 
 	t.Run("override with older timestamp loses", func(t *testing.T) {
@@ -234,12 +263,14 @@ func TestResolveLatestRegistrations(t *testing.T) {
 			},
 		}
 
-		entries := resolveLatestRegistrations(lock, overrides, nil)
+		entries := resolveLatestRegistrations(lock, overrides, nil, nil)
 		require.Len(t, entries, 2)
 
 		// Should keep lock values.
 		require.Equal(t, "0x"+hex.EncodeToString(lock.Validators[0].BuilderRegistration.Message.FeeRecipient), entries[0].FeeRecipient)
 		require.Equal(t, uint64(lock.Validators[0].BuilderRegistration.Message.GasLimit), entries[0].GasLimit)
+		require.Equal(t, []string{"lock"}, entries[0].Sources)
+		require.Equal(t, []string{"lock"}, entries[1].Sources)
 	})
 
 	t.Run("pubkey filter", func(t *testing.T) {
@@ -247,9 +278,98 @@ func TestResolveLatestRegistrations(t *testing.T) {
 			normalizedPubkey: {},
 		}
 
-		entries := resolveLatestRegistrations(lock, nil, filter)
+		entries := resolveLatestRegistrations(lock, nil, nil, filter)
 		require.Len(t, entries, 1)
 		require.Equal(t, lock.Validators[0].PublicKeyHex(), entries[0].Pubkey)
+		require.Equal(t, []string{"lock"}, entries[0].Sources)
+	})
+
+	t.Run("remote only, newer than lock, no override", func(t *testing.T) {
+		remote := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000aaaa",
+				GasLimit:     11111,
+				Timestamp:    lockTimestamp.Add(time.Hour),
+			},
+		}
+
+		entries := resolveLatestRegistrations(lock, nil, remote, nil)
+		require.Len(t, entries, 2)
+
+		require.Equal(t, "0x000000000000000000000000000000000000aaaa", entries[0].FeeRecipient)
+		require.Equal(t, uint64(11111), entries[0].GasLimit)
+		require.Equal(t, []string{"remote"}, entries[0].Sources)
+		require.Equal(t, []string{"lock"}, entries[1].Sources)
+	})
+
+	t.Run("override and remote equivalent, both newer than lock", func(t *testing.T) {
+		equalTS := lockTimestamp.Add(time.Hour)
+		overrides := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000bbbb",
+				GasLimit:     22222,
+				Timestamp:    equalTS,
+			},
+		}
+		remote := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000bbbb",
+				GasLimit:     22222,
+				Timestamp:    equalTS,
+			},
+		}
+
+		entries := resolveLatestRegistrations(lock, overrides, remote, nil)
+		require.Len(t, entries, 2)
+
+		require.Equal(t, "0x000000000000000000000000000000000000bbbb", entries[0].FeeRecipient)
+		require.Equal(t, []string{"overrides", "remote"}, entries[0].Sources)
+	})
+
+	t.Run("override and remote diverge, override wins by timestamp", func(t *testing.T) {
+		overrides := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000cccc",
+				GasLimit:     33333,
+				Timestamp:    lockTimestamp.Add(2 * time.Hour),
+			},
+		}
+		remote := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000dddd",
+				GasLimit:     44444,
+				Timestamp:    lockTimestamp.Add(time.Hour),
+			},
+		}
+
+		entries := resolveLatestRegistrations(lock, overrides, remote, nil)
+		require.Len(t, entries, 2)
+
+		require.Equal(t, "0x000000000000000000000000000000000000cccc", entries[0].FeeRecipient)
+		require.Equal(t, []string{"overrides"}, entries[0].Sources)
+	})
+
+	t.Run("remote newer than override, remote wins", func(t *testing.T) {
+		overrides := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000eeee",
+				GasLimit:     55555,
+				Timestamp:    lockTimestamp.Add(time.Hour),
+			},
+		}
+		remote := map[string]registrationEntry{
+			normalizedPubkey: {
+				FeeRecipient: "0x000000000000000000000000000000000000ffff",
+				GasLimit:     66666,
+				Timestamp:    lockTimestamp.Add(2 * time.Hour),
+			},
+		}
+
+		entries := resolveLatestRegistrations(lock, overrides, remote, nil)
+		require.Len(t, entries, 2)
+
+		require.Equal(t, "0x000000000000000000000000000000000000ffff", entries[0].FeeRecipient)
+		require.Equal(t, []string{"remote"}, entries[0].Sources)
 	})
 }
 
@@ -276,6 +396,16 @@ func TestFeeRecipientListCLI(t *testing.T) {
 				"--validator-public-keys=0x" + strings.Repeat("ab", 48),
 			},
 		},
+		{
+			name:        "correct flags with publish flags",
+			expectedErr: "read cluster-lock.json: open test: no such file or directory",
+			flags: []string{
+				"--lock-file=test",
+				"--overrides-file=test",
+				"--publish-address=http://example.test",
+				"--publish-timeout=2s",
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -292,4 +422,349 @@ func TestFeeRecipientListCLI(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFeeRecipientListFetchesRemote(t *testing.T) {
+	ctx := t.Context()
+	ctx = log.WithCtx(ctx, z.Str("test_case", t.Name()))
+
+	valAmt := 4
+	operatorAmt := 4
+
+	random := rand.New(rand.NewSource(0))
+
+	lock, enrs, keyShares := cluster.NewForT(t, valAmt, operatorAmt, operatorAmt, 0, random)
+
+	root := t.TempDir()
+
+	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
+	for opIdx := range operatorAmt {
+		for _, share := range keyShares {
+			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
+		}
+	}
+
+	lockJSON, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, lockJSON)
+
+	handler, addLockFiles := obolapimock.MockServer(false, nil)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	addLockFiles(lock)
+
+	// Submit partial signatures from threshold operators so the API has quorum.
+	newFeeRecipient := "0x0000000000000000000000000000000000001234"
+	validatorPubkey := lock.Validators[0].PublicKeyHex()
+
+	for opIdx := range lock.Threshold {
+		baseDir := filepath.Join(root, fmt.Sprintf("op%d", opIdx))
+
+		signConfig := feerecipientSignConfig{
+			feerecipientConfig: feerecipientConfig{
+				ValidatorPublicKeys: []string{validatorPubkey},
+				PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+				LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:      srv.URL,
+				PublishTimeout:      10 * time.Second,
+			},
+			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
+			FeeRecipient:     newFeeRecipient,
+		}
+
+		require.NoError(t, runFeeRecipientSign(ctx, signConfig), "operator %d submit feerecipient sign", opIdx)
+	}
+
+	overridesFile := filepath.Join(root, "output", "builder_registrations_overrides.json")
+
+	listConfig := feerecipientListConfig{
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      filepath.Join(root, "op0", "cluster-lock.json"),
+			OverridesFilePath: overridesFile,
+			PublishAddress:    srv.URL,
+			PublishTimeout:    10 * time.Second,
+		},
+	}
+
+	require.NoError(t, runFeeRecipientList(ctx, listConfig))
+
+	// list must not write to disk.
+	_, err = os.Stat(overridesFile)
+	require.True(t, os.IsNotExist(err), "list must not write the overrides file")
+}
+
+func TestFeeRecipientListRemoteOnlyTriggersSuggestion(t *testing.T) {
+	ctx, logs := captureListLogs(t, t.Context())
+
+	valAmt := 4
+	operatorAmt := 4
+
+	random := rand.New(rand.NewSource(0))
+	lock, enrs, keyShares := cluster.NewForT(t, valAmt, operatorAmt, operatorAmt, 0, random)
+
+	root := t.TempDir()
+
+	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
+	for opIdx := range operatorAmt {
+		for _, share := range keyShares {
+			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
+		}
+	}
+
+	lockJSON, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, lockJSON)
+
+	handler, addLockFiles := obolapimock.MockServer(false, nil)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	addLockFiles(lock)
+
+	newFeeRecipient := "0x0000000000000000000000000000000000001234"
+
+	validatorPubkey := lock.Validators[0].PublicKeyHex()
+	for opIdx := range lock.Threshold {
+		baseDir := filepath.Join(root, fmt.Sprintf("op%d", opIdx))
+		signConfig := feerecipientSignConfig{
+			feerecipientConfig: feerecipientConfig{
+				ValidatorPublicKeys: []string{validatorPubkey},
+				PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+				LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:      srv.URL,
+				PublishTimeout:      10 * time.Second,
+			},
+			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
+			FeeRecipient:     newFeeRecipient,
+		}
+		require.NoError(t, runFeeRecipientSign(ctx, signConfig))
+	}
+
+	listConfig := feerecipientListConfig{
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      filepath.Join(root, "op0", "cluster-lock.json"),
+			OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+			PublishAddress:    srv.URL,
+			PublishTimeout:    10 * time.Second,
+		},
+	}
+
+	require.NoError(t, runFeeRecipientList(ctx, listConfig))
+
+	output := logs.String()
+
+	require.Regexp(t,
+		`Builder registration for `+regexp.QuoteMeta(validatorPubkey)+`[^\n]*source=remote`,
+		output,
+	)
+	require.Contains(t, output, "Updated registrations are available")
+}
+
+func TestFeeRecipientListOverridesMatchRemote(t *testing.T) {
+	ctx, logs := captureListLogs(t, t.Context())
+
+	valAmt := 4
+	operatorAmt := 4
+
+	random := rand.New(rand.NewSource(0))
+	lock, enrs, keyShares := cluster.NewForT(t, valAmt, operatorAmt, operatorAmt, 0, random)
+
+	root := t.TempDir()
+
+	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
+	for opIdx := range operatorAmt {
+		for _, share := range keyShares {
+			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
+		}
+	}
+
+	lockJSON, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, lockJSON)
+
+	handler, addLockFiles := obolapimock.MockServer(false, nil)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	addLockFiles(lock)
+
+	newFeeRecipient := "0x0000000000000000000000000000000000001234"
+
+	validatorPubkey := lock.Validators[0].PublicKeyHex()
+	for opIdx := range lock.Threshold {
+		baseDir := filepath.Join(root, fmt.Sprintf("op%d", opIdx))
+		signConfig := feerecipientSignConfig{
+			feerecipientConfig: feerecipientConfig{
+				ValidatorPublicKeys: []string{validatorPubkey},
+				PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+				LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:      srv.URL,
+				PublishTimeout:      10 * time.Second,
+			},
+			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
+			FeeRecipient:     newFeeRecipient,
+		}
+		require.NoError(t, runFeeRecipientSign(ctx, signConfig))
+	}
+
+	overridesFile := filepath.Join(root, "output", "builder_registrations_overrides.json")
+	require.NoError(t, os.MkdirAll(filepath.Dir(overridesFile), 0o755))
+
+	fetchConfig := feerecipientFetchConfig{
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      filepath.Join(root, "op0", "cluster-lock.json"),
+			OverridesFilePath: overridesFile,
+			PublishAddress:    srv.URL,
+			PublishTimeout:    10 * time.Second,
+		},
+	}
+	require.NoError(t, runFeeRecipientFetch(ctx, fetchConfig))
+
+	listConfig := feerecipientListConfig{
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      filepath.Join(root, "op0", "cluster-lock.json"),
+			OverridesFilePath: overridesFile,
+			PublishAddress:    srv.URL,
+			PublishTimeout:    10 * time.Second,
+		},
+	}
+	require.NoError(t, runFeeRecipientList(ctx, listConfig))
+
+	output := logs.String()
+
+	require.Regexp(t,
+		`Builder registration for `+regexp.QuoteMeta(validatorPubkey)+`[^\n]*source=overrides\+remote`,
+		output,
+	)
+	require.NotContains(t, output, "Updated registrations are available")
+}
+
+func TestFeeRecipientListRemoteUnreachable(t *testing.T) {
+	ctx, logs := captureListLogs(t, t.Context())
+
+	valAmt := 4
+	operatorAmt := 4
+
+	random := rand.New(rand.NewSource(0))
+	lock, _, _ := cluster.NewForT(t, valAmt, operatorAmt, operatorAmt, 0, random)
+
+	lockJSON, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	lockFile := filepath.Join(t.TempDir(), "cluster-lock.json")
+	require.NoError(t, os.WriteFile(lockFile, lockJSON, 0o644))
+
+	// Start and immediately close the server so the URL is unreachable.
+	srv := httptest.NewServer(http.NotFoundHandler())
+	srv.Close()
+
+	listConfig := feerecipientListConfig{
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      lockFile,
+			OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+			PublishAddress:    srv.URL,
+			PublishTimeout:    500 * time.Millisecond,
+		},
+	}
+
+	require.NoError(t, runFeeRecipientList(ctx, listConfig))
+
+	output := logs.String()
+
+	require.Contains(t, output, "Unable to fetch remote builder registrations")
+	require.NotContains(t, output, "Updated registrations are available")
+	require.NotContains(t, output, "Validators with partial builder registrations")
+	require.NotContains(t, output, "Validators unknown to remote API")
+}
+
+func TestFeeRecipientListIncompleteNoQuorum(t *testing.T) {
+	ctx, logs := captureListLogs(t, t.Context())
+
+	valAmt := 1
+	operatorAmt := 4
+
+	random := rand.New(rand.NewSource(0))
+	lock, enrs, keyShares := cluster.NewForT(t, valAmt, operatorAmt, operatorAmt, 0, random)
+
+	root := t.TempDir()
+
+	operatorShares := make([][]tbls.PrivateKey, operatorAmt)
+	for opIdx := range operatorAmt {
+		for _, share := range keyShares {
+			operatorShares[opIdx] = append(operatorShares[opIdx], share[opIdx])
+		}
+	}
+
+	lockJSON, err := json.Marshal(lock)
+	require.NoError(t, err)
+
+	writeAllLockData(t, root, operatorAmt, enrs, operatorShares, lockJSON)
+
+	// dropOnePsig=true prevents quorum from being reached.
+	handler, addLockFiles := obolapimock.MockServer(true, nil)
+
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	addLockFiles(lock)
+
+	// Submit partials from fewer than threshold operators so the API reports
+	// the registration as incomplete (below quorum).
+	newFeeRecipient := "0x0000000000000000000000000000000000001234"
+
+	validatorPubkey := lock.Validators[0].PublicKeyHex()
+	for opIdx := range lock.Threshold - 1 {
+		baseDir := filepath.Join(root, fmt.Sprintf("op%d", opIdx))
+		signConfig := feerecipientSignConfig{
+			feerecipientConfig: feerecipientConfig{
+				ValidatorPublicKeys: []string{validatorPubkey},
+				PrivateKeyPath:      filepath.Join(baseDir, "charon-enr-private-key"),
+				LockFilePath:        filepath.Join(baseDir, "cluster-lock.json"),
+				PublishAddress:      srv.URL,
+				PublishTimeout:      10 * time.Second,
+			},
+			ValidatorKeysDir: filepath.Join(baseDir, "validator_keys"),
+			FeeRecipient:     newFeeRecipient,
+		}
+		require.NoError(t, runFeeRecipientSign(ctx, signConfig))
+	}
+
+	listConfig := feerecipientListConfig{
+		feerecipientConfig: feerecipientConfig{
+			LockFilePath:      filepath.Join(root, "op0", "cluster-lock.json"),
+			OverridesFilePath: filepath.Join(t.TempDir(), "nonexistent-overrides.json"),
+			PublishAddress:    srv.URL,
+			PublishTimeout:    10 * time.Second,
+		},
+	}
+
+	require.NoError(t, runFeeRecipientList(ctx, listConfig))
+
+	output := logs.String()
+
+	require.Contains(t, output, "Validators with partial builder registrations on remote")
+	require.NotContains(t, output, "Updated registrations are available")
+	require.Regexp(t,
+		`Builder registration for `+regexp.QuoteMeta(validatorPubkey)+`[^\n]*source=lock`,
+		output,
+	)
+}
+
+// captureListLogs returns a context that routes charon logs into a buffer.
+// Tests read the buffer bytes (as text) to assert on log content. The buffer
+// uses logfmt formatting so tests can assert on "key=value" pairs.
+func captureListLogs(t *testing.T, ctx context.Context) (context.Context, *zaptest.Buffer) {
+	t.Helper()
+
+	buf := &zaptest.Buffer{}
+	log.InitLogfmtForT(t, buf)
+
+	return ctx, buf
 }


### PR DESCRIPTION
Extend `feerecipient list` to also read builder-registration state from the Obol API. Each row carries a `source` field indicating where the winning record came from: `lock`, `overrides`, `remote`, or combinations like `overrides+remote` when the same record exists in multiple places.

When the API has a quorum that is not yet in the overrides file, print a suggestion to run `charon feerecipient fetch` (or `charon run --fetch-feerecipient-updates` for periodic updates). Nothing  is written to disk.                                                                                                                                                                              

API failures are soft: a warning is logged and the command falls back  to local-only rendering.                                                                                                                                                                         
                               
Add `--publish-address` and `--publish-timeout` flags with the same defaults as `fetch`. `fetch` and `charon run` behavior are unchanged.
                                          
category: feature
ticket: none