### PR TITLE
fix: prevent duty loss and fix misleading comment in deadliner

### DIFF
--- a/core/deadline.go
+++ b/core/deadline.go
@@ -176,14 +176,14 @@ func (d *deadliner) run(ctx context.Context, deadlineFunc DeadlineFunc) {
 				setCurrState()
 			}
 		case <-currTimer.Chan():
-		    select {
-		    case <-ctx.Done():
-		        return
-		    case d.deadlineChan <- currDuty:
-		    }
-		
-		    delete(duties, currDuty)
-		    setCurrState()
+			select {
+			case <-ctx.Done():
+				return
+			case d.deadlineChan <- currDuty:
+			}
+
+			delete(duties, currDuty)
+			setCurrState()
 		}
 	}
 }

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -176,20 +176,14 @@ func (d *deadliner) run(ctx context.Context, deadlineFunc DeadlineFunc) {
 				setCurrState()
 			}
 		case <-currTimer.Chan():
-			// Send deadlined duty to receiver.
-			select {
-			case <-ctx.Done():
-				return
-			case d.deadlineChan <- currDuty:
-			default:
-				log.Warn(ctx, "Deadliner output channel full", nil,
-					z.Str("label", d.label),
-					z.Any("duty", currDuty),
-				)
-			}
-
-			delete(duties, currDuty)
-			setCurrState()
+		    select {
+		    case <-ctx.Done():
+		        return
+		    case d.deadlineChan <- currDuty:
+		    }
+		
+		    delete(duties, currDuty)
+		    setCurrState()
 		}
 	}
 }
@@ -217,7 +211,7 @@ func (d *deadliner) C() <-chan Duty {
 	return d.deadlineChan
 }
 
-// getCurrDuty gets the duty to process next along-with the duty deadline. It selects duty with the latest deadline.
+// getCurrDuty gets the duty to process next along-with the duty deadline. It selects duty with the earliest deadline.
 func getCurrDuty(duties map[Duty]bool, deadlineFunc DeadlineFunc) (Duty, time.Time) {
 	var currDuty Duty
 

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -211,7 +211,7 @@ func (d *deadliner) C() <-chan Duty {
 	return d.deadlineChan
 }
 
-// getCurrDuty gets the duty to process next along-with the duty deadline. It selects duty with the earliest deadline.
+// getCurrDuty gets the duty to process next along with the duty deadline. It selects duty with the earliest deadline.
 func getCurrDuty(duties map[Duty]bool, deadlineFunc DeadlineFunc) (Duty, time.Time) {
 	var currDuty Duty
 

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -214,3 +214,59 @@ func setupData(t *testing.T) ([]core.Duty, []core.Duty, []core.Duty, func(core.D
 
 	return expiredDuties, nonExpiredDuties, voluntaryExits, dutyExpired
 }
+
+func TestDeadlinerNoDutyLossOnFullChannel(t *testing.T) {
+	// This test verifies that no duties are lost when the deadlineChan buffer is full.
+	//
+	// Previously, a non-blocking select with a `default` case would silently drop duties
+	// when the output channel was at capacity (outputBuffer = 10), logging only a warning.
+	// The fix removes the `default` case, making the send blocking and guaranteeing
+	// that every deadlined duty is eventually delivered to the consumer.
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	clock := clockwork.NewFakeClock()
+	startTime := clock.Now()
+
+	// numDuties exceeds outputBuffer (10) to guarantee the channel fills up
+	// before the consumer starts reading, exercising the previously broken path.
+	const numDuties = 12
+
+	duties := make([]core.Duty, numDuties)
+	for i := range numDuties {
+		duties[i] = core.NewAttesterDuty(uint64(i + 1))
+	}
+
+	// Stagger deadlines by slot so Deadliner processes them one-by-one in order.
+	deadlineFunc := func(duty core.Duty) (time.Time, bool) {
+		return startTime.Add(time.Duration(duty.Slot) * time.Millisecond), true
+	}
+
+	deadliner := core.NewDeadlinerForT(ctx, t, deadlineFunc, clock)
+
+	for _, duty := range duties {
+		require.True(t, deadliner.Add(duty))
+	}
+
+	// Advance the clock past all deadlines in one shot.
+	// With the old default-case code, duties 11 and 12 would be silently dropped
+	// once the 10-slot buffer was full.
+	clock.Advance(time.Duration(numDuties+1) * time.Millisecond)
+
+	// Collect every duty. The per-iteration timeout detects a dropped duty.
+	received := make([]core.Duty, 0, numDuties)
+	for range numDuties {
+		select {
+		case duty := <-deadliner.C():
+			received = append(received, duty)
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "duty lost",
+				"received %d/%d duties — remaining duties were silently dropped when channel was full",
+				len(received), numDuties,
+			)
+		}
+	}
+
+	require.Len(t, received, numDuties, "all duties must be delivered without loss")
+}


### PR DESCRIPTION
Remove the default branch from the timer case in deadliner.run to ensure deadlined duties are never silently dropped when the output channel is full. Also fix an incorrect comment in getCurrDuty that said latest instead of earliest