### PR TITLE
*: exclude unprepared beacon nodes from proposal calls

### DIFF
--- a/app/eth2wrap/classify_internal_test.go
+++ b/app/eth2wrap/classify_internal_test.go
@@ -1,0 +1,104 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import (
+	"testing"
+
+	eth2api "github.com/attestantio/go-eth2-client/api"
+	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
+	"github.com/stretchr/testify/require"
+)
+
+const classifyExpectedHex = "0xabcd000000000000000000000000000000000000"
+
+func denebProposal(addr bellatrix.ExecutionAddress) *eth2api.VersionedProposal {
+	return &eth2api.VersionedProposal{
+		Version: eth2spec.DataVersionDeneb,
+		Deneb: &eth2deneb.BlockContents{
+			Block: &deneb.BeaconBlock{
+				Body: &deneb.BeaconBlockBody{
+					ExecutionPayload: &deneb.ExecutionPayload{FeeRecipient: addr},
+				},
+			},
+		},
+	}
+}
+
+func TestClassifyProposal(t *testing.T) {
+	matching := bellatrix.ExecutionAddress{0xab, 0xcd}
+	mismatching := bellatrix.ExecutionAddress{0xde, 0xad}
+
+	tests := []struct {
+		name     string
+		proposal *eth2api.VersionedProposal
+		want     proposalDecision
+	}{
+		{
+			name:     "matching fee recipient",
+			proposal: denebProposal(matching),
+			want:     decisionAccept,
+		},
+		{
+			name:     "mismatching fee recipient",
+			proposal: denebProposal(mismatching),
+			want:     decisionRejectMismatch,
+		},
+		{
+			name: "blinded proposal accepted (recipient is builder's, not validator's)",
+			proposal: &eth2api.VersionedProposal{
+				Version: eth2spec.DataVersionDeneb,
+				Blinded: true,
+			},
+			want: decisionAccept,
+		},
+		{
+			name:     "phase0 accepted (no execution payload)",
+			proposal: &eth2api.VersionedProposal{Version: eth2spec.DataVersionPhase0},
+			want:     decisionAccept,
+		},
+		{
+			name:     "altair accepted (no execution payload)",
+			proposal: &eth2api.VersionedProposal{Version: eth2spec.DataVersionAltair},
+			want:     decisionAccept,
+		},
+		{
+			name:     "nil proposal rejected as malformed",
+			proposal: nil,
+			want:     decisionRejectMalformed,
+		},
+		{
+			name:     "deneb with nil Deneb rejected as malformed",
+			proposal: &eth2api.VersionedProposal{Version: eth2spec.DataVersionDeneb},
+			want:     decisionRejectMalformed,
+		},
+		{
+			name: "deneb with nil ExecutionPayload rejected as malformed",
+			proposal: &eth2api.VersionedProposal{
+				Version: eth2spec.DataVersionDeneb,
+				Deneb:   &eth2deneb.BlockContents{Block: &deneb.BeaconBlock{Body: &deneb.BeaconBlockBody{}}},
+			},
+			want: decisionRejectMalformed,
+		},
+		{
+			name:     "bellatrix with nil Bellatrix rejected as malformed",
+			proposal: &eth2api.VersionedProposal{Version: eth2spec.DataVersionBellatrix},
+			want:     decisionRejectMalformed,
+		},
+		{
+			name:     "unknown fork rejected as malformed",
+			proposal: &eth2api.VersionedProposal{Version: eth2spec.DataVersion(99)},
+			want:     decisionRejectMalformed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := classifyProposal(tt.proposal, classifyExpectedHex)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/app/eth2wrap/eth2wrap_gen.go
+++ b/app/eth2wrap/eth2wrap_gen.go
@@ -421,26 +421,7 @@ func (m multi) SyncCommitteeSelections(ctx context.Context, opts *api.SyncCommit
 	return res0, err
 }
 
-// Proposal fetches a proposal for signing.
-func (m multi) Proposal(ctx context.Context, opts *api.ProposalOpts) (*api.Response[*api.VersionedProposal], error) {
-	const label = "proposal"
-	defer latency(ctx, label, true)()
-	defer incRequest(label)
-
-	res0, err := provide(ctx, m.clients, m.fallbacks,
-		func(ctx context.Context, args provideArgs) (*api.Response[*api.VersionedProposal], error) {
-			return args.client.Proposal(ctx, opts)
-		},
-		nil, m.selector,
-	)
-
-	if err != nil {
-		incError(label)
-		err = wrapError(ctx, err, label)
-	}
-
-	return res0, err
-}
+// Note: multi.Proposal is hand-written in multi.go (skipped by genwrap).
 
 // BeaconBlockRoot fetches a block's root given a set of options.
 // Note this endpoint is cached in go-eth2-client.
@@ -741,27 +722,7 @@ func (m multi) NodeVersion(ctx context.Context, opts *api.NodeVersionOpts) (*api
 	return res0, err
 }
 
-// SubmitProposalPreparations provides the beacon node with information required if a proposal for the given validators
-// shows up in the next epoch.
-func (m multi) SubmitProposalPreparations(ctx context.Context, preparations []*apiv1.ProposalPreparation) error {
-	const label = "submit_proposal_preparations"
-	defer latency(ctx, label, true)()
-	defer incRequest(label)
-
-	err := submit(ctx, m.clients, m.fallbacks,
-		func(ctx context.Context, args provideArgs) error {
-			return args.client.SubmitProposalPreparations(ctx, preparations)
-		},
-		m.selector,
-	)
-
-	if err != nil {
-		incError(label)
-		err = wrapError(ctx, err, label)
-	}
-
-	return err
-}
+// Note: multi.SubmitProposalPreparations is hand-written in multi.go (skipped by genwrap).
 
 // ProposerDuties obtains proposer duties for the given options.
 func (m multi) ProposerDuties(ctx context.Context, opts *api.ProposerDutiesOpts) (*api.Response[[]*apiv1.ProposerDuty], error) {
@@ -894,6 +855,8 @@ func (m multi) GenesisDomain(ctx context.Context, domainType phase0.DomainType) 
 
 	return res0, err
 }
+
+// Note: multi.Proxy is hand-written in multi.go (skipped by genwrap).
 
 // SlotDuration provides the duration of a slot of the chain.
 //

--- a/app/eth2wrap/genwrap/genwrap.go
+++ b/app/eth2wrap/genwrap/genwrap.go
@@ -65,7 +65,7 @@ type Client interface {
 }
 
 {{range .Methods}}
-	{{- if ne .Name "Proxy"}}
+	{{- if and (ne .Name "Proxy") (ne .Name "Proposal") (ne .Name "SubmitProposalPreparations")}}
 	{{.Doc}}
     {{- if not .Latency}}// Note this endpoint is cached in go-eth2-client.
     {{end -}}
@@ -88,6 +88,8 @@ type Client interface {
 
 		return {{.ResultNames}}
 	}
+	{{- else}}
+	// Note: multi.{{.Name}} is hand-written in multi.go (skipped by genwrap).
 	{{- end}}
 {{end}}
 

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -326,8 +326,10 @@ func ExpectedFeeRecipient(ctx context.Context) string {
 
 // ProposalFeeRecipient returns the fee recipient address of an unsigned proposal as a
 // hex string with 0x prefix. The second return value is false for forks earlier than
-// bellatrix (no execution payload) or for blinded proposals (recipient is the builder,
-// not the validator's configured address).
+// bellatrix (no execution payload), for blinded proposals (recipient is the builder,
+// not the validator's configured address), and for malformed responses missing any
+// nested struct in the chain to FeeRecipient — callers receive a BN response and
+// must not panic on partial/malformed input.
 func ProposalFeeRecipient(proposal *eth2api.VersionedProposal) (string, bool) {
 	if proposal == nil || proposal.Blinded {
 		return "", false
@@ -335,14 +337,34 @@ func ProposalFeeRecipient(proposal *eth2api.VersionedProposal) (string, bool) {
 
 	switch proposal.Version {
 	case eth2spec.DataVersionBellatrix:
+		if proposal.Bellatrix == nil || proposal.Bellatrix.Body == nil || proposal.Bellatrix.Body.ExecutionPayload == nil {
+			return "", false
+		}
+
 		return fmt.Sprintf("%#x", proposal.Bellatrix.Body.ExecutionPayload.FeeRecipient), true
 	case eth2spec.DataVersionCapella:
+		if proposal.Capella == nil || proposal.Capella.Body == nil || proposal.Capella.Body.ExecutionPayload == nil {
+			return "", false
+		}
+
 		return fmt.Sprintf("%#x", proposal.Capella.Body.ExecutionPayload.FeeRecipient), true
 	case eth2spec.DataVersionDeneb:
+		if proposal.Deneb == nil || proposal.Deneb.Block == nil || proposal.Deneb.Block.Body == nil || proposal.Deneb.Block.Body.ExecutionPayload == nil {
+			return "", false
+		}
+
 		return fmt.Sprintf("%#x", proposal.Deneb.Block.Body.ExecutionPayload.FeeRecipient), true
 	case eth2spec.DataVersionElectra:
+		if proposal.Electra == nil || proposal.Electra.Block == nil || proposal.Electra.Block.Body == nil || proposal.Electra.Block.Body.ExecutionPayload == nil {
+			return "", false
+		}
+
 		return fmt.Sprintf("%#x", proposal.Electra.Block.Body.ExecutionPayload.FeeRecipient), true
 	case eth2spec.DataVersionFulu:
+		if proposal.Fulu == nil || proposal.Fulu.Block == nil || proposal.Fulu.Block.Body == nil || proposal.Fulu.Block.Body.ExecutionPayload == nil {
+			return "", false
+		}
+
 		return fmt.Sprintf("%#x", proposal.Fulu.Block.Body.ExecutionPayload.FeeRecipient), true
 	default:
 		return "", false
@@ -361,14 +383,29 @@ func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2a
 	defer latency(ctx, label, true)()
 	defer incRequest(label)
 
-	clients := m.prep.preparedClients(m.clients)
+	// For Proposal, merge primaries and fallbacks into a single pool: fee recipient validation
+	// is a content check, but provide()'s built-in fallback retry only triggers on transport
+	// errors (timeout / syncing / bad-gateway). Without merging, primaries returning technically-
+	// successful-but-wrong-recipient blocks would fail the duty even when a fallback would have
+	// returned a correct proposal. See #4477.
+	primaries := m.prep.preparedClients(m.clients)
 	fallbacks := m.prep.preparedClients(m.fallbacks)
+
+	clients := make([]Client, 0, len(primaries)+len(fallbacks))
+	clients = append(clients, primaries...)
+	clients = append(clients, fallbacks...)
 
 	expected := ExpectedFeeRecipient(ctx)
 
 	var isSuccess func(*eth2api.Response[*eth2api.VersionedProposal]) bool
 	if expected != "" {
 		isSuccess = func(resp *eth2api.Response[*eth2api.VersionedProposal]) bool {
+			// A misbehaving client could return (nil, nil); treat as non-success so provide
+			// moves on rather than panicking on resp.Data.
+			if resp == nil {
+				return false
+			}
+
 			actual, ok := ProposalFeeRecipient(resp.Data)
 			if !ok {
 				return true
@@ -385,12 +422,19 @@ func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2a
 		}
 	}
 
-	res0, err := provide(ctx, clients, fallbacks,
+	res0, err := provide(ctx, clients, nil,
 		func(ctx context.Context, args provideArgs) (*eth2api.Response[*eth2api.VersionedProposal], error) {
 			return args.client.Proposal(ctx, opts)
 		},
 		isSuccess, m.selector,
 	)
+
+	// Defend against (nil, nil) from provide — the caller dereferences eth2Resp.Data and would
+	// panic. This can happen if every backend's Proposal returns (nil, nil), or via the
+	// nokResp path when expected is set and all responses failed isSuccess (all nil).
+	if err == nil && res0 == nil {
+		err = errors.New("all beacon node proposals returned nil response")
+	}
 
 	// provide returns the last non-success response with nil error when all responses fail
 	// the isSuccess check. Promote that to a real error so the caller doesn't sign a bad block.

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -5,12 +5,20 @@ package eth2wrap
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
+	apiv1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/forkjoin"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 // NewMultiForT creates a new mutil client for testing.
@@ -19,6 +27,7 @@ func NewMultiForT(clients []Client, fallbacks []Client) Client {
 		clients:   clients,
 		fallbacks: fallbacks,
 		selector:  newBestSelector(bestPeriod),
+		prep:      newPrepState(),
 	}
 }
 
@@ -27,6 +36,7 @@ func newMulti(clients []Client, fallbacks []Client) Client {
 		clients:   clients,
 		fallbacks: fallbacks,
 		selector:  newBestSelector(bestPeriod),
+		prep:      newPrepState(),
 	}
 }
 
@@ -40,6 +50,7 @@ type multi struct {
 	clients   []Client
 	fallbacks []Client
 	selector  *bestSelector
+	prep      *prepState
 }
 
 func (m multi) SetForkVersion(forkVersion [4]byte) {
@@ -77,6 +88,7 @@ func (m multi) ClientForAddress(addr string) Client {
 				clients:   []Client{cl},
 				fallbacks: m.fallbacks,
 				selector:  m.selector,
+				prep:      m.prep,
 			}
 		}
 	}
@@ -88,6 +100,7 @@ func (m multi) ClientForAddress(addr string) Client {
 				clients:   []Client{cl},
 				fallbacks: nil,
 				selector:  m.selector,
+				prep:      m.prep,
 			}
 		}
 	}
@@ -286,4 +299,186 @@ func (m multi) Proxy(ctx context.Context, req *http.Request) (*http.Response, er
 	)
 
 	return res0, err
+}
+
+// expectedFeeRecipientCtxKey is a context key for the expected fee recipient address
+// of a Proposal call. multi.Proposal uses it to discard responses with a mismatched
+// fee recipient so they don't end up signed and broadcast. See issue #4477.
+type expectedFeeRecipientCtxKey struct{}
+
+// ContextWithExpectedFeeRecipient returns ctx with addr attached as the expected fee
+// recipient for any Proposal call made with the returned context. addr should be a hex
+// string with 0x prefix; comparison is case-insensitive.
+func ContextWithExpectedFeeRecipient(ctx context.Context, addr string) context.Context {
+	return context.WithValue(ctx, expectedFeeRecipientCtxKey{}, addr)
+}
+
+// ExpectedFeeRecipient returns the expected fee recipient address attached to ctx by
+// ContextWithExpectedFeeRecipient, or "" if none is attached.
+func ExpectedFeeRecipient(ctx context.Context) string {
+	v, ok := ctx.Value(expectedFeeRecipientCtxKey{}).(string)
+	if !ok {
+		return ""
+	}
+
+	return v
+}
+
+// ProposalFeeRecipient returns the fee recipient address of an unsigned proposal as a
+// hex string with 0x prefix. The second return value is false for forks earlier than
+// bellatrix (no execution payload) or for blinded proposals (recipient is the builder,
+// not the validator's configured address).
+func ProposalFeeRecipient(proposal *eth2api.VersionedProposal) (string, bool) {
+	if proposal == nil || proposal.Blinded {
+		return "", false
+	}
+
+	switch proposal.Version {
+	case eth2spec.DataVersionBellatrix:
+		return fmt.Sprintf("%#x", proposal.Bellatrix.Body.ExecutionPayload.FeeRecipient), true
+	case eth2spec.DataVersionCapella:
+		return fmt.Sprintf("%#x", proposal.Capella.Body.ExecutionPayload.FeeRecipient), true
+	case eth2spec.DataVersionDeneb:
+		return fmt.Sprintf("%#x", proposal.Deneb.Block.Body.ExecutionPayload.FeeRecipient), true
+	case eth2spec.DataVersionElectra:
+		return fmt.Sprintf("%#x", proposal.Electra.Block.Body.ExecutionPayload.FeeRecipient), true
+	case eth2spec.DataVersionFulu:
+		return fmt.Sprintf("%#x", proposal.Fulu.Block.Body.ExecutionPayload.FeeRecipient), true
+	default:
+		return "", false
+	}
+}
+
+// Proposal fetches a proposal for signing.
+//
+// Hand-written (skipped by genwrap) for two reasons:
+//   - excludes BNs whose most recent SubmitProposalPreparations failed (Solution A for #4477)
+//   - rejects responses whose fee recipient doesn't match the value attached to ctx via
+//     ContextWithExpectedFeeRecipient, so a still-misconfigured BN can't poison the result
+//     (Solution B for #4477)
+func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.Response[*eth2api.VersionedProposal], error) {
+	const label = "proposal"
+	defer latency(ctx, label, true)()
+	defer incRequest(label)
+
+	clients := m.prep.preparedClients(m.clients)
+	fallbacks := m.prep.preparedClients(m.fallbacks)
+
+	expected := ExpectedFeeRecipient(ctx)
+
+	var isSuccess func(*eth2api.Response[*eth2api.VersionedProposal]) bool
+	if expected != "" {
+		isSuccess = func(resp *eth2api.Response[*eth2api.VersionedProposal]) bool {
+			actual, ok := ProposalFeeRecipient(resp.Data)
+			if !ok {
+				return true
+			}
+
+			if strings.EqualFold(actual, expected) {
+				return true
+			}
+
+			log.Warn(ctx, "Discarded beacon node proposal with unexpected fee recipient", nil,
+				z.Str("expected", expected), z.Str("actual", actual))
+
+			return false
+		}
+	}
+
+	res0, err := provide(ctx, clients, fallbacks,
+		func(ctx context.Context, args provideArgs) (*eth2api.Response[*eth2api.VersionedProposal], error) {
+			return args.client.Proposal(ctx, opts)
+		},
+		isSuccess, m.selector,
+	)
+
+	// provide returns the last non-success response with nil error when all responses fail
+	// the isSuccess check. Promote that to a real error so the caller doesn't sign a bad block.
+	// Compare directly here (rather than reusing isSuccess) so the warn line isn't logged twice.
+	if err == nil && expected != "" && res0 != nil {
+		if actual, ok := ProposalFeeRecipient(res0.Data); ok && !strings.EqualFold(actual, expected) {
+			err = errors.New("all beacon node proposals had an unexpected fee recipient")
+		}
+	}
+
+	if err != nil {
+		incError(label)
+		err = wrapError(ctx, err, label)
+	}
+
+	return res0, err
+}
+
+// SubmitProposalPreparations provides the beacon node with information required if a proposal for
+// the given validators shows up in the next epoch.
+//
+// Hand-written (skipped by genwrap): fans out to every BN (primaries and fallbacks) and records
+// per-BN outcome in m.prep so failed BNs are excluded from subsequent Proposal calls (Solution A
+// for #4477). Returns success if at least one BN succeeded so the duty cycle continues; per-BN
+// failures are logged and counted in errors_total to give operators visibility into partial
+// degradation — the very signal whose absence allowed #4477 to go unnoticed.
+func (m multi) SubmitProposalPreparations(ctx context.Context, preparations []*apiv1.ProposalPreparation) error {
+	const label = "submit_proposal_preparations"
+	defer latency(ctx, label, true)()
+	defer incRequest(label)
+
+	all := make([]Client, 0, len(m.clients)+len(m.fallbacks))
+	all = append(all, m.clients...)
+	all = append(all, m.fallbacks...)
+
+	work := func(ctx context.Context, cl Client) (struct{}, error) {
+		return struct{}{}, cl.SubmitProposalPreparations(ctx, preparations)
+	}
+
+	fork, join, cancel := forkjoin.New(ctx, work,
+		forkjoin.WithoutFailFast(),
+		forkjoin.WithWorkers(len(all)),
+	)
+	defer cancel()
+
+	for _, cl := range all {
+		fork(cl)
+	}
+
+	var (
+		successCount int
+		lastErr      error
+	)
+
+	for res := range join() {
+		addr := res.Input.Address()
+		if res.Err == nil {
+			m.prep.markSuccess(addr)
+
+			successCount++
+
+			continue
+		}
+
+		lastErr = res.Err
+
+		// If the parent ctx was cancelled, BN state is unknown — don't poison prepState by
+		// excluding BNs that may actually still be prepared.
+		if ctx.Err() != nil {
+			continue
+		}
+
+		m.prep.markFailure(addr)
+		incError(label)
+
+		log.Warn(ctx, "Failed to submit proposal preparations to beacon node, excluding from next Proposal call", res.Err,
+			z.Str("address", addr))
+	}
+
+	if successCount > 0 {
+		return nil
+	}
+
+	// If ctx was cancelled before any worker ran, lastErr is nil; surface ctx.Err() so the
+	// returned error isn't a confusing wrapped-nil.
+	if lastErr == nil {
+		lastErr = ctx.Err()
+	}
+
+	return wrapError(ctx, lastErr, label)
 }

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -40,12 +40,9 @@ func newMulti(clients []Client, fallbacks []Client) Client {
 	}
 }
 
-// multi implements Client by wrapping multiple clients, calling them in parallel
-// and returning the first successful response.
-// It also adds prometheus metrics and error wrapping.
-// It also implements a "best client" selector.
-// When any of the Clients specified fails a request, it will re-try it on the specified
-// fallback endpoints, if any.
+// multi wraps multiple clients, calling them in parallel and returning the first successful
+// response. Adds prometheus metrics, error wrapping, a "best client" selector, and retries
+// failed requests against the configured fallback endpoints.
 type multi struct {
 	clients   []Client
 	fallbacks []Client
@@ -73,9 +70,8 @@ func (m multi) Address() string {
 }
 
 // ClientForAddress returns a scoped multi client that only queries the specified address.
-// Returns the original multi client if the address is not found or is empty, meaning requests
-// will be sent to all configured clients using the multi-client's normal selection strategy
-// rather than being scoped to a single node.
+// Returns the original multi client if addr is empty or not found, falling back to the
+// normal multi-client selection strategy.
 func (m multi) ClientForAddress(addr string) Client {
 	if addr == "" {
 		return m
@@ -324,12 +320,9 @@ func ExpectedFeeRecipient(ctx context.Context) string {
 	return v
 }
 
-// ProposalFeeRecipient returns the fee recipient address of an unsigned proposal as a
-// hex string with 0x prefix. The second return value is false for forks earlier than
-// bellatrix (no execution payload), for blinded proposals (recipient is the builder,
-// not the validator's configured address), and for malformed responses missing any
-// nested struct in the chain to FeeRecipient — callers receive a BN response and
-// must not panic on partial/malformed input.
+// ProposalFeeRecipient returns the fee recipient address as 0x-prefixed hex. The bool is false
+// for pre-bellatrix forks, blinded proposals (builder's recipient, not validator's), and
+// malformed responses with nil nested structs — BN input must not panic on partial data.
 func ProposalFeeRecipient(proposal *eth2api.VersionedProposal) (string, bool) {
 	if proposal == nil || proposal.Blinded {
 		return "", false
@@ -371,23 +364,72 @@ func ProposalFeeRecipient(proposal *eth2api.VersionedProposal) (string, bool) {
 	}
 }
 
-// Proposal fetches a proposal for signing.
-//
-// Hand-written (skipped by genwrap) for two reasons:
-//   - excludes BNs whose most recent SubmitProposalPreparations failed (Solution A for #4477)
-//   - rejects responses whose fee recipient doesn't match the value attached to ctx via
-//     ContextWithExpectedFeeRecipient, so a still-misconfigured BN can't poison the result
-//     (Solution B for #4477)
+// proposalDecision is the outcome of validating a Proposal response against an expected fee
+// recipient. Shared by isSuccess (inside provide) and the post-provide promotion check.
+type proposalDecision int
+
+const (
+	decisionAccept          proposalDecision = iota // OK to use (recipient matches OR no recipient applicable)
+	decisionRejectMismatch                          // unblinded bellatrix+ with the wrong recipient
+	decisionRejectMalformed                         // nil response, missing nested fields, or unknown fork
+)
+
+// proposalIsRecipientExempt reports whether a proposal can legitimately skip fee recipient
+// validation: blinded (builder's recipient) and known pre-bellatrix forks (no execution
+// payload). Unknown forks are NOT exempt — they get treated as malformed.
+func proposalIsRecipientExempt(p *eth2api.VersionedProposal) bool {
+	if p == nil {
+		return false
+	}
+
+	if p.Blinded {
+		return true
+	}
+
+	switch p.Version {
+	case eth2spec.DataVersionPhase0, eth2spec.DataVersionAltair:
+		return true
+	default:
+		return false
+	}
+}
+
+// classifyProposal decides whether a proposal response is acceptable. Returns the actual fee
+// recipient hex when it could be extracted (useful for logging on mismatch).
+func classifyProposal(p *eth2api.VersionedProposal, expected string) (proposalDecision, string) {
+	if p == nil {
+		return decisionRejectMalformed, ""
+	}
+
+	actual, ok := ProposalFeeRecipient(p)
+	if ok {
+		if strings.EqualFold(actual, expected) {
+			return decisionAccept, actual
+		}
+
+		return decisionRejectMismatch, actual
+	}
+
+	// ProposalFeeRecipient returned ok=false. Accept only if validation is legitimately
+	// inapplicable; otherwise (malformed payload or unknown fork) reject.
+	if proposalIsRecipientExempt(p) {
+		return decisionAccept, ""
+	}
+
+	return decisionRejectMalformed, ""
+}
+
+// Proposal fetches a proposal for signing. Hand-written (skipped by genwrap) to exclude BNs
+// whose most recent prep failed (Solution A) and reject responses whose fee recipient doesn't
+// match ctx's ContextWithExpectedFeeRecipient — also rejects malformed responses. See #4477.
 func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2api.Response[*eth2api.VersionedProposal], error) {
 	const label = "proposal"
 	defer latency(ctx, label, true)()
 	defer incRequest(label)
 
-	// For Proposal, merge primaries and fallbacks into a single pool: fee recipient validation
-	// is a content check, but provide()'s built-in fallback retry only triggers on transport
-	// errors (timeout / syncing / bad-gateway). Without merging, primaries returning technically-
-	// successful-but-wrong-recipient blocks would fail the duty even when a fallback would have
-	// returned a correct proposal. See #4477.
+	// Merge primaries and fallbacks into a single pool: provide()'s built-in fallback retry
+	// only fires on transport errors, not content checks like a wrong fee recipient. Without
+	// merging, a fallback can't rescue the duty when primaries return wrong-recipient blocks.
 	primaries := m.prep.preparedClients(m.clients)
 	fallbacks := m.prep.preparedClients(m.fallbacks)
 
@@ -406,19 +448,22 @@ func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2a
 				return false
 			}
 
-			actual, ok := ProposalFeeRecipient(resp.Data)
-			if !ok {
+			decision, actual := classifyProposal(resp.Data, expected)
+			switch decision {
+			case decisionAccept:
 				return true
+			case decisionRejectMismatch:
+				log.Warn(ctx, "Discarded beacon node proposal with unexpected fee recipient", nil,
+					z.Str("expected", expected), z.Str("actual", actual))
+
+				return false
+			case decisionRejectMalformed:
+				log.Warn(ctx, "Discarded malformed beacon node proposal", nil)
+
+				return false
+			default:
+				return false
 			}
-
-			if strings.EqualFold(actual, expected) {
-				return true
-			}
-
-			log.Warn(ctx, "Discarded beacon node proposal with unexpected fee recipient", nil,
-				z.Str("expected", expected), z.Str("actual", actual))
-
-			return false
 		}
 	}
 
@@ -429,19 +474,24 @@ func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2a
 		isSuccess, m.selector,
 	)
 
-	// Defend against (nil, nil) from provide — the caller dereferences eth2Resp.Data and would
-	// panic. This can happen if every backend's Proposal returns (nil, nil), or via the
-	// nokResp path when expected is set and all responses failed isSuccess (all nil).
+	// Defend against (nil, nil) from provide — caller dereferences eth2Resp.Data. Happens when
+	// every backend returns (nil, nil), or all responses failed isSuccess via the nokResp path.
 	if err == nil && res0 == nil {
 		err = errors.New("all beacon node proposals returned nil response")
 	}
 
 	// provide returns the last non-success response with nil error when all responses fail
-	// the isSuccess check. Promote that to a real error so the caller doesn't sign a bad block.
-	// Compare directly here (rather than reusing isSuccess) so the warn line isn't logged twice.
+	// isSuccess. Promote that to a real error so we don't sign a bad block downstream;
+	// classify directly rather than reusing isSuccess to avoid double-logging the warn line.
 	if err == nil && expected != "" && res0 != nil {
-		if actual, ok := ProposalFeeRecipient(res0.Data); ok && !strings.EqualFold(actual, expected) {
+		decision, _ := classifyProposal(res0.Data, expected)
+		switch decision {
+		case decisionRejectMismatch:
 			err = errors.New("all beacon node proposals had an unexpected fee recipient")
+		case decisionRejectMalformed:
+			err = errors.New("all beacon node proposals were malformed")
+		default:
+			// decisionAccept — provide selected an acceptable response.
 		}
 	}
 
@@ -453,14 +503,9 @@ func (m multi) Proposal(ctx context.Context, opts *eth2api.ProposalOpts) (*eth2a
 	return res0, err
 }
 
-// SubmitProposalPreparations provides the beacon node with information required if a proposal for
-// the given validators shows up in the next epoch.
-//
-// Hand-written (skipped by genwrap): fans out to every BN (primaries and fallbacks) and records
-// per-BN outcome in m.prep so failed BNs are excluded from subsequent Proposal calls (Solution A
-// for #4477). Returns success if at least one BN succeeded so the duty cycle continues; per-BN
-// failures are logged and counted in errors_total to give operators visibility into partial
-// degradation — the very signal whose absence allowed #4477 to go unnoticed.
+// SubmitProposalPreparations fans out to every BN (primaries+fallbacks) and records per-BN
+// outcome in m.prep so failed BNs are excluded from subsequent Proposal calls. Returns success
+// if any BN succeeded; per-BN failures are logged and counted for operator visibility. See #4477.
 func (m multi) SubmitProposalPreparations(ctx context.Context, preparations []*apiv1.ProposalPreparation) error {
 	const label = "submit_proposal_preparations"
 	defer latency(ctx, label, true)()

--- a/app/eth2wrap/multi_test.go
+++ b/app/eth2wrap/multi_test.go
@@ -502,6 +502,60 @@ func TestMulti_Proposal_FallbackRescuesFromBadPrimaries(t *testing.T) {
 	require.Equal(t, expected, resp.Data.Deneb.Block.Body.ExecutionPayload.FeeRecipient)
 }
 
+// TestMulti_Proposal_RejectsMalformedResponse verifies that when expected fee recipient is set,
+// a malformed Bellatrix+ response (missing nested fields) is rejected rather than accepted as
+// success. Previously isSuccess returned true on any ProposalFeeRecipient(_)=ok=false, which
+// meant a backend could win selection with an unverifiable proposal.
+func TestMulti_Proposal_RejectsMalformedResponse(t *testing.T) {
+	ctx := t.Context()
+
+	// Deneb proposal with nil ExecutionPayload — ProposalFeeRecipient returns ok=false but
+	// the proposal is NOT legitimately recipient-less (Deneb unblinded should have one).
+	malformed := &eth2api.Response[*eth2api.VersionedProposal]{
+		Data: &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Deneb: &eth2deneb.BlockContents{
+				Block: &deneb.BeaconBlock{Body: &deneb.BeaconBlockBody{}},
+			},
+		},
+	}
+
+	bn := mocks.NewClient(t)
+	bn.On("Address").Return("http://bn:5051").Maybe()
+	bn.On("Proposal", mock.Anything, mock.Anything).Return(malformed, nil).Maybe()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, testFeeRecipientHex)
+	_, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.Error(t, err)
+}
+
+// TestMulti_Proposal_AcceptsBlindedWithoutRecipientCheck verifies that blinded proposals are
+// accepted even when expected recipient is set — the recipient on a blinded block is the
+// builder's, not the validator's, so the validator's expected address doesn't apply.
+func TestMulti_Proposal_AcceptsBlindedWithoutRecipientCheck(t *testing.T) {
+	ctx := t.Context()
+
+	blinded := &eth2api.Response[*eth2api.VersionedProposal]{
+		Data: &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Blinded: true,
+		},
+	}
+
+	bn := mocks.NewClient(t)
+	bn.On("Address").Return("http://bn:5051").Maybe()
+	bn.On("Proposal", mock.Anything, mock.Anything).Return(blinded, nil).Once()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, testFeeRecipientHex)
+	resp, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
 // TestMulti_Proposal_NilBackendResponseDoesNotPanic verifies that a misbehaving backend returning
 // (nil, nil) for Proposal cannot crash the process. With expected fee recipient attached the
 // isSuccess closure must treat nil resp as non-success; without it, multi.Proposal must convert

--- a/app/eth2wrap/multi_test.go
+++ b/app/eth2wrap/multi_test.go
@@ -8,9 +8,15 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
+	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -232,4 +238,235 @@ func TestMulti_ClientForAddress(t *testing.T) {
 		require.NotNil(t, scoped)
 		require.Equal(t, "http://bn1:5051", scoped.Address())
 	})
+}
+
+// testFeeRecipientHex is the hex form of bellatrix.ExecutionAddress{0xab, 0xcd} (used across the
+// per-BN prep / fee-recipient validation tests below).
+const testFeeRecipientHex = "0xabcd000000000000000000000000000000000000"
+
+// proposalWithFeeRecipient builds a minimal Deneb proposal with the given fee recipient.
+func proposalWithFeeRecipient(addr bellatrix.ExecutionAddress) *eth2api.Response[*eth2api.VersionedProposal] {
+	return &eth2api.Response[*eth2api.VersionedProposal]{
+		Data: &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Deneb: &eth2deneb.BlockContents{
+				Block: &deneb.BeaconBlock{
+					Body: &deneb.BeaconBlockBody{
+						ExecutionPayload: &deneb.ExecutionPayload{
+							FeeRecipient: addr,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// TestMulti_SubmitProposalPreparations_FansOutAndTracks verifies that prep is sent to every BN
+// (not first-success-wins) and that per-BN failures are recorded so the failing BN gets excluded
+// from the next Proposal call. Regression test for #4477.
+func TestMulti_SubmitProposalPreparations_FansOutAndTracks(t *testing.T) {
+	ctx := t.Context()
+
+	expected := bellatrix.ExecutionAddress{0xab, 0xcd}
+	expectedHex := testFeeRecipientHex
+	zero := bellatrix.ExecutionAddress{}
+
+	good := mocks.NewClient(t)
+	good.On("Address").Return("http://good:5051").Maybe()
+	good.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(nil).Once()
+	good.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(expected), nil).Maybe()
+
+	bad := mocks.NewClient(t)
+	bad.On("Address").Return("http://bad:5051").Maybe()
+	bad.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(errors.New("silent fail")).Once()
+	// bad.Proposal must NOT be called once it has been recorded as unprepared. If it is, the test fails
+	// because mockery rejects unexpected calls.
+	bad.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(zero), nil).Maybe()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{good, bad}, nil)
+
+	// First, submit preparations. The good BN succeeds, the bad BN errors. Multi should still return
+	// nil (≥1 succeeded) but record the failure per-BN.
+	require.NoError(t, m.SubmitProposalPreparations(ctx, []*eth2v1.ProposalPreparation{
+		{ValidatorIndex: 0, FeeRecipient: expected},
+	}))
+
+	// Now request a proposal with the expected fee recipient attached. The bad BN must be excluded.
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, expectedHex)
+	resp, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+
+	// Confirm bad.Proposal was never called: the mock library's AssertExpectations (run via
+	// NewClient(t) cleanup) verifies no unexpected calls beyond what was set as Maybe(). To make
+	// the assertion stronger, count calls explicitly.
+	badCalls := 0
+
+	for _, call := range bad.Calls {
+		if call.Method == "Proposal" {
+			badCalls++
+		}
+	}
+
+	require.Zero(t, badCalls, "unprepared BN should be excluded from Proposal calls")
+}
+
+// TestMulti_Proposal_RejectsMismatchedFeeRecipient verifies that even if a BN slips past the prep
+// tracking (e.g. it ack'd prep but lost state on restart) and returns a proposal with the wrong
+// fee recipient, multi.Proposal discards that response and returns one from another BN.
+// Regression test for #4477.
+func TestMulti_Proposal_RejectsMismatchedFeeRecipient(t *testing.T) {
+	ctx := t.Context()
+
+	expected := bellatrix.ExecutionAddress{0xab, 0xcd}
+	expectedHex := testFeeRecipientHex
+	zero := bellatrix.ExecutionAddress{}
+
+	// Both BNs ack'd prep; one is misconfigured at proposal time.
+	goodCalled := atomic.Bool{}
+
+	good := mocks.NewClient(t)
+	good.On("Address").Return("http://good:5051").Maybe()
+	good.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(nil).Once()
+	good.On("Proposal", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+		goodCalled.Store(true)
+	}).Return(proposalWithFeeRecipient(expected), nil).Maybe()
+
+	bad := mocks.NewClient(t)
+	bad.On("Address").Return("http://bad:5051").Maybe()
+	bad.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(nil).Once()
+	bad.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(zero), nil).Maybe()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{good, bad}, nil)
+	require.NoError(t, m.SubmitProposalPreparations(ctx, []*eth2v1.ProposalPreparation{
+		{ValidatorIndex: 0, FeeRecipient: expected},
+	}))
+
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, expectedHex)
+	resp, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Data)
+	require.True(t, goodCalled.Load(), "good BN must have been queried")
+
+	// The returned proposal must be the one with the correct fee recipient.
+	require.Equal(t, expected, resp.Data.Deneb.Block.Body.ExecutionPayload.FeeRecipient)
+}
+
+// TestMulti_Proposal_AllMismatch_ReturnsError verifies that if every BN returns a proposal with
+// the wrong fee recipient, multi.Proposal returns an error (so the duty fails loudly) instead of
+// silently signing a zero-recipient block. Regression test for #4477.
+func TestMulti_Proposal_AllMismatch_ReturnsError(t *testing.T) {
+	ctx := t.Context()
+
+	expectedHex := testFeeRecipientHex
+	zero := bellatrix.ExecutionAddress{}
+
+	bn1 := mocks.NewClient(t)
+	bn1.On("Address").Return("http://bn1:5051").Maybe()
+	bn1.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(zero), nil).Maybe()
+
+	bn2 := mocks.NewClient(t)
+	bn2.On("Address").Return("http://bn2:5051").Maybe()
+	bn2.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(zero), nil).Maybe()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn1, bn2}, nil)
+
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, expectedHex)
+	_, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.Error(t, err)
+}
+
+// TestMulti_Proposal_NoExpectedFeeRecipient_AcceptsAny verifies that without an expected fee
+// recipient attached to ctx, the Proposal call accepts any response (preserves prior behavior).
+func TestMulti_Proposal_NoExpectedFeeRecipient_AcceptsAny(t *testing.T) {
+	ctx := t.Context()
+
+	zero := bellatrix.ExecutionAddress{}
+
+	bn := mocks.NewClient(t)
+	bn.On("Address").Return("http://bn:5051").Maybe()
+	bn.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(zero), nil).Once()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+	resp, err := m.Proposal(ctx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// TestMulti_Proposal_NoPrepYet_UsesAllClients verifies that before SubmitProposalPreparations has
+// run (or if all BNs are currently unprepared), Proposal falls back to all clients rather than
+// blocking — better to risk a mismatch (still detected by validation) than miss the slot entirely.
+func TestMulti_Proposal_NoPrepYet_UsesAllClients(t *testing.T) {
+	ctx := t.Context()
+
+	expected := bellatrix.ExecutionAddress{0xab, 0xcd}
+
+	bn := mocks.NewClient(t)
+	bn.On("Address").Return("http://bn:5051").Maybe()
+	bn.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(expected), nil).Once()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+	resp, err := m.Proposal(ctx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+}
+
+// TestMulti_SubmitProposalPreparations_FansOutToFallbacks verifies that prep is also sent to
+// fallback BNs — provide() may route a Proposal call to a fallback when all primaries fail, so
+// fallbacks need to be prepared too.
+func TestMulti_SubmitProposalPreparations_FansOutToFallbacks(t *testing.T) {
+	ctx := t.Context()
+
+	primary := mocks.NewClient(t)
+	primary.On("Address").Return("http://primary:5051").Maybe()
+	primary.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(nil).Once()
+
+	fallback := mocks.NewClient(t)
+	fallback.On("Address").Return("http://fallback:5051").Maybe()
+	fallback.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(nil).Once()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{primary}, []eth2wrap.Client{fallback})
+
+	require.NoError(t, m.SubmitProposalPreparations(ctx, []*eth2v1.ProposalPreparation{
+		{ValidatorIndex: 0, FeeRecipient: bellatrix.ExecutionAddress{0xab, 0xcd}},
+	}))
+	// mocks.NewClient(t)'s cleanup asserts the .Once() expectations on both BNs.
+}
+
+// TestMulti_SubmitProposalPreparations_CtxCancelDoesNotPoisonState verifies that if the parent
+// context is cancelled mid-flight, prepState is not updated with failures — BN state is unknown
+// in that case, so excluding them on the next epoch would be incorrect.
+func TestMulti_SubmitProposalPreparations_CtxCancelDoesNotPoisonState(t *testing.T) {
+	expected := bellatrix.ExecutionAddress{0xab, 0xcd}
+	expectedHex := testFeeRecipientHex
+
+	bn := mocks.NewClient(t)
+	bn.On("Address").Return("http://bn:5051").Maybe()
+	// forkjoin may short-circuit before invoking the worker when ctx is already cancelled, so
+	// SubmitProposalPreparations on the mock may or may not be called — Maybe() either way.
+	bn.On("SubmitProposalPreparations", mock.Anything, mock.Anything).Return(context.Canceled).Maybe()
+	// After cancellation, bn must still be considered prepared on the next slot.
+	bn.On("Proposal", mock.Anything, mock.Anything).Return(proposalWithFeeRecipient(expected), nil).Once()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+	cancelledCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Prep will fail (context already cancelled). We don't care about the err — the assertion
+	// is about prepState side effects.
+	_ = m.SubmitProposalPreparations(cancelledCtx, []*eth2v1.ProposalPreparation{
+		{ValidatorIndex: 0, FeeRecipient: expected},
+	})
+
+	// On the next slot, bn must still be queried (not excluded).
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(t.Context(), expectedHex)
+	resp, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
 }

--- a/app/eth2wrap/multi_test.go
+++ b/app/eth2wrap/multi_test.go
@@ -470,3 +470,101 @@ func TestMulti_SubmitProposalPreparations_CtxCancelDoesNotPoisonState(t *testing
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
+
+// TestMulti_Proposal_FallbackRescuesFromBadPrimaries verifies that if every primary BN returns a
+// proposal with the wrong fee recipient, multi.Proposal still queries fallbacks and returns the
+// correct proposal from a fallback. provide()'s built-in fallback-on-error path only triggers
+// on transport errors, so multi.Proposal must merge primaries and fallbacks itself for content
+// failures to be recoverable. Regression test for #4477.
+func TestMulti_Proposal_FallbackRescuesFromBadPrimaries(t *testing.T) {
+	ctx := t.Context()
+
+	expected := bellatrix.ExecutionAddress{0xab, 0xcd}
+	expectedHex := testFeeRecipientHex
+	zero := bellatrix.ExecutionAddress{}
+
+	badPrimary := mocks.NewClient(t)
+	badPrimary.On("Address").Return("http://bad-primary:5051").Maybe()
+	badPrimary.On("Proposal", mock.Anything, mock.Anything).
+		Return(proposalWithFeeRecipient(zero), nil).Maybe()
+
+	goodFallback := mocks.NewClient(t)
+	goodFallback.On("Address").Return("http://good-fallback:5051").Maybe()
+	goodFallback.On("Proposal", mock.Anything, mock.Anything).
+		Return(proposalWithFeeRecipient(expected), nil).Maybe()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{badPrimary}, []eth2wrap.Client{goodFallback})
+
+	proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, expectedHex)
+	resp, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, expected, resp.Data.Deneb.Block.Body.ExecutionPayload.FeeRecipient)
+}
+
+// TestMulti_Proposal_NilBackendResponseDoesNotPanic verifies that a misbehaving backend returning
+// (nil, nil) for Proposal cannot crash the process. With expected fee recipient attached the
+// isSuccess closure must treat nil resp as non-success; without it, multi.Proposal must convert
+// an all-nil result to an error so the caller doesn't dereference eth2Resp.Data on nil.
+func TestMulti_Proposal_NilBackendResponseDoesNotPanic(t *testing.T) {
+	t.Run("with expected fee recipient", func(t *testing.T) {
+		bn := mocks.NewClient(t)
+		bn.On("Address").Return("http://bn:5051").Maybe()
+		bn.On("Proposal", mock.Anything, mock.Anything).
+			Return((*eth2api.Response[*eth2api.VersionedProposal])(nil), nil).Maybe()
+
+		m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+		proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(t.Context(), testFeeRecipientHex)
+		_, err := m.Proposal(proposalCtx, &eth2api.ProposalOpts{Slot: 1})
+		require.Error(t, err)
+	})
+
+	t.Run("without expected fee recipient", func(t *testing.T) {
+		bn := mocks.NewClient(t)
+		bn.On("Address").Return("http://bn:5051").Maybe()
+		bn.On("Proposal", mock.Anything, mock.Anything).
+			Return((*eth2api.Response[*eth2api.VersionedProposal])(nil), nil).Maybe()
+
+		m := eth2wrap.NewMultiForT([]eth2wrap.Client{bn}, nil)
+
+		_, err := m.Proposal(t.Context(), &eth2api.ProposalOpts{Slot: 1})
+		require.Error(t, err)
+	})
+}
+
+// TestProposalFeeRecipient_HandlesMalformedResponses verifies that ProposalFeeRecipient does not
+// panic on responses with nil fork-specific fields — the function is called against untrusted BN
+// output inside multi.Proposal's isSuccess closure and must fail closed (return false) rather
+// than panic.
+func TestProposalFeeRecipient_HandlesMalformedResponses(t *testing.T) {
+	tests := []struct {
+		name     string
+		proposal *eth2api.VersionedProposal
+	}{
+		{"nil proposal", nil},
+		{"deneb version with nil Deneb", &eth2api.VersionedProposal{Version: eth2spec.DataVersionDeneb}},
+		{"deneb version with nil Block", &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Deneb:   &eth2deneb.BlockContents{},
+		}},
+		{"deneb version with nil Body", &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Deneb:   &eth2deneb.BlockContents{Block: &deneb.BeaconBlock{}},
+		}},
+		{"deneb version with nil ExecutionPayload", &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Deneb:   &eth2deneb.BlockContents{Block: &deneb.BeaconBlock{Body: &deneb.BeaconBlockBody{}}},
+		}},
+		{"bellatrix version with nil Bellatrix", &eth2api.VersionedProposal{Version: eth2spec.DataVersionBellatrix}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Must not panic.
+			addr, ok := eth2wrap.ProposalFeeRecipient(test.proposal)
+			require.False(t, ok)
+			require.Empty(t, addr)
+		})
+	}
+}

--- a/app/eth2wrap/prepstate.go
+++ b/app/eth2wrap/prepstate.go
@@ -1,0 +1,62 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import "sync"
+
+// prepState tracks per-beacon-node outcomes of the most recent SubmitProposalPreparations call.
+// A BN whose most recent prep failed is excluded from subsequent Proposal calls so it cannot
+// return a block with the wrong fee recipient. See issue #4477.
+type prepState struct {
+	mu       sync.RWMutex
+	prepared map[string]bool
+	seen     bool
+}
+
+func newPrepState() *prepState {
+	return &prepState{prepared: make(map[string]bool)}
+}
+
+// markSuccess records a successful prep call for the given BN address.
+func (p *prepState) markSuccess(addr string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.prepared[addr] = true
+	p.seen = true
+}
+
+// markFailure records a failed prep call for the given BN address.
+func (p *prepState) markFailure(addr string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.prepared[addr] = false
+	p.seen = true
+}
+
+// preparedClients returns the subset of clients whose most recent prep succeeded.
+// Before the first prep has run, or if no client is currently prepared, returns clients unchanged
+// — failing closed here would cause missed proposals, which is worse than risking a mismatch
+// (fee recipient mismatches are still rejected during proposal validation in multi.Proposal).
+func (p *prepState) preparedClients(clients []Client) []Client {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if !p.seen {
+		return clients
+	}
+
+	var prepared []Client
+	for _, c := range clients {
+		if p.prepared[c.Address()] {
+			prepared = append(prepared, c)
+		}
+	}
+
+	if len(prepared) == 0 {
+		return clients
+	}
+
+	return prepared
+}

--- a/app/eth2wrap/prepstate.go
+++ b/app/eth2wrap/prepstate.go
@@ -35,10 +35,9 @@ func (p *prepState) markFailure(addr string) {
 	p.seen = true
 }
 
-// preparedClients returns the subset of clients whose most recent prep succeeded.
-// Before the first prep has run, or if no client is currently prepared, returns clients unchanged
-// — failing closed here would cause missed proposals, which is worse than risking a mismatch
-// (fee recipient mismatches are still rejected during proposal validation in multi.Proposal).
+// preparedClients returns clients minus those whose most recent prep was explicitly recorded
+// as a failure. Missing entries count as "unknown — include" (the cancellation guard records
+// no outcome). Returns the full list rather than empty when every client would be excluded.
 func (p *prepState) preparedClients(clients []Client) []Client {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
@@ -49,7 +48,8 @@ func (p *prepState) preparedClients(clients []Client) []Client {
 
 	var prepared []Client
 	for _, c := range clients {
-		if p.prepared[c.Address()] {
+		recorded, present := p.prepared[c.Address()]
+		if !present || recorded {
 			prepared = append(prepared, c)
 		}
 	}

--- a/app/eth2wrap/prepstate_internal_test.go
+++ b/app/eth2wrap/prepstate_internal_test.go
@@ -1,0 +1,72 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// addrClient is a minimal Client stub for prepState tests. preparedClients only calls Address(),
+// so the embedded nil Client never has its other methods invoked.
+type addrClient struct {
+	Client
+
+	addr string
+}
+
+func (c addrClient) Address() string { return c.addr }
+
+// TestPrepState_BeforeAnyPrep returns clients unchanged before any markSuccess/markFailure
+// — failing closed here would cause missed proposals.
+func TestPrepState_BeforeAnyPrep(t *testing.T) {
+	p := newPrepState()
+	a := addrClient{addr: "http://a"}
+	b := addrClient{addr: "http://b"}
+
+	got := p.preparedClients([]Client{a, b})
+	require.Equal(t, []Client{a, b}, got)
+}
+
+// TestPrepState_AllFailed falls back to the full client list rather than excluding everyone.
+func TestPrepState_AllFailed(t *testing.T) {
+	p := newPrepState()
+	p.markFailure("http://a")
+	p.markFailure("http://b")
+
+	a := addrClient{addr: "http://a"}
+	b := addrClient{addr: "http://b"}
+
+	got := p.preparedClients([]Client{a, b})
+	require.Equal(t, []Client{a, b}, got)
+}
+
+// TestPrepState_MixedSuccessAndFailure excludes only the explicitly-failed BN.
+func TestPrepState_MixedSuccessAndFailure(t *testing.T) {
+	p := newPrepState()
+	p.markSuccess("http://a")
+	p.markFailure("http://b")
+
+	a := addrClient{addr: "http://a"}
+	b := addrClient{addr: "http://b"}
+
+	got := p.preparedClients([]Client{a, b})
+	require.Equal(t, []Client{a}, got)
+}
+
+// TestPrepState_MissingKeysAreIncluded verifies that a client never recorded — e.g. its prep
+// was skipped by the cancellation guard — is included rather than incorrectly excluded.
+// Without this, a BN whose state is "unknown" gets dropped from future Proposal calls until
+// its next markSuccess, which is the failure mode #4477's cancellation guard exists to prevent.
+func TestPrepState_MissingKeysAreIncluded(t *testing.T) {
+	p := newPrepState()
+	// Only one BN got a recorded outcome; the other was never touched.
+	p.markSuccess("http://recorded")
+
+	recorded := addrClient{addr: "http://recorded"}
+	missing := addrClient{addr: "http://missing"}
+
+	got := p.preparedClients([]Client{recorded, missing})
+	require.Equal(t, []Client{recorded, missing}, got, "missing-key client must be included")
+}

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -4,7 +4,6 @@ package fetcher
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"strings"
 	"sync"
@@ -345,7 +344,14 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot uint64, defSet cor
 			BuilderBoostFactor: &bbf,
 		}
 
-		eth2Resp, err := f.eth2Cl.Proposal(ctx, opts)
+		feeRecipient := f.feeRecipientFunc(pubkey)
+
+		// Tell eth2wrap.multi to discard local proposals whose fee recipient doesn't match
+		// the expected one — guards against a beacon node that silently dropped its
+		// SubmitProposalPreparations and would otherwise return a zero-recipient block. See #4477.
+		proposalCtx := eth2wrap.ContextWithExpectedFeeRecipient(ctx, feeRecipient)
+
+		eth2Resp, err := f.eth2Cl.Proposal(proposalCtx, opts)
 		if err != nil {
 			return nil, err
 		}
@@ -355,7 +361,7 @@ func (f *Fetcher) fetchProposerData(ctx context.Context, slot uint64, defSet cor
 		// Builders set fee recipient to themselves so it's always different from validator's.
 		if !proposal.Blinded {
 			// Ensure fee recipient is correctly populated in proposal.
-			verifyFeeRecipient(ctx, proposal, f.feeRecipientFunc(pubkey))
+			verifyFeeRecipient(ctx, proposal, feeRecipient)
 		}
 
 		coreProposal, err := core.NewVersionedProposal(proposal)
@@ -450,26 +456,15 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 }
 
 // verifyFeeRecipient logs a warning when fee recipient is not correctly populated in the block.
+// Returns silently for forks earlier than bellatrix and for blinded proposals (where the recipient
+// is the builder, not the validator's configured address).
 func verifyFeeRecipient(ctx context.Context, proposal *eth2api.VersionedProposal, feeRecipientAddress string) {
-	// Note that fee-recipient is not available in forks earlier than bellatrix.
-	var actualAddr string
-
-	switch proposal.Version {
-	case eth2spec.DataVersionBellatrix:
-		actualAddr = fmt.Sprintf("%#x", proposal.Bellatrix.Body.ExecutionPayload.FeeRecipient)
-	case eth2spec.DataVersionCapella:
-		actualAddr = fmt.Sprintf("%#x", proposal.Capella.Body.ExecutionPayload.FeeRecipient)
-	case eth2spec.DataVersionDeneb:
-		actualAddr = fmt.Sprintf("%#x", proposal.Deneb.Block.Body.ExecutionPayload.FeeRecipient)
-	case eth2spec.DataVersionElectra:
-		actualAddr = fmt.Sprintf("%#x", proposal.Electra.Block.Body.ExecutionPayload.FeeRecipient)
-	case eth2spec.DataVersionFulu:
-		actualAddr = fmt.Sprintf("%#x", proposal.Fulu.Block.Body.ExecutionPayload.FeeRecipient)
-	default:
+	actualAddr, ok := eth2wrap.ProposalFeeRecipient(proposal)
+	if !ok {
 		return
 	}
 
-	if actualAddr != "" && !strings.EqualFold(actualAddr, feeRecipientAddress) {
+	if !strings.EqualFold(actualAddr, feeRecipientAddress) {
 		log.Warn(ctx, "Proposal with unexpected fee recipient address", nil,
 			z.Str("expected", feeRecipientAddress), z.Str("actual", actualAddr))
 		proposalLocalMismatchFeeRecipientGauge.Set(2.0)

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -456,8 +456,8 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 }
 
 // verifyFeeRecipient logs a warning when fee recipient is not correctly populated in the block.
-// Returns silently for forks earlier than bellatrix and for blinded proposals (where the recipient
-// is the builder, not the validator's configured address).
+// Returns silently when ProposalFeeRecipient cannot extract a recipient (pre-bellatrix, blinded,
+// or malformed bellatrix+); malformed responses are already rejected upstream in multi.Proposal.
 func verifyFeeRecipient(ctx context.Context, proposal *eth2api.VersionedProposal, feeRecipientAddress string) {
 	actualAddr, ok := eth2wrap.ProposalFeeRecipient(proposal)
 	if !ok {

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -11,13 +11,17 @@ import (
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
+	eth2deneb "github.com/attestantio/go-eth2-client/api/v1/deneb"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
 	"github.com/attestantio/go-eth2-client/spec/altair"
+	"github.com/attestantio/go-eth2-client/spec/bellatrix"
+	"github.com/attestantio/go-eth2-client/spec/deneb"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/eth2wrap/mocks"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/fetcher"
@@ -737,4 +741,66 @@ func TestFetchOnly(t *testing.T) {
 		err = fetch.Fetch(ctx, duty, defSet)
 		require.NoError(t, err)
 	})
+}
+
+// TestFetchProposer_AttachesExpectedFeeRecipientToContext verifies that fetchProposerData
+// attaches the expected fee recipient (from feeRecipientFunc) to the context passed into
+// eth2Cl.Proposal. This is the contract that lets eth2wrap.multi discard responses from
+// beacon nodes that silently dropped their SubmitProposalPreparations and would otherwise
+// return a zero-recipient block. Regression guard for the fetcher half of #4477.
+func TestFetchProposer_AttachesExpectedFeeRecipientToContext(t *testing.T) {
+	const (
+		slot                = 1
+		vIdx                = 2
+		expectedFeeRecipHex = "0xabcd000000000000000000000000000000000000"
+	)
+
+	pubkey := testutil.RandomCorePubKey(t)
+	defSet := core.DutyDefinitionSet{
+		pubkey: core.NewProposerDefinition(&eth2v1.ProposerDuty{Slot: slot, ValidatorIndex: vIdx}),
+	}
+
+	expectedFeeRecip := bellatrix.ExecutionAddress{0xab, 0xcd}
+	proposalResp := &eth2api.Response[*eth2api.VersionedProposal]{
+		Data: &eth2api.VersionedProposal{
+			Version: eth2spec.DataVersionDeneb,
+			Deneb: &eth2deneb.BlockContents{
+				Block: &deneb.BeaconBlock{
+					Body: &deneb.BeaconBlockBody{
+						ExecutionPayload: &deneb.ExecutionPayload{FeeRecipient: expectedFeeRecip},
+					},
+				},
+			},
+		},
+	}
+
+	ctxCh := make(chan context.Context, 1)
+
+	eth2Cl := mocks.NewClient(t)
+	eth2Cl.On("Proposal", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			ctxCh <- args.Get(0).(context.Context)
+		}).
+		Return(proposalResp, nil).
+		Once()
+
+	fetch, err := fetcher.New(eth2Cl, func(core.PubKey) string {
+		return expectedFeeRecipHex
+	}, true, &fetcher.GraffitiBuilder{}, 5, false)
+	require.NoError(t, err)
+
+	fetch.RegisterAggSigDB(func(_ context.Context, _ core.Duty, _ core.PubKey) (core.SignedData, error) {
+		return testutil.RandomCoreSignature(), nil
+	})
+
+	err = fetch.Fetch(t.Context(), core.NewProposerDuty(slot), defSet)
+	require.NoError(t, err)
+
+	select {
+	case capturedCtx := <-ctxCh:
+		require.Equal(t, expectedFeeRecipHex, eth2wrap.ExpectedFeeRecipient(capturedCtx),
+			"fetcher must attach the expected fee recipient via eth2wrap.ContextWithExpectedFeeRecipient")
+	default:
+		t.Fatal("Proposal must have been called")
+	}
 }


### PR DESCRIPTION
Track per-beacon-node `SubmitProposalPreparations` outcomes so failed BNs are excluded from subsequent `Proposal` calls. As a backstop, reject proposals whose fee recipient doesn't match the validator's configured address. Per-BN prep failures are logged and counted in `errors_total` so partial degradation is visible to operators.

category: bug                                                                                                                                                                             
ticket: #4477                          
