### PR TITLE
core/consensus: skip redundant proposal hash

### DIFF
--- a/core/consensus/instance/instance_io.go
+++ b/core/consensus/instance/instance_io.go
@@ -20,11 +20,19 @@ func NewIO[T any]() *IO[T] {
 	return &IO[T]{
 		RecvBuffer:  make(chan T, RecvBufferSize),
 		HashCh:      make(chan [32]byte, 1),
-		ValueCh:     make(chan proto.Message, 1),
+		ValueCh:     make(chan ValueWithHash, 1),
 		VerifyCh:    make(chan proto.Message, 1),
 		ErrCh:       make(chan error, 1),
 		DecidedAtCh: make(chan time.Time, 1),
 	}
+}
+
+// ValueWithHash carries a proposed proto value together with its precomputed
+// hash to the consensus transport, avoiding a duplicate hash on the leader's
+// broadcast path.
+type ValueWithHash struct {
+	Hash  [32]byte
+	Value proto.Message
 }
 
 // IO defines the async input and output channels of a
@@ -35,7 +43,7 @@ type IO[T any] struct {
 	Running      atomic.Bool        // True when runInstance was already called.
 	RecvBuffer   chan T             // Outer receive buffers.
 	HashCh       chan [32]byte      // Async input hash channel.
-	ValueCh      chan proto.Message // Async input value channel.
+	ValueCh      chan ValueWithHash // Async input value channel carrying the value with its precomputed hash.
 	VerifyCh     chan proto.Message // Async input value channel used for comparing local value to leader value during consensus.
 	ErrCh        chan error         // Async output error channel.
 	DecidedAtCh  chan time.Time     // Async output decided timestamp channel.

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -420,7 +420,7 @@ func (c *Consensus) propose(ctx context.Context, duty core.Duty, value proto.Mes
 
 	// Provide proposal inputs to the instance.
 	select {
-	case inst.ValueCh <- value:
+	case inst.ValueCh <- instance.ValueWithHash{Hash: hash, Value: value}:
 	default:
 		return errors.New("input channel full")
 	}

--- a/core/consensus/qbft/transport.go
+++ b/core/consensus/qbft/transport.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/core"
+	"github.com/obolnetwork/charon/core/consensus/instance"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	"github.com/obolnetwork/charon/core/qbft"
 )
@@ -32,12 +33,12 @@ type transport struct {
 
 	// Mutable state
 	valueMu sync.Mutex
-	valueCh <-chan proto.Message    // Channel providing lazy proposed values.
-	values  map[[32]byte]*anypb.Any // maps any-wrapped proposed values to their hashes
+	valueCh <-chan instance.ValueWithHash // Channel providing the proposed value paired with its precomputed hash.
+	values  map[[32]byte]*anypb.Any       // maps any-wrapped proposed values to their hashes
 }
 
 // newTransport creates a new qbftTransport.
-func newTransport(broadcaster broadcaster, privkey *k1.PrivateKey, valueCh <-chan proto.Message,
+func newTransport(broadcaster broadcaster, privkey *k1.PrivateKey, valueCh <-chan instance.ValueWithHash,
 	recvBuffer chan qbft.Msg[core.Duty, [32]byte, proto.Message], sniffer *sniffer,
 ) *transport {
 	return &transport{
@@ -65,18 +66,13 @@ func (t *transport) getValue(hash [32]byte) (*anypb.Any, error) {
 
 	// First check if we have a new value.
 	select {
-	case value := <-t.valueCh:
-		valueHash, err := hashProto(value)
-		if err != nil {
-			return nil, err
-		}
-
-		anyValue, err := anypb.New(value)
+	case pair := <-t.valueCh:
+		anyValue, err := anypb.New(pair.Value)
 		if err != nil {
 			return nil, errors.Wrap(err, "wrap any value")
 		}
 
-		t.values[valueHash] = anyValue
+		t.values[pair.Hash] = anyValue
 	default:
 		// No new values
 	}


### PR DESCRIPTION
This saves us one hashing. Hashing of a local block with all of its blobs on Hoodi is 2.7-2.8MB, which costs ~6ms for hashing on M3 chip.

category: refactor
ticket: none