### PR TITLE
*: add p2p send duration metric

### DIFF
--- a/app/peerinfo/adhoc.go
+++ b/app/peerinfo/adhoc.go
@@ -27,7 +27,7 @@ func DoOnce(ctx context.Context, p2pNode host.Host, peerID peer.ID) (*pbv1.PeerI
 	resp := new(pbv1.PeerInfo)
 
 	err := p2p.SendReceive(ctx, p2pNode, peerID, req, resp, protocolID2,
-		p2p.WithSendReceiveRTT(rttCallback))
+		p2p.WithSendReceiveRTT(rttCallback), p2p.WithSendMetricTopic("peerinfo_adhoc"))
 	if err != nil {
 		return nil, 0, false, err
 	}

--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -197,7 +197,7 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 
 			resp := new(pbv1.PeerInfo)
 
-			err := p.sendFunc(ctx, p.p2pNode, peerID, req, resp, protocolID2, p2p.WithSendReceiveRTT(rttCallback))
+			err := p.sendFunc(ctx, p.p2pNode, peerID, req, resp, protocolID2, p2p.WithSendReceiveRTT(rttCallback), p2p.WithSendMetricTopic("peerinfo"))
 			if err != nil {
 				return // Logging handled by send func.
 			} else if resp.GetSentAt() == nil || resp.GetStartedAt() == nil {

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -487,13 +487,15 @@ func (c *Consensus) Participate(ctx context.Context, duty core.Duty) error {
 
 // Broadcast implements Broadcaster interface.
 func (c *Consensus) Broadcast(ctx context.Context, msg *pbv1.QBFTConsensusMsg) error {
+	topic := p2p.WithSendMetricTopic("qbft_" + qbft.MsgType(msg.GetMsg().GetType()).String())
+
 	for _, peer := range c.peers {
 		if peer.ID == c.p2pNode.ID() {
 			// Do not broadcast to self
 			continue
 		}
 
-		if err := c.sender.SendAsync(ctx, c.p2pNode, protocols.QBFTv2ProtocolID, peer.ID, msg); err != nil {
+		if err := c.sender.SendAsync(ctx, c.p2pNode, protocols.QBFTv2ProtocolID, peer.ID, msg, topic); err != nil {
 			return err
 		}
 	}

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -142,13 +142,15 @@ func (m *ParSigEx) Broadcast(ctx context.Context, duty core.Duty, set core.ParSi
 		DataSet: pb,
 	}
 
+	topic := p2p.WithSendMetricTopic("parsigex_" + duty.Type.String())
+
 	for i, p := range m.peers {
 		// Don't send to self
 		if i == m.peerIdx {
 			continue
 		}
 
-		if err := m.sendFunc(ctx, m.p2pNode, protocolID2, p, &msg); err != nil {
+		if err := m.sendFunc(ctx, m.p2pNode, protocolID2, p, &msg, topic); err != nil {
 			return err
 		}
 	}

--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -341,7 +341,7 @@ func exchange(ctx context.Context, p2pNode host.Host, peers []peer.ID, msgValida
 		go func(pID peer.ID) {
 			response := new(pbv1.PriorityMsg)
 
-			err := sendFunc(ctx, p2pNode, pID, own, response, protocolID2)
+			err := sendFunc(ctx, p2pNode, pID, own, response, protocolID2, p2p.WithSendMetricTopic("priority_consensus"))
 			if err != nil {
 				// No need to log, since transport will do it.
 				return

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -107,6 +107,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `p2p_reachability_status` | Gauge | Current libp2p reachability status of this node as detected by autonat: unknown(0), public(1) or private(2). |  |
 | `p2p_relay_connection_types` | Gauge | Current number of libp2p connections by relay, type (`direct` or `relay`), and protocol (`tcp`, `quic`). Note that peers may have multiple connections. | `peer, type, protocol` |
 | `p2p_relay_connections` | Gauge | Connected relays by name | `peer` |
+| `p2p_send_duration_seconds` | Histogram | Wall-clock duration of synchronous libp2p Send (one-way) and SendReceive (round-trip) calls, by peer, protocol, and topic. Topic is a sub-protocol label (e.g. qbft_pre_prepare, parsigex_proposer); empty when not set by the caller. | `peer, protocol, topic` |
 | `relay_p2p_active_connections` | Gauge | Current number of active connections by peer and cluster | `peer, peer_cluster` |
 | `relay_p2p_connection_total` | Counter | Total number of new connections by peer and cluster | `peer, peer_cluster` |
 | `relay_p2p_network_receive_bytes_total` | Counter | Total number of network bytes received from the peer and cluster | `peer, peer_cluster` |

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -33,6 +33,13 @@ var (
 		Help:      "Ping latencies in seconds per peer",
 	}, []string{"peer"})
 
+	sendDurations = promauto.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "p2p",
+		Name:      "send_duration_seconds",
+		Help:      "Wall-clock duration of synchronous libp2p Send (one-way) and SendReceive (round-trip) calls, by peer, protocol, and topic. Topic is a sub-protocol label (e.g. qbft_pre_prepare, parsigex_proposer); empty when not set by the caller.",
+		Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 16), // 0.1ms .. ~3.3s
+	}, []string{"peer", "protocol", "topic"})
+
 	pingErrors = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "p2p",
 		Name:      "ping_error_total",

--- a/p2p/metrics.go
+++ b/p2p/metrics.go
@@ -37,7 +37,7 @@ var (
 		Namespace: "p2p",
 		Name:      "send_duration_seconds",
 		Help:      "Wall-clock duration of synchronous libp2p Send (one-way) and SendReceive (round-trip) calls, by peer, protocol, and topic. Topic is a sub-protocol label (e.g. qbft_pre_prepare, parsigex_proposer); empty when not set by the caller.",
-		Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 16), // 0.1ms .. ~3.3s
+		Buckets:   prometheus.ExponentialBuckets(0.0001, 2, 18), // 0.1ms .. ~13.1s, covers the ~7s default SendReceive timeout
 	}, []string{"peer", "protocol", "topic"})
 
 	pingErrors = promauto.NewCounterVec(prometheus.CounterOpts{

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -291,8 +291,9 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 		opt(&o)
 	}
 
+	protoLabel := string(pID) // Updated to the negotiated protocol once NewStream succeeds.
 	defer func() {
-		sendDurations.WithLabelValues(PeerName(peerID), string(pID), o.metricTopic).Observe(time.Since(tStart).Seconds())
+		sendDurations.WithLabelValues(PeerName(peerID), protoLabel, o.metricTopic).Observe(time.Since(tStart).Seconds())
 	}()
 
 	// Circuit relay connections are transient
@@ -300,6 +301,8 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 	if err != nil {
 		return errors.Wrap(err, "new stream", z.Any("protocols", o.protocols))
 	}
+
+	protoLabel = string(s.Protocol())
 
 	if err := s.SetDeadline(time.Now().Add(o.sendTimeout)); err != nil {
 		return errors.Wrap(err, "set deadline")
@@ -360,14 +363,17 @@ func Send(ctx context.Context, p2pNode host.Host, protoID protocol.ID, peerID pe
 		opt(&o)
 	}
 
+	protoLabel := string(protoID) // Updated to the negotiated protocol once NewStream succeeds.
 	defer func() {
-		sendDurations.WithLabelValues(PeerName(peerID), string(protoID), o.metricTopic).Observe(time.Since(t0).Seconds())
+		sendDurations.WithLabelValues(PeerName(peerID), protoLabel, o.metricTopic).Observe(time.Since(t0).Seconds())
 	}()
 	// Circuit relay connections are transient
 	s, err := p2pNode.NewStream(network.WithAllowLimitedConn(ctx, ""), peerID, o.protocols...)
 	if err != nil {
 		return errors.Wrap(err, "p2pNode stream")
 	}
+
+	protoLabel = string(s.Protocol())
 
 	if err := s.SetDeadline(time.Now().Add(o.sendTimeout)); err != nil {
 		return errors.Wrap(err, "set deadline")

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -202,6 +202,7 @@ type sendRecvOpts struct {
 	rttCallback       func(time.Duration)
 	receiveTimeout    time.Duration
 	sendTimeout       time.Duration
+	metricTopic       string // Optional sub-protocol label for the send_duration metric.
 }
 
 // WithReceiveTimeout returns an option for SendReceive that sets a timeout for handling incoming messages.
@@ -215,6 +216,14 @@ func WithReceiveTimeout(timeout time.Duration) func(*sendRecvOpts) {
 func WithSendTimeout(timeout time.Duration) func(*sendRecvOpts) {
 	return func(opts *sendRecvOpts) {
 		opts.sendTimeout = timeout
+	}
+}
+
+// WithSendMetricTopic returns an option that adds a topic label to the send_duration metric.
+// Use a small bounded set of values (e.g. a message-type name) to keep metric cardinality low.
+func WithSendMetricTopic(topic string) func(*sendRecvOpts) {
+	return func(opts *sendRecvOpts) {
+		opts.metricTopic = topic
 	}
 }
 
@@ -271,6 +280,8 @@ func defaultSendRecvOpts(pID protocol.ID) sendRecvOpts {
 func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 	req, resp proto.Message, pID protocol.ID, opts ...SendRecvOption,
 ) error {
+	tStart := time.Now()
+
 	if !isZeroProto(resp) {
 		return errors.New("bug: response proto must be zero value")
 	}
@@ -279,6 +290,10 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 	for _, opt := range opts {
 		opt(&o)
 	}
+
+	defer func() {
+		sendDurations.WithLabelValues(PeerName(peerID), string(pID), o.metricTopic).Observe(time.Since(tStart).Seconds())
+	}()
 
 	// Circuit relay connections are transient
 	s, err := p2pNode.NewStream(network.WithAllowLimitedConn(ctx, ""), peerID, o.protocols...)
@@ -338,10 +353,16 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 func Send(ctx context.Context, p2pNode host.Host, protoID protocol.ID, peerID peer.ID, msg proto.Message,
 	opts ...SendRecvOption,
 ) error {
+	t0 := time.Now()
+
 	o := defaultSendRecvOpts(protoID)
 	for _, opt := range opts {
 		opt(&o)
 	}
+
+	defer func() {
+		sendDurations.WithLabelValues(PeerName(peerID), string(protoID), o.metricTopic).Observe(time.Since(t0).Seconds())
+	}()
 	// Circuit relay connections are transient
 	s, err := p2pNode.NewStream(network.WithAllowLimitedConn(ctx, ""), peerID, o.protocols...)
 	if err != nil {

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -363,7 +363,10 @@ func Send(ctx context.Context, p2pNode host.Host, protoID protocol.ID, peerID pe
 		opt(&o)
 	}
 
-	protoLabel := string(protoID) // Updated to the negotiated protocol once NewStream succeeds.
+	protoLabel := string(protoID)
+	if len(o.protocols) > 0 {
+		protoLabel = string(o.protocols[0])
+	}
 	defer func() {
 		sendDurations.WithLabelValues(PeerName(peerID), protoLabel, o.metricTopic).Observe(time.Since(t0).Seconds())
 	}()


### PR DESCRIPTION
Add p2p send duration histogram with topic labels. This can help us debug potential contentions.

category: feature
ticket: none
