### PR TITLE
*: insufficient round change metric

### DIFF
--- a/app/health/checks.go
+++ b/app/health/checks.go
@@ -225,6 +225,24 @@ var checks = []check{
 		},
 	},
 	{
+		Name: "insufficient_round_changes",
+		Description: `Consensus round timed out due to insufficient round change messages.
+		This indicates the block payload was propagated timely to only a subset of peers, likely because the leader received it too late.
+		When outcome=decided, peers decided without this node but it recovered via a MsgDecided message.
+		When outcome=timeout, consensus timed out entirely, causing a missed duty.
+
+		Check peer latencies, BN calls latencies and MEV relays connectivity.`,
+		Severity: severityWarning,
+		Func: func(q query, _ Metadata) (bool, error) {
+			val, err := q("core_consensus_insufficient_round_changes_total", sumLabels(), increase)
+			if err != nil {
+				return false, err
+			}
+
+			return val > 0, nil
+		},
+	},
+	{
 		Name: "high_consensus_rounds",
 		Description: `Consensus required >=2 rounds for proposer or attester duty.
 		This usually indicates some other underlying issue like poor peer connectivity or slow connection to the beacon node.

--- a/app/health/checks.go
+++ b/app/health/checks.go
@@ -99,7 +99,7 @@ var checks = []check{
 		Description: "High rate of failed validator registrations. Please check the logs for more details.",
 		Severity:    severityWarning,
 		Func: func(q query, _ Metadata) (bool, error) {
-			increase, err := q("core_scheduler_submit_registration_errors_total", sumLabels(), increase)
+			increase, err := q("core_scheduler_submit_registration_errors_total", sumAll(), increase)
 			if err != nil {
 				return false, err
 			}
@@ -112,7 +112,7 @@ var checks = []check{
 		Description: "Metrics have reached the high cardinality threshold. Please check metrics reported by app_health_metrics_high_cardinality.",
 		Severity:    severityWarning,
 		Func: func(q query, _ Metadata) (bool, error) {
-			maxVal, err := q("app_health_metrics_high_cardinality", sumLabels(), gaugeMax)
+			maxVal, err := q("app_health_metrics_high_cardinality", sumAll(), gaugeMax)
 			if err != nil {
 				return false, err
 			}
@@ -216,7 +216,7 @@ var checks = []check{
 		Check the health of the main beacon node(s).`,
 		Severity: severityWarning,
 		Func: func(q query, _ Metadata) (bool, error) {
-			maxVal, err := q("app_eth2_using_fallback", sumLabels(), gaugeMax)
+			maxVal, err := q("app_eth2_using_fallback", sumAll(), gaugeMax)
 			if err != nil {
 				return false, err
 			}
@@ -234,7 +234,7 @@ var checks = []check{
 		Check peer latencies, BN calls latencies and MEV relays connectivity.`,
 		Severity: severityWarning,
 		Func: func(q query, _ Metadata) (bool, error) {
-			val, err := q("core_consensus_insufficient_round_changes_total", sumLabels(), increase)
+			val, err := q("core_consensus_insufficient_round_changes_total", sumAll(), increase)
 			if err != nil {
 				return false, err
 			}

--- a/app/health/checks_internal_test.go
+++ b/app/health/checks_internal_test.go
@@ -388,6 +388,52 @@ func TestHighPeerPingLatencyCheck(t *testing.T) {
 	})
 }
 
+func TestInsufficientRoundChangesCheck(t *testing.T) {
+	m := Metadata{}
+	checkName := "insufficient_round_changes"
+	metricName := "core_consensus_insufficient_round_changes_total"
+
+	decidedLabels := genLabels("protocol", "qbft", "duty", "attester", "timer", "eager_double_linear", "outcome", "decided")
+	timeoutLabels := genLabels("protocol", "qbft", "duty", "attester", "timer", "eager_double_linear", "outcome", "timeout")
+
+	t.Run("no data", func(t *testing.T) {
+		testCheck(t, m, checkName, false, nil)
+	})
+
+	t.Run("no increase", func(t *testing.T) {
+		testCheck(t, m, checkName, false,
+			genFam(metricName,
+				genCounter(decidedLabels, 1, 1, 1),
+			),
+		)
+	})
+
+	t.Run("decided outcome increasing", func(t *testing.T) {
+		testCheck(t, m, checkName, true,
+			genFam(metricName,
+				genCounter(decidedLabels, 0, 1, 2),
+			),
+		)
+	})
+
+	t.Run("timeout outcome increasing", func(t *testing.T) {
+		testCheck(t, m, checkName, true,
+			genFam(metricName,
+				genCounter(timeoutLabels, 0, 0, 1),
+			),
+		)
+	})
+
+	t.Run("both outcomes increasing", func(t *testing.T) {
+		testCheck(t, m, checkName, true,
+			genFam(metricName,
+				genCounter(decidedLabels, 0, 1, 2),
+				genCounter(timeoutLabels, 0, 0, 1),
+			),
+		)
+	})
+}
+
 func TestHighConsensusRoundsCheck(t *testing.T) {
 	m := Metadata{}
 	checkName := "high_consensus_rounds"

--- a/app/health/select.go
+++ b/app/health/select.go
@@ -60,8 +60,8 @@ func countLabels(labels ...*pb.LabelPair) func(metricsFam *pb.MetricFamily) (*pb
 	}
 }
 
-// sumLabels returns a selector that sums all metrics that match all of the label pairs.
-func sumLabels(labels ...*pb.LabelPair) func(metricsFam *pb.MetricFamily) (*pb.Metric, error) {
+// sumLabels returns a selector that sums all metrics.
+func sumLabels() func(metricsFam *pb.MetricFamily) (*pb.Metric, error) {
 	return func(metricsFam *pb.MetricFamily) (*pb.Metric, error) {
 		if metricsFam.GetType() != pb.MetricType_GAUGE && metricsFam.GetType() != pb.MetricType_COUNTER {
 			return nil, errors.New("bug: unsupported metric type")
@@ -74,11 +74,9 @@ func sumLabels(labels ...*pb.LabelPair) func(metricsFam *pb.MetricFamily) (*pb.M
 		}
 
 		for _, metric := range metricsFam.GetMetric() {
-			if labelsContain(metric.GetLabel(), labels) {
-				value := metric.GetGauge().GetValue() + metric.GetCounter().GetValue()
-				summed := sum.GetGauge().GetValue() + value
-				sum.Gauge.Value = &summed
-			}
+			value := metric.GetGauge().GetValue() + metric.GetCounter().GetValue()
+			summed := sum.GetGauge().GetValue() + value
+			sum.Gauge.Value = &summed
 		}
 
 		return sum, nil

--- a/app/health/select.go
+++ b/app/health/select.go
@@ -60,8 +60,8 @@ func countLabels(labels ...*pb.LabelPair) func(metricsFam *pb.MetricFamily) (*pb
 	}
 }
 
-// sumLabels returns a selector that sums all metrics.
-func sumLabels() func(metricsFam *pb.MetricFamily) (*pb.Metric, error) {
+// sumAll returns a selector that sums all metrics.
+func sumAll() func(metricsFam *pb.MetricFamily) (*pb.Metric, error) {
 	return func(metricsFam *pb.MetricFamily) (*pb.Metric, error) {
 		if metricsFam.GetType() != pb.MetricType_GAUGE && metricsFam.GetType() != pb.MetricType_COUNTER {
 			return nil, errors.New("bug: unsupported metric type")

--- a/core/consensus/metrics/metrics.go
+++ b/core/consensus/metrics/metrics.go
@@ -44,6 +44,13 @@ var (
 		Name:      "error_total",
 		Help:      "Total count of consensus errors by protocol",
 	}, []string{"protocol"})
+
+	consensusInsufficientRoundChanges = promauto.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "core",
+		Subsystem: "consensus",
+		Name:      "insufficient_round_changes_total",
+		Help:      "Total count of round timeouts due to insufficient round change messages by protocol, duty, and timer",
+	}, []string{"protocol", "duty", "timer"})
 )
 
 // ConsensusMetrics defines the interface for consensus metrics.
@@ -62,6 +69,9 @@ type ConsensusMetrics interface {
 
 	// IncConsensusError increments the consensus error counter.
 	IncConsensusError()
+
+	// IncInsufficientRoundChanges increments the counter for round timeouts caused by insufficient round change messages.
+	IncInsufficientRoundChanges(duty, timer string)
 }
 
 type consensusMetrics struct {
@@ -98,4 +108,9 @@ func (m *consensusMetrics) IncConsensusTimeout(duty, timer string) {
 // IncConsensusError increments the consensus error counter.
 func (m *consensusMetrics) IncConsensusError() {
 	consensusError.WithLabelValues(m.protocolID).Inc()
+}
+
+// IncInsufficientRoundChanges increments the counter for round timeouts caused by insufficient round change messages.
+func (m *consensusMetrics) IncInsufficientRoundChanges(duty, timer string) {
+	consensusInsufficientRoundChanges.WithLabelValues(m.protocolID, duty, timer).Inc()
 }

--- a/core/consensus/metrics/metrics.go
+++ b/core/consensus/metrics/metrics.go
@@ -49,8 +49,8 @@ var (
 		Namespace: "core",
 		Subsystem: "consensus",
 		Name:      "insufficient_round_changes_total",
-		Help:      "Total count of round timeouts due to insufficient round change messages by protocol, duty, and timer",
-	}, []string{"protocol", "duty", "timer"})
+		Help:      "Total count of consensus instances with insufficient round change messages by protocol, duty, timer, and outcome (decided or timeout)",
+	}, []string{"protocol", "duty", "timer", "outcome"})
 )
 
 // ConsensusMetrics defines the interface for consensus metrics.
@@ -70,8 +70,9 @@ type ConsensusMetrics interface {
 	// IncConsensusError increments the consensus error counter.
 	IncConsensusError()
 
-	// IncInsufficientRoundChanges increments the counter for round timeouts caused by insufficient round change messages.
-	IncInsufficientRoundChanges(duty, timer string)
+	// IncInsufficientRoundChanges increments the counter for consensus instances with insufficient round change messages.
+	// Outcome is "decided" if the node recovered via MsgDecided, or "timeout" if consensus timed out entirely.
+	IncInsufficientRoundChanges(duty, timer, outcome string)
 }
 
 type consensusMetrics struct {
@@ -110,7 +111,7 @@ func (m *consensusMetrics) IncConsensusError() {
 	consensusError.WithLabelValues(m.protocolID).Inc()
 }
 
-// IncInsufficientRoundChanges increments the counter for round timeouts caused by insufficient round change messages.
-func (m *consensusMetrics) IncInsufficientRoundChanges(duty, timer string) {
-	consensusInsufficientRoundChanges.WithLabelValues(m.protocolID, duty, timer).Inc()
+// IncInsufficientRoundChanges increments the counter for consensus instances with insufficient round change messages.
+func (m *consensusMetrics) IncInsufficientRoundChanges(duty, timer, outcome string) {
+	consensusInsufficientRoundChanges.WithLabelValues(m.protocolID, duty, timer, outcome).Inc()
 }

--- a/core/consensus/metrics/metrics.go
+++ b/core/consensus/metrics/metrics.go
@@ -53,6 +53,11 @@ var (
 	}, []string{"protocol", "duty", "timer", "outcome"})
 )
 
+const (
+	OutcomeDecided = "decided"
+	OutcomeTimeout = "timeout"
+)
+
 // ConsensusMetrics defines the interface for consensus metrics.
 type ConsensusMetrics interface {
 	// SetDecidedRounds sets the number of decided rounds for a given duty and timer.

--- a/core/consensus/metrics/metrics_test.go
+++ b/core/consensus/metrics/metrics_test.go
@@ -72,13 +72,18 @@ func TestConsensusMetrics_IncConsensusError(t *testing.T) {
 func TestConsensusMetrics_IncInsufficientRoundChanges(t *testing.T) {
 	cm := metrics.NewConsensusMetrics("test")
 
-	cm.IncInsufficientRoundChanges("duty", "timer")
+	cm.IncInsufficientRoundChanges("duty", "timer", "decided")
+	cm.IncInsufficientRoundChanges("duty", "timer", "timeout")
 
 	m := gatherMetric(t, "core_consensus_insufficient_round_changes_total")
-	require.InEpsilon(t, 1, m.GetMetric()[0].GetCounter().GetValue(), 0.0001)
-	verifyLabel(t, m.GetMetric()[0].GetLabel(), "protocol", "test")
-	verifyLabel(t, m.GetMetric()[0].GetLabel(), "duty", "duty")
-	verifyLabel(t, m.GetMetric()[0].GetLabel(), "timer", "timer")
+	require.Len(t, m.GetMetric(), 2)
+
+	for _, metric := range m.GetMetric() {
+		require.InEpsilon(t, 1, metric.GetCounter().GetValue(), 0.0001)
+		verifyLabel(t, metric.GetLabel(), "protocol", "test")
+		verifyLabel(t, metric.GetLabel(), "duty", "duty")
+		verifyLabel(t, metric.GetLabel(), "timer", "timer")
+	}
 }
 
 func gatherMetric(t *testing.T, name string) *pb.MetricFamily {

--- a/core/consensus/metrics/metrics_test.go
+++ b/core/consensus/metrics/metrics_test.go
@@ -69,6 +69,18 @@ func TestConsensusMetrics_IncConsensusError(t *testing.T) {
 	verifyLabel(t, m.GetMetric()[0].GetLabel(), "protocol", "test")
 }
 
+func TestConsensusMetrics_IncInsufficientRoundChanges(t *testing.T) {
+	cm := metrics.NewConsensusMetrics("test")
+
+	cm.IncInsufficientRoundChanges("duty", "timer")
+
+	m := gatherMetric(t, "core_consensus_insufficient_round_changes_total")
+	require.InEpsilon(t, 1, m.GetMetric()[0].GetCounter().GetValue(), 0.0001)
+	verifyLabel(t, m.GetMetric()[0].GetLabel(), "protocol", "test")
+	verifyLabel(t, m.GetMetric()[0].GetLabel(), "duty", "duty")
+	verifyLabel(t, m.GetMetric()[0].GetLabel(), "timer", "timer")
+}
+
 func gatherMetric(t *testing.T, name string) *pb.MetricFamily {
 	t.Helper()
 

--- a/core/consensus/metrics/metrics_test.go
+++ b/core/consensus/metrics/metrics_test.go
@@ -72,18 +72,28 @@ func TestConsensusMetrics_IncConsensusError(t *testing.T) {
 func TestConsensusMetrics_IncInsufficientRoundChanges(t *testing.T) {
 	cm := metrics.NewConsensusMetrics("test")
 
-	cm.IncInsufficientRoundChanges("duty", "timer", "decided")
-	cm.IncInsufficientRoundChanges("duty", "timer", "timeout")
+	cm.IncInsufficientRoundChanges("duty", "timer", metrics.OutcomeDecided)
+	cm.IncInsufficientRoundChanges("duty", "timer", metrics.OutcomeTimeout)
 
 	m := gatherMetric(t, "core_consensus_insufficient_round_changes_total")
 	require.Len(t, m.GetMetric(), 2)
+
+	var outcomes []string
 
 	for _, metric := range m.GetMetric() {
 		require.InEpsilon(t, 1, metric.GetCounter().GetValue(), 0.0001)
 		verifyLabel(t, metric.GetLabel(), "protocol", "test")
 		verifyLabel(t, metric.GetLabel(), "duty", "duty")
 		verifyLabel(t, metric.GetLabel(), "timer", "timer")
+
+		for _, label := range metric.GetLabel() {
+			if label.GetName() == "outcome" {
+				outcomes = append(outcomes, label.GetValue())
+			}
+		}
 	}
+
+	require.ElementsMatch(t, []string{"decided", "timeout"}, outcomes)
 }
 
 func gatherMetric(t *testing.T, name string) *pb.MetricFamily {

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -608,8 +608,13 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 			}
 		}
 
-		if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
-			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), metrics.OutcomeDecided)
+		if uponRule == qbft.UponJustifiedDecided {
+			quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
+
+			steps := groupRoundMessages(msgs, nodes, round, int(leader(duty, round, nodes)))
+			if hadInsufficientRoundChanges || isInsufficientRoundChanges(steps, round, quorum) {
+				c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), metrics.OutcomeDecided)
+			}
 		}
 	}
 

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -595,6 +595,15 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 
 		span.AddEvent("Round Changed")
 		span.SetAttributes(attribute.Int64("new_round", newRound))
+
+		if uponRule == qbft.UponRoundTimeout {
+			quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
+
+			steps := groupRoundMessages(msgs, nodes, round, int(leader(duty, round, nodes)))
+			if isInsufficientRoundChanges(steps, round, quorum) {
+				c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()))
+			}
+		}
 	}
 
 	// Create a new transport that handles sending and receiving for this instance.
@@ -874,6 +883,20 @@ func timeoutReason(steps []roundStep, round int64, quorum int) string {
 	}
 
 	return "unknown reason"
+}
+
+func isInsufficientRoundChanges(steps []roundStep, round int64, quorum int) bool {
+	if round <= 1 {
+		return false
+	}
+
+	for _, step := range steps {
+		if step.Type == qbft.MsgRoundChange {
+			return len(step.Present) < quorum
+		}
+	}
+
+	return false
 }
 
 // fmtStepPeers returns a string representing the present and missing peers.

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -609,7 +609,7 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 		}
 
 		if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
-			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()))
+			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), "decided")
 		}
 	}
 
@@ -642,6 +642,10 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 	if !decided {
 		span.AddEvent("qbft.Timeout")
 		c.metrics.IncConsensusTimeout(duty.Type.String(), string(roundTimer.Type()))
+
+		if hadInsufficientRoundChanges {
+			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), "timeout")
+		}
 
 		return errors.New("consensus timeout", z.Str("duty", duty.String()))
 	}

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -588,6 +588,9 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 	// Create a new qbft definition for this instance.
 	def := newDefinition(len(c.peers), c.subscribers, roundTimer, decideCallback, c.compareAttestations)
 	origLogRoundChange := def.LogRoundChange
+
+	var hadInsufficientRoundChanges bool
+
 	def.LogRoundChange = func(ctx context.Context, instance core.Duty, process, round, newRound int64, uponRule qbft.UponRule, msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
 		if origLogRoundChange != nil {
 			origLogRoundChange(ctx, instance, process, round, newRound, uponRule, msgs)
@@ -601,8 +604,12 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 
 			steps := groupRoundMessages(msgs, nodes, round, int(leader(duty, round, nodes)))
 			if isInsufficientRoundChanges(steps, round, quorum) {
-				c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()))
+				hadInsufficientRoundChanges = true
 			}
+		}
+
+		if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
+			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()))
 		}
 	}
 

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -609,7 +609,7 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 		}
 
 		if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
-			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), "decided")
+			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), metrics.OutcomeDecided)
 		}
 	}
 
@@ -644,7 +644,7 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 		c.metrics.IncConsensusTimeout(duty.Type.String(), string(roundTimer.Type()))
 
 		if hadInsufficientRoundChanges {
-			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), "timeout")
+			c.metrics.IncInsufficientRoundChanges(duty.Type.String(), string(roundTimer.Type()), metrics.OutcomeTimeout)
 		}
 
 		return errors.New("consensus timeout", z.Str("duty", duty.String()))

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -135,21 +135,21 @@ func TestIsInsufficientRoundChanges(t *testing.T) {
 	}
 }
 
-// TestInsufficientRoundChangesMetric tests the combined metric condition:
-// the metric is only emitted when a round times out with insufficient round changes
-// AND the node later decides via a MsgDecided from another peer (UponJustifiedDecided).
+// TestInsufficientRoundChangesMetric tests the two metric outcomes for insufficient round changes:
+//   - outcome="decided": round timed out with insufficient round changes, but the node
+//     recovered via MsgDecided from a peer that already decided.
+//   - outcome="timeout": round timed out with insufficient round changes, and consensus
+//     timed out entirely without ever receiving MsgDecided.
 //
 // This targets the scenario from https://github.com/ObolNetwork/charon/issues/4478:
 // a locally-built block payload arrives late, the leader propagates it to only a subset
 // of peers, those peers proceed through QBFT and decide, while the remaining peers
-// (including ours) time out with insufficient round changes. When the decided peers
-// respond to our RoundChange with a MsgDecided, we decide and emit the metric.
+// (including ours) time out with insufficient round changes.
 func TestInsufficientRoundChangesMetric(t *testing.T) {
 	const nodes = 4
 
 	quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
 
-	// roundMsgs builds message lists for groupRoundMessages.
 	roundMsgs := func(roundChangeSources ...int64) []qbft.Msg[core.Duty, [32]byte, proto.Message] {
 		var msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]
 		for _, src := range roundChangeSources {
@@ -159,15 +159,19 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		return msgs
 	}
 
-	// simulateCallback mirrors the LogRoundChange wrapper logic in runInstance.
-	// It returns a callback and a function to query whether the metric was emitted.
-	simulateCallback := func() (
-		callback func(uponRule qbft.UponRule, round int64, msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]),
-		metricEmitted func() bool,
+	// simulateInstance mirrors the LogRoundChange wrapper and post-run timeout logic in runInstance.
+	// It returns:
+	//   - onRoundChange: simulates LogRoundChange callback invocations during qbft.Run
+	//   - onTimeout: simulates the post-run timeout path (called when !decided)
+	//   - outcomes: returns the list of metric outcomes emitted ("decided" and/or "timeout")
+	simulateInstance := func() (
+		onRoundChange func(uponRule qbft.UponRule, round int64, msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]),
+		onTimeout func(),
+		outcomes func() []string,
 	) {
 		var (
 			hadInsufficientRoundChanges bool
-			emitted                     int
+			emittedOutcomes             []string
 		)
 
 		return func(uponRule qbft.UponRule, round int64, msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
@@ -179,10 +183,14 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 				}
 
 				if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
-					emitted++
+					emittedOutcomes = append(emittedOutcomes, "decided")
 				}
-			}, func() bool {
-				return emitted > 0
+			}, func() {
+				if hadInsufficientRoundChanges {
+					emittedOutcomes = append(emittedOutcomes, "timeout")
+				}
+			}, func() []string {
+				return emittedOutcomes
 			}
 	}
 
@@ -190,91 +198,105 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		// Scenario: 4 nodes, our node (peer 3) times out in round 1, moves to round 2.
 		// Only peer 3 sends a RoundChange (peers 0,1,2 decided in round 1).
 		// Then peers respond with MsgDecided, triggering UponJustifiedDecided.
-		callback, metricEmitted := simulateCallback()
+		onRoundChange, _, outcomes := simulateInstance()
 
 		// Round 1 → round 2: timeout with only our own RoundChange (insufficient).
-		callback(qbft.UponRoundTimeout, 2, roundMsgs(3))
-		require.False(t, metricEmitted(), "metric should not be emitted on timeout alone")
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		require.Empty(t, outcomes(), "no metric yet on timeout alone")
 
-		// Later: decided peers respond with MsgDecided → UponJustifiedDecided.
-		callback(qbft.UponJustifiedDecided, 2, nil)
-		require.True(t, metricEmitted(), "metric should be emitted: insufficient round changes + decided via MsgDecided")
+		// Decided peers respond with MsgDecided → UponJustifiedDecided.
+		onRoundChange(qbft.UponJustifiedDecided, 2, nil)
+		require.Equal(t, []string{"decided"}, outcomes())
 	})
 
-	t.Run("bad network: insufficient round changes but no MsgDecided", func(t *testing.T) {
+	t.Run("bad network: insufficient round changes and full timeout", func(t *testing.T) {
 		// Scenario: our node times out due to a bad network connection.
-		// Nobody decided — no MsgDecided ever arrives.
-		// The metric should NOT fire because this isn't the late-payload scenario.
-		callback, metricEmitted := simulateCallback()
+		// Nobody decided — consensus times out entirely.
+		onRoundChange, onTimeout, outcomes := simulateInstance()
 
 		// Round 1 → round 2: timeout with only our own RoundChange.
-		callback(qbft.UponRoundTimeout, 2, roundMsgs(3))
-		require.False(t, metricEmitted())
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		require.Empty(t, outcomes())
 
-		// Round 2 → round 3: another timeout, still insufficient round changes.
-		callback(qbft.UponRoundTimeout, 3, roundMsgs(3))
-		require.False(t, metricEmitted())
+		// Round 2 → round 3: another timeout, still insufficient.
+		onRoundChange(qbft.UponRoundTimeout, 3, roundMsgs(3))
+		require.Empty(t, outcomes())
 
-		// Consensus eventually times out entirely — no metric emitted.
-		require.False(t, metricEmitted(), "metric should not be emitted when no peer decided")
+		// Consensus times out entirely — timeout outcome emitted.
+		onTimeout()
+		require.Equal(t, []string{"timeout"}, outcomes())
 	})
 
 	t.Run("normal round change: sufficient round changes then decided via MsgDecided", func(t *testing.T) {
 		// Scenario: round change happens normally with enough peers participating.
-		// Even if we later get a MsgDecided, the metric should not fire because
-		// the round changes were sufficient (not the late-payload scenario).
-		callback, metricEmitted := simulateCallback()
+		// Even if we later get a MsgDecided, no metric should fire.
+		onRoundChange, _, outcomes := simulateInstance()
 
 		// Round 1 → round 2: timeout but with quorum round changes (3 out of 4).
-		callback(qbft.UponRoundTimeout, 2, roundMsgs(0, 1, 3))
-		require.False(t, metricEmitted())
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(0, 1, 3))
+		require.Empty(t, outcomes())
 
-		// Later: MsgDecided arrives.
-		callback(qbft.UponJustifiedDecided, 2, nil)
-		require.False(t, metricEmitted(), "metric should not fire when round changes were sufficient")
+		// MsgDecided arrives.
+		onRoundChange(qbft.UponJustifiedDecided, 2, nil)
+		require.Empty(t, outcomes(), "no metric when round changes were sufficient")
+	})
+
+	t.Run("normal round change: sufficient round changes then full timeout", func(t *testing.T) {
+		// Scenario: round changes were sufficient but consensus still times out
+		// (e.g., stuck at prepare/commit phase). No insufficient round changes metric.
+		onRoundChange, onTimeout, outcomes := simulateInstance()
+
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(0, 1, 3))
+		onTimeout()
+		require.Empty(t, outcomes(), "no metric when round changes were sufficient")
 	})
 
 	t.Run("normal consensus: decided via commits without any round changes", func(t *testing.T) {
-		// Scenario: happy path — consensus completes in round 1 via quorum commits.
-		// No round timeout ever happens. No metric.
-		callback, metricEmitted := simulateCallback()
+		// Happy path — consensus completes in round 1 via quorum commits.
+		onRoundChange, _, outcomes := simulateInstance()
 
-		// UponQuorumCommits triggers changeRound, but with UponQuorumCommits rule,
-		// not UponRoundTimeout or UponJustifiedDecided.
-		callback(qbft.UponQuorumCommits, 1, nil)
-		require.False(t, metricEmitted(), "metric should not fire on normal consensus")
+		onRoundChange(qbft.UponQuorumCommits, 1, nil)
+		require.Empty(t, outcomes(), "no metric on normal consensus")
 	})
 
 	t.Run("round 1 timeout does not trigger flag", func(t *testing.T) {
 		// Round 1 timeouts don't check for round changes (round changes are only
-		// relevant for rounds > 1). Even if followed by MsgDecided, no metric.
-		callback, metricEmitted := simulateCallback()
+		// relevant for rounds > 1). Neither decided nor timeout outcome should fire.
+		onRoundChange, onTimeout, outcomes := simulateInstance()
 
-		// Round 1 timeout (no round changes expected in round 1).
-		callback(qbft.UponRoundTimeout, 1, nil)
-		require.False(t, metricEmitted())
+		onRoundChange(qbft.UponRoundTimeout, 1, nil)
+		onRoundChange(qbft.UponJustifiedDecided, 1, nil)
+		require.Empty(t, outcomes(), "no decided metric for round 1 timeout")
 
-		// MsgDecided arrives.
-		callback(qbft.UponJustifiedDecided, 1, nil)
-		require.False(t, metricEmitted(), "metric should not fire for round 1 timeout")
+		onTimeout()
+		require.Empty(t, outcomes(), "no timeout metric for round 1 timeout")
 	})
 
 	t.Run("multiple insufficient rounds then decided", func(t *testing.T) {
-		// Scenario: multiple rounds time out with insufficient round changes
-		// before finally receiving MsgDecided. Metric fires exactly once.
-		callback, metricEmitted := simulateCallback()
+		// Multiple rounds time out with insufficient round changes
+		// before finally receiving MsgDecided. Decided outcome fires once.
+		onRoundChange, _, outcomes := simulateInstance()
 
-		// Round 1 → 2: timeout, insufficient round changes.
-		callback(qbft.UponRoundTimeout, 2, roundMsgs(3))
-		require.False(t, metricEmitted())
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		onRoundChange(qbft.UponRoundTimeout, 3, roundMsgs(3))
+		require.Empty(t, outcomes())
 
-		// Round 2 → 3: timeout again, still insufficient.
-		callback(qbft.UponRoundTimeout, 3, roundMsgs(3))
-		require.False(t, metricEmitted())
+		onRoundChange(qbft.UponJustifiedDecided, 3, nil)
+		require.Equal(t, []string{"decided"}, outcomes())
+	})
 
-		// Finally MsgDecided arrives.
-		callback(qbft.UponJustifiedDecided, 3, nil)
-		require.True(t, metricEmitted(), "metric should fire after multiple insufficient rounds + MsgDecided")
+	t.Run("multiple insufficient rounds then full timeout", func(t *testing.T) {
+		// Multiple rounds time out with insufficient round changes,
+		// then consensus times out entirely. Timeout outcome fires once.
+		onRoundChange, onTimeout, outcomes := simulateInstance()
+
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		onRoundChange(qbft.UponRoundTimeout, 3, roundMsgs(3))
+		onRoundChange(qbft.UponRoundTimeout, 4, roundMsgs(3))
+		require.Empty(t, outcomes())
+
+		onTimeout()
+		require.Equal(t, []string{"timeout"}, outcomes())
 	})
 }
 

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -183,8 +183,11 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 					}
 				}
 
-				if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
-					emittedOutcomes = append(emittedOutcomes, metrics.OutcomeDecided)
+				if uponRule == qbft.UponJustifiedDecided {
+					steps := groupRoundMessages(msgs, nodes, round, int(leader(core.Duty{Slot: 1, Type: core.DutyAttester}, round, nodes)))
+					if hadInsufficientRoundChanges || isInsufficientRoundChanges(steps, round, quorum) {
+						emittedOutcomes = append(emittedOutcomes, metrics.OutcomeDecided)
+					}
 				}
 			}, func() {
 				if hadInsufficientRoundChanges {
@@ -198,15 +201,22 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 	t.Run("issue 4478: insufficient round changes then decided via MsgDecided", func(t *testing.T) {
 		// Scenario: 4 nodes, our node (peer 3) times out in round 1, moves to round 2.
 		// Only peer 3 sends a RoundChange (peers 0,1,2 decided in round 1).
-		// Then peers respond with MsgDecided, triggering UponJustifiedDecided.
+		// MsgDecided arrives before round 2 times out.
+		//
+		// In production, LogRoundChange receives round=oldRound, so the round 1
+		// timeout callback gets round=1. The UponJustifiedDecided callback gets
+		// round=2 (current round) with round 2's messages (containing only our
+		// own MsgRoundChange).
 		onRoundChange, _, outcomes := simulateInstance()
 
-		// Round 1 → round 2: timeout with only our own RoundChange (insufficient).
-		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
-		require.Empty(t, outcomes(), "no metric yet on timeout alone")
+		// Round 1 timeout: LogRoundChange(round=1, newRound=2, UponRoundTimeout).
+		// isInsufficientRoundChanges returns false for round 1 (no round changes expected).
+		onRoundChange(qbft.UponRoundTimeout, 1, nil)
+		require.Empty(t, outcomes(), "no metric for round 1 timeout")
 
-		// Decided peers respond with MsgDecided → UponJustifiedDecided.
-		onRoundChange(qbft.UponJustifiedDecided, 2, nil)
+		// MsgDecided arrives while in round 2: LogRoundChange(round=2, UponJustifiedDecided).
+		// Round 2 messages contain only our own MsgRoundChange — insufficient.
+		onRoundChange(qbft.UponJustifiedDecided, 2, roundMsgs(3))
 		require.Equal(t, []string{metrics.OutcomeDecided}, outcomes())
 	})
 
@@ -215,12 +225,12 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		// Nobody decided — consensus times out entirely.
 		onRoundChange, onTimeout, outcomes := simulateInstance()
 
-		// Round 1 → round 2: timeout with only our own RoundChange.
-		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		// Round 1 timeout: LogRoundChange(round=1). No flag set (round 1).
+		onRoundChange(qbft.UponRoundTimeout, 1, nil)
 		require.Empty(t, outcomes())
 
-		// Round 2 → round 3: another timeout, still insufficient.
-		onRoundChange(qbft.UponRoundTimeout, 3, roundMsgs(3))
+		// Round 2 timeout: LogRoundChange(round=2). Only our RoundChange — insufficient.
+		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
 		require.Empty(t, outcomes())
 
 		// Consensus times out entirely — timeout outcome emitted.
@@ -233,12 +243,12 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		// Even if we later get a MsgDecided, no metric should fire.
 		onRoundChange, _, outcomes := simulateInstance()
 
-		// Round 1 → round 2: timeout but with quorum round changes (3 out of 4).
+		// Round 2 timeout: LogRoundChange(round=2). Quorum round changes (3 out of 4).
 		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(0, 1, 3))
 		require.Empty(t, outcomes())
 
-		// MsgDecided arrives.
-		onRoundChange(qbft.UponJustifiedDecided, 2, nil)
+		// MsgDecided arrives while in round 3. Round 3 messages also have sufficient round changes.
+		onRoundChange(qbft.UponJustifiedDecided, 3, roundMsgs(0, 1, 3))
 		require.Empty(t, outcomes(), "no metric when round changes were sufficient")
 	})
 
@@ -247,6 +257,7 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		// (e.g., stuck at prepare/commit phase). No insufficient round changes metric.
 		onRoundChange, onTimeout, outcomes := simulateInstance()
 
+		// Round 2 timeout: LogRoundChange(round=2). Quorum round changes.
 		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(0, 1, 3))
 		onTimeout()
 		require.Empty(t, outcomes(), "no metric when round changes were sufficient")
@@ -278,11 +289,13 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		// before finally receiving MsgDecided. Decided outcome fires once.
 		onRoundChange, _, outcomes := simulateInstance()
 
+		// Round 2 and 3 timeout with insufficient round changes.
 		onRoundChange(qbft.UponRoundTimeout, 2, roundMsgs(3))
 		onRoundChange(qbft.UponRoundTimeout, 3, roundMsgs(3))
 		require.Empty(t, outcomes())
 
-		onRoundChange(qbft.UponJustifiedDecided, 3, nil)
+		// MsgDecided arrives while in round 4.
+		onRoundChange(qbft.UponJustifiedDecided, 4, roundMsgs(3))
 		require.Equal(t, []string{metrics.OutcomeDecided}, outcomes())
 	})
 

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/obolnetwork/charon/app/k1util"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/consensus/instance"
+	"github.com/obolnetwork/charon/core/consensus/metrics"
 	"github.com/obolnetwork/charon/core/consensus/timer"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	coremocks "github.com/obolnetwork/charon/core/mocks"
@@ -183,11 +184,11 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 				}
 
 				if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
-					emittedOutcomes = append(emittedOutcomes, "decided")
+					emittedOutcomes = append(emittedOutcomes, metrics.OutcomeDecided)
 				}
 			}, func() {
 				if hadInsufficientRoundChanges {
-					emittedOutcomes = append(emittedOutcomes, "timeout")
+					emittedOutcomes = append(emittedOutcomes, metrics.OutcomeTimeout)
 				}
 			}, func() []string {
 				return emittedOutcomes
@@ -206,7 +207,7 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 
 		// Decided peers respond with MsgDecided → UponJustifiedDecided.
 		onRoundChange(qbft.UponJustifiedDecided, 2, nil)
-		require.Equal(t, []string{"decided"}, outcomes())
+		require.Equal(t, []string{metrics.OutcomeDecided}, outcomes())
 	})
 
 	t.Run("bad network: insufficient round changes and full timeout", func(t *testing.T) {
@@ -224,7 +225,7 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 
 		// Consensus times out entirely — timeout outcome emitted.
 		onTimeout()
-		require.Equal(t, []string{"timeout"}, outcomes())
+		require.Equal(t, []string{metrics.OutcomeTimeout}, outcomes())
 	})
 
 	t.Run("normal round change: sufficient round changes then decided via MsgDecided", func(t *testing.T) {
@@ -282,7 +283,7 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		require.Empty(t, outcomes())
 
 		onRoundChange(qbft.UponJustifiedDecided, 3, nil)
-		require.Equal(t, []string{"decided"}, outcomes())
+		require.Equal(t, []string{metrics.OutcomeDecided}, outcomes())
 	})
 
 	t.Run("multiple insufficient rounds then full timeout", func(t *testing.T) {
@@ -296,7 +297,7 @@ func TestInsufficientRoundChangesMetric(t *testing.T) {
 		require.Empty(t, outcomes())
 
 		onTimeout()
-		require.Equal(t, []string{"timeout"}, outcomes())
+		require.Equal(t, []string{metrics.OutcomeTimeout}, outcomes())
 	})
 }
 

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -81,6 +81,60 @@ func TestDebugRoundChange(t *testing.T) {
 	}
 }
 
+func TestIsInsufficientRoundChanges(t *testing.T) {
+	const n = 4
+
+	tests := []struct {
+		name     string
+		msgs     []qbft.Msg[core.Duty, [32]byte, proto.Message]
+		round    int64
+		quorum   int
+		expected bool
+	}{
+		{
+			name:     "round 1 always false",
+			round:    1,
+			quorum:   3,
+			expected: false,
+		},
+		{
+			name: "round 2 with quorum",
+			msgs: []qbft.Msg[core.Duty, [32]byte, proto.Message]{
+				m(0, qbft.MsgRoundChange),
+				m(1, qbft.MsgRoundChange),
+				m(2, qbft.MsgRoundChange),
+			},
+			round:    2,
+			quorum:   3,
+			expected: false,
+		},
+		{
+			name: "round 2 without quorum",
+			msgs: []qbft.Msg[core.Duty, [32]byte, proto.Message]{
+				m(0, qbft.MsgRoundChange),
+				m(1, qbft.MsgRoundChange),
+			},
+			round:    2,
+			quorum:   3,
+			expected: true,
+		},
+		{
+			name:     "round 2 with no messages",
+			round:    2,
+			quorum:   3,
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			steps := groupRoundMessages(test.msgs, n, test.round, 0)
+			result := isInsufficientRoundChanges(steps, test.round, test.quorum)
+			require.Equal(t, test.expected, result)
+		})
+	}
+}
+
 func m(source int64, typ qbft.MsgType) testMsg {
 	return testMsg{
 		source: source,

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -135,6 +135,149 @@ func TestIsInsufficientRoundChanges(t *testing.T) {
 	}
 }
 
+// TestInsufficientRoundChangesMetric tests the combined metric condition:
+// the metric is only emitted when a round times out with insufficient round changes
+// AND the node later decides via a MsgDecided from another peer (UponJustifiedDecided).
+//
+// This targets the scenario from https://github.com/ObolNetwork/charon/issues/4478:
+// a locally-built block payload arrives late, the leader propagates it to only a subset
+// of peers, those peers proceed through QBFT and decide, while the remaining peers
+// (including ours) time out with insufficient round changes. When the decided peers
+// respond to our RoundChange with a MsgDecided, we decide and emit the metric.
+func TestInsufficientRoundChangesMetric(t *testing.T) {
+	const nodes = 4
+
+	quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
+
+	// roundMsgs builds message lists for groupRoundMessages.
+	roundMsgs := func(roundChangeSources ...int64) []qbft.Msg[core.Duty, [32]byte, proto.Message] {
+		var msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]
+		for _, src := range roundChangeSources {
+			msgs = append(msgs, m(src, qbft.MsgRoundChange))
+		}
+
+		return msgs
+	}
+
+	// simulateCallback mirrors the LogRoundChange wrapper logic in runInstance.
+	// It returns a callback and a function to query whether the metric was emitted.
+	simulateCallback := func() (
+		callback func(uponRule qbft.UponRule, round int64, msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]),
+		metricEmitted func() bool,
+	) {
+		var (
+			hadInsufficientRoundChanges bool
+			emitted                     int
+		)
+
+		return func(uponRule qbft.UponRule, round int64, msgs []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
+				if uponRule == qbft.UponRoundTimeout {
+					steps := groupRoundMessages(msgs, nodes, round, int(leader(core.Duty{Slot: 1, Type: core.DutyAttester}, round, nodes)))
+					if isInsufficientRoundChanges(steps, round, quorum) {
+						hadInsufficientRoundChanges = true
+					}
+				}
+
+				if uponRule == qbft.UponJustifiedDecided && hadInsufficientRoundChanges {
+					emitted++
+				}
+			}, func() bool {
+				return emitted > 0
+			}
+	}
+
+	t.Run("issue 4478: insufficient round changes then decided via MsgDecided", func(t *testing.T) {
+		// Scenario: 4 nodes, our node (peer 3) times out in round 1, moves to round 2.
+		// Only peer 3 sends a RoundChange (peers 0,1,2 decided in round 1).
+		// Then peers respond with MsgDecided, triggering UponJustifiedDecided.
+		callback, metricEmitted := simulateCallback()
+
+		// Round 1 → round 2: timeout with only our own RoundChange (insufficient).
+		callback(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		require.False(t, metricEmitted(), "metric should not be emitted on timeout alone")
+
+		// Later: decided peers respond with MsgDecided → UponJustifiedDecided.
+		callback(qbft.UponJustifiedDecided, 2, nil)
+		require.True(t, metricEmitted(), "metric should be emitted: insufficient round changes + decided via MsgDecided")
+	})
+
+	t.Run("bad network: insufficient round changes but no MsgDecided", func(t *testing.T) {
+		// Scenario: our node times out due to a bad network connection.
+		// Nobody decided — no MsgDecided ever arrives.
+		// The metric should NOT fire because this isn't the late-payload scenario.
+		callback, metricEmitted := simulateCallback()
+
+		// Round 1 → round 2: timeout with only our own RoundChange.
+		callback(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		require.False(t, metricEmitted())
+
+		// Round 2 → round 3: another timeout, still insufficient round changes.
+		callback(qbft.UponRoundTimeout, 3, roundMsgs(3))
+		require.False(t, metricEmitted())
+
+		// Consensus eventually times out entirely — no metric emitted.
+		require.False(t, metricEmitted(), "metric should not be emitted when no peer decided")
+	})
+
+	t.Run("normal round change: sufficient round changes then decided via MsgDecided", func(t *testing.T) {
+		// Scenario: round change happens normally with enough peers participating.
+		// Even if we later get a MsgDecided, the metric should not fire because
+		// the round changes were sufficient (not the late-payload scenario).
+		callback, metricEmitted := simulateCallback()
+
+		// Round 1 → round 2: timeout but with quorum round changes (3 out of 4).
+		callback(qbft.UponRoundTimeout, 2, roundMsgs(0, 1, 3))
+		require.False(t, metricEmitted())
+
+		// Later: MsgDecided arrives.
+		callback(qbft.UponJustifiedDecided, 2, nil)
+		require.False(t, metricEmitted(), "metric should not fire when round changes were sufficient")
+	})
+
+	t.Run("normal consensus: decided via commits without any round changes", func(t *testing.T) {
+		// Scenario: happy path — consensus completes in round 1 via quorum commits.
+		// No round timeout ever happens. No metric.
+		callback, metricEmitted := simulateCallback()
+
+		// UponQuorumCommits triggers changeRound, but with UponQuorumCommits rule,
+		// not UponRoundTimeout or UponJustifiedDecided.
+		callback(qbft.UponQuorumCommits, 1, nil)
+		require.False(t, metricEmitted(), "metric should not fire on normal consensus")
+	})
+
+	t.Run("round 1 timeout does not trigger flag", func(t *testing.T) {
+		// Round 1 timeouts don't check for round changes (round changes are only
+		// relevant for rounds > 1). Even if followed by MsgDecided, no metric.
+		callback, metricEmitted := simulateCallback()
+
+		// Round 1 timeout (no round changes expected in round 1).
+		callback(qbft.UponRoundTimeout, 1, nil)
+		require.False(t, metricEmitted())
+
+		// MsgDecided arrives.
+		callback(qbft.UponJustifiedDecided, 1, nil)
+		require.False(t, metricEmitted(), "metric should not fire for round 1 timeout")
+	})
+
+	t.Run("multiple insufficient rounds then decided", func(t *testing.T) {
+		// Scenario: multiple rounds time out with insufficient round changes
+		// before finally receiving MsgDecided. Metric fires exactly once.
+		callback, metricEmitted := simulateCallback()
+
+		// Round 1 → 2: timeout, insufficient round changes.
+		callback(qbft.UponRoundTimeout, 2, roundMsgs(3))
+		require.False(t, metricEmitted())
+
+		// Round 2 → 3: timeout again, still insufficient.
+		callback(qbft.UponRoundTimeout, 3, roundMsgs(3))
+		require.False(t, metricEmitted())
+
+		// Finally MsgDecided arrives.
+		callback(qbft.UponJustifiedDecided, 3, nil)
+		require.True(t, metricEmitted(), "metric should fire after multiple insufficient rounds + MsgDecided")
+	})
+}
+
 func m(source int64, typ qbft.MsgType) testMsg {
 	return testMsg{
 		source: source,

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -60,6 +60,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `core_consensus_decided_rounds` | Gauge | Number of decided rounds by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_consensus_duration_seconds` | Histogram | Duration of the consensus process by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_consensus_error_total` | Counter | Total count of consensus errors by protocol | `protocol` |
+| `core_consensus_insufficient_round_changes_total` | Counter | Total count of round timeouts due to insufficient round change messages by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_consensus_timeout_total` | Counter | Total count of consensus timeouts by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_fetcher_proposal_blinded` | Gauge | Whether the fetched proposal was blinded (1) or local (2) |  |
 | `core_fetcher_proposal_local_mismatch_fee_recipient` | Gauge | Counts the number of times a local proposal has a mismatched fee recipient |  |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -60,7 +60,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `core_consensus_decided_rounds` | Gauge | Number of decided rounds by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_consensus_duration_seconds` | Histogram | Duration of the consensus process by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_consensus_error_total` | Counter | Total count of consensus errors by protocol | `protocol` |
-| `core_consensus_insufficient_round_changes_total` | Counter | Total count of round timeouts due to insufficient round change messages by protocol, duty, and timer | `protocol, duty, timer` |
+| `core_consensus_insufficient_round_changes_total` | Counter | Total count of consensus instances with insufficient round change messages by protocol, duty, timer, and outcome (decided or timeout) | `protocol, duty, timer, outcome` |
 | `core_consensus_timeout_total` | Counter | Total count of consensus timeouts by protocol, duty, and timer | `protocol, duty, timer` |
 | `core_fetcher_proposal_blinded` | Gauge | Whether the fetched proposal was blinded (1) or local (2) |  |
 | `core_fetcher_proposal_local_mismatch_fee_recipient` | Gauge | Counts the number of times a local proposal has a mismatched fee recipient |  |

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -292,6 +292,7 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 	}
 
 	protoLabel := string(pID) // Updated to the negotiated protocol once NewStream succeeds.
+
 	defer func() {
 		sendDurations.WithLabelValues(PeerName(peerID), protoLabel, o.metricTopic).Observe(time.Since(tStart).Seconds())
 	}()
@@ -367,6 +368,7 @@ func Send(ctx context.Context, p2pNode host.Host, protoID protocol.ID, peerID pe
 	if len(o.protocols) > 0 {
 		protoLabel = string(o.protocols[0])
 	}
+
 	defer func() {
 		sendDurations.WithLabelValues(PeerName(peerID), protoLabel, o.metricTopic).Observe(time.Since(t0).Seconds())
 	}()


### PR DESCRIPTION
If a proposed value from leader is too close to the threshold of round expiration, we can see some peers receiving it on time while others don't. It'd be nice to track such discrepancies.

Here I'm adding a metric that tracks "insufficient round change messages" which in the majority of the scenarios means other peers did not agree on a round change. The case when they don't agree is if they are already doing another round. I'm splitting the metric in 2 - received "consensus decided" message or not. If a node receives "consensus decided", even if it wasn't part of the consensus (i.e.: stuck on another round), it still counts the consensus as successful and propagates the data decided upon to the subscribers (= the VC). If it doesn't receive it though, then the QBFT fails after some timeouts (= the VC never receives the data)

category: feature
ticket: #4478 

