### PR TITLE
*: fix lock share binding validation

### DIFF
--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -283,6 +283,9 @@ func recoverDistributedPubkeyFromShares(pubShares [][]byte, threshold int) ([]by
 		if err := pubkey.Deserialize(pubShares[i]); err != nil {
 			return nil, errors.Wrap(err, "deserialize public share", z.Int("share_index", i))
 		}
+		if pubkey.IsZero() {
+			return nil, errors.New("identity point share", z.Int("share_index", i))
+		}
 		rawKeys = append(rawKeys, pubkey)
 
 		var id bls.ID

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -170,6 +170,15 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 		return err
 	}
 
+	uniqueDVKeys := make(map[string]struct{}, len(l.Validators))
+	for _, val := range l.Validators {
+		key := string(val.PubKey)
+		if _, exists := uniqueDVKeys[key]; exists {
+			return errors.New("duplicate distributed validator public key")
+		}
+		uniqueDVKeys[key] = struct{}{}
+	}
+
 	var pubkeys []tbls.PublicKey
 
 	for _, val := range l.Validators {

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -5,10 +5,8 @@ package cluster
 import (
 	"bytes"
 	"encoding/json"
-	"strconv"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	"github.com/herumi/bls-eth-go-binary/bls"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth1wrap"
@@ -170,14 +168,7 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 		return err
 	}
 
-	uniqueDVKeys := make(map[string]struct{}, len(l.Validators))
-	for _, val := range l.Validators {
-		key := string(val.PubKey)
-		if _, exists := uniqueDVKeys[key]; exists {
-			return errors.New("duplicate distributed validator public key")
-		}
-		uniqueDVKeys[key] = struct{}{}
-	}
+	seenDVKeys := make(map[tbls.PublicKey]struct{}, len(l.Validators))
 
 	var pubkeys []tbls.PublicKey
 
@@ -185,48 +176,28 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 		if len(val.PubShares) != len(l.Operators) {
 			return errors.New("invalid public share count")
 		}
-		uniqueShareCount := make(map[string]struct{}, len(val.PubShares))
-		for _, share := range val.PubShares {
-			shareKey := string(share)
-			if _, exists := uniqueShareCount[shareKey]; exists {
-				return errors.New("duplicate public share")
-			}
-			uniqueShareCount[shareKey] = struct{}{}
-		}
 
-		recoveredPubkey, err := recoverDistributedPubkeyFromShares(val.PubShares, l.Threshold)
+		dvKey, err := tblsconv.PubkeyFromBytes(val.PubKey)
 		if err != nil {
-			return errors.Wrap(err, "recover distributed public key from shares")
+			return err
 		}
 
-		if !bytes.Equal(recoveredPubkey, val.PubKey) {
-			return errors.New("public shares do not reconstruct distributed public key")
+		if _, exists := seenDVKeys[dvKey]; exists {
+			return errors.New("duplicate distributed validator public key")
 		}
 
-		for i := l.Threshold; i < len(val.PubShares); i++ {
-			extraShares := append(append([][]byte{}, val.PubShares[:l.Threshold-1]...), val.PubShares[i])
-			extraIDs := make([]int, l.Threshold)
-			for j := 0; j < l.Threshold-1; j++ {
-				extraIDs[j] = j + 1
-			}
-			extraIDs[l.Threshold-1] = i + 1
-			recoveredExtra, err := recoverDistributedPubkeyFromSharesWithIDs(extraShares, extraIDs)
-			if err != nil {
-				return errors.Wrap(err, "recover extra share", z.Int("share_index", i))
-			}
-			if !bytes.Equal(recoveredExtra, val.PubKey) {
-				return errors.New("extra share does not lie on distributed key polynomial", z.Int("share_index", i))
-			}
+		seenDVKeys[dvKey] = struct{}{}
+
+		shares, err := parsePubShares(val.PubShares)
+		if err != nil {
+			return err
 		}
 
-		for _, share := range val.PubShares {
-			pubkey, err := tblsconv.PubkeyFromBytes(share)
-			if err != nil {
-				return err
-			}
-
-			pubkeys = append(pubkeys, pubkey)
+		if err := verifySharesReconstruct(dvKey, shares, l.Threshold); err != nil {
+			return err
 		}
+
+		pubkeys = append(pubkeys, shares...)
 	}
 
 	hash, err := hashLock(l)
@@ -283,67 +254,61 @@ func (l Lock) verifyNodeSignatures() error {
 	return nil
 }
 
-func recoverDistributedPubkeyFromSharesWithIDs(pubShares [][]byte, ids []int) ([]byte, error) {
-	if len(pubShares) != len(ids) || len(pubShares) == 0 {
-		return nil, errors.New("share and id count mismatch")
-	}
+func parsePubShares(raw [][]byte) ([]tbls.PublicKey, error) {
+	seen := make(map[tbls.PublicKey]struct{}, len(raw))
+	parsed := make([]tbls.PublicKey, len(raw))
 
-	rawKeys := make([]bls.PublicKey, 0, len(pubShares))
-	rawIDs := make([]bls.ID, 0, len(pubShares))
-
-	for i, share := range pubShares {
-		var pubkey bls.PublicKey
-		if err := pubkey.Deserialize(share); err != nil {
-			return nil, errors.Wrap(err, "deserialize public share", z.Int("share_index", i))
+	for i, share := range raw {
+		pk, err := tblsconv.PubkeyFromBytes(share)
+		if err != nil {
+			return nil, err
 		}
-		rawKeys = append(rawKeys, pubkey)
 
-		var id bls.ID
-		if err := id.SetDecString(strconv.Itoa(ids[i])); err != nil {
-			return nil, errors.Wrap(err, "set share id", z.Int("share_index", i))
+		if _, exists := seen[pk]; exists {
+			return nil, errors.New("duplicate public share")
 		}
-		rawIDs = append(rawIDs, id)
+
+		seen[pk] = struct{}{}
+		parsed[i] = pk
 	}
 
-	var recovered bls.PublicKey
-	if err := recovered.Recover(rawKeys, rawIDs); err != nil {
-		return nil, errors.Wrap(err, "recover distributed public key")
-	}
-
-	return recovered.Serialize(), nil
+	return parsed, nil
 }
 
-func recoverDistributedPubkeyFromShares(pubShares [][]byte, threshold int) ([]byte, error) {
-	if threshold <= 0 {
-		return nil, errors.New("invalid threshold")
-	}
-	if len(pubShares) < threshold {
-		return nil, errors.New("insufficient public shares for threshold")
+func verifySharesReconstruct(dvKey tbls.PublicKey, shares []tbls.PublicKey, threshold int) error {
+	subset := make(map[int]tbls.PublicKey, threshold)
+	for i := range threshold {
+		subset[i+1] = shares[i]
 	}
 
-	rawKeys := make([]bls.PublicKey, 0, threshold)
-	rawIDs := make([]bls.ID, 0, threshold)
+	recovered, err := tbls.RecoverPubkey(subset)
+	if err != nil {
+		return errors.Wrap(err, "recover distributed public key from shares")
+	}
 
-	for i := 0; i < threshold; i++ {
-		var pubkey bls.PublicKey
-		if err := pubkey.Deserialize(pubShares[i]); err != nil {
-			return nil, errors.Wrap(err, "deserialize public share", z.Int("share_index", i))
+	if recovered != dvKey {
+		return errors.New("public shares do not reconstruct distributed public key")
+	}
+
+	for i := threshold; i < len(shares); i++ {
+		subset := make(map[int]tbls.PublicKey, threshold)
+		for j := range threshold - 1 {
+			subset[j+1] = shares[j]
 		}
-		rawKeys = append(rawKeys, pubkey)
 
-		var id bls.ID
-		if err := id.SetDecString(strconv.Itoa(i + 1)); err != nil {
-			return nil, errors.Wrap(err, "set share id", z.Int("share_index", i))
+		subset[i+1] = shares[i]
+
+		recovered, err := tbls.RecoverPubkey(subset)
+		if err != nil {
+			return errors.Wrap(err, "verify extra share", z.Int("share_index", i))
 		}
-		rawIDs = append(rawIDs, id)
+
+		if recovered != dvKey {
+			return errors.New("extra share does not lie on distributed key polynomial", z.Int("share_index", i))
+		}
 	}
 
-	var recovered bls.PublicKey
-	if err := recovered.Recover(rawKeys, rawIDs); err != nil {
-		return nil, errors.Wrap(err, "recover distributed public key")
-	}
-
-	return recovered.Serialize(), nil
+	return nil
 }
 
 // verifyBuilderRegistrations returns an error if the populated builder registrations are invalid.

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -173,6 +173,18 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 	var pubkeys []tbls.PublicKey
 
 	for _, val := range l.Validators {
+		if len(val.PubShares) != len(l.Operators) {
+			return errors.New("invalid public share count")
+		}
+		uniqueShareCount := make(map[string]struct{}, len(val.PubShares))
+		for _, share := range val.PubShares {
+			shareKey := string(share)
+			if _, exists := uniqueShareCount[shareKey]; exists {
+				return errors.New("duplicate public share")
+			}
+			uniqueShareCount[shareKey] = struct{}{}
+		}
+
 		recoveredPubkey, err := recoverDistributedPubkeyFromShares(val.PubShares, l.Threshold)
 		if err != nil {
 			return errors.Wrap(err, "recover distributed public key from shares")

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -172,9 +172,13 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 
 	var pubkeys []tbls.PublicKey
 
-	for _, val := range l.Validators {
+	for i, val := range l.Validators {
 		if len(val.PubShares) != len(l.Operators) {
-			return errors.New("invalid public share count")
+			return errors.New("invalid public share count",
+				z.Int("dv_index", i),
+				z.Int("expected", len(l.Operators)),
+				z.Int("got", len(val.PubShares)),
+			)
 		}
 
 		dvKey, err := tblsconv.PubkeyFromBytes(val.PubKey)
@@ -183,18 +187,20 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 		}
 
 		if _, exists := seenDVKeys[dvKey]; exists {
-			return errors.New("duplicate distributed validator public key")
+			return errors.New("duplicate distributed validator public key",
+				z.Int("dv_index", i),
+			)
 		}
 
 		seenDVKeys[dvKey] = struct{}{}
 
 		shares, err := parsePubShares(val.PubShares)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "parse public shares", z.Int("dv_index", i))
 		}
 
 		if err := verifySharesReconstruct(dvKey, shares, l.Threshold); err != nil {
-			return err
+			return errors.Wrap(err, "verify share reconstruction", z.Int("dv_index", i))
 		}
 
 		pubkeys = append(pubkeys, shares...)
@@ -265,7 +271,7 @@ func parsePubShares(raw [][]byte) ([]tbls.PublicKey, error) {
 		}
 
 		if _, exists := seen[pk]; exists {
-			return nil, errors.New("duplicate public share")
+			return nil, errors.New("duplicate public share", z.Int("share_index", i))
 		}
 
 		seen[pk] = struct{}{}
@@ -276,6 +282,13 @@ func parsePubShares(raw [][]byte) ([]tbls.PublicKey, error) {
 }
 
 func verifySharesReconstruct(dvKey tbls.PublicKey, shares []tbls.PublicKey, threshold int) error {
+	if threshold < 1 || threshold > len(shares) {
+		return errors.New("invalid threshold",
+			z.Int("threshold", threshold),
+			z.Int("shares", len(shares)),
+		)
+	}
+
 	subset := make(map[int]tbls.PublicKey, threshold)
 	for i := range threshold {
 		subset[i+1] = shares[i]

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -194,6 +194,14 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			uniqueShareCount[shareKey] = struct{}{}
 		}
 
+		var identityPoint tbls.PublicKey
+		identityPoint[0] = 0xc0
+		for _, share := range val.PubShares {
+			if *(*tbls.PublicKey)(share) == identityPoint {
+				return errors.New("identity point share")
+			}
+		}
+
 		recoveredPubkey, err := recoverDistributedPubkeyFromShares(val.PubShares, l.Threshold)
 		if err != nil {
 			return errors.Wrap(err, "recover distributed public key from shares")
@@ -282,9 +290,6 @@ func recoverDistributedPubkeyFromShares(pubShares [][]byte, threshold int) ([]by
 		var pubkey bls.PublicKey
 		if err := pubkey.Deserialize(pubShares[i]); err != nil {
 			return nil, errors.Wrap(err, "deserialize public share", z.Int("share_index", i))
-		}
-		if pubkey.IsZero() {
-			return nil, errors.New("identity point share", z.Int("share_index", i))
 		}
 		rawKeys = append(rawKeys, pubkey)
 

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -194,14 +194,6 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			uniqueShareCount[shareKey] = struct{}{}
 		}
 
-		var identityPoint tbls.PublicKey
-		identityPoint[0] = 0xc0
-		for _, share := range val.PubShares {
-			if *(*tbls.PublicKey)(share) == identityPoint {
-				return errors.New("identity point share")
-			}
-		}
-
 		recoveredPubkey, err := recoverDistributedPubkeyFromShares(val.PubShares, l.Threshold)
 		if err != nil {
 			return errors.Wrap(err, "recover distributed public key from shares")

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -211,6 +211,22 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			return errors.New("public shares do not reconstruct distributed public key")
 		}
 
+		for i := l.Threshold; i < len(val.PubShares); i++ {
+			extraShares := append(append([][]byte{}, val.PubShares[:l.Threshold-1]...), val.PubShares[i])
+			extraIDs := make([]int, l.Threshold)
+			for j := 0; j < l.Threshold-1; j++ {
+				extraIDs[j] = j + 1
+			}
+			extraIDs[l.Threshold-1] = i + 1
+			recoveredExtra, err := recoverDistributedPubkeyFromSharesWithIDs(extraShares, extraIDs)
+			if err != nil {
+				return errors.Wrap(err, "recover extra share", z.Int("share_index", i))
+			}
+			if !bytes.Equal(recoveredExtra, val.PubKey) {
+				return errors.New("extra share does not lie on distributed key polynomial", z.Int("share_index", i))
+			}
+		}
+
 		for _, share := range val.PubShares {
 			pubkey, err := tblsconv.PubkeyFromBytes(share)
 			if err != nil {
@@ -273,6 +289,36 @@ func (l Lock) verifyNodeSignatures() error {
 	}
 
 	return nil
+}
+
+func recoverDistributedPubkeyFromSharesWithIDs(pubShares [][]byte, ids []int) ([]byte, error) {
+	if len(pubShares) != len(ids) || len(pubShares) == 0 {
+		return nil, errors.New("share and id count mismatch")
+	}
+
+	rawKeys := make([]bls.PublicKey, 0, len(pubShares))
+	rawIDs := make([]bls.ID, 0, len(pubShares))
+
+	for i, share := range pubShares {
+		var pubkey bls.PublicKey
+		if err := pubkey.Deserialize(share); err != nil {
+			return nil, errors.Wrap(err, "deserialize public share", z.Int("share_index", i))
+		}
+		rawKeys = append(rawKeys, pubkey)
+
+		var id bls.ID
+		if err := id.SetDecString(strconv.Itoa(ids[i])); err != nil {
+			return nil, errors.Wrap(err, "set share id", z.Int("share_index", i))
+		}
+		rawIDs = append(rawIDs, id)
+	}
+
+	var recovered bls.PublicKey
+	if err := recovered.Recover(rawKeys, rawIDs); err != nil {
+		return nil, errors.Wrap(err, "recover distributed public key")
+	}
+
+	return recovered.Serialize(), nil
 }
 
 func recoverDistributedPubkeyFromShares(pubShares [][]byte, threshold int) ([]byte, error) {

--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -5,8 +5,10 @@ package cluster
 import (
 	"bytes"
 	"encoding/json"
+	"strconv"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/herumi/bls-eth-go-binary/bls"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/eth1wrap"
@@ -171,6 +173,15 @@ func (l Lock) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 	var pubkeys []tbls.PublicKey
 
 	for _, val := range l.Validators {
+		recoveredPubkey, err := recoverDistributedPubkeyFromShares(val.PubShares, l.Threshold)
+		if err != nil {
+			return errors.Wrap(err, "recover distributed public key from shares")
+		}
+
+		if !bytes.Equal(recoveredPubkey, val.PubKey) {
+			return errors.New("public shares do not reconstruct distributed public key")
+		}
+
 		for _, share := range val.PubShares {
 			pubkey, err := tblsconv.PubkeyFromBytes(share)
 			if err != nil {
@@ -233,6 +244,39 @@ func (l Lock) verifyNodeSignatures() error {
 	}
 
 	return nil
+}
+
+func recoverDistributedPubkeyFromShares(pubShares [][]byte, threshold int) ([]byte, error) {
+	if threshold <= 0 {
+		return nil, errors.New("invalid threshold")
+	}
+	if len(pubShares) < threshold {
+		return nil, errors.New("insufficient public shares for threshold")
+	}
+
+	rawKeys := make([]bls.PublicKey, 0, threshold)
+	rawIDs := make([]bls.ID, 0, threshold)
+
+	for i := 0; i < threshold; i++ {
+		var pubkey bls.PublicKey
+		if err := pubkey.Deserialize(pubShares[i]); err != nil {
+			return nil, errors.Wrap(err, "deserialize public share", z.Int("share_index", i))
+		}
+		rawKeys = append(rawKeys, pubkey)
+
+		var id bls.ID
+		if err := id.SetDecString(strconv.Itoa(i + 1)); err != nil {
+			return nil, errors.Wrap(err, "set share id", z.Int("share_index", i))
+		}
+		rawIDs = append(rawIDs, id)
+	}
+
+	var recovered bls.PublicKey
+	if err := recovered.Recover(rawKeys, rawIDs); err != nil {
+		return nil, errors.Wrap(err, "recover distributed public key")
+	}
+
+	return recovered.Serialize(), nil
 }
 
 // verifyBuilderRegistrations returns an error if the populated builder registrations are invalid.

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -45,21 +45,6 @@ func TestVerifyLockRejectsDuplicateDistributedKeys(t *testing.T) {
 	require.Contains(t, err.Error(), "duplicate distributed validator public key")
 }
 
-func TestVerifyLockRejectsIdentityPointShare(t *testing.T) {
-	seed := 0
-	random := rand.New(rand.NewSource(int64(seed)))
-	lock, _, _ := cluster.NewForT(t, 1, 3, 4, seed, random)
-
-	// Replace one share with the BLS G1 identity point (0xc0 followed by zeros).
-	identityPoint := make([]byte, 48)
-	identityPoint[0] = 0xc0
-	lock.Validators[0].PubShares[0] = identityPoint
-
-	err := lock.VerifySignatures(nil)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "identity point share")
-}
-
 func TestVerifyLockRejectsExtraShareNotOnPolynomial(t *testing.T) {
 	seed := 0
 	random := rand.New(rand.NewSource(int64(seed)))

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -45,6 +45,21 @@ func TestVerifyLockRejectsDuplicateDistributedKeys(t *testing.T) {
 	require.Contains(t, err.Error(), "duplicate distributed validator public key")
 }
 
+func TestVerifyLockRejectsIdentityPointShare(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := cluster.NewForT(t, 1, 3, 4, seed, random)
+
+	// Replace one share with the BLS G1 identity point (0xc0 followed by zeros).
+	identityPoint := make([]byte, 48)
+	identityPoint[0] = 0xc0
+	lock.Validators[0].PubShares[0] = identityPoint
+
+	err := lock.VerifySignatures(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "identity point share")
+}
+
 func TestVerifyLockRejectsDuplicatePublicShares(t *testing.T) {
 	seed := 0
 	random := rand.New(rand.NewSource(int64(seed)))

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -32,6 +32,19 @@ func TestVerifyLockRejectsMismatchedPublicShares(t *testing.T) {
 	require.Contains(t, err.Error(), "public shares do not reconstruct distributed public key")
 }
 
+func TestVerifyLockRejectsDuplicateDistributedKeys(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := cluster.NewForT(t, 3, 3, 4, seed, random)
+
+	// Duplicate validator 0 so two entries share the same distributed public key.
+	lock.Validators = append(lock.Validators, lock.Validators[0])
+
+	err := lock.VerifySignatures(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate distributed validator public key")
+}
+
 func TestVerifyLockRejectsDuplicatePublicShares(t *testing.T) {
 	seed := 0
 	random := rand.New(rand.NewSource(int64(seed)))

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -60,6 +60,21 @@ func TestVerifyLockRejectsIdentityPointShare(t *testing.T) {
 	require.Contains(t, err.Error(), "identity point share")
 }
 
+func TestVerifyLockRejectsExtraShareNotOnPolynomial(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := cluster.NewForT(t, 1, 3, 4, seed, random)
+
+	// Keep first threshold (3) shares intact so the main reconstruction passes;
+	// replace the extra share with the DV pubkey — a valid, unique, non-identity
+	// G1 point that does not lie on the share polynomial.
+	lock.Validators[0].PubShares[3] = append([]byte(nil), lock.Validators[0].PubKey...)
+
+	err := lock.VerifySignatures(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "extra share does not lie on distributed key polynomial")
+}
+
 func TestVerifyLockRejectsDuplicatePublicShares(t *testing.T) {
 	seed := 0
 	random := rand.New(rand.NewSource(int64(seed)))

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -18,3 +18,16 @@ func TestVerifyLock(t *testing.T) {
 	require.NoError(t, lock.Definition.VerifySignatures(nil))
 	require.NoError(t, lock.VerifySignatures(nil))
 }
+
+func TestVerifyLockRejectsMismatchedPublicShares(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := cluster.NewForT(t, 3, 3, 4, seed, random)
+
+	// Tamper validator shares so they no longer reconstruct validator 0 group key.
+	lock.Validators[0].PubShares = append([][]byte(nil), lock.Validators[1].PubShares...)
+
+	err := lock.VerifySignatures(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "public shares do not reconstruct distributed public key")
+}

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -31,3 +31,16 @@ func TestVerifyLockRejectsMismatchedPublicShares(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "public shares do not reconstruct distributed public key")
 }
+
+func TestVerifyLockRejectsDuplicatePublicShares(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := cluster.NewForT(t, 3, 3, 4, seed, random)
+
+	// Duplicate one share so the share list is not unique.
+	lock.Validators[0].PubShares[1] = append([]byte(nil), lock.Validators[0].PubShares[0]...)
+
+	err := lock.VerifySignatures(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "duplicate public share")
+}

--- a/tbls/herumi.go
+++ b/tbls/herumi.go
@@ -227,6 +227,44 @@ func (Herumi) RecoverSecret(shares map[int]PrivateKey, _, _ uint) (PrivateKey, e
 	return *(*PrivateKey)(pk.Serialize()), nil
 }
 
+func (Herumi) RecoverPubkey(shares map[int]PublicKey) (PublicKey, error) {
+	var (
+		pk      bls.PublicKey
+		rawKeys []bls.PublicKey
+		rawIDs  []bls.ID
+	)
+
+	for idx, key := range shares {
+		var kpk bls.PublicKey
+		if err := kpk.Deserialize(key[:]); err != nil {
+			return PublicKey{}, errors.Wrap(
+				err,
+				"deserialize public key share",
+				z.Int("key_number", idx),
+			)
+		}
+
+		rawKeys = append(rawKeys, kpk)
+
+		var id bls.ID
+		if err := id.SetDecString(strconv.Itoa(idx)); err != nil {
+			return PublicKey{}, errors.Wrap(
+				err,
+				"set share id",
+				z.Int("key_number", idx),
+			)
+		}
+
+		rawIDs = append(rawIDs, id)
+	}
+
+	if err := pk.Recover(rawKeys, rawIDs); err != nil {
+		return PublicKey{}, errors.Wrap(err, "recover public key from shares")
+	}
+
+	return *(*PublicKey)(pk.Serialize()), nil
+}
+
 func (Herumi) Aggregate(signs []Signature) (Signature, error) {
 	var (
 		sig      bls.Sign

--- a/tbls/tbls.go
+++ b/tbls/tbls.go
@@ -48,6 +48,9 @@ type Implementation interface {
 	// RecoverSecret recovers the original secret off the input shares.
 	RecoverSecret(shares map[int]PrivateKey, total uint, threshold uint) (PrivateKey, error)
 
+	// RecoverPubkey recovers the distributed public key from the given public key shares.
+	RecoverPubkey(shares map[int]PublicKey) (PublicKey, error)
+
 	// ThresholdAggregate aggregates the partial signatures passed in input in the final original signature.
 	ThresholdAggregate(partialSignaturesByIndex map[int]Signature) (Signature, error)
 
@@ -110,6 +113,11 @@ func ThresholdSplitInsecure(t *testing.T, secret PrivateKey, total uint, thresho
 // RecoverSecret recovers the original secret off the input shares.
 func RecoverSecret(shares map[int]PrivateKey, total uint, threshold uint) (PrivateKey, error) {
 	return impl.RecoverSecret(shares, total, threshold)
+}
+
+// RecoverPubkey recovers the distributed public key from the given public key shares.
+func RecoverPubkey(shares map[int]PublicKey) (PublicKey, error) {
+	return impl.RecoverPubkey(shares)
 }
 
 // ThresholdAggregate aggregates the partial signatures passed in input in the final original signature.

--- a/tbls/tbls_test.go
+++ b/tbls/tbls_test.go
@@ -69,6 +69,29 @@ func (ts *TestSuite) Test_RecoverSecret() {
 	ts.Require().ElementsMatch(secret, recovered)
 }
 
+func (ts *TestSuite) Test_RecoverPubkey() {
+	secret, err := tbls.GenerateSecretKey()
+	ts.Require().NoError(err)
+
+	expectedPub, err := tbls.SecretToPublicKey(secret)
+	ts.Require().NoError(err)
+
+	privShares, err := tbls.ThresholdSplit(secret, 5, 3)
+	ts.Require().NoError(err)
+
+	pubShares := make(map[int]tbls.PublicKey, len(privShares))
+	for idx, priv := range privShares {
+		pub, err := tbls.SecretToPublicKey(priv)
+		ts.Require().NoError(err)
+
+		pubShares[idx] = pub
+	}
+
+	recovered, err := tbls.RecoverPubkey(pubShares)
+	ts.Require().NoError(err)
+	ts.Require().Equal(expectedPub, recovered)
+}
+
 func (ts *TestSuite) Test_ThresholdAggregate() {
 	data := []byte("hello obol!")
 
@@ -201,6 +224,7 @@ func runBenchmark(b *testing.B, impl tbls.Implementation) {
 		s.Test_SecretToPublicKey()
 		s.Test_ThresholdSplit()
 		s.Test_RecoverSecret()
+		s.Test_RecoverPubkey()
 		s.Test_ThresholdAggregate()
 		s.Test_Verify()
 		s.Test_Sign()
@@ -298,6 +322,15 @@ func (r randomizedImpl) RecoverSecret(shares map[int]tbls.PrivateKey, total uint
 	}
 
 	return impl.RecoverSecret(shares, total, threshold)
+}
+
+func (r randomizedImpl) RecoverPubkey(shares map[int]tbls.PublicKey) (tbls.PublicKey, error) {
+	impl, err := r.selectImpl()
+	if err != nil {
+		return tbls.PublicKey{}, err
+	}
+
+	return impl.RecoverPubkey(shares)
 }
 
 func (r randomizedImpl) ThresholdAggregate(partialSignaturesByIndex map[int]tbls.Signature) (tbls.Signature, error) {


### PR DESCRIPTION
This PR hardens cluster lock validation to close a reported vulnerability where malformed validator entries could pass per-validator checks.

### What changed

- Enforce **distributed validator key uniqueness** across all validators in the lock.
- Enforce **public share uniqueness** within each validator.
- Validate full **share-binding to the distributed key polynomial**:
  - Reconstruct the DV key from the first `threshold` shares.
  - For every extra share beyond threshold, reconstruct again with a subset that includes that share and confirm it yields the same DV key.
- Refactor reconstruction logic to use a dedicated `tbls.RecoverPubkey` path (Herumi-backed) and improve error context.
- Remove the now-redundant identity-share guard because full share-binding verification supersedes it.
- Add tests around extra-share polynomial consistency and pubkey recovery behavior.

### Why

Previously, duplicated/malformed lock entries could satisfy local checks while still being structurally unsafe.  
These checks ensure each validator’s shares are globally consistent with its distributed key and prevent duplicate-key lock entries from being accepted.

### Compatibility / behavior

- No API changes.
- Validation is stricter by design; previously accepted malformed locks are now rejected.
- Logic remains aligned with the equivalent fix in `obol-sdk` (`fix/lock-share-binding-validation`).

category: bug
ticket: none