### PR TITLE
cmd: redact header flag values in config log

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -223,11 +223,17 @@ func flagsToLogFields(flags *pflag.FlagSet) []z.Field {
 	return fields
 }
 
-// redact returns a redacted version of the given flag value. It currently supports redacting
-// passwords in valid URLs provided in ".*address.*" flags and redacting auth tokens.
+// redact returns a redacted version of the given flag value. It supports:
+//   - Full redaction of auth token flags (e.g., keymanager-auth-token)
+//   - Value redaction of header flags (e.g., beacon-node-headers, otlp-headers) keeping keys visible
+//   - Password redaction in URLs for address flags (e.g., loki-addresses)
 func redact(flag, val string) string {
 	if strings.Contains(flag, "auth-token") {
 		return "xxxxx"
+	}
+
+	if strings.Contains(flag, "header") {
+		return redactHeaderValue(val)
 	}
 
 	if !strings.Contains(flag, "address") {
@@ -240,4 +246,15 @@ func redact(flag, val string) string {
 	}
 
 	return u.Redacted()
+}
+
+// redactHeaderValue redacts the value portion of a "key=value" header string,
+// preserving the key for debuggability. E.g., "Authorization=Basic abc123" becomes "Authorization=xxxxx".
+func redactHeaderValue(val string) string {
+	key, _, ok := strings.Cut(val, "=")
+	if !ok {
+		return val
+	}
+
+	return key + "=xxxxx"
 }

--- a/cmd/cmd_internal_test.go
+++ b/cmd/cmd_internal_test.go
@@ -224,6 +224,27 @@ func TestFlagsToLogFields(t *testing.T) {
 	}
 }
 
+func TestFlagsToLogFieldsRedactsHeaders(t *testing.T) {
+	set := pflag.NewFlagSet("test", pflag.PanicOnError)
+
+	var headers []string
+	set.StringSliceVar(&headers, "beacon-node-headers", nil, "")
+
+	err := set.Parse([]string{
+		"--beacon-node-headers=Authorization=Basic b2JvbDpzZWNyZXQ=,X-Api-Key=supersecret",
+	})
+	require.NoError(t, err)
+
+	for _, field := range flagsToLogFields(set) {
+		field(func(f zap.Field) {
+			require.NotContains(t, f.String, "b2JvbDpzZWNyZXQ=")
+			require.NotContains(t, f.String, "supersecret")
+			require.Contains(t, f.String, "Authorization=xxxxx")
+			require.Contains(t, f.String, "X-Api-Key=xxxxx")
+		})
+	}
+}
+
 func TestRedact(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -242,6 +263,24 @@ func TestRedact(t *testing.T) {
 			flag:     "api-address",
 			value:    "https://user:password@example.com/foo/bar",
 			expected: "https://user:xxxxx@example.com/foo/bar",
+		},
+		{
+			name:     "redact beacon node header values",
+			flag:     "beacon-node-headers",
+			value:    "Authorization=Basic b2JvbDpzZWNyZXQ=",
+			expected: "Authorization=xxxxx",
+		},
+		{
+			name:     "redact otlp header values",
+			flag:     "otlp-headers",
+			value:    "X-Api-Key=supersecret123",
+			expected: "X-Api-Key=xxxxx",
+		},
+		{
+			name:     "redact header without value keeps original",
+			flag:     "beacon-node-headers",
+			value:    "X-No-Value",
+			expected: "X-No-Value",
 		},
 		{
 			name:     "no redact",


### PR DESCRIPTION
## Description

The `redact()` function in `cmd/cmd.go` controls which CLI flag values are masked in the "Parsed config" INFO log line emitted at startup. It currently redacts `*auth-token*` flags and passwords embedded in `*address*` flag URLs, but does **not** redact `*header*` flags (`beacon-node-headers`, `otlp-headers`).

This means authentication credentials passed as HTTP headers (e.g., `Authorization=Basic <base64>`) are logged in cleartext. A recent incident confirmed this: a Charon log file containing a Basic Auth credential for a beacon node was accidentally committed to a public repository, and GitHub secret scanning flagged it.

This PR adds a header-aware redaction path that:
- Matches any flag whose name contains `header`
- Preserves the header **key** for debuggability (operators can still see *which* headers are configured)
- Masks the header **value** (e.g., `Authorization=Basic abc123` → `Authorization=xxxxx`)

Before: `"beacon-node-headers": "[Authorization=Basic b2JvbDpzZWNyZXQ=]"`
After:  `"beacon-node-headers": "[Authorization=xxxxx]"`

category: bug
ticket: none

## Test plan

- [ ] Unit tests for `redact()` covering `beacon-node-headers`, `otlp-headers`, and edge cases (no `=` separator)
- [ ] Integration test (`TestFlagsToLogFieldsRedactsHeaders`) verifying slice flag values are redacted through the `flagsToLogFields` → log pipeline