### PR TITLE
core: dedup fetch contrib

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -11,6 +11,7 @@ import (
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/altair"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"go.opentelemetry.io/otel/trace"
 
@@ -382,7 +383,14 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 	pt := newPubkeysTracker("sync committee contribution")
 	defer pt.log(ctx)
 
+	type contributionKey struct {
+		slot       uint64
+		subcommIdx uint64
+		blockRoot  eth2p0.Root
+	}
+
 	resp := make(core.UnsignedDataSet)
+	contributions := make(map[contributionKey]*altair.SyncCommitteeContribution)
 
 	for pubkey := range defSet {
 		// Query AggSigDB for DutyPrepareSyncContribution to get sync committee selection.
@@ -420,23 +428,34 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 
 		blockRoot := msg.BeaconBlockRoot
 
-		// Query BN for sync committee contribution.
-		opts := &eth2api.SyncCommitteeContributionOpts{
-			Slot:              eth2p0.Slot(slot),
-			SubcommitteeIndex: subcommIdx,
-			BeaconBlockRoot:   blockRoot,
+		key := contributionKey{
+			slot:       slot,
+			subcommIdx: subcommIdx,
+			blockRoot:  blockRoot,
 		}
 
-		eth2Resp, err := f.eth2Cl.SyncCommitteeContribution(ctx, opts)
-		if err != nil {
-			return core.UnsignedDataSet{}, err
-		}
+		contribution, ok := contributions[key]
+		if !ok {
+			// Query BN for sync committee contribution.
+			opts := &eth2api.SyncCommitteeContributionOpts{
+				Slot:              eth2p0.Slot(slot),
+				SubcommitteeIndex: subcommIdx,
+				BeaconBlockRoot:   blockRoot,
+			}
 
-		contribution := eth2Resp.Data
-		if contribution == nil {
-			// Some beacon nodes return nil if the beacon block root is not found for the subcommittee, return retryable error.
-			// This could happen if the beacon node didn't subscribe to the correct subnet.
-			return core.UnsignedDataSet{}, errors.New("sync committee contribution not found by root (retryable)", z.U64("subcommidx", subcommIdx), z.Hex("root", blockRoot[:]))
+			eth2Resp, err := f.eth2Cl.SyncCommitteeContribution(ctx, opts)
+			if err != nil {
+				return core.UnsignedDataSet{}, err
+			}
+
+			contribution = eth2Resp.Data
+			if contribution == nil {
+				// Some beacon nodes return nil if the beacon block root is not found for the subcommittee, return retryable error.
+				// This could happen if the beacon node didn't subscribe to the correct subnet.
+				return core.UnsignedDataSet{}, errors.New("sync committee contribution not found by root (retryable)", z.U64("subcommidx", subcommIdx), z.Hex("root", blockRoot[:]))
+			}
+
+			contributions[key] = contribution
 		}
 
 		pt.addResolved(pubkey.String())

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -356,6 +356,7 @@ func TestFetchSyncContribution(t *testing.T) {
 		slot        = 1
 		vIdxA       = 2
 		vIdxB       = 3
+		vIdxC       = 4
 		subCommIdxA = 4
 		subCommIdxB = 5
 	)
@@ -369,12 +370,14 @@ func TestFetchSyncContribution(t *testing.T) {
 	pubkeysByIdx := map[eth2p0.ValidatorIndex]core.PubKey{
 		vIdxA: testutil.RandomCorePubKey(t),
 		vIdxB: testutil.RandomCorePubKey(t),
+		vIdxC: testutil.RandomCorePubKey(t),
 	}
 
 	// Construct duty definition set.
 	defSet := map[core.PubKey]core.DutyDefinition{
 		pubkeysByIdx[vIdxA]: core.NewSyncCommitteeDefinition(testutil.RandomSyncCommitteeDuty(t)),
 		pubkeysByIdx[vIdxB]: core.NewSyncCommitteeDefinition(testutil.RandomSyncCommitteeDuty(t)),
+		pubkeysByIdx[vIdxC]: core.NewSyncCommitteeDefinition(testutil.RandomSyncCommitteeDuty(t)),
 	}
 
 	var (
@@ -396,9 +399,16 @@ func TestFetchSyncContribution(t *testing.T) {
 		SubcommitteeIndex: subCommIdxB,
 		SelectionProof:    blsSigFromHex(t, sigB),
 	}
+	selectionC := &eth2v1.SyncCommitteeSelection{
+		ValidatorIndex:    vIdxC,
+		Slot:              slot,
+		SubcommitteeIndex: subCommIdxA,
+		SelectionProof:    blsSigFromHex(t, sigA),
+	}
 	commSelectionsByPubkey := map[core.PubKey]core.SignedData{
 		pubkeysByIdx[vIdxA]: core.NewSyncCommitteeSelection(selectionA),
 		pubkeysByIdx[vIdxB]: core.NewSyncCommitteeSelection(selectionB),
+		pubkeysByIdx[vIdxC]: core.NewSyncCommitteeSelection(selectionC),
 	}
 
 	// Construct sync committee messages.
@@ -409,14 +419,18 @@ func TestFetchSyncContribution(t *testing.T) {
 	syncMsgsByPubkey := map[core.PubKey]core.SignedData{
 		pubkeysByIdx[vIdxA]: core.NewSignedSyncMessage(msgA),
 		pubkeysByIdx[vIdxB]: core.NewSignedSyncMessage(msgB),
+		pubkeysByIdx[vIdxC]: core.NewSignedSyncMessage(msgA),
 	}
 
 	t.Run("contribution aggregator", func(t *testing.T) {
 		bmock, err := beaconmock.New(t.Context())
 		require.NoError(t, err)
 
+		contributionRequests := make(map[string]int)
 		bmock.SyncCommitteeContributionFunc = func(ctx context.Context, resSlot eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
 			require.Equal(t, eth2p0.Slot(slot), resSlot)
+
+			contributionRequests[fmt.Sprintf("%d/%#x", subcommitteeIndex, beaconBlockRoot)]++
 
 			var (
 				signedMsg       core.SignedSyncMessage
@@ -471,7 +485,7 @@ func TestFetchSyncContribution(t *testing.T) {
 
 		fetch.Subscribe(func(ctx context.Context, resDuty core.Duty, resDataSet core.UnsignedDataSet) error {
 			require.Equal(t, duty, resDuty)
-			require.Len(t, resDataSet, 2)
+			require.Len(t, resDataSet, 3)
 
 			for pubkey, data := range resDataSet {
 				contribution, ok := data.(core.SyncContribution)
@@ -494,6 +508,8 @@ func TestFetchSyncContribution(t *testing.T) {
 					require.Equal(t, uint64(subCommIdxA), selection.SubcommitteeIndex)
 				} else if selection.ValidatorIndex == eth2p0.ValidatorIndex(vIdxB) {
 					require.Equal(t, uint64(subCommIdxB), selection.SubcommitteeIndex)
+				} else if selection.ValidatorIndex == eth2p0.ValidatorIndex(vIdxC) {
+					require.Equal(t, uint64(subCommIdxA), selection.SubcommitteeIndex)
 				}
 
 				message, ok := syncMsgsByPubkey[pubkey].(core.SignedSyncMessage)
@@ -506,6 +522,9 @@ func TestFetchSyncContribution(t *testing.T) {
 
 		err = fetch.Fetch(ctx, duty, defSet)
 		require.NoError(t, err)
+		require.Len(t, contributionRequests, 2)
+		require.Equal(t, 1, contributionRequests[fmt.Sprintf("%d/%#x", subCommIdxA, beaconBlockRootA)])
+		require.Equal(t, 1, contributionRequests[fmt.Sprintf("%d/%#x", subCommIdxB, beaconBlockRootB)])
 	})
 
 	t.Run("not contribution aggregator", func(t *testing.T) {

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -37,6 +38,9 @@ import (
 
 const (
 	defaultGasLimit = 30000000
+
+	syncContributionCacheTTL     = 30 * time.Second
+	syncContributionAwaitTimeout = 2 * defaultRequestTimeout
 )
 
 // SlotFromTimestamp returns the Ethereum slot associated to a timestamp, given the genesis configuration fetched
@@ -80,6 +84,7 @@ func NewComponentInsecure(_ *testing.T, eth2Cl eth2wrap.Client, shareIdx int) (*
 		shareIdx:       shareIdx,
 		builderEnabled: false,
 		insecureTest:   true,
+		syncContrib:    newSyncContributionState(),
 	}, nil
 }
 
@@ -165,6 +170,7 @@ func NewComponent(eth2Cl eth2wrap.Client, allPubSharesByKey map[core.PubKey]map[
 		builderEnabled:     builderEnabled,
 		targetGasLimit:     targetGasLimit,
 		swallowRegFilter:   log.Filter(),
+		syncContrib:        newSyncContributionState(),
 	}, nil
 }
 
@@ -196,6 +202,38 @@ type Component struct {
 	awaitAggSigDBFunc         func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
 	dutyDefFunc               func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
 	subs                      []func(context.Context, core.Duty, core.ParSignedDataSet) error
+
+	syncContrib *syncContributionState
+}
+
+type syncContributionState struct {
+	mu       sync.Mutex
+	inflight map[syncContributionKey]*syncContributionCall
+	cache    map[syncContributionKey]syncContributionCacheEntry
+}
+
+func newSyncContributionState() *syncContributionState {
+	return &syncContributionState{
+		inflight: make(map[syncContributionKey]*syncContributionCall),
+		cache:    make(map[syncContributionKey]syncContributionCacheEntry),
+	}
+}
+
+type syncContributionKey struct {
+	slot       uint64
+	subcommIdx uint64
+	root       eth2p0.Root
+}
+
+type syncContributionCall struct {
+	done    chan struct{}
+	contrib *altair.SyncCommitteeContribution
+	err     error
+}
+
+type syncContributionCacheEntry struct {
+	contrib *altair.SyncCommitteeContribution
+	expires time.Time
 }
 
 // RegisterAwaitProposal registers a function to query unsigned beacon block proposals by providing necessary options.
@@ -905,13 +943,92 @@ func (c Component) SubmitAggregateAttestations(ctx context.Context, opts *eth2ap
 }
 
 // SyncCommitteeContribution returns sync committee contribution data for the given subcommittee and beacon block root.
-func (c Component) SyncCommitteeContribution(ctx context.Context, opts *eth2api.SyncCommitteeContributionOpts) (*eth2api.Response[*altair.SyncCommitteeContribution], error) {
-	contrib, err := c.awaitSyncContributionFunc(ctx, uint64(opts.Slot), opts.SubcommitteeIndex, opts.BeaconBlockRoot)
-	if err != nil {
-		return nil, err
+func (c *Component) SyncCommitteeContribution(ctx context.Context, opts *eth2api.SyncCommitteeContributionOpts) (*eth2api.Response[*altair.SyncCommitteeContribution], error) {
+	key := syncContributionKey{
+		slot:       uint64(opts.Slot),
+		subcommIdx: opts.SubcommitteeIndex,
+		root:       opts.BeaconBlockRoot,
 	}
 
-	return wrapResponse(contrib), nil
+	call := c.getOrStartSyncContributionCall(ctx, key)
+
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-call.done:
+		if call.err != nil {
+			return nil, call.err
+		}
+
+		return wrapResponse(call.contrib), nil
+	}
+}
+
+func (c *Component) getOrStartSyncContributionCall(ctx context.Context, key syncContributionKey) *syncContributionCall {
+	state := c.syncContrib
+	state.mu.Lock()
+
+	now := time.Now()
+	for k, entry := range state.cache {
+		if !now.Before(entry.expires) {
+			delete(state.cache, k)
+		}
+	}
+
+	if entry, ok := state.cache[key]; ok {
+		state.mu.Unlock()
+
+		return &syncContributionCall{
+			done:    closedSyncContribChan,
+			contrib: entry.contrib,
+		}
+	}
+
+	if call, ok := state.inflight[key]; ok {
+		state.mu.Unlock()
+		return call
+	}
+
+	call := &syncContributionCall{
+		done: make(chan struct{}),
+	}
+	state.inflight[key] = call
+	state.mu.Unlock()
+
+	go c.awaitSyncContribution(context.WithoutCancel(ctx), call, key)
+
+	return call
+}
+
+var closedSyncContribChan = func() chan struct{} {
+	done := make(chan struct{})
+	close(done)
+
+	return done
+}()
+
+func (c *Component) awaitSyncContribution(parent context.Context, call *syncContributionCall, key syncContributionKey) {
+	ctx, cancel := context.WithTimeout(parent, syncContributionAwaitTimeout)
+	defer cancel()
+
+	contrib, err := c.awaitSyncContributionFunc(ctx, key.slot, key.subcommIdx, key.root)
+
+	state := c.syncContrib
+	state.mu.Lock()
+	defer state.mu.Unlock()
+
+	call.contrib = contrib
+
+	call.err = err
+	if err == nil {
+		state.cache[key] = syncContributionCacheEntry{
+			contrib: contrib,
+			expires: time.Now().Add(syncContributionCacheTTL),
+		}
+	}
+
+	delete(state.inflight, key)
+	close(call.done)
 }
 
 // SubmitSyncCommitteeMessages receives the partially signed altair.SyncCommitteeMessage.

--- a/core/validatorapi/validatorapi_test.go
+++ b/core/validatorapi/validatorapi_test.go
@@ -2068,6 +2068,179 @@ func TestComponent_SubmitSyncCommitteeContributions(t *testing.T) {
 	require.Equal(t, count, 1)
 }
 
+func TestComponent_SyncCommitteeContributionSingleflightAndCache(t *testing.T) {
+	ctx := context.Background()
+
+	vapi, err := validatorapi.NewComponentInsecure(t, nil, 0)
+	require.NoError(t, err)
+
+	contrib := testutil.RandomSyncCommitteeContribution()
+	opts := &eth2api.SyncCommitteeContributionOpts{
+		Slot:              contrib.Slot,
+		SubcommitteeIndex: contrib.SubcommitteeIndex,
+		BeaconBlockRoot:   contrib.BeaconBlockRoot,
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+
+	var (
+		mu         sync.Mutex
+		awaitCalls int
+	)
+
+	vapi.RegisterAwaitSyncContribution(func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
+		mu.Lock()
+
+		awaitCalls++
+		if awaitCalls == 1 {
+			close(started)
+		}
+		mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-release:
+			return contrib, nil
+		}
+	})
+
+	const requests = 16
+
+	results := make(chan *eth2api.Response[*altair.SyncCommitteeContribution], requests)
+
+	errs := make(chan error, requests)
+	for range requests {
+		go func() {
+			resp, err := vapi.SyncCommitteeContribution(ctx, opts)
+			if err != nil {
+				errs <- err
+				return
+			}
+
+			results <- resp
+		}()
+	}
+
+	<-started
+	close(release)
+
+	for range requests {
+		select {
+		case err := <-errs:
+			require.NoError(t, err)
+		case resp := <-results:
+			require.Equal(t, contrib, resp.Data)
+		case <-time.After(time.Second):
+			require.Fail(t, "timeout waiting for sync contribution response")
+		}
+	}
+
+	mu.Lock()
+	require.Equal(t, 1, awaitCalls)
+	mu.Unlock()
+
+	resp, err := vapi.SyncCommitteeContribution(ctx, opts)
+	require.NoError(t, err)
+	require.Equal(t, contrib, resp.Data)
+
+	mu.Lock()
+	require.Equal(t, 1, awaitCalls, "cached result should avoid a second await")
+	mu.Unlock()
+}
+
+func TestComponent_SyncCommitteeContributionClientCancelDoesNotCancelInflightAwait(t *testing.T) {
+	ctx := context.Background()
+
+	vapi, err := validatorapi.NewComponentInsecure(t, nil, 0)
+	require.NoError(t, err)
+
+	contrib := testutil.RandomSyncCommitteeContribution()
+	opts := &eth2api.SyncCommitteeContributionOpts{
+		Slot:              contrib.Slot,
+		SubcommitteeIndex: contrib.SubcommitteeIndex,
+		BeaconBlockRoot:   contrib.BeaconBlockRoot,
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	errs := make(chan error, 1)
+
+	var (
+		mu         sync.Mutex
+		awaitCalls int
+	)
+
+	vapi.RegisterAwaitSyncContribution(func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
+		mu.Lock()
+
+		awaitCalls++
+		if awaitCalls == 1 {
+			close(started)
+		}
+		mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			select {
+			case errs <- ctx.Err():
+			default:
+			}
+
+			return nil, ctx.Err()
+		case <-release:
+			return contrib, nil
+		}
+	})
+
+	cancelCtx, cancel := context.WithCancel(ctx)
+	firstDone := make(chan error, 1)
+
+	go func() {
+		_, err := vapi.SyncCommitteeContribution(cancelCtx, opts)
+		firstDone <- err
+	}()
+
+	<-started
+	cancel()
+	require.ErrorIs(t, <-firstDone, context.Canceled)
+
+	select {
+	case err := <-errs:
+		require.NoError(t, err, "underlying await should not inherit the client cancellation")
+	default:
+	}
+
+	secondDone := make(chan *eth2api.Response[*altair.SyncCommitteeContribution], 1)
+	secondErr := make(chan error, 1)
+
+	go func() {
+		resp, err := vapi.SyncCommitteeContribution(ctx, opts)
+		if err != nil {
+			secondErr <- err
+			return
+		}
+
+		secondDone <- resp
+	}()
+
+	close(release)
+
+	select {
+	case err := <-secondErr:
+		require.NoError(t, err)
+	case resp := <-secondDone:
+		require.Equal(t, contrib, resp.Data)
+	case <-time.After(time.Second):
+		require.Fail(t, "timeout waiting for second sync contribution response")
+	}
+
+	mu.Lock()
+	require.Equal(t, 1, awaitCalls)
+	mu.Unlock()
+}
+
 func TestComponent_SubmitSyncCommitteeContributionsVerify(t *testing.T) {
 	const shareIdx = 1
 


### PR DESCRIPTION
Added BN-response deduplication to `fetchContributionData` in `core/fetcher/fetcher.go`. The change caches `SyncCommitteeContribution` responses by `(slot, subcommitteeIndex, beaconBlockRoot)` so that multiple cluster validators that fall in the same subcommittee share one BN call instead of N.

Confirmed with teku-teku combo run in AWS. Next is to confirm the fix with all the combos.

category: refactor
ticket: none
