### PR TITLE
core/*: use comm idx as key in DutyDB for agg duty

### DIFF
--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -207,7 +207,7 @@ func (db *MemDB) AwaitAttestation(ctx context.Context, slot uint64, commIdx uint
 
 // AwaitAggAttestation blocks and returns the aggregated attestation for the slot
 // and attestation when available.
-func (db *MemDB) AwaitAggAttestation(ctx context.Context, slot uint64, attestationRoot eth2p0.Root,
+func (db *MemDB) AwaitAggAttestation(ctx context.Context, slot uint64, attestationRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex,
 ) (*eth2spec.VersionedAttestation, error) {
 	cancel := make(chan struct{})
 	defer close(cancel)
@@ -217,8 +217,9 @@ func (db *MemDB) AwaitAggAttestation(ctx context.Context, slot uint64, attestati
 	db.mu.Lock()
 	db.aggQueries = append(db.aggQueries, aggQuery{
 		Key: aggKey{
-			Slot: slot,
-			Root: attestationRoot,
+			Slot:           slot,
+			Root:           attestationRoot,
+			CommitteeIndex: committeeIndex,
 		},
 		Response: response,
 		Cancel:   cancel,
@@ -428,10 +429,18 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error
 
 	slot := uint64(aggAttData.Slot)
 
+	// In Electra+, AttestationData.Index is always 0 so all committees share the same root.
+	// Use CommitteeIndex() which reads CommitteeBits for Electra/Fulu to distinguish them.
+	commIdx, err := aggAtt.CommitteeIndex()
+	if err != nil {
+		return errors.Wrap(err, "get aggregate attestation committee index")
+	}
+
 	// Store key and value for PubKeyByAttestation
 	key := aggKey{
-		Slot: slot,
-		Root: aggRoot,
+		Slot:           slot,
+		Root:           aggRoot,
+		CommitteeIndex: commIdx,
 	}
 	if existing, ok := db.aggDuties[key]; ok {
 		existingData, err := existing.Data()
@@ -683,8 +692,9 @@ type pkKey struct {
 
 // aggKey is the key to lookup an aggregated attestation by root in the DB.
 type aggKey struct {
-	Slot uint64
-	Root eth2p0.Root
+	Slot           uint64
+	Root           eth2p0.Root
+	CommitteeIndex eth2p0.CommitteeIndex
 }
 
 // contribKey is the key to look up sync contribution by root and subcommittee index in the DB.

--- a/core/dutydb/memory.go
+++ b/core/dutydb/memory.go
@@ -429,8 +429,8 @@ func (db *MemDB) storeAggAttestationUnsafe(unsignedData core.UnsignedData) error
 
 	slot := uint64(aggAttData.Slot)
 
-	// In Electra+, AttestationData.Index is always 0 so all committees share the same root.
-	// Use CommitteeIndex() which reads CommitteeBits for Electra/Fulu to distinguish them.
+	// In post-Electra, AttestationData.Index is always 0, so committees in the same slot share the
+	// same AttestationDataRoot. CommitteeIndex() reads CommitteeBits to distinguish them.
 	commIdx, err := aggAtt.CommitteeIndex()
 	if err != nil {
 		return errors.Wrap(err, "get aggregate attestation committee index")

--- a/core/dutydb/memory_internal_test.go
+++ b/core/dutydb/memory_internal_test.go
@@ -24,7 +24,7 @@ func TestCancelledQueries(t *testing.T) {
 	_, err := db.AwaitAttestation(ctx, slot, 0)
 	require.ErrorContains(t, err, "shutdown")
 
-	_, err = db.AwaitAggAttestation(ctx, slot, eth2p0.Root{})
+	_, err = db.AwaitAggAttestation(ctx, slot, eth2p0.Root{}, 0)
 	require.ErrorContains(t, err, "shutdown")
 
 	_, err = db.AwaitProposal(ctx, slot)

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -8,9 +8,11 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/OffchainLabs/go-bitfield"
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
+	"github.com/attestantio/go-eth2-client/spec/electra"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
 
@@ -252,6 +254,60 @@ func TestMemDBAggregator(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, agg.Deneb, resp.Deneb)
 	}
+}
+
+func TestMemDBAggregatorElectraMultiCommittee(t *testing.T) {
+	// In post-Electra, AttestationData.Index is always 0, so aggregates for different committees
+	// in the same slot share the same AttestationDataRoot. Verify each is stored and retrieved
+	// independently using CommitteeIndex as part of the key.
+	ctx := context.Background()
+	db := dutydb.NewMemDB(new(testDeadliner))
+
+	attData := testutil.RandomAttestationDataElectra()
+
+	makeAgg := func(commIdx int) core.VersionedAggregatedAttestation {
+		bits := bitfield.NewBitvector64()
+		bits.SetBitAt(uint64(commIdx), true)
+
+		return core.VersionedAggregatedAttestation{
+			VersionedAttestation: eth2spec.VersionedAttestation{
+				Version: eth2spec.DataVersionElectra,
+				Electra: &electra.Attestation{
+					AggregationBits: testutil.RandomBitList(64),
+					Data:            attData,
+					Signature:       testutil.RandomEth2Signature(),
+					CommitteeBits:   bits,
+				},
+			},
+		}
+	}
+
+	const (
+		commIdx1 = 5
+		commIdx2 = 17
+	)
+
+	agg1 := makeAgg(commIdx1)
+	agg2 := makeAgg(commIdx2)
+
+	slot := uint64(attData.Slot)
+	set := core.UnsignedDataSet{
+		testutil.RandomCorePubKey(t): agg1,
+		testutil.RandomCorePubKey(t): agg2,
+	}
+
+	require.NoError(t, db.Store(ctx, core.NewAggregatorDuty(slot), set))
+
+	root, err := attData.HashTreeRoot()
+	require.NoError(t, err)
+
+	resp1, err := db.AwaitAggAttestation(ctx, slot, root, eth2p0.CommitteeIndex(commIdx1))
+	require.NoError(t, err)
+	require.Equal(t, agg1.Electra, resp1.Electra)
+
+	resp2, err := db.AwaitAggAttestation(ctx, slot, root, eth2p0.CommitteeIndex(commIdx2))
+	require.NoError(t, err)
+	require.Equal(t, agg2.Electra, resp2.Electra)
 }
 
 func TestMemDBSyncContribution(t *testing.T) {

--- a/core/dutydb/memory_test.go
+++ b/core/dutydb/memory_test.go
@@ -248,7 +248,7 @@ func TestMemDBAggregator(t *testing.T) {
 		require.NoError(t, err)
 		err = <-errCh
 		require.NoError(t, err)
-		resp, err := db.AwaitAggAttestation(ctx, slot, root)
+		resp, err := db.AwaitAggAttestation(ctx, slot, root, agg.Deneb.Data.Index)
 		require.NoError(t, err)
 		require.Equal(t, agg.Deneb, resp.Deneb)
 	}

--- a/core/interfaces.go
+++ b/core/interfaces.go
@@ -68,7 +68,7 @@ type DutyDB interface {
 
 	// AwaitAggAttestation blocks and returns the aggregated attestation for the slot
 	// and attestation when available.
-	AwaitAggAttestation(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)
+	AwaitAggAttestation(ctx context.Context, slot uint64, attestationRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex) (*eth2spec.VersionedAttestation, error)
 
 	// AwaitSyncContribution blocks and returns the sync committee contribution data for the slot and
 	// the subcommittee and the beacon block root when available.
@@ -139,7 +139,7 @@ type ValidatorAPI interface {
 	RegisterGetDutyDefinition(func(context.Context, Duty) (DutyDefinitionSet, error))
 
 	// RegisterAwaitAggAttestation registers a function to query aggregated attestation.
-	RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationDataRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error))
+	RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationDataRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex) (*eth2spec.VersionedAttestation, error))
 
 	// RegisterAwaitAggSigDB registers a function to query aggregated signed data from aggSigDB.
 	RegisterAwaitAggSigDB(func(context.Context, Duty, PubKey) (SignedData, error))
@@ -261,14 +261,14 @@ type wireFuncs struct {
 	DutyDBAwaitProposal               func(ctx context.Context, slot uint64) (*eth2api.VersionedProposal, error)
 	DutyDBAwaitAttestation            func(ctx context.Context, slot, commIdx uint64) (*eth2p0.AttestationData, error)
 	DutyDBPubKeyByAttestation         func(ctx context.Context, slot, commIdx, valIdx uint64) (PubKey, error)
-	DutyDBAwaitAggAttestation         func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)
+	DutyDBAwaitAggAttestation         func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex) (*eth2spec.VersionedAttestation, error)
 	DutyDBAwaitSyncContribution       func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
 	VAPIRegisterAwaitAttestation      func(func(ctx context.Context, slot, commIdx uint64) (*eth2p0.AttestationData, error))
 	VAPIRegisterAwaitSyncContribution func(func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error))
 	VAPIRegisterAwaitProposal         func(func(ctx context.Context, slot uint64) (*eth2api.VersionedProposal, error))
 	VAPIRegisterGetDutyDefinition     func(func(context.Context, Duty) (DutyDefinitionSet, error))
 	VAPIRegisterPubKeyByAttestation   func(func(ctx context.Context, slot, commIdx, valIdx uint64) (PubKey, error))
-	VAPIRegisterAwaitAggAttestation   func(func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error))
+	VAPIRegisterAwaitAggAttestation   func(func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex) (*eth2spec.VersionedAttestation, error))
 	VAPIRegisterAwaitAggSigDB         func(func(context.Context, Duty, PubKey) (SignedData, error))
 	VAPISubscribe                     func(func(context.Context, Duty, ParSignedDataSet) error)
 	ParSigDBStoreInternal             func(context.Context, Duty, ParSignedDataSet) error

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -885,42 +885,43 @@ func reportParSigs(ctx context.Context, duty core.Duty, parsigMsgs parsigsByMsg)
 			continue // Nothing to report for this pubkey.
 		}
 
-		// Build a list of {share_indexes, sample_data} per distinct root for logging.
+		// Build one entry per distinct root showing which shares submitted it and a sample parsig.
 		type rootEntry struct {
-			ShareIdxs  []int
-			SampleData json.RawMessage
+			MsgRoot    string          `json:"msg_root"`
+			ShareIdxs  []int           `json:"share_idxs"`
+			SignedData json.RawMessage `json:"signed_data"`
 		}
 
 		entries := make([]rootEntry, 0, len(parsigsByRoot))
-		for _, parsigs := range parsigsByRoot {
+		for root, parsigs := range parsigsByRoot {
 			var idxs []int
 			for _, parsig := range parsigs {
 				idxs = append(idxs, parsig.ShareIdx)
 			}
 
-			sample, err := json.Marshal(parsigs[0].SignedData)
-			if err != nil {
-				sample = json.RawMessage(fmt.Sprintf("%q", err.Error()))
-			}
+			sample, _ := json.Marshal(parsigs[0].SignedData)
 
 			entries = append(entries, rootEntry{
+				MsgRoot:    fmt.Sprintf("%x", root[:]),
 				ShareIdxs:  idxs,
-				SampleData: sample,
+				SignedData: sample,
 			})
 		}
+
+		entriesJSON, _ := json.Marshal(entries)
 
 		if expectInconsistentParSigs(duty.Type) {
 			log.Debug(ctx, "Inconsistent sync committee partial signed data",
 				z.Any("pubkey", pubkey),
 				z.Any("duty", duty),
 				z.Int("distinct_roots", len(parsigsByRoot)),
-				z.Any("data_by_root", entries))
+				z.Str("data_by_root", string(entriesJSON)))
 		} else {
 			log.Warn(ctx, "Inconsistent partial signed data", nil,
 				z.Any("pubkey", pubkey),
 				z.Any("duty", duty),
 				z.Int("distinct_roots", len(parsigsByRoot)),
-				z.Any("data_by_root", entries))
+				z.Str("data_by_root", string(entriesJSON)))
 		}
 	}
 }

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -880,40 +880,49 @@ func reportParSigs(ctx context.Context, duty core.Duty, parsigMsgs parsigsByMsg)
 
 	inconsistentCounter.WithLabelValues(duty.Type.String()).Inc()
 
-	for pubkey, parsigsByMsg := range parsigMsgs {
-		if len(parsigMsgs) <= 1 {
+	for pubkey, parsigsByRoot := range parsigMsgs {
+		if len(parsigsByRoot) <= 1 {
 			continue // Nothing to report for this pubkey.
 		}
 
-		// Group indexes by json for logging.
-		indexesByJSON := make(map[string][]int)
+		// Build a list of {share_indexes, sample_data} per distinct root for logging.
+		type rootEntry struct {
+			ShareIdxs  []int
+			SampleData json.RawMessage
+		}
 
-		for _, parsigs := range parsigsByMsg {
-			var key string
+		entries := make([]rootEntry, 0, len(parsigsByRoot))
+		for _, parsigs := range parsigsByRoot {
+			var idxs []int
 			for _, parsig := range parsigs {
-				if key == "" {
-					bytes, err := json.Marshal(parsig)
-					if err != nil {
-						continue // Ignore error, just skip it.
-					}
-
-					key = string(bytes)
-				}
-
-				indexesByJSON[key] = append(indexesByJSON[key], parsig.ShareIdx)
+				idxs = append(idxs, parsig.ShareIdx)
 			}
+
+			// Marshal one sample so the log shows what's actually different
+			// (e.g. a differing SelectionProof or AggregationBits).
+			sample, err := json.Marshal(parsigs[0].SignedData)
+			if err != nil {
+				sample = json.RawMessage(fmt.Sprintf("%q", err.Error()))
+			}
+
+			entries = append(entries, rootEntry{
+				ShareIdxs:  idxs,
+				SampleData: sample,
+			})
 		}
 
 		if expectInconsistentParSigs(duty.Type) {
 			log.Debug(ctx, "Inconsistent sync committee partial signed data",
 				z.Any("pubkey", pubkey),
 				z.Any("duty", duty),
-				z.Any("data", indexesByJSON))
+				z.Int("distinct_roots", len(parsigsByRoot)),
+				z.Any("data_by_root", entries))
 		} else {
 			log.Warn(ctx, "Inconsistent partial signed data", nil,
 				z.Any("pubkey", pubkey),
 				z.Any("duty", duty),
-				z.Any("data", indexesByJSON))
+				z.Int("distinct_roots", len(parsigsByRoot)),
+				z.Any("data_by_root", entries))
 		}
 	}
 }

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -898,8 +898,6 @@ func reportParSigs(ctx context.Context, duty core.Duty, parsigMsgs parsigsByMsg)
 				idxs = append(idxs, parsig.ShareIdx)
 			}
 
-			// Marshal one sample so the log shows what's actually different
-			// (e.g. a differing SelectionProof or AggregationBits).
 			sample, err := json.Marshal(parsigs[0].SignedData)
 			if err != nil {
 				sample = json.RawMessage(fmt.Sprintf("%q", err.Error()))

--- a/core/tracker/tracker.go
+++ b/core/tracker/tracker.go
@@ -4,6 +4,7 @@ package tracker
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -899,16 +900,22 @@ func reportParSigs(ctx context.Context, duty core.Duty, parsigMsgs parsigsByMsg)
 				idxs = append(idxs, parsig.ShareIdx)
 			}
 
-			sample, _ := json.Marshal(parsigs[0].SignedData)
+			sample, err := json.Marshal(parsigs[0].SignedData)
+			if err != nil {
+				sample = json.RawMessage(fmt.Sprintf("%q", err.Error()))
+			}
 
 			entries = append(entries, rootEntry{
-				MsgRoot:    fmt.Sprintf("%x", root[:]),
+				MsgRoot:    hex.EncodeToString(root[:]),
 				ShareIdxs:  idxs,
 				SignedData: sample,
 			})
 		}
 
-		entriesJSON, _ := json.Marshal(entries)
+		entriesJSON, err := json.Marshal(entries)
+		if err != nil {
+			entriesJSON = json.RawMessage(fmt.Sprintf("%q", err.Error()))
+		}
 
 		if expectInconsistentParSigs(duty.Type) {
 			log.Debug(ctx, "Inconsistent sync committee partial signed data",

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -192,7 +192,7 @@ type Component struct {
 	awaitAttFunc              func(ctx context.Context, slot, commIdx uint64) (*eth2p0.AttestationData, error)
 	awaitProposalFunc         func(ctx context.Context, slot uint64) (*eth2api.VersionedProposal, error)
 	awaitSyncContributionFunc func(ctx context.Context, slot, subcommIdx uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error)
-	awaitAggAttFunc           func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)
+	awaitAggAttFunc           func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex) (*eth2spec.VersionedAttestation, error)
 	awaitAggSigDBFunc         func(context.Context, core.Duty, core.PubKey) (core.SignedData, error)
 	dutyDefFunc               func(ctx context.Context, duty core.Duty) (core.DutyDefinitionSet, error)
 	subs                      []func(context.Context, core.Duty, core.ParSignedDataSet) error
@@ -230,7 +230,7 @@ func (c *Component) RegisterGetDutyDefinition(fn func(ctx context.Context, duty 
 
 // RegisterAwaitAggAttestation registers a function to query an aggregated attestation.
 // It supports a single function, since it is an input of the component.
-func (c *Component) RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root) (*eth2spec.VersionedAttestation, error)) {
+func (c *Component) RegisterAwaitAggAttestation(fn func(ctx context.Context, slot uint64, attestationRoot eth2p0.Root, committeeIndex eth2p0.CommitteeIndex) (*eth2spec.VersionedAttestation, error)) {
 	c.awaitAggAttFunc = fn
 }
 
@@ -818,7 +818,7 @@ func (c Component) AggregateAttestation(ctx context.Context, opts *eth2api.Aggre
 	span.SetAttributes(attribute.Int64("committee_index", int64(opts.CommitteeIndex)))
 	defer span.End()
 
-	aggAtt, err := c.awaitAggAttFunc(ctx, uint64(opts.Slot), opts.AttestationDataRoot)
+	aggAtt, err := c.awaitAggAttFunc(ctx, uint64(opts.Slot), opts.AttestationDataRoot, opts.CommitteeIndex)
 	if err != nil {
 		return nil, err
 	}

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -883,23 +883,6 @@ func (c Component) SubmitAggregateAttestations(ctx context.Context, opts *eth2ap
 			return err
 		}
 
-		if selProof, err := agg.SelectionProof(); err == nil && agg.Fulu != nil {
-			msgRoot, _ := parSigData.MessageRoot()
-			log.Debug(ctx, "Aggregate and proof submitted by VC",
-				z.Int("share_idx", c.shareIdx),
-				z.U64("slot", uint64(slot)),
-				z.U64("validator_index", uint64(aggregatorIndex)),
-				z.Str("selection_proof_prefix", fmt.Sprintf("%#x", selProof)),
-				z.Any("msg_root", msgRoot),
-				z.U64("aggregator_index", uint64(agg.Fulu.Message.AggregatorIndex)),
-				z.Str("aggregate_aggregation_bits", fmt.Sprintf("%#x", agg.Fulu.Message.Aggregate.AggregationBits)),
-				z.Any("aggregate_data", agg.Fulu.Message.Aggregate.Data),
-				z.Any("aggregate_committee_bits", agg.Fulu.Message.Aggregate.CommitteeBits),
-				z.Str("aggregate_signature", fmt.Sprintf("%#x", agg.Fulu.Message.Aggregate.Signature)),
-				z.Str("selection_proof_prefix", fmt.Sprintf("%#x", selProof)),
-			)
-		}
-
 		_, ok = psigsBySlot[slot]
 		if !ok {
 			psigsBySlot[slot] = make(core.ParSignedDataSet)

--- a/core/validatorapi/validatorapi.go
+++ b/core/validatorapi/validatorapi.go
@@ -883,6 +883,23 @@ func (c Component) SubmitAggregateAttestations(ctx context.Context, opts *eth2ap
 			return err
 		}
 
+		if selProof, err := agg.SelectionProof(); err == nil && agg.Fulu != nil {
+			msgRoot, _ := parSigData.MessageRoot()
+			log.Debug(ctx, "Aggregate and proof submitted by VC",
+				z.Int("share_idx", c.shareIdx),
+				z.U64("slot", uint64(slot)),
+				z.U64("validator_index", uint64(aggregatorIndex)),
+				z.Str("selection_proof_prefix", fmt.Sprintf("%#x", selProof)),
+				z.Any("msg_root", msgRoot),
+				z.U64("aggregator_index", uint64(agg.Fulu.Message.AggregatorIndex)),
+				z.Str("aggregate_aggregation_bits", fmt.Sprintf("%#x", agg.Fulu.Message.Aggregate.AggregationBits)),
+				z.Any("aggregate_data", agg.Fulu.Message.Aggregate.Data),
+				z.Any("aggregate_committee_bits", agg.Fulu.Message.Aggregate.CommitteeBits),
+				z.Str("aggregate_signature", fmt.Sprintf("%#x", agg.Fulu.Message.Aggregate.Signature)),
+				z.Str("selection_proof_prefix", fmt.Sprintf("%#x", selProof)),
+			)
+		}
+
 		_, ok = psigsBySlot[slot]
 		if !ok {
 			psigsBySlot[slot] = make(core.ParSignedDataSet)


### PR DESCRIPTION
Fixing 2 bugs with partial sigs during aggregation duties.

1. reportParSigs never warned on inconsistencies (core/tracker/tracker.go)
The guard checked `len(parsigsByRoot) <= 1` against the outer map (number of pubkeys) instead of the inner map (number of distinct roots per pubkey), so the warning was effectively dead code for single-validator cases. Fixed, and improved the log to show per-root `msg_root` hex, share indices, and a sample parsig JSON.

2. Wrong aggregate returned to VCs in post-Electra (core/dutydb/memory.go, core/validatorapi/validatorapi.go, core/interfaces.go)
In Electra, `AttestationData.Index` is always 0, so all committees in a slot share the same `AttestationDataRoot`. The `aggKey` in DutyDB only used {slot, root}, causing later committee aggregates to silently overwrite earlier ones. `AggregateAttestation` also ignored `opts.CommitteeIndex` entirely. Fixed by adding `CommitteeIndex` to `aggKey` (derived from `CommitteeBits` on post-Electra aggregates) and threading it through `AwaitAggAttestation`.

category: bug
ticket: #4006 
