### PR TITLE
*: fix pre-commit lint tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,10 @@ repos:
         language: script
         entry: .pre-commit/run_linter.sh
         types: [file, go]
+        # The script lints the whole repo, so run it once: parallel invocations
+        # with fix enabled write to the same files concurrently and corrupt them.
+        pass_filenames: false
+        require_serial: true
       - id: run-go-tests
         name: run-go-tests
         language: script

--- a/.pre-commit/run_linter.sh
+++ b/.pre-commit/run_linter.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="2.11.3"
+VERSION="2.11.4"
 
 if ! command -v golangci-lint &>/dev/null; then
     echo "golangci-lint could not be found"

--- a/app/health/checker.go
+++ b/app/health/checker.go
@@ -236,6 +236,7 @@ func (c *Checker) sampleMemory() {
 func sseHeadDelayCheck(scrapes [][]*pb.MetricFamily, _ Metadata) (bool, error) {
 	const (
 		metricName = "app_beacon_node_sse_head_delay"
+		addrLabel  = "addr"
 		threshold  = 0.04
 	)
 
@@ -260,7 +261,7 @@ func sseHeadDelayCheck(scrapes [][]*pb.MetricFamily, _ Metadata) (bool, error) {
 				var addr string
 
 				for _, lbl := range metric.GetLabel() {
-					if lbl.GetName() == "addr" {
+					if lbl.GetName() == addrLabel {
 						addr = lbl.GetValue()
 						break
 					}

--- a/app/health/checks_internal_test.go
+++ b/app/health/checks_internal_test.go
@@ -687,7 +687,7 @@ func TestHighBeaconNodeSSEHeadDelayCheck(t *testing.T) {
 				Name: &name,
 				Type: &typ,
 				Metric: []*pb.Metric{{
-					Label: []*pb.LabelPair{{Name: func() *string { s := "addr"; return &s }(), Value: &addrVal}}, //nolint:goconst
+					Label: []*pb.LabelPair{{Name: func() *string { s := "addr"; return &s }(), Value: &addrVal}},
 					Histogram: &pb.Histogram{
 						SampleCount: &count,
 						SampleSum:   &sum,


### PR DESCRIPTION
Update the pre-commit golangci-lint version pin to 2.11.4 to match CI, which was bumped in #4412 without updating the script. Run the lint hook serially: pre-commit invoked the whole-repo lint script once per file batch, and concurrent runs with fix enabled corrupted files. Fix the goconst finding golangci-lint 2.11.4 reports in app/health and drop the then-unused nolint directive.

category: fixbuild
ticket: none