### PR TITLE
*: fix remove-operators threshold default and harden reshare

### DIFF
--- a/cmd/edit_addvalidators.go
+++ b/cmd/edit_addvalidators.go
@@ -68,7 +68,7 @@ func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) erro
 	cmd.Flags().StringVar(&config.ValidatorKeysDir, "validator-keys-dir", ".charon/validator_keys", "Path to the directory containing the validator private key share files and passwords.")
 	cmd.Flags().StringVar(&config.OutputDir, "output-dir", "distributed_validator", "The destination folder for the new (combined) cluster data. Must be empty.")
 	cmd.Flags().BoolVar(&config.Unverified, "unverified", false,
-		"If charon has no access to the existing validator keys, this flag allows the addition to proceed, but skips hashing and signing the new cluster lock data. charon run must be started with --no-verify flag.")
+		"If charon has no access to the existing validator keys, this flag allows the addition to proceed, but skips hashing and signing the new cluster lock data. Requires the --keymanager-address flag to import the new validator key shares. charon run must be started with --no-verify flag.")
 
 	// Bind `dkg` flags.
 	bindKeymanagerFlags(cmd.Flags(), &config.DKG.KeymanagerAddr, &config.DKG.KeymanagerAuthToken)

--- a/cmd/edit_removeoperators.go
+++ b/cmd/edit_removeoperators.go
@@ -138,7 +138,7 @@ func validateRemoveOperatorsConfig(ctx context.Context, config *dkg.RemoveOperat
 	}
 
 	newN := len(lock.Operators) - len(config.RemovingENRs)
-	newT := newN - (newN-1)/3
+	newT := cluster.Threshold(newN)
 
 	if config.NewThreshold != 0 {
 		if config.NewThreshold >= newN || config.NewThreshold < newT {

--- a/dkg/pedersen/dkg.go
+++ b/dkg/pedersen/dkg.go
@@ -63,16 +63,6 @@ func RunDKG(ctx context.Context, config *Config, board *Board, numVals int) ([]s
 		return nil, err
 	}
 
-	dkgConfig := &kdkg.Config{
-		Longterm:  nodePrivateKey,
-		Suite:     config.Suite,
-		NewNodes:  nodes,
-		Threshold: threshold,
-		FastSync:  true,
-		Auth:      drandbls.NewSchemeOnG2(kbls.NewBLS12381Suite()),
-		Log:       newLogger(log.WithTopic(ctx, "pedersen")),
-	}
-
 	log.Info(ctx, "Starting pedersen DKG...")
 
 	shares := make([]share.Share, 0, numVals)
@@ -83,7 +73,18 @@ func RunDKG(ctx context.Context, config *Config, board *Board, numVals int) ([]s
 			return nil, err
 		}
 
-		dkgConfig.Nonce = nonce
+		// Construct a fresh config per protocol run: kyber's NewDistKeyHandler
+		// mutates the config it is given, so sharing one across runs is unsafe.
+		dkgConfig := &kdkg.Config{
+			Longterm:  nodePrivateKey,
+			Suite:     config.Suite,
+			NewNodes:  nodes,
+			Threshold: threshold,
+			FastSync:  true,
+			Auth:      drandbls.NewSchemeOnG2(kbls.NewBLS12381Suite()),
+			Log:       newLogger(log.WithTopic(ctx, "pedersen")),
+			Nonce:     nonce,
+		}
 
 		phaser := kdkg.NewTimePhaser(config.PhaseDuration)
 

--- a/dkg/pedersen/reshare.go
+++ b/dkg/pedersen/reshare.go
@@ -73,6 +73,10 @@ func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []s
 		return int(a.Index) - int(b.Index)
 	})
 
+	if err := validatePubKeyShares(pubKeyShares, config.Reshare.TotalShares); err != nil {
+		return nil, err
+	}
+
 	// Restore pubkey shares from the exchange
 	for i := range len(shares) {
 		shares[i].PublicShares = make(map[int]tbls.PublicKey)
@@ -214,18 +218,6 @@ func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []s
 		return nil, errors.Wrap(err, "invalid new threshold")
 	}
 
-	reshareConfig := &kdkg.Config{
-		Longterm:     nodePrivateKey,
-		Suite:        config.Suite,
-		NewNodes:     newNodes,
-		OldNodes:     oldNodes,
-		Threshold:    newThreshold,
-		OldThreshold: config.Threshold,
-		FastSync:     true,
-		Auth:         drandbls.NewSchemeOnG2(kbls.NewBLS12381Suite()),
-		Log:          newLogger(log.WithTopic(ctx, "pedersen")),
-	}
-
 	log.Info(ctx, "Starting pedersen reshare...",
 		z.Int("oldNodes", len(oldNodes)), z.Int("newNodes", len(newNodes)),
 		z.Int("oldThreshold", config.Threshold), z.Int("newThreshold", newThreshold),
@@ -239,18 +231,18 @@ func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []s
 			return nil, err
 		}
 
-		reshareConfig.Nonce = nonce
-
 		phaser := kdkg.NewTimePhaser(config.PhaseDuration)
 
 		// Nodes with existing shares provide their share to the reshare protocol.
 		// New nodes without shares provide public coefficients instead.
-		isNodeWithExistingShares := len(distKeyShares) > 0
+		var (
+			distKeyShare *kdkg.DistKeyShare
+			publicCoeffs []kyber.Point
+		)
 
-		if isNodeWithExistingShares {
+		if len(distKeyShares) > 0 {
 			// This node has existing shares to contribute to the reshare
-			reshareConfig.Share = distKeyShares[shareNum]
-			reshareConfig.PublicCoeffs = nil
+			distKeyShare = distKeyShares[shareNum]
 		} else {
 			// This is a new node - restore public coefficients from exchanged public key shares
 			// Validate that the recovered group public key matches the expected validator public key
@@ -259,13 +251,27 @@ func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []s
 				expectedPubKey = &expectedValidatorPubKeys[shareNum]
 			}
 
-			commits, err := restoreCommits(pubKeyShares, shareNum, config.Threshold, expectedPubKey)
+			publicCoeffs, err = restoreCommits(pubKeyShares, shareNum, config.Threshold, expectedPubKey)
 			if err != nil {
 				return nil, errors.Wrap(err, "restore commits")
 			}
+		}
 
-			reshareConfig.Share = nil
-			reshareConfig.PublicCoeffs = commits
+		// Construct a fresh config per protocol run: kyber's NewDistKeyHandler
+		// mutates the config it is given, so sharing one across runs is unsafe.
+		reshareConfig := &kdkg.Config{
+			Longterm:     nodePrivateKey,
+			Suite:        config.Suite,
+			NewNodes:     newNodes,
+			OldNodes:     oldNodes,
+			Threshold:    newThreshold,
+			OldThreshold: config.Threshold,
+			FastSync:     true,
+			Auth:         drandbls.NewSchemeOnG2(kbls.NewBLS12381Suite()),
+			Log:          newLogger(log.WithTopic(ctx, "pedersen")),
+			Nonce:        nonce,
+			Share:        distKeyShare,
+			PublicCoeffs: publicCoeffs,
 		}
 
 		protocol, err := kdkg.NewProtocol(
@@ -469,6 +475,30 @@ func generateNonce(nodes []kdkg.Node, iteration int) ([]byte, error) {
 	}
 
 	return hash[:], nil
+}
+
+// validatePubKeyShares verifies that every node that sent public key shares sent exactly
+// one valid-length share per validator. Nodes without existing shares (e.g. newly added)
+// are not present in the map and are not validated here.
+func validatePubKeyShares(pubKeyShares map[int][][]byte, totalShares int) error {
+	for nodeIdx, pks := range pubKeyShares {
+		if len(pks) != totalShares {
+			return errors.New("unexpected number of public key shares from node",
+				z.Int("node_index", nodeIdx),
+				z.Int("expected", totalShares),
+				z.Int("actual", len(pks)))
+		}
+
+		for _, pk := range pks {
+			if len(pk) != len(tbls.PublicKey{}) {
+				return errors.New("invalid public key share length from node",
+					z.Int("node_index", nodeIdx),
+					z.Int("length", len(pk)))
+			}
+		}
+	}
+
+	return nil
 }
 
 // validateReshareNodeCounts validates that there are enough nodes to complete the reshare.

--- a/dkg/pedersen/reshare_internal_test.go
+++ b/dkg/pedersen/reshare_internal_test.go
@@ -210,6 +210,67 @@ func TestRestoreCommitsOutOfBounds(t *testing.T) {
 	}
 }
 
+func TestValidatePubKeyShares(t *testing.T) {
+	validShare := make([]byte, len(tbls.PublicKey{}))
+
+	tests := []struct {
+		name         string
+		pubKeyShares map[int][][]byte
+		totalShares  int
+		errContains  string
+	}{
+		{
+			name:         "empty map is valid",
+			pubKeyShares: map[int][][]byte{},
+			totalShares:  2,
+		},
+		{
+			name: "correct count and length",
+			pubKeyShares: map[int][][]byte{
+				0: {validShare, validShare},
+				2: {validShare, validShare},
+			},
+			totalShares: 2,
+		},
+		{
+			name: "too few shares from one node",
+			pubKeyShares: map[int][][]byte{
+				0: {validShare, validShare},
+				1: {validShare},
+			},
+			totalShares: 2,
+			errContains: "unexpected number of public key shares",
+		},
+		{
+			name: "too many shares from one node",
+			pubKeyShares: map[int][][]byte{
+				0: {validShare, validShare, validShare},
+			},
+			totalShares: 2,
+			errContains: "unexpected number of public key shares",
+		},
+		{
+			name: "share with invalid length",
+			pubKeyShares: map[int][][]byte{
+				0: {validShare, []byte("short")},
+			},
+			totalShares: 2,
+			errContains: "invalid public key share length",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePubKeyShares(tc.pubKeyShares, tc.totalShares)
+			if tc.errContains != "" {
+				require.ErrorContains(t, err, tc.errContains)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestGenerateNonce(t *testing.T) {
 	suite := kbls.NewBLS12381Suite().G1().(kdkg.Suite)
 	_, pub1 := randomKeyPair(suite)

--- a/dkg/protocol_removeoperators.go
+++ b/dkg/protocol_removeoperators.go
@@ -106,7 +106,7 @@ func (p *removeOperatorsProtocol) PostInit(ctx context.Context, pctx *ProtocolCo
 	_, peerMap := buildPeerMap(allPeers)
 
 	newN := len(allPeers) - len(p.oldENRs)
-	newT := newN - (newN-1)/3
+	newT := cluster.Threshold(newN)
 
 	if p.newThreshold != 0 {
 		if p.newThreshold >= newN || p.newThreshold < newT {

--- a/dkg/protocol_test.go
+++ b/dkg/protocol_test.go
@@ -18,7 +18,9 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/obolnetwork/charon/app"
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/cmd"
 	"github.com/obolnetwork/charon/dkg"
@@ -77,11 +79,10 @@ func TestRemoveOperatorsProtocol_BelowF(t *testing.T) {
 
 		err := dkg.RunRemoveOperatorsProtocol(ctx, removeConfig, dkgConfig)
 		if err != nil {
-			cancel()
-			require.FailNowf(t, "Protocol failed", "Node %d failed: %v", n, err)
+			return failNode(t, cancel, n, err)
 		}
 
-		return err
+		return nil
 	})
 
 	verifyClusterValidators(t, numValidators, outputNodeDirs)
@@ -138,11 +139,10 @@ func TestRemoveOperatorsProtocol_MoreThanF(t *testing.T) {
 
 		err := dkg.RunRemoveOperatorsProtocol(ctx, removeConfig, dkgConfig)
 		if err != nil {
-			cancel()
-			require.FailNowf(t, "Protocol failed", "Node %d failed: %v", n, err)
+			return failNode(t, cancel, n, err)
 		}
 
-		return err
+		return nil
 	})
 
 	verifyClusterValidators(t, numValidators, outputNodeDirs)
@@ -207,6 +207,62 @@ func TestRemoveOperatorsProtocol_AllNodes(t *testing.T) {
 	require.True(t, errorReported.Load(), "Expected error when attempting to remove all nodes from original cluster")
 }
 
+func TestRemoveOperatorsProtocol_DefaultThreshold(t *testing.T) {
+	const (
+		numValidators = 2
+		numNodes      = 4
+		threshold     = 3
+	)
+
+	srcClusterDir := createTestCluster(t, numNodes, threshold, numValidators)
+	dstClusterDir := t.TempDir()
+
+	lockFilePath := path.Join(nodeDir(srcClusterDir, 0), clusterLockFile)
+	lock, err := dkg.LoadAndVerifyClusterLock(t.Context(), lockFilePath, "", false)
+	require.NoError(t, err)
+
+	// Removing a middle operator so the resulting cluster size (3) exercises
+	// both the ceil(2n/3) threshold default and share index compaction.
+	oldENRs := []string{lock.Operators[1].ENR}
+	outputNodeDirs := getNodeDirs(dstClusterDir, numNodes, 1)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	runProtocol(t, numNodes, func(relayAddr string, n int) error {
+		if n == 1 {
+			// Removed node does not run the protocol.
+			return nil
+		}
+
+		dkgConfig := createDKGConfig(t, relayAddr)
+		ndir := nodeDir(srcClusterDir, n)
+		removeConfig := dkg.RemoveOperatorsConfig{
+			LockFilePath:     path.Join(ndir, clusterLockFile),
+			PrivateKeyPath:   p2p.KeyPath(ndir),
+			ValidatorKeysDir: path.Join(ndir, validatorKeysDir),
+			OutputDir:        nodeDir(dstClusterDir, n),
+			RemovingENRs:     oldENRs,
+		}
+
+		err := dkg.RunRemoveOperatorsProtocol(ctx, removeConfig, dkgConfig)
+		if err != nil {
+			return failNode(t, cancel, n, err)
+		}
+
+		return nil
+	})
+
+	for _, ndir := range outputNodeDirs {
+		newLock, err := dkg.LoadAndVerifyClusterLock(t.Context(), path.Join(ndir, clusterLockFile), "", false)
+		require.NoError(t, err)
+		require.Equal(t, cluster.Threshold(numNodes-1), newLock.Threshold)
+		require.Equal(t, 2, newLock.Threshold)
+	}
+
+	verifyClusterValidators(t, numValidators, outputNodeDirs)
+}
+
 func TestRunAddOperatorsProtocol(t *testing.T) {
 	const (
 		numValidators = 3
@@ -246,11 +302,10 @@ func TestRunAddOperatorsProtocol(t *testing.T) {
 
 		err := dkg.RunAddOperatorsProtocol(ctx, addConfig, dkgConfig)
 		if err != nil {
-			cancel()
-			require.FailNowf(t, "Protocol failed", "Node %d failed: %v", n, err)
+			return failNode(t, cancel, n, err)
 		}
 
-		return err
+		return nil
 	})
 
 	verifyClusterValidators(t, numValidators, getNodeDirs(dstClusterDir, totalNodes))
@@ -308,8 +363,7 @@ func TestRunReplaceOperatorProtocol(t *testing.T) {
 
 		err := dkg.RunReplaceOperatorProtocol(ctx, replaceConfig, dkgConfig)
 		if err != nil {
-			cancel()
-			require.FailNowf(t, "Protocol failed", "Node %d failed: %v", n, err)
+			return failNode(t, cancel, n, err)
 		}
 
 		return nil
@@ -346,11 +400,10 @@ func TestRunReshareProtocol(t *testing.T) {
 
 		err := dkg.RunReshareProtocol(ctx, reshareConfig)
 		if err != nil {
-			cancel()
-			require.FailNowf(t, "Protocol failed", "Node %d failed: %v", n, err)
+			return failNode(t, cancel, n, err)
 		}
 
-		return err
+		return nil
 	})
 
 	verifyClusterValidators(t, numValidators, getNodeDirs(dstClusterDir, numNodes))
@@ -562,6 +615,17 @@ func runProtocol(t *testing.T, numNodes int, nodeFunc func(string, int) error) {
 	require.NoError(t, eg.Wait())
 }
 
+// failNode cancels the other nodes and returns the node's failure as a wrapped error.
+// It also logs the failure, since the errgroup surfaces only the first returned error.
+// Note that require.FailNow (runtime.Goexit) must not be called from runProtocol goroutines.
+func failNode(t *testing.T, cancel context.CancelFunc, n int, err error) error {
+	t.Helper()
+	t.Logf("Node %d failed: %v", n, err)
+	cancel()
+
+	return errors.Wrap(err, "run node protocol", z.Int("node", n))
+}
+
 func createDKGConfig(t *testing.T, relayAddr string) dkg.Config {
 	t.Helper()
 
@@ -593,7 +657,7 @@ func getNodeDirs(clusterDir string, numNodes int, skip ...int) []string {
 	return dirs
 }
 
-func verifyClusterValidators(t *testing.T, numVals int, nodeDirs []string) { //nolint:unparam
+func verifyClusterValidators(t *testing.T, numVals int, nodeDirs []string) {
 	t.Helper()
 
 	numNodes := len(nodeDirs)


### PR DESCRIPTION
Changes the remove-operators default threshold to `cluster.Threshold` (`ceil(2n/3)`), matching fresh DKG defaults, the `--new-threshold` flag help and the public docs. The previous formula `n-(n-1)/3` diverged at resulting cluster sizes 3, 6 and 9; for example a 4→3 removal produced threshold 3 (no fault tolerance) instead of the documented 2, and the validation rejected the documented default as a `--new-threshold` override.

Validates exchanged validator public key shares in `RunReshareDKG` (one share per validator, correct length) before indexing, replacing an unchecked access that panicked on a malformed peer message.

Constructs a fresh kyber DKG config per protocol run in `RunDKG`/`RunReshareDKG`, since kyber's `NewDistKeyHandler` mutates the config it receives and reusing one across runs relied on resetting the right fields.

States the `--unverified`/keymanager coupling in the add-validators flag help (the related error message fixes landed separately in #4579).

Adds a remove-operators regression test (4 nodes, removing a middle operator) asserting the new lock records threshold 2, and replaces `require.FailNowf` inside test goroutines with wrapped error returns, since `FailNow` must not be called outside the test goroutine and its error never reached the errgroup.

Documentation updates: ObolNetwork/obol-gitbook#163

category: refactor
ticket: none

