### PR TITLE
*: allow incomplete validator_keys store when parsing

### DIFF
--- a/eth2util/keystore/keystore.go
+++ b/eth2util/keystore/keystore.go
@@ -242,13 +242,13 @@ func checkDir(dir string) error {
 	return nil
 }
 
-// KeysharesToValidatorPubkey maps each share in cl to the associated validator private key.
-// It returns an error if a keyshare does not appear in cl, or if there's a validator public key associated to no
-// keyshare.
+// KeysharesToValidatorPubkey maps each provided private key share to the associated validator
+// public key in the cluster lock. It returns an error if a provided private key share does not belong to any validator
+// in the lock.
 func KeysharesToValidatorPubkey(lock cluster.Lock, shares []tbls.PrivateKey) (ValidatorShares, error) {
 	ret := make(map[core.PubKey]IndexedKeyShare)
 
-	var pubShares []tbls.PublicKey
+	pubShares := make([]tbls.PublicKey, 0, len(shares))
 
 	for _, share := range shares {
 		ps, err := tbls.SecretToPublicKey(share)
@@ -259,6 +259,9 @@ func KeysharesToValidatorPubkey(lock cluster.Lock, shares []tbls.PrivateKey) (Va
 		pubShares = append(pubShares, ps)
 	}
 
+	// matched tracks which provided private key shares were found in the cluster lock.
+	matched := make([]bool, len(pubShares))
+
 	// this is sadly a O(n^2) search
 	for _, validator := range lock.Validators {
 		valHex := validator.PublicKeyHex()
@@ -267,8 +270,6 @@ func KeysharesToValidatorPubkey(lock cluster.Lock, shares []tbls.PrivateKey) (Va
 		for _, valShare := range validator.PubShares {
 			valPubShares[tbls.PublicKey(valShare)] = struct{}{}
 		}
-
-		found := false
 
 		for shareIdx, share := range pubShares {
 			if _, ok := valPubShares[share]; !ok {
@@ -279,18 +280,17 @@ func KeysharesToValidatorPubkey(lock cluster.Lock, shares []tbls.PrivateKey) (Va
 				Share: shares[shareIdx],
 				Index: shareIdx + 1,
 			}
-			found = true
+			matched[shareIdx] = true
 
 			break
 		}
-
-		if !found {
-			return nil, errors.New("public key share from provided private key share not found in provided lock")
-		}
 	}
 
-	if len(ret) != len(lock.Validators) {
-		return nil, errors.New("key shares and validator public keys count mismatch")
+	// Every provided private key share must belong to a validator in the cluster lock.
+	for shareIdx, ok := range matched {
+		if !ok {
+			return nil, errors.New("public key share from provided private key share not found in provided lock", z.Int("share_index", shareIdx))
+		}
 	}
 
 	return ret, nil

--- a/eth2util/keystore/keystore_test.go
+++ b/eth2util/keystore/keystore_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/cluster"
+	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util/keystore"
 	"github.com/obolnetwork/charon/tbls"
 	"github.com/obolnetwork/charon/tbls/tblsconv"
@@ -435,6 +436,80 @@ func TestKeyshareToValidatorPubkey(t *testing.T) {
 		require.True(t, valFound, "validator pubkey not found")
 		require.True(t, sharePrivKeyFound, "share priv key not found")
 	}
+}
+
+// mkValidatorWithLocalShare appends a validator with 10 public shares to lock, selecting one of
+// its private shares as the operator's local share. It returns that local private share.
+func mkValidatorWithLocalShare(t *testing.T, lock *cluster.Lock) tbls.PrivateKey {
+	t.Helper()
+
+	const sharesAmt = 10
+
+	valPubk, err := tblsconv.PubkeyFromCore(testutil.RandomCorePubKey(t))
+	require.NoError(t, err)
+
+	validator := cluster.DistValidator{PubKey: valPubk[:]}
+
+	var localShare tbls.PrivateKey
+
+	for i := range sharesAmt {
+		sharePriv, err := tbls.GenerateSecretKey()
+		require.NoError(t, err)
+
+		sharePub, err := tbls.SecretToPublicKey(sharePriv)
+		require.NoError(t, err)
+
+		if i == 0 {
+			localShare = sharePriv
+		}
+
+		validator.PubShares = append(validator.PubShares, sharePub[:])
+	}
+
+	rand.Shuffle(len(validator.PubShares), func(i, j int) {
+		validator.PubShares[i], validator.PubShares[j] = validator.PubShares[j], validator.PubShares[i]
+	})
+
+	lock.Validators = append(lock.Validators, validator)
+
+	return localShare
+}
+
+// TestKeysharesToValidatorPubkeySubset ensures that providing local key shares for only a
+// subset of the cluster's validators succeeds and returns just that subset. This mirrors the
+// `charon exit sign --validator-public-key` flow where an operator holds keystores for fewer
+// validators than exist in the cluster lock.
+func TestKeysharesToValidatorPubkeySubset(t *testing.T) {
+	lock := cluster.Lock{}
+
+	// Validator we hold a local share for.
+	localShare := mkValidatorWithLocalShare(t, &lock)
+
+	// Additional validators we do NOT hold local shares for.
+	mkValidatorWithLocalShare(t, &lock)
+	mkValidatorWithLocalShare(t, &lock)
+
+	ret, err := keystore.KeysharesToValidatorPubkey(lock, []tbls.PrivateKey{localShare})
+	require.NoError(t, err)
+	require.Len(t, ret, 1)
+
+	wantPubk := lock.Validators[0].PublicKeyHex()
+	got, ok := ret[core.PubKey(wantPubk)]
+	require.True(t, ok, "expected local validator present in result")
+	require.Equal(t, localShare, got.Share)
+}
+
+// TestKeysharesToValidatorPubkeyForeignShare ensures a provided private key share that belongs
+// to no validator in the cluster lock is reported as an error.
+func TestKeysharesToValidatorPubkeyForeignShare(t *testing.T) {
+	lock := cluster.Lock{}
+	mkValidatorWithLocalShare(t, &lock)
+
+	foreign, err := tbls.GenerateSecretKey()
+	require.NoError(t, err)
+
+	_, err = keystore.KeysharesToValidatorPubkey(lock, []tbls.PrivateKey{foreign})
+	require.ErrorContains(t, err, "not found in provided lock")
 }
 
 func TestShareIdxForCluster(t *testing.T) {


### PR DESCRIPTION
Previously Charon failed commands requiring the partial keys when only a subset of the keys is available in `validator_keys` directory:

```
13:54:58.491 ERRO cmd        Application failed to start: match local validator key shares with their counterparty in cluster lock: public key share from provided private key share not found in provided lock
        eth2util/keystore/keystore.go:288 .KeysharesToValidatorPubkey
        cmd/exit_sign.go:126 .runSignPartialExit
        cmd/exit_sign.go:44 .func1
        cmd/cmd.go:111 .func1
        main.go:19 .main
```

This is actually incorrect as the said key did exist, however, not the full set of keys in the lock were available in the directory. Scenarios in which allowing this is useful:
1. Operator has Charon in one machine and VC in separate machine;
2. Operator does not hold the validator keys in the Charon machine;
3. Operator wants to do some action with Charon's CLI (e.g.: sign exit, sign new deposit, etc.);
4. Operator moves part of the keys for which the operation will be done inside the Charon machine;
5. Operator runs the command for the said keys.

category: bug
ticket: none
