### PR TITLE
*: fix invalid flag names in user-facing messages

### DIFF
--- a/cmd/edit_addvalidators.go
+++ b/cmd/edit_addvalidators.go
@@ -216,9 +216,9 @@ func validateConfig(ctx context.Context, config *addValidatorsConfig) (err error
 	}
 
 	if !validatorKeysDirPresent && len(config.DKG.KeymanagerAddr) == 0 {
-		log.Error(ctx, "The --keymanager flag is required when the validator_keys directory is empty.", nil)
+		log.Error(ctx, "The --keymanager-address flag is required when the validator_keys directory is empty.", nil)
 
-		return errors.New("the --keymanager flag is required when the validator_keys directory is empty")
+		return errors.New("the --keymanager-address flag is required when the validator_keys directory is empty")
 	}
 
 	config.FeeRecipientAddrs, config.WithdrawalAddrs, err = validateAddresses(config.NumValidators, config.FeeRecipientAddrs, config.WithdrawalAddrs)

--- a/cmd/edit_addvalidators_internal_test.go
+++ b/cmd/edit_addvalidators_internal_test.go
@@ -416,7 +416,7 @@ func TestValidateConfigAddValidators(t *testing.T) {
 
 		cfg.Unverified = true
 		err = validateConfig(t.Context(), &cfg)
-		require.Equal(t, "the --keymanager flag is required when the validator_keys directory is empty", err.Error())
+		require.Equal(t, "the --keymanager-address flag is required when the validator_keys directory is empty", err.Error())
 
 		cfg.DKG.KeymanagerAddr = "http://localhost:1234"
 		err = validateConfig(t.Context(), &cfg)

--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -74,7 +74,7 @@ func NewNode(ctx context.Context, cfg Config, key *k1.PrivateKey, connGater Conn
 		}
 
 		if len(udpAddrs) == 0 {
-			log.Warn(ctx, "LibP2P QUIC enabled but --p2p-udp-addresses is empty", nil)
+			log.Warn(ctx, "LibP2P QUIC enabled but --p2p-udp-address is empty", nil)
 		}
 
 		addrs = append(addrs, udpAddrs...)


### PR DESCRIPTION
Corrects two user-facing messages that reference flags that do not exist:

- `p2p/p2p.go`: the QUIC warning referenced `--p2p-udp-addresses` (plural); the registered flag is `--p2p-udp-address`.
- `cmd/edit_addvalidators.go`: the error and log referenced a non-existent `--keymanager` flag; the registered flag is `--keymanager-address`. The test asserting the old error string is updated accordingly.

category: bug
ticket: none
