### PR TITLE
*: fix grammar and clarity of error messages

### DIFF
--- a/app/utils.go
+++ b/app/utils.go
@@ -147,7 +147,7 @@ func ExtractArchive(archivePath, targetDir string) error {
 		cleanName := filepath.Clean(header.Name)
 		// Disallow absolute paths and paths with ".." as first element
 		if strings.HasPrefix(cleanName, "..") || filepath.IsAbs(cleanName) || strings.Contains(cleanName, ".."+string(os.PathSeparator)) {
-			return errors.New("invalid archive entry path: " + header.Name)
+			return errors.New("invalid archive entry path", z.Str("path", header.Name))
 		}
 
 		target := filepath.Join(targetDir, cleanName)
@@ -163,7 +163,7 @@ func ExtractArchive(archivePath, targetDir string) error {
 		}
 
 		if !strings.HasPrefix(absTarget, absTargetDir+string(os.PathSeparator)) && absTarget != absTargetDir {
-			return errors.New("archive entry path escapes target directory: " + header.Name)
+			return errors.New("archive entry path escapes target directory", z.Str("path", header.Name))
 		}
 
 		switch header.Typeflag {

--- a/cluster/cluster_internal_test.go
+++ b/cluster/cluster_internal_test.go
@@ -154,7 +154,7 @@ func TestDefinitionVerify(t *testing.T) {
 
 		err = definition.VerifySignatures(nil)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "some operators signed while others didn't")
+		require.ErrorContains(t, err, "some operators signed while others did not")
 	})
 
 	t.Run("no operators no creator", func(t *testing.T) {

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -284,7 +284,7 @@ func (d Definition) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 	}
 
 	if noOpSigs > 0 && noOpSigs != len(d.Operators) {
-		return errors.New("some operators signed while others didn't")
+		return errors.New("some operators signed while others did not")
 	}
 
 	// Verify creator signature
@@ -293,9 +293,9 @@ func (d Definition) VerifySignatures(eth1 eth1wrap.EthClientRunner) error {
 			return errors.New("unexpected creator config signature in old version")
 		}
 	} else if d.Creator.Address == "" && len(d.Creator.ConfigSignature) == 0 {
-		// Empty creator is fine if also not operator signatures either.
+		// An empty creator is fine if there are no operator signatures either.
 		if noOpSigs == 0 {
-			return errors.New("operators signed while creator didn't")
+			return errors.New("operators signed while creator did not")
 		}
 	} else {
 		if len(d.Creator.ConfigSignature) == 0 {
@@ -798,7 +798,7 @@ func marshalDefinitionV1x10to11(def Definition) ([]byte, error) {
 func unmarshalDefinitionV1x0or1(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x0or1
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1_1")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.0 or v1.1")
 	}
 
 	operators, err := operatorsFromV1x1(defJSON.Operators)
@@ -836,7 +836,7 @@ func unmarshalDefinitionV1x0or1(data []byte) (def Definition, err error) {
 func unmarshalDefinitionV1x2or3(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x2or3
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1v2")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.2 or v1.3")
 	}
 
 	vaddrs := ValidatorAddresses{
@@ -865,7 +865,7 @@ func unmarshalDefinitionV1x2or3(data []byte) (def Definition, err error) {
 func unmarshalDefinitionV1x4(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x4
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1v2")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.4")
 	}
 
 	vaddrs := ValidatorAddresses{
@@ -896,11 +896,11 @@ func unmarshalDefinitionV1x4(data []byte) (def Definition, err error) {
 func unmarshalDefinitionV1x5to7(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x5to7
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1_5")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.5 to v1.7")
 	}
 
 	if len(defJSON.ValidatorAddresses) != defJSON.NumValidators {
-		return Definition{}, errors.New("num_validators not matching validators length")
+		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
 	return Definition{
@@ -926,11 +926,11 @@ func unmarshalDefinitionV1x5to7(data []byte) (def Definition, err error) {
 func unmarshalDefinitionV1x8(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x8
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1_8")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.8")
 	}
 
 	if len(defJSON.ValidatorAddresses) != defJSON.NumValidators {
-		return Definition{}, errors.New("num_validators not matching validators length")
+		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
 	if err := deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding); err != nil {
@@ -961,11 +961,11 @@ func unmarshalDefinitionV1x8(data []byte) (def Definition, err error) {
 func unmarshalDefinitionV1x9(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x9
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1_9")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.9")
 	}
 
 	if len(defJSON.ValidatorAddresses) != defJSON.NumValidators {
-		return Definition{}, errors.New("num_validators not matching validators length")
+		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
 	if err := deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding); err != nil {
@@ -997,11 +997,11 @@ func unmarshalDefinitionV1x9(data []byte) (def Definition, err error) {
 func unmarshalDefinitionV1x10to11(data []byte) (def Definition, err error) {
 	var defJSON definitionJSONv1x10to11
 	if err := json.Unmarshal(data, &defJSON); err != nil {
-		return Definition{}, errors.Wrap(err, "unmarshal definition v1_10 to v1_11")
+		return Definition{}, errors.Wrap(err, "unmarshal definition v1.10 to v1.11")
 	}
 
 	if len(defJSON.ValidatorAddresses) != defJSON.NumValidators {
-		return Definition{}, errors.New("num_validators not matching validators length")
+		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
 	if err := deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding); err != nil {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -264,7 +264,7 @@ func runCreateCluster(ctx context.Context, w io.Writer, conf clusterConfig) erro
 	}
 
 	if len(secrets) != def.NumValidators {
-		return errors.New("amount of keys read from disk differs from cluster definition", z.Int("disk", len(secrets)), z.Int("definition", def.NumValidators))
+		return errors.New("number of keys read from disk differs from cluster definition", z.Int("disk", len(secrets)), z.Int("definition", def.NumValidators))
 	}
 
 	numNodes := len(def.Operators)
@@ -402,7 +402,7 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 
 	// Ensure sufficient auth tokens are provided for the keymanager addresses
 	if len(conf.KeymanagerAddrs) != len(conf.KeymanagerAuthTokens) {
-		return errors.New("number of --keymanager-addresses do not match --keymanager-auth-tokens. Please fix configuration flags")
+		return errors.New("number of --keymanager-addresses does not match number of --keymanager-auth-tokens")
 	}
 
 	if len(conf.DepositAmounts) > 0 {
@@ -453,7 +453,7 @@ func detectNodeDirs(clusterDir string, nodeAmount int) error {
 		}
 
 		if _, err := os.Stat(filepath.Join(absPath, clusterLockFile)); err == nil {
-			return errors.New("existing node directory found, please delete it before running this command", z.Str("node_path", absPath))
+			return errors.New("existing node directory found", z.Str("node_path", absPath))
 		}
 	}
 
@@ -779,7 +779,7 @@ func getValidators(
 
 		depositDatasList, ok := depositDatasMap[dv]
 		if !ok {
-			return nil, errors.New("deposit data not found for dv", z.Str("dv", hex.EncodeToString(dv[:])))
+			return nil, errors.New("deposit data not found for distributed validator", z.Str("dv", hex.EncodeToString(dv[:])))
 		}
 
 		for _, dd := range depositDatasList {
@@ -1011,7 +1011,7 @@ func validateDef(ctx context.Context, insecureKeys bool, keymanagerAddrs []strin
 	}
 
 	if len(keymanagerAddrs) > 0 && (len(keymanagerAddrs) != len(def.Operators)) {
-		return errors.New("insufficient no of keymanager addresses", z.Int("expected", len(def.Operators)), z.Int("got", len(keymanagerAddrs)))
+		return errors.New("number of keymanager addresses does not match number of operators", z.Int("expected", len(def.Operators)), z.Int("got", len(keymanagerAddrs)))
 	}
 
 	if len(def.DepositAmounts) > 0 {

--- a/cmd/createcluster.go
+++ b/cmd/createcluster.go
@@ -402,7 +402,7 @@ func validateCreateConfig(ctx context.Context, conf clusterConfig) error {
 
 	// Ensure sufficient auth tokens are provided for the keymanager addresses
 	if len(conf.KeymanagerAddrs) != len(conf.KeymanagerAuthTokens) {
-		return errors.New("number of --keymanager-addresses does not match number of --keymanager-auth-tokens")
+		return errors.New("number of --keymanager-addresses does not match number of --keymanager-auth-tokens, please fix configuration flags")
 	}
 
 	if len(conf.DepositAmounts) > 0 {
@@ -453,7 +453,7 @@ func detectNodeDirs(clusterDir string, nodeAmount int) error {
 		}
 
 		if _, err := os.Stat(filepath.Join(absPath, clusterLockFile)); err == nil {
-			return errors.New("existing node directory found", z.Str("node_path", absPath))
+			return errors.New("existing node directory found, please delete it before running this command", z.Str("node_path", absPath))
 		}
 	}
 

--- a/cmd/createcluster_internal_test.go
+++ b/cmd/createcluster_internal_test.go
@@ -157,7 +157,7 @@ func TestCreateCluster(t *testing.T) {
 
 				return config
 			},
-			expectedErr: "amount of keys read from disk differs from cluster definition",
+			expectedErr: "number of keys read from disk differs from cluster definition",
 		},
 		{
 			Name: "missing nodes amount flag",
@@ -694,7 +694,7 @@ func TestMultipleAddresses(t *testing.T) {
 		defer srv.Close()
 
 		err := runCreateCluster(context.Background(), io.Discard, clusterConfig{DefFile: srv.URL, NumNodes: minNodes, NumDVs: 2, Network: defaultNetwork})
-		require.ErrorContains(t, err, "num_validators not matching validators length")
+		require.ErrorContains(t, err, "num_validators does not match validators length")
 	})
 }
 
@@ -973,7 +973,7 @@ func TestKeymanager(t *testing.T) {
 		incorrectConf.KeymanagerAuthTokens = incorrectConf.KeymanagerAuthTokens[1:]
 
 		err = runCreateCluster(context.Background(), nil, incorrectConf)
-		require.ErrorContains(t, err, "number of --keymanager-addresses do not match --keymanager-auth-tokens. Please fix configuration flags")
+		require.ErrorContains(t, err, "number of --keymanager-addresses does not match number of --keymanager-auth-tokens")
 	})
 }
 

--- a/core/bcast/bcast.go
+++ b/core/bcast/bcast.go
@@ -82,7 +82,7 @@ func (b Broadcaster) Broadcast(ctx context.Context, duty core.Duty, set core.Sig
 		// - another charon node at version v1.3.2, v1.4.2 or newer
 		// this (expensive) code block will not be triggered.
 		if checkValIdxs {
-			log.Warn(ctx, "One or more cluster nodes are running outdated Charon versions (v1.3.0, v1.3.1, v1.4.0, or v1.4.1) which cause performance degradation. Please coordinate with operators to upgrade all nodes to v1.3.2, v1.4.2, or newer", errors.New("peer version causes slowdown"))
+			log.Warn(ctx, "One or more cluster nodes are running outdated Charon versions (v1.3.0, v1.3.1, v1.4.0, or v1.4.1) which cause performance degradation; operators should upgrade all nodes to v1.3.2, v1.4.2, or newer", errors.New("peer version causes slowdown"))
 
 			if len(atts) == 0 {
 				return errors.New("no attestations")


### PR DESCRIPTION
Fixes English grammar, clarity and consistency issues in error and log string literals:

- Replace contractions with formal phrasing (`didn't` → `did not`) in cluster definition signature errors.
- Fix countable-noun usage: `amount of keys` → `number of keys`, `insufficient no of` → proper wording.
- Fix subject-verb agreement and make the keymanager flags mismatch error symmetric: `number of --keymanager-addresses does not match number of --keymanager-auth-tokens`.
- Reword `insufficient number of keymanager addresses` to `number of keymanager addresses does not match number of operators`, since the check fires on any mismatch, not only too few.
- Soften the outdated-peer-version warning in bcast while keeping the upgrade guidance.
- Replace string concatenation with structured `z.Str` fields in archive extraction errors.
- Normalize definition unmarshal version strings to dotted `v1.N` format and fix a copy-paste error where `unmarshalDefinitionV1x4` reported `v1v2` instead of `v1.4`.
- Spell out the `dv` abbreviation as `distributed validator`.
- Fix a garbled comment in `VerifySignatures`.

Test assertions relying on the exact strings are updated to match.

category: misc
ticket: none
