### PR TITLE
core/priority: add leading slash to protocol ID

### DIFF
--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -36,11 +36,19 @@ import (
 	"github.com/obolnetwork/charon/p2p"
 )
 
-const protocolID2 = "charon/priority/2.0.0"
+const (
+	// protocolIDLegacy is the pre-v1.12 priority protocol ID. It was erroneously
+	// registered without a leading slash, unlike every other charon protocol.
+	// It remains supported so that patched and unpatched nodes interoperate.
+	// TODO(v1.14): Remove once all supported versions advertise protocolID2.
+	protocolIDLegacy = "charon/priority/2.0.0"
+
+	protocolID2 = "/charon/priority/2.0.0"
+)
 
 // Protocols returns the supported protocols of this package in order of precedence.
 func Protocols() []protocol.ID {
-	return []protocol.ID{protocolID2}
+	return []protocol.ID{protocolID2, protocolIDLegacy}
 }
 
 // Topic groups priorities in an instance.
@@ -114,23 +122,30 @@ func newInternal(p2pNode host.Host, peers []peer.ID, minRequired int,
 		return nil
 	})
 
-	// Register prioritiser protocol handler.
-	registerHandlerFunc("priority", p2pNode, protocolID2,
-		func() proto.Message { return new(pbv1.PriorityMsg) },
-		func(ctx context.Context, pID peer.ID, msg proto.Message) (proto.Message, bool, error) {
-			prioMsg, ok := msg.(*pbv1.PriorityMsg)
-			if !ok || prioMsg == nil {
-				return nil, false, errors.New("invalid priority message")
-			}
+	newReq := func() proto.Message { return new(pbv1.PriorityMsg) }
 
-			resp, err := p.handleRequest(ctx, pID, prioMsg)
-			if err != nil {
-				return nil, false, errors.Wrap(err, "handle priority request",
-					z.Any("duty", core.DutyFromProto(prioMsg.GetDuty())))
-			}
+	handler := func(ctx context.Context, pID peer.ID, msg proto.Message) (proto.Message, bool, error) {
+		prioMsg, ok := msg.(*pbv1.PriorityMsg)
+		if !ok || prioMsg == nil {
+			return nil, false, errors.New("invalid priority message")
+		}
 
-			return resp, true, nil
-		})
+		resp, err := p.handleRequest(ctx, pID, prioMsg)
+		if err != nil {
+			return nil, false, errors.Wrap(err, "handle priority request",
+				z.Any("duty", core.DutyFromProto(prioMsg.GetDuty())))
+		}
+
+		return resp, true, nil
+	}
+
+	// Register prioritiser protocol handlers, one exact-match registration per protocol ID.
+	// Do not collapse these into a single call with p2p.WithDelimitedProtocol: the two IDs
+	// share no common prefix, so protocolPrefix would register (and libp2p identify would
+	// advertise) the bare wildcard "*" instead of the actual protocol IDs.
+	registerHandlerFunc("priority", p2pNode, protocolID2, newReq, handler)
+	// TODO(v1.14): Remove together with protocolIDLegacy.
+	registerHandlerFunc("priority", p2pNode, protocolIDLegacy, newReq, handler)
 
 	return p
 }
@@ -341,7 +356,12 @@ func exchange(ctx context.Context, p2pNode host.Host, peers []peer.ID, msgValida
 		go func(pID peer.ID) {
 			response := new(pbv1.PriorityMsg)
 
-			err := sendFunc(ctx, p2pNode, pID, own, response, protocolID2, p2p.WithSendMetricTopic("priority_consensus"))
+			// WithDelimitedProtocol prepends, so this offers protocolID2 first and
+			// falls back to protocolIDLegacy for peers that only support the latter.
+			// TODO(v1.14): Send protocolID2 directly, dropping the delimited option.
+			err := sendFunc(ctx, p2pNode, pID, own, response, protocolIDLegacy,
+				p2p.WithDelimitedProtocol(protocolID2),
+				p2p.WithSendMetricTopic("priority_consensus"))
 			if err != nil {
 				// No need to log, since transport will do it.
 				return

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -13,11 +13,13 @@ import (
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/peerstore"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/core"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	"github.com/obolnetwork/charon/core/priority"
@@ -110,6 +112,220 @@ func TestPrioritiser(t *testing.T) {
 		err := <-errCh
 		require.ErrorIs(t, err, context.Canceled)
 	}
+}
+
+// Priority protocol IDs as they appear on the wire. These literals must not change:
+// legacyProtocol keeps unpatched peers interoperable and is what they dial, while
+// slashedProtocol is the normalised ID all other charon protocols already use.
+const (
+	legacyProtocol  = protocol.ID("charon/priority/2.0.0")
+	slashedProtocol = protocol.ID("/charon/priority/2.0.0")
+)
+
+func TestProtocols(t *testing.T) {
+	// Order matters: it is the negotiation precedence offered to peers.
+	require.Equal(t, []protocol.ID{slashedProtocol, legacyProtocol}, priority.Protocols())
+}
+
+// TestProtocolNegotiation asserts a patched node prefers the slash-prefixed protocol
+// but falls back to the legacy one when the peer only supports that.
+func TestProtocolNegotiation(t *testing.T) {
+	tests := []struct {
+		name       string
+		register   p2p.RegisterHandlerFunc
+		advertised []protocol.ID // Protocol IDs the listener is expected to advertise.
+		expect     protocol.ID   // Protocol ID expected to be negotiated.
+	}{
+		{
+			name:       "patched peer",
+			register:   p2p.RegisterHandler,
+			advertised: []protocol.ID{slashedProtocol, legacyProtocol},
+			expect:     slashedProtocol,
+		},
+		{
+			name:       "unpatched peer",
+			register:   registerLegacyOnly,
+			advertised: []protocol.ID{legacyProtocol},
+			expect:     legacyProtocol,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := t.Context()
+
+			dialer := testutil.CreateHost(t, testutil.AvailableAddr(t))
+			listener := testutil.CreateHost(t, testutil.AvailableAddr(t))
+			dialer.Peerstore().AddAddrs(listener.ID(), listener.Addrs(), peerstore.PermanentAddrTTL)
+
+			peers := []peer.ID{dialer.ID(), listener.ID()}
+			newTestPrioritiser(t, listener, peers, p2p.SendReceive, test.register,
+				&testConsensus{t: t}, newTestDeadliner(ctx))
+
+			// Guard the protocolPrefix trap: registering both IDs via a single
+			// RegisterHandler call would advertise the bare wildcard "*" to peers
+			// (via libp2p identify) instead of the actual protocol IDs.
+			require.Subset(t, listener.Mux().Protocols(), test.advertised)
+			require.NotContains(t, listener.Mux().Protocols(), protocol.ID("*"))
+
+			s, err := dialer.NewStream(ctx, listener.ID(), priority.Protocols()...)
+			require.NoError(t, err)
+
+			defer s.Close()
+
+			require.Equal(t, test.expect, s.Protocol())
+		})
+	}
+}
+
+// TestPrioritiserLegacyPeer asserts a patched and an unpatched node complete a
+// priority exchange, testing each dial direction in isolation. Only one node dials
+// per case, since a node can otherwise reach quorum off its peer's inbound request
+// and mask a broken dial of its own.
+func TestPrioritiserLegacyPeer(t *testing.T) {
+	tests := []struct {
+		name        string
+		patchedSend p2p.SendReceiveFunc
+		legacySend  p2p.SendReceiveFunc
+	}{
+		{
+			// Only the patched node dials, so it must fall back to the legacy protocol.
+			name:        "patched dials unpatched",
+			patchedSend: p2p.SendReceive,
+			legacySend:  sendUnreachable,
+		},
+		{
+			// Only the unpatched node dials, so the patched node must serve the legacy protocol.
+			name:        "unpatched dials patched",
+			patchedSend: sendUnreachable,
+			legacySend:  sendLegacyOnly,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				ctx, cancel = context.WithCancel(context.Background())
+				n           = 2
+				duty        = core.Duty{Slot: 99}
+				consensus   = &testConsensus{t: t}
+				results     = make(chan []*pbv1.PriorityScoredResult, n)
+				topic       = &pbv1.ParSignedData{Data: []byte("test topic")}
+				errCh       = make(chan error, n)
+			)
+
+			defer cancel()
+
+			patched := testutil.CreateHost(t, testutil.AvailableAddr(t))
+			legacy := testutil.CreateHost(t, testutil.AvailableAddr(t))
+			peers := []peer.ID{patched.ID(), legacy.ID()}
+			deadliner := newTestDeadliner(ctx)
+
+			patched.Peerstore().AddAddrs(legacy.ID(), legacy.Addrs(), peerstore.PermanentAddrTTL)
+			legacy.Peerstore().AddAddrs(patched.ID(), patched.Addrs(), peerstore.PermanentAddrTTL)
+			// The patched node only ever learns the legacy protocol from its unpatched peer.
+			require.NoError(t, patched.Peerstore().AddProtocols(legacy.ID(), legacyProtocol))
+			require.NoError(t, legacy.Peerstore().AddProtocols(patched.ID(), priority.Protocols()...))
+
+			nodes := []struct {
+				host     host.Host
+				send     p2p.SendReceiveFunc
+				register p2p.RegisterHandlerFunc
+			}{
+				{host: patched, send: test.patchedSend, register: p2p.RegisterHandler},
+				{host: legacy, send: test.legacySend, register: registerLegacyOnly},
+			}
+
+			for _, node := range nodes {
+				prio := newTestPrioritiser(t, node.host, peers, node.send, node.register, consensus, deadliner)
+
+				prio.Subscribe(func(_ context.Context, gotDuty core.Duty, result *pbv1.PriorityResult) error {
+					require.Equal(t, duty, gotDuty)
+					require.Len(t, result.GetTopics(), 1)
+
+					results <- result.GetTopics()[0].GetPriorities()
+
+					return nil
+				})
+
+				msg := &pbv1.PriorityMsg{
+					Topics: []*pbv1.PriorityTopicProposal{{Topic: mustAny(topic), Priorities: []*anypb.Any{prioToAny(0)}}},
+					Duty:   core.DutyToProto(duty),
+					PeerId: node.host.ID().String(),
+				}
+
+				go func() {
+					errCh <- prio.Prioritise(ctx, msg)
+				}()
+			}
+
+			// Both nodes exchanged and agreed, so the single priority is scored by both.
+			// A broken fallback leaves the exchange waiting on the (1h) exchange timeout,
+			// so bound the wait rather than hanging until the go test timeout.
+			for range n {
+				var res []*pbv1.PriorityScoredResult
+
+				select {
+				case res = <-results:
+				case <-time.After(15 * time.Second):
+					require.FailNow(t, "timeout waiting for priority result, protocol fallback likely broken")
+				}
+
+				require.Len(t, res, 1)
+				require.EqualValues(t, n*1000, res[0].GetScore())
+				requireProtoEqual(t, prioToAny(0), res[0].GetPriority())
+			}
+
+			cancel()
+
+			for range n {
+				require.ErrorIs(t, <-errCh, context.Canceled)
+			}
+		})
+	}
+}
+
+// registerLegacyOnly simulates an unpatched node by dropping handler registrations
+// for the slash-prefixed protocol. It implements p2p.RegisterHandlerFunc.
+func registerLegacyOnly(logTopic string, p2pNode host.Host, pID protocol.ID,
+	zeroReq func() proto.Message, handlerFunc p2p.HandlerFunc, opts ...p2p.SendRecvOption,
+) {
+	if pID == slashedProtocol {
+		return
+	}
+
+	p2p.RegisterHandler(logTopic, p2pNode, pID, zeroReq, handlerFunc, opts...)
+}
+
+// sendLegacyOnly simulates an unpatched node by always dialing the legacy protocol
+// and never offering the slash-prefixed one. It implements p2p.SendReceiveFunc.
+func sendLegacyOnly(ctx context.Context, p2pNode host.Host, peerID peer.ID,
+	req, resp proto.Message, _ protocol.ID, _ ...p2p.SendRecvOption,
+) error {
+	return p2p.SendReceive(ctx, p2pNode, peerID, req, resp, legacyProtocol)
+}
+
+// sendUnreachable simulates a node that cannot dial out, forcing its exchange to
+// complete via the peer's inbound request. It implements p2p.SendReceiveFunc.
+func sendUnreachable(context.Context, host.Host, peer.ID, proto.Message, proto.Message,
+	protocol.ID, ...p2p.SendRecvOption,
+) error {
+	return errors.New("unreachable")
+}
+
+func newTestDeadliner(ctx context.Context) core.Deadliner {
+	return core.NewDeadliner(ctx, "", func(core.Duty) (time.Time, bool) {
+		return time.Now().Add(time.Hour), true
+	})
+}
+
+func newTestPrioritiser(t *testing.T, p2pNode host.Host, peers []peer.ID, send p2p.SendReceiveFunc,
+	register p2p.RegisterHandlerFunc, consensus *testConsensus, deadliner core.Deadliner,
+) *priority.Prioritiser {
+	t.Helper()
+
+	return priority.NewForT(t, p2pNode, peers, len(peers), send, register, consensus,
+		func(*pbv1.PriorityMsg) error { return nil }, time.Hour, deadliner)
 }
 
 // testConsensus is a mock consensus implementation that "decides" on the first proposal.

--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -440,7 +440,13 @@ func isCanceledStreamErr(err error) bool {
 	return err != nil && strings.Contains(err.Error(), "close called for canceled stream")
 }
 
-// protocolPrefix returns the common prefix of the provided protocol IDs.
+// protocolPrefix returns the common prefix of the provided protocol IDs,
+// suffixed with "*" if they are not all identical.
+//
+// Only pass IDs that share a non-empty common prefix. The result is the name
+// RegisterHandler registers with the stream muxer, which libp2p identify then
+// advertises to peers, so IDs that diverge at the first byte collapse to a bare
+// "*" and peers are told we support that instead of any real protocol.
 func protocolPrefix(pIDs ...protocol.ID) protocol.ID {
 	if len(pIDs) == 0 {
 		return ""


### PR DESCRIPTION
Normalises the priority protocol ID to `/charon/priority/2.0.0`, matching every other charon libp2p protocol. It was the only one registered without a leading slash, which defeats `/charon/`-prefix matching.

The wire format does not change, so the version stays at `2.0.0` and the old spelling `charon/priority/2.0.0` is kept as a legacy alias. Nodes offer both IDs when dialling, preferring the slash-prefixed one, and serve both. This keeps patched and unpatched nodes interoperable in all four combinations:

| Dialer | Listener | Negotiated |
|---|---|---|
| patched | patched | `/charon/priority/2.0.0` |
| patched | unpatched | `charon/priority/2.0.0` |
| unpatched | patched | `charon/priority/2.0.0` |
| unpatched | unpatched | `charon/priority/2.0.0` |

The two IDs are registered as separate exact-match handlers rather than via a single `RegisterHandler` call with `WithDelimitedProtocol`. They share no common prefix, so one call would collapse `protocolPrefix` to the bare wildcard `"*"`, and that string is what gets advertised to peers through libp2p identify — peers would be told we support `"*"` and neither real ID. A code comment, a `protocolPrefix` doc comment, and a test assertion all pin this down.

`TODO(v1.14)` markers on the alias, the dual registration, and the send-side fallback mark them for removal once no supported version dials the legacy ID.

Tests: `TestProtocols` pins the wire-visible strings and their precedence, `TestProtocolNegotiation` covers what each peer type advertises and negotiates, and `TestPrioritiserLegacyPeer` runs a full exchange between a patched and an unpatched node. The latter isolates one dial direction per case — with both nodes dialling, either can reach quorum off its peer's inbound request and mask a broken outbound dial.

category: refactor
ticket: none
