### PR TITLE
p2p: fix flaky TestWithReceiveTimeout on QUIC

### DIFF
--- a/p2p/sender_test.go
+++ b/p2p/sender_test.go
@@ -5,6 +5,8 @@ package p2p_test
 import (
 	"context"
 	"math"
+	"slices"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,8 +28,17 @@ func TestWithReceiveTimeout(t *testing.T) {
 	servers := []host.Host{testutil.CreateHost(t, testutil.AvailableAddr(t)), testutil.CreateQUICHost(t, testutil.AvailableUDPAddr(t))}
 	clients := []host.Host{testutil.CreateHost(t, testutil.AvailableAddr(t)), testutil.CreateQUICHost(t, testutil.AvailableUDPAddr(t))}
 
+	// The zero receive timeout makes the server close the stream almost immediately,
+	// racing the client's request write. TCP closes gracefully, so the write always
+	// lands and the failure surfaces as an EOF on the response read. QUIC instead
+	// resets the stream, which can abort the write already in flight, so accept either.
+	expected := [][]string{
+		{"read response: EOF"},
+		{"read response: EOF", "stream reset"},
+	}
+
 	for i := range len(servers) {
-		client, server := clients[i], servers[i]
+		client, server, expect := clients[i], servers[i], expected[i]
 
 		client.Peerstore().AddAddrs(server.ID(), server.Addrs(), time.Hour)
 
@@ -40,7 +51,9 @@ func TestWithReceiveTimeout(t *testing.T) {
 
 		err := p2p.SendReceive(context.Background(), client, server.ID(), new(pbv1.Duty), new(pbv1.Duty), protocolID)
 		require.Error(t, err)
-		require.ErrorContains(t, err, "read response: EOF")
+		require.True(t, slices.ContainsFunc(expect, func(s string) bool {
+			return strings.Contains(err.Error(), s)
+		}), "error %q contains none of %v", err, expect)
 	}
 }
 


### PR DESCRIPTION
`TestWithReceiveTimeout` fails intermittently in CI on the QUIC iteration:

```
--- FAIL: TestWithReceiveTimeout (0.47s)
    Error: Error "write request: stream reset (remote): code: 0x0: transport error:
           stream 4 canceled by remote with error code 0" does not contain "read response: EOF"
```

The test registers the server handler with `WithReceiveTimeout(0)`, so the read deadline in `p2p/receive.go` is already expired when the handler starts. `ReadMsg` fails instantly and the deferred `s.Close()` tears the stream down — the CI log shows this happening 101µs in. Meanwhile the client is still in `WriteMsg`. Nothing synchronises the two, so which call reports the failure depends on who wins the race.

The transport decides the usual winner. The test loops over both:

- **TCP/yamux** — `Close()` is a graceful FIN. The in-flight write is absorbed by the buffer and succeeds, so the failure surfaces at the read as EOF. Deterministic.
- **QUIC** — `Close()` with unread incoming data emits `STOP_SENDING`/`RESET_STREAM`. If that lands mid-write, `WriteMsg` fails first and the read is never reached.

The assertion only allowed the first outcome, so a loaded runner could flip it. This is the same class of QUIC behaviour `sender.go` already tolerates via `isCanceledStreamErr`, whose comment notes these errors appear "much more frequently when QUIC is enabled" — that handling just does not extend to `WriteMsg`.

This accepts either terminal error on the QUIC iteration. The TCP iteration stays strict, since it has no race, and an unrelated error still fails on both.

category: test
ticket: none
