### PR TITLE
core/deadline: increase sync message deadline

### DIFF
--- a/core/deadline.go
+++ b/core/deadline.go
@@ -112,11 +112,12 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 			duration time.Duration
 		)
 
+		//nolint: revive // prioritise clarity
 		switch duty.Type {
 		case DutyProposer, DutyRandao:
 			duration = slotDuration / 3
-		case DutySyncMessage:
-			duration = 2 * slotDuration / 3
+		case DutySyncMessage, DutySyncContribution:
+			duration = slotDuration
 		case DutyAttester, DutyAggregator:
 			// Attestations and aggregations are kept for a full epoch so late partial signatures are not dropped.
 			duration = time.Duration(slotsPerEpoch) * slotDuration

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -168,7 +168,7 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 		},
 		{
 			duty:             core.NewSyncMessageDuty(currentSlot),
-			expectedDuration: 2*slotDuration/3 + margin,
+			expectedDuration: slotDuration + margin,
 		},
 		{
 			duty:             core.NewSyncContributionDuty(currentSlot),


### PR DESCRIPTION
Increase sync message deadline. This is done as after the deadline hits, the aggregated sync message signatures are cleaned from the DB (previously at 8s + 1s margin). However, the sync contribution does need them as part of the data, so sometimes, under specific network conditions or VC types, the contribution might take a bit more than 9s and the sync message is missing by then.

category: bug
ticket: none
