### PR TITLE
core/priority: use stable sort for scored priorities

### DIFF
--- a/core/priority/calculate.go
+++ b/core/priority/calculate.go
@@ -69,8 +69,10 @@ func calculateResult(msgs []*pbv1.PriorityMsg, minRequired int) (*pbv1.PriorityR
 			}
 		}
 
-		// Order by score decreasing
-		slices.SortFunc(allPriorities, func(i, j [32]byte) int {
+		// Order by score decreasing. The sort must be stable so that
+		// equal-score priorities keep first-seen order, with messages
+		// processed in ascending peer ID order.
+		slices.SortStableFunc(allPriorities, func(i, j [32]byte) int {
 			if scores[i] > scores[j] {
 				return -1
 			}

--- a/core/priority/calculate_internal_test.go
+++ b/core/priority/calculate_internal_test.go
@@ -3,6 +3,7 @@
 package priority
 
 import (
+	"fmt"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -213,6 +214,81 @@ func TestCalculateResults(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCalculateResultTieBreak ensures that equal-score priorities are returned
+// in first-seen order, processing messages in ascending peer ID order. Topics
+// with 13 or more priorities exercise pdqsort proper (not its insertion sort
+// fallback for short slices), which reorders equal elements unless the sort is stable.
+func TestCalculateResultTieBreak(t *testing.T) {
+	const (
+		numPriorities = 24
+		half          = numPriorities / 2
+		quorum        = 3
+	)
+
+	// Peers 0 and 1 propose p00..p23, peers 2 and 3 propose the same list
+	// rotated by half its length. So p(k) and p(k+12) receive equal scores,
+	// while first-seen order (peer 0's list) is not score-ordered, forcing
+	// the sort to do real work on the tied pairs.
+	inOrder := make([]string, numPriorities)
+	for i := range inOrder {
+		inOrder[i] = fmt.Sprintf("p%02d", i)
+	}
+
+	rotated := append(append([]string(nil), inOrder[half:]...), inOrder[:half]...)
+
+	// Pair k=(p(k), p(k+12)) scores 2*(1000-k) + 2*(1000-k-12) with ties
+	// ordered by first occurrence in peer 0's list.
+	var (
+		expectedResult []string
+		expectedScores []int64
+	)
+
+	for k := range half {
+		score := int64(4*countWeight - 4*k - numPriorities)
+		expectedResult = append(expectedResult, inOrder[k], inOrder[k+half])
+		expectedScores = append(expectedScores, score, score)
+	}
+
+	topic := toAny("versions")
+
+	var msgs []*pbv1.PriorityMsg
+
+	for j, prioritySet := range [][]string{inOrder, inOrder, rotated, rotated} {
+		msgs = append(msgs, &pbv1.PriorityMsg{
+			Topics: []*pbv1.PriorityTopicProposal{
+				{
+					Topic:      topic,
+					Priorities: toAnys(prioritySet),
+				},
+			},
+			PeerId: strconv.Itoa(j),
+			Duty:   &pbv1.Duty{Slot: 99},
+		})
+	}
+
+	// Shuffle since function should be deterministic.
+	rand.Shuffle(len(msgs), func(i, j int) {
+		msgs[i], msgs[j] = msgs[j], msgs[i]
+	})
+
+	result, err := calculateResult(msgs, quorum)
+	require.NoError(t, err)
+	require.Len(t, result.GetTopics(), 1)
+
+	var (
+		actualResult []string
+		actualScores []int64
+	)
+
+	for _, prio := range result.GetTopics()[0].GetPriorities() {
+		actualResult = append(actualResult, fromAny(prio.GetPriority()))
+		actualScores = append(actualScores, prio.GetScore())
+	}
+
+	require.Equal(t, expectedResult, actualResult)
+	require.Equal(t, expectedScores, actualScores)
 }
 
 // pl returns a slice of priority sets. It is an abridged convenience function.


### PR DESCRIPTION
Replaces `slices.SortFunc` with `slices.SortStableFunc` when ordering scored priorities, so equal-score priorities keep first-seen order, with messages processed in ascending peer ID order.

Go's sort is unstable for slices longer than ~12 elements (below that, pdqsort falls back to insertion sort, which is stable in practice). For topics with 13+ priorities, the order of equal-score entries was unspecified: it could change whenever Go changes its sort implementation, making mixed-version clusters compute different `PriorityResult` values from identical inputs, and other implementations could not reproduce Charon's result bytes. The serialized `PriorityResult` feeds QBFT proposals, so ordering must be a pure deterministic function of the message set.

Adds a regression test with 4 peers and a 24-priority topic where tied pairs arrive out of score order; it fails with `SortFunc` and passes with `SortStableFunc`.

category: bug
ticket: none