### PR TITLE
*: optimise sync contribution fetching

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -448,6 +448,12 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 	// won't decode the plural form and simply skip contributing.
 	syncContribV2 := f.syncContributionV2Func != nil && f.syncContributionV2Func(slot)
 
+	// A sync committee contribution is identified by its subcommittee and beacon block
+	// root, not by validator, so all aggregators sharing both contribute the same one.
+	// Cache it for the duration of this fetch to query the beacon node once per distinct
+	// contribution instead of once per aggregating validator.
+	contribByKey := make(map[syncContribKey]core.SyncContribution)
+
 	for pubkey, def := range defSet {
 		// A validator can occupy multiple sync subcommittees in the same slot,
 		// producing a distinct contribution for each it aggregates.
@@ -459,7 +465,7 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 		var contribs core.SyncContributions
 
 		for _, subcommIdx := range subcommIdxs {
-			contrib, ok, err := f.fetchSubcommContribution(ctx, slot, pubkey, subcommIdx)
+			contrib, ok, err := f.fetchSubcommContribution(ctx, slot, pubkey, subcommIdx, contribByKey)
 			if err != nil {
 				return core.UnsignedDataSet{}, err
 			} else if !ok {
@@ -492,10 +498,17 @@ func (f *Fetcher) fetchContributionData(ctx context.Context, slot uint64, defSet
 	return resp, nil
 }
 
+// syncContribKey identifies a sync committee contribution within a slot.
+type syncContribKey struct {
+	SubcommIdx core.SubcommitteeIndex
+	BlockRoot  eth2p0.Root
+}
+
 // fetchSubcommContribution fetches the sync committee contribution for a single
-// validator and subcommittee. It returns ok=false if the validator is not an
+// validator and subcommittee, reusing any contribution already fetched for the same
+// subcommittee and beacon block root. It returns ok=false if the validator is not an
 // aggregator for the subcommittee.
-func (f *Fetcher) fetchSubcommContribution(ctx context.Context, slot uint64, pubkey core.PubKey, subcommIdx core.SubcommitteeIndex) (core.SyncContribution, bool, error) {
+func (f *Fetcher) fetchSubcommContribution(ctx context.Context, slot uint64, pubkey core.PubKey, subcommIdx core.SubcommitteeIndex, contribByKey map[syncContribKey]core.SyncContribution) (core.SyncContribution, bool, error) {
 	// Query AggSigDB for DutyPrepareSyncContribution to get the sync committee selection.
 	selectionData, err := f.aggSigDBFunc(ctx, core.NewPrepareSyncContributionDuty(slot), pubkey, subcommIdx)
 	if err != nil {
@@ -528,26 +541,39 @@ func (f *Fetcher) fetchSubcommContribution(ctx context.Context, slot uint64, pub
 
 	blockRoot := msg.BeaconBlockRoot
 
-	// Query BN for the sync committee contribution.
-	opts := &eth2api.SyncCommitteeContributionOpts{
-		Slot:              eth2p0.Slot(slot),
-		SubcommitteeIndex: uint64(subcommIdx),
-		BeaconBlockRoot:   blockRoot,
+	// Another aggregator may already have fetched this contribution. Reusing it avoids a
+	// redundant beacon node query and keeps the contributions consistent, since a beacon
+	// node aggregates sync committee messages as they arrive and therefore returns a
+	// different aggregate to each query. Fetch clones the set per subscriber, so sharing
+	// the value between validators here is safe.
+	key := syncContribKey{SubcommIdx: subcommIdx, BlockRoot: blockRoot}
+
+	contrib, ok := contribByKey[key]
+	if !ok {
+		// Query BN for the sync committee contribution.
+		opts := &eth2api.SyncCommitteeContributionOpts{
+			Slot:              eth2p0.Slot(slot),
+			SubcommitteeIndex: uint64(subcommIdx),
+			BeaconBlockRoot:   blockRoot,
+		}
+
+		eth2Resp, err := f.eth2Cl.SyncCommitteeContribution(ctx, opts)
+		if err != nil {
+			return core.SyncContribution{}, false, err
+		}
+
+		contribution := eth2Resp.Data
+		if contribution == nil {
+			// Some beacon nodes return nil if the beacon block root is not found for the subcommittee, return retryable error.
+			// This could happen if the beacon node didn't subscribe to the correct subnet.
+			return core.SyncContribution{}, false, errors.New("sync committee contribution not found by root (retryable)", z.U64("subcommidx", uint64(subcommIdx)), z.Hex("root", blockRoot[:]))
+		}
+
+		contrib = core.SyncContribution{SyncCommitteeContribution: *contribution}
+		contribByKey[key] = contrib
 	}
 
-	eth2Resp, err := f.eth2Cl.SyncCommitteeContribution(ctx, opts)
-	if err != nil {
-		return core.SyncContribution{}, false, err
-	}
-
-	contribution := eth2Resp.Data
-	if contribution == nil {
-		// Some beacon nodes return nil if the beacon block root is not found for the subcommittee, return retryable error.
-		// This could happen if the beacon node didn't subscribe to the correct subnet.
-		return core.SyncContribution{}, false, errors.New("sync committee contribution not found by root (retryable)", z.U64("subcommidx", uint64(subcommIdx)), z.Hex("root", blockRoot[:]))
-	}
-
-	return core.SyncContribution{SyncCommitteeContribution: *contribution}, true, nil
+	return contrib, true, nil
 }
 
 // syncSubcommitteeSize returns the number of validators per sync subcommittee

--- a/core/fetcher/fetcher_test.go
+++ b/core/fetcher/fetcher_test.go
@@ -9,6 +9,7 @@ import (
 	"math"
 	"testing"
 
+	"github.com/OffchainLabs/go-bitfield"
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
@@ -661,6 +662,106 @@ func TestFetchSyncContribution(t *testing.T) {
 
 		err = fetch.Fetch(ctx, duty, defSet)
 		require.NoError(t, err)
+	})
+
+	// A contribution is identified by its subcommittee and beacon block root, so
+	// aggregators sharing both must reuse one beacon node query. Querying per validator
+	// returns a different aggregate each time, since a beacon node aggregates sync
+	// committee messages as they arrive.
+	t.Run("aggregators sharing a subcommittee query beacon node once", func(t *testing.T) {
+		bmock, err := beaconmock.New(t.Context())
+		require.NoError(t, err)
+
+		sharedRoot := testutil.RandomRoot()
+
+		// Both validators hold a position in subcommittee 0.
+		aggDutyA := testutil.RandomSyncCommitteeDuty(t)
+		aggDutyA.ValidatorIndex = vIdxA
+		aggDutyA.ValidatorSyncCommitteeIndices = []eth2p0.CommitteeIndex{0}
+		aggDutyB := testutil.RandomSyncCommitteeDuty(t)
+		aggDutyB.ValidatorIndex = vIdxB
+		aggDutyB.ValidatorSyncCommitteeIndices = []eth2p0.CommitteeIndex{1}
+
+		sharedDefSet := core.DutyDefinitionSet{
+			pubkeysByIdx[vIdxA]: core.NewSyncCommitteeDefinition(aggDutyA),
+			pubkeysByIdx[vIdxB]: core.NewSyncCommitteeDefinition(aggDutyB),
+		}
+
+		// Both validators are aggregators for subcommittee 0.
+		selectionsByPubkey := map[core.PubKey]core.SignedData{
+			pubkeysByIdx[vIdxA]: core.NewSyncCommitteeSelection(&eth2v1.SyncCommitteeSelection{
+				ValidatorIndex: vIdxA, Slot: slot, SubcommitteeIndex: subCommIdxA, SelectionProof: blsSigFromHex(t, sigA),
+			}),
+			pubkeysByIdx[vIdxB]: core.NewSyncCommitteeSelection(&eth2v1.SyncCommitteeSelection{
+				ValidatorIndex: vIdxB, Slot: slot, SubcommitteeIndex: subCommIdxA, SelectionProof: blsSigFromHex(t, sigB),
+			}),
+		}
+
+		// Both validators agree on the head, so both resolve to the same block root.
+		sharedMsgA := testutil.RandomSyncCommitteeMessage()
+		sharedMsgA.BeaconBlockRoot = sharedRoot
+		sharedMsgB := testutil.RandomSyncCommitteeMessage()
+		sharedMsgB.BeaconBlockRoot = sharedRoot
+		sharedMsgsByPubkey := map[core.PubKey]core.SignedData{
+			pubkeysByIdx[vIdxA]: core.NewSignedSyncMessage(sharedMsgA),
+			pubkeysByIdx[vIdxB]: core.NewSignedSyncMessage(sharedMsgB),
+		}
+
+		var queries int
+
+		bmock.SyncCommitteeContributionFunc = func(_ context.Context, _ eth2p0.Slot, subcommitteeIndex uint64, beaconBlockRoot eth2p0.Root) (*altair.SyncCommitteeContribution, error) {
+			queries++
+
+			// Return a distinct aggregate per query, growing as a real beacon node's would.
+			aggBits := bitfield.NewBitvector128()
+			for i := range queries {
+				aggBits.SetBitAt(uint64(i), true)
+			}
+
+			return &altair.SyncCommitteeContribution{
+				Slot:              slot,
+				BeaconBlockRoot:   beaconBlockRoot,
+				SubcommitteeIndex: subcommitteeIndex,
+				AggregationBits:   aggBits,
+				Signature:         testutil.RandomEth2Signature(),
+			}, nil
+		}
+
+		fetch := mustCreateFetcher(t, bmock)
+		fetch.RegisterSyncContributionV2(func(uint64) bool { return true })
+		fetch.RegisterAggSigDB(func(_ context.Context, duty core.Duty, key core.PubKey, _ core.SubcommitteeIndex) (core.SignedData, error) {
+			switch duty.Type {
+			case core.DutyPrepareSyncContribution:
+				return selectionsByPubkey[key], nil
+			case core.DutySyncMessage:
+				return sharedMsgsByPubkey[key], nil
+			default:
+				return nil, errors.New("unsupported duty")
+			}
+		})
+
+		fetch.Subscribe(func(_ context.Context, _ core.Duty, resDataSet core.UnsignedDataSet) error {
+			require.Len(t, resDataSet, 2)
+
+			contribA, ok := resDataSet[pubkeysByIdx[vIdxA]].(core.SyncContributions)
+			require.True(t, ok)
+			require.Len(t, contribA, 1)
+
+			contribB, ok := resDataSet[pubkeysByIdx[vIdxB]].(core.SyncContributions)
+			require.True(t, ok)
+			require.Len(t, contribB, 1)
+
+			// Both aggregators carry the identical contribution, so DutyDB stores it
+			// without contention.
+			require.Equal(t, contribA[0], contribB[0])
+			require.EqualValues(t, subCommIdxA, contribA[0].SubcommitteeIndex)
+
+			return nil
+		})
+
+		err = fetch.Fetch(ctx, duty, sharedDefSet)
+		require.NoError(t, err)
+		require.Equal(t, 1, queries)
 	})
 
 	t.Run("fetch contribution data error", func(t *testing.T) {


### PR DESCRIPTION
A sync committee contribution is identified by its subcommittee and beacon block root, not by validator, but the fetcher queried the beacon node once per aggregating validator. Since a beacon node aggregates sync committee messages as
they arrive, those redundant queries returned aggregates differing in aggregation bits, which `DutyDB` rejected as clashing contributions, losing every contribution for the slot...

Cache the contribution per subcommittee and beacon block root for the duration of the fetch, mirroring how attester data is already cached per committee index.

category: bug
ticket: none
