### PR TITLE
dkg: fail fast on peer restart or death during ceremonies

### DIFF
--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -46,6 +46,10 @@ import (
 	"github.com/obolnetwork/charon/tbls/tblsconv"
 )
 
+// shutdownSyncTimeout bounds the final shutdown synchronization between peers. All protocol
+// steps are complete and artifacts are stored by then, so waiting longer serves no purpose.
+const shutdownSyncTimeout = 2 * time.Minute
+
 type Config struct {
 	DefFile       string
 	NoVerify      bool
@@ -283,11 +287,29 @@ func Run(ctx context.Context, conf Config) (err error) {
 	// Improve UX of "context cancelled" errors when sync fails.
 	ctx = errors.WithCtxErr(ctx, "p2p connection failed, please retry DKG")
 
-	nextStepSync, stopSync, err := startSyncProtocol(ctx, p2pNode, key, def.DefinitionHash, peerIDs, cancel, conf.TestConfig, conf.Nickname)
+	nextStepSyncRaw, stopSync, fatalErr, err := startSyncProtocol(ctx, p2pNode, key, def.DefinitionHash, peerIDs, cancel, conf.TestConfig, conf.Nickname)
 	if err != nil {
 		log.Error(ctx, "Failed to start sync protocol, please make sure you don't have any other long-running charon or dkg processes running", err)
 
 		return err
+	}
+
+	// fatalOr returns the actionable fatal sync failure (e.g. a peer restarting
+	// mid-ceremony) instead of the generic error the interrupted operation returned.
+	fatalOr := func(err error) error {
+		if fatal := fatalErr(); fatal != nil {
+			return fatal
+		}
+
+		return err
+	}
+
+	nextStepSync := func(ctx context.Context) error {
+		if err := nextStepSyncRaw(ctx); err != nil {
+			return fatalOr(err)
+		}
+
+		return nil
 	}
 
 	log.Info(ctx, "All peers connected, starting DKG ceremony")
@@ -298,12 +320,12 @@ func Run(ctx context.Context, conf Config) (err error) {
 	case "default", "frost":
 		shares, err = runFrostParallel(ctx, tp, uint32(newValidators), uint32(len(peerMap)), uint32(def.Threshold), uint32(nodeIdx.ShareIdx), defHash)
 		if err != nil {
-			return err
+			return fatalOr(err)
 		}
 	case "pedersen":
 		shares, err = pedersen.RunDKG(ctx, pedersenConfig, pedersenBoard, newValidators)
 		if err != nil {
-			return err
+			return fatalOr(err)
 		}
 	default:
 		return errors.New("unsupported dkg algorithm")
@@ -497,12 +519,12 @@ func Run(ctx context.Context, conf Config) (err error) {
 // when all peers are connected.
 func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKey, defHash []byte,
 	peerIDs []peer.ID, onFailure func(), testConfig TestConfig, nickname string,
-) (stepSyncFunc func(context.Context) error, shutdownFunc func(context.Context) error, err error) {
+) (stepSyncFunc func(context.Context) error, shutdownFunc func(context.Context) error, fatalFunc func() error, err error) {
 	// Sign definition hash with charon-enr-private-key
 	// Note: libp2p signing does another hash of the defHash.
 	hashSig, err := ((*libp2pcrypto.Secp256k1PrivateKey)(key)).Sign(defHash)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "sign definition hash")
+		return nil, nil, nil, errors.Wrap(err, "sign definition hash")
 	}
 
 	// DKG compatibility is minor version dependent.
@@ -514,7 +536,22 @@ func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKe
 	var (
 		clients         []*sync.Client
 		shutdownStarted atomic.Bool
+		fatal           atomic.Pointer[error]
 	)
+
+	// recordFatal stores the first fatal sync failure so callers can return an
+	// actionable error instead of a generic "context canceled" one.
+	recordFatal := func(err error) {
+		fatal.CompareAndSwap(nil, &err)
+	}
+
+	fatalFunc = func() error {
+		if p := fatal.Load(); p != nil {
+			return *p
+		}
+
+		return nil
+	}
 
 	for _, pID := range peerIDs {
 		if p2pNode.ID() == pID {
@@ -532,6 +569,7 @@ func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKe
 			// During shutdown, connection errors are expected and should not fail the protocol.
 			if err != nil && !errors.Is(err, context.Canceled) && !shutdownStarted.Load() {
 				log.Error(ctx, "Failed to sync with peer during DKG. Check network connectivity and peer availability", err)
+				recordFatal(errors.Wrap(err, "sync failed with peer", z.Str("peer", p2p.PeerName(pID))))
 				onFailure()
 			}
 		}()
@@ -541,11 +579,15 @@ func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKe
 	for {
 		// Return if there is a context error.
 		if ctx.Err() != nil {
-			return nil, nil, ctx.Err()
+			if fatal := fatalFunc(); fatal != nil {
+				return nil, nil, nil, fatal
+			}
+
+			return nil, nil, nil, ctx.Err()
 		}
 
 		if err := server.Err(); err != nil {
-			return nil, nil, errors.Wrap(err, "sync server error")
+			return nil, nil, nil, errors.Wrap(err, "sync server error")
 		}
 
 		var connectedCount int
@@ -575,8 +617,34 @@ func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKe
 
 	err = server.AwaitAllConnected(ctx)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+
+	// Monitor the sync server for fatal errors (e.g. a peer restarting mid-ceremony)
+	// and abort the protocol promptly instead of hanging inside a protocol step.
+	go func() {
+		ticker := time.NewTicker(100 * time.Millisecond)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if shutdownStarted.Load() {
+					return
+				}
+
+				if err := server.Err(); err != nil {
+					log.Error(ctx, "Aborting DKG ceremony due to peer failure", err)
+					recordFatal(err)
+					onFailure()
+
+					return
+				}
+			}
+		}
+	}()
 
 	var step int
 
@@ -598,13 +666,23 @@ func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKe
 
 	// All peer start on step 0, so advance to step 1.
 	if err := stepSyncFunc(ctx); err != nil {
-		return nil, nil, err
+		if fatal := fatalFunc(); fatal != nil {
+			return nil, nil, nil, fatal
+		}
+
+		return nil, nil, nil, err
 	}
 
 	// Shutdown function stops all clients and server
 	shutdownFunc = func(ctx context.Context) error {
 		// Mark shutdown as started so client errors don't trigger onFailure.
 		shutdownStarted.Store(true)
+
+		// All protocol steps have completed and artifacts are stored by now, so bound the
+		// shutdown sync: a peer dying at this point must not hang the process forever,
+		// especially since failure detection is disabled during shutdown.
+		ctx, cancel := context.WithTimeout(ctx, shutdownSyncTimeout)
+		defer cancel()
 
 		// Sync all peers to a "shutdown ready" step before sending shutdown messages.
 		// This ensures all peers have completed their work before any starts teardown.
@@ -627,7 +705,7 @@ func startSyncProtocol(ctx context.Context, p2pNode host.Host, key *k1.PrivateKe
 		return server.AwaitAllShutdown(ctx)
 	}
 
-	return stepSyncFunc, shutdownFunc, nil
+	return stepSyncFunc, shutdownFunc, fatalFunc, nil
 }
 
 // signAndAggLockHash returns cluster lock file with aggregated signature after signing, exchange and aggregation of partial signatures.

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -66,6 +66,7 @@ type exchanger struct {
 	sigTypes      map[sigType]bool
 	sigData       dataByPubkey
 	dutyGaterFunc func(duty core.Duty) bool
+	timeout       time.Duration
 }
 
 func newExchanger(p2pNode host.Host, peerIdx int, peers []peer.ID, peerMap map[peer.ID]cluster.NodeIdx, sigTypes []sigType, timeout time.Duration) (*exchanger, error) {
@@ -117,6 +118,7 @@ func newExchanger(p2pNode host.Host, peerIdx int, peers []peer.ID, peerMap map[p
 			lock:  sync.Mutex{},
 		},
 		dutyGaterFunc: dutyGaterFunc,
+		timeout:       timeout,
 	}
 
 	// Wiring core workflow components
@@ -173,9 +175,15 @@ func (e *exchanger) exchange(ctx context.Context, sigType sigType, set core.ParS
 	e.resolveQueriesUnsafe()
 	e.sigData.lock.Unlock()
 
+	timer := time.NewTimer(e.timeout)
+	defer timer.Stop()
+
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()
+	case <-timer.C:
+		return nil, errors.New("timed out waiting for peer signatures",
+			z.Int("sig_type", int(sigType)))
 	case data := <-response:
 		return data, nil
 	}

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -400,3 +400,67 @@ func TestNewExchangerRejectsIncompletePeerMap(t *testing.T) {
 	_, err := newExchanger(h, 0, peers, peerMap, []sigType{sigLock}, time.Second)
 	require.ErrorContains(t, err, "missing valid share index")
 }
+
+// TestExchangerTimeout verifies that a signature exchange does not block forever when
+// peers never deliver their partial signatures, but fails with a timeout error instead.
+func TestExchangerTimeout(t *testing.T) {
+	const nodes = 3
+
+	var (
+		peers     []peer.ID
+		hosts     []host.Host
+		hostsInfo []peer.AddrInfo
+	)
+
+	for range nodes {
+		h := testutil.CreateHost(t, testutil.AvailableAddr(t))
+		info := peer.AddrInfo{
+			ID:    h.ID(),
+			Addrs: h.Addrs(),
+		}
+		hostsInfo = append(hostsInfo, info)
+		peers = append(peers, h.ID())
+		hosts = append(hosts, h)
+	}
+
+	for i := range nodes {
+		for j := range nodes {
+			if i == j {
+				continue
+			}
+
+			hosts[i].Peerstore().AddAddrs(hostsInfo[j].ID, hostsInfo[j].Addrs, peerstore.PermanentAddrTTL)
+		}
+	}
+
+	// All nodes create exchangers (registering stream handlers), but only node 0
+	// exchanges. The other nodes never deliver their signatures.
+	var exchangers []*exchanger
+
+	for i := range nodes {
+		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), []sigType{sigLock}, 2*time.Second)
+		require.NoError(t, err)
+
+		exchangers = append(exchangers, ex)
+	}
+
+	pubkey := testutil.RandomCorePubKey(t)
+	set := core.ParSignedDataSet{
+		pubkey: core.NewPartialSignature(testutil.RandomCoreSignature(), 1),
+	}
+
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := exchangers[0].exchange(t.Context(), sigLock, set)
+		errCh <- err
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "timed out waiting")
+	case <-time.After(10 * time.Second):
+		t.Fatal("exchange did not time out, expected timeout error")
+	}
+}

--- a/dkg/pedersen/board.go
+++ b/dkg/pedersen/board.go
@@ -5,7 +5,9 @@ package pedersen
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"path"
+	"sync"
 
 	kdkg "github.com/drand/kyber/share/dkg"
 	"github.com/libp2p/go-libp2p/core/host"
@@ -25,16 +27,20 @@ import (
 // Board implements kdkg.Board used to exchange protocol messages.
 // Also, it implements logic for exchanging public keys before and after the DKG.
 type Board struct {
-	logCtx            context.Context
-	host              host.Host
-	sender            *p2p.Sender
-	config            *Config
-	bcastComp         *bcast.Component
-	dealCh            chan kdkg.DealBundle
-	responseCh        chan kdkg.ResponseBundle
-	justificationCh   chan kdkg.JustificationBundle
-	nodePubKeysCh     chan NodePubKeys
-	valPubKeySharesCh chan ValidatorPubKeyShare
+	logCtx             context.Context
+	host               host.Host
+	sender             *p2p.Sender
+	config             *Config
+	bcastComp          *bcast.Component
+	dedup              *bundleDedup
+	dealCh             chan kdkg.DealBundle
+	responseCh         chan kdkg.ResponseBundle
+	justificationCh    chan kdkg.JustificationBundle
+	dealOutCh          chan kdkg.DealBundle
+	responseOutCh      chan kdkg.ResponseBundle
+	justificationOutCh chan kdkg.JustificationBundle
+	nodePubKeysCh      chan NodePubKeys
+	valPubKeySharesCh  chan ValidatorPubKeyShare
 }
 
 type NodePubKeys struct {
@@ -66,17 +72,28 @@ var (
 // In the future Kyber fork we will address this and fix all logging as well.
 func NewBoard(ctx context.Context, host host.Host, config *Config, bcastComp *bcast.Component) *Board {
 	board := &Board{
-		logCtx:            log.WithTopic(ctx, "pedersen"),
-		host:              host,
-		sender:            new(p2p.Sender),
-		config:            config,
-		bcastComp:         bcastComp,
-		dealCh:            make(chan kdkg.DealBundle),
-		responseCh:        make(chan kdkg.ResponseBundle),
-		justificationCh:   make(chan kdkg.JustificationBundle),
-		nodePubKeysCh:     make(chan NodePubKeys, config.Nodes()),
-		valPubKeySharesCh: make(chan ValidatorPubKeyShare, config.Nodes()),
+		logCtx:             log.WithTopic(ctx, "pedersen"),
+		host:               host,
+		sender:             new(p2p.Sender),
+		config:             config,
+		bcastComp:          bcastComp,
+		dedup:              newBundleDedup(),
+		dealCh:             make(chan kdkg.DealBundle),
+		responseCh:         make(chan kdkg.ResponseBundle),
+		justificationCh:    make(chan kdkg.JustificationBundle),
+		dealOutCh:          make(chan kdkg.DealBundle),
+		responseOutCh:      make(chan kdkg.ResponseBundle),
+		justificationOutCh: make(chan kdkg.JustificationBundle),
+		nodePubKeysCh:      make(chan NodePubKeys, config.Nodes()),
+		valPubKeySharesCh:  make(chan ValidatorPubKeyShare, config.Nodes()),
 	}
+
+	// Bundles reach kyber via forwarders that close their output channels when the
+	// protocol context is done. Kyber FastSync protocol goroutines exit when a board
+	// channel closes, so an aborted ceremony does not leak running DKG goroutines.
+	go forwardBundles(ctx, board.dealCh, board.dealOutCh)
+	go forwardBundles(ctx, board.responseCh, board.responseOutCh)
+	go forwardBundles(ctx, board.justificationCh, board.justificationOutCh)
 
 	// We use bcast for exchanging node public keys only as they are invariant and sent only once.
 	// This will leverage reliable broadcast and deduplication.
@@ -104,17 +121,17 @@ func (b *Board) IncomingValidatorPubKeyShares() <-chan ValidatorPubKeyShare {
 
 // IncomingDeal implements the kdkg.Board interface.
 func (b *Board) IncomingDeal() <-chan kdkg.DealBundle {
-	return b.dealCh
+	return b.dealOutCh
 }
 
 // IncomingResponse implements the kdkg.Board interface.
 func (b *Board) IncomingResponse() <-chan kdkg.ResponseBundle {
-	return b.responseCh
+	return b.responseOutCh
 }
 
 // IncomingJustification implements the kdkg.Board interface.
 func (b *Board) IncomingJustification() <-chan kdkg.JustificationBundle {
-	return b.justificationCh
+	return b.justificationOutCh
 }
 
 // BroadcastNodePubKey broadcasts a public key and collects the public keys of all peers.
@@ -182,12 +199,17 @@ func (b *Board) PushDeals(bundle *kdkg.DealBundle) {
 	}
 
 	go func() {
-		b.dealCh <- *bundle
+		select {
+		case b.dealCh <- *bundle:
+		case <-b.logCtx.Done(): // Do not leak the self-send once the protocol is aborted.
+		}
 	}()
 }
 
 // PushResponses implements the kdkg.Board interface.
 func (b *Board) PushResponses(bundle *kdkg.ResponseBundle) {
+	logComplaints(b.logCtx, "Sending DKG complaints, deals from these dealers failed verification", b.config.ThisPeerID, *bundle)
+
 	msg, err := ResponseBundleToProto(*bundle)
 	if err != nil {
 		log.Error(b.logCtx, "Failed to create envelope from response bundle", err)
@@ -199,7 +221,10 @@ func (b *Board) PushResponses(bundle *kdkg.ResponseBundle) {
 	}
 
 	go func() {
-		b.responseCh <- *bundle
+		select {
+		case b.responseCh <- *bundle:
+		case <-b.logCtx.Done(): // Do not leak the self-send once the protocol is aborted.
+		}
 	}()
 }
 
@@ -216,7 +241,10 @@ func (b *Board) PushJustifications(bundle *kdkg.JustificationBundle) {
 	}
 
 	go func() {
-		b.justificationCh <- *bundle
+		select {
+		case b.justificationCh <- *bundle:
+		case <-b.logCtx.Done(): // Do not leak the self-send once the protocol is aborted.
+		}
 	}()
 }
 
@@ -292,6 +320,12 @@ func (b *Board) handleDealBundleMessage(ctx context.Context, peerID peer.ID, msg
 		return nil, false, errors.New("deal bundle request malformed", z.Str("peer_id", peerID.String()))
 	}
 
+	// Drop identical re-deliveries: kyber evicts a dealer when it sees a duplicate bundle.
+	if b.dedup.isDuplicate(dealBundleMsg, protoBundle.GetSignature()) {
+		log.Debug(b.logCtx, "Dropping duplicate deal bundle", z.Str("from", peerID.String()))
+		return nil, true, nil
+	}
+
 	bundle, err := DealBundleFromProto(protoBundle, b.config.Suite)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "deal bundle request invalid", z.Str("peer_id", peerID.String()))
@@ -312,10 +346,18 @@ func (b *Board) handleResponseBundleMessage(ctx context.Context, peerID peer.ID,
 		return nil, false, errors.New("response bundle request malformed", z.Str("peer_id", peerID.String()))
 	}
 
+	// Drop identical re-deliveries: kyber evicts a share holder when it sees a duplicate bundle.
+	if b.dedup.isDuplicate(respBundleMsg, protoBundle.GetSignature()) {
+		log.Debug(b.logCtx, "Dropping duplicate response bundle", z.Str("from", peerID.String()))
+		return nil, true, nil
+	}
+
 	bundle, err := ResponseBundleFromProto(protoBundle)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "response bundle request invalid", z.Str("peer_id", peerID.String()))
 	}
+
+	logComplaints(b.logCtx, "Received DKG complaints, this peer rejected deals from these dealers", peerID, bundle)
 
 	select {
 	case b.responseCh <- bundle:
@@ -332,6 +374,12 @@ func (b *Board) handleJustificationBundleMessage(ctx context.Context, peerID pee
 		return nil, false, errors.New("justification bundle request malformed", z.Str("peer_id", peerID.String()))
 	}
 
+	// Drop identical re-deliveries: kyber evicts a dealer when it sees a duplicate bundle.
+	if b.dedup.isDuplicate(justBundleMsg, protoBundle.GetSignature()) {
+		log.Debug(b.logCtx, "Dropping duplicate justification bundle", z.Str("from", peerID.String()))
+		return nil, true, nil
+	}
+
 	bundle, err := JustificationBundleFromProto(protoBundle, b.config.Suite)
 	if err != nil {
 		return nil, false, errors.Wrap(err, "justification bundle request invalid", z.Str("peer_id", peerID.String()))
@@ -344,6 +392,76 @@ func (b *Board) handleJustificationBundleMessage(ctx context.Context, peerID pee
 	}
 
 	return nil, true, nil
+}
+
+// logComplaints surfaces complaint responses which kyber processes silently. A complaint
+// means the sender could not verify a dealer's deal (e.g. undecryptable share or a share
+// inconsistent with the cluster's public commitments).
+func logComplaints(ctx context.Context, msg string, peerID peer.ID, bundle kdkg.ResponseBundle) {
+	var dealers []uint32
+
+	for _, resp := range bundle.Responses {
+		if resp.Status == kdkg.Complaint {
+			dealers = append(dealers, resp.DealerIndex)
+		}
+	}
+
+	if len(dealers) == 0 {
+		return
+	}
+
+	log.Warn(ctx, msg, nil,
+		z.Str("peer_id", peerID.String()),
+		z.U64("share_index", uint64(bundle.ShareIndex)),
+		z.Any("dealer_indices", dealers))
+}
+
+// bundleDedup drops byte-identical re-deliveries of DKG bundles. Bundles are keyed by
+// their signature, which is unique per dealer, content and session.
+type bundleDedup struct {
+	mu   sync.Mutex
+	seen map[[32]byte]struct{}
+}
+
+func newBundleDedup() *bundleDedup {
+	return &bundleDedup{seen: make(map[[32]byte]struct{})}
+}
+
+// isDuplicate returns true if a bundle of this type with this signature was already delivered,
+// and records it otherwise.
+func (d *bundleDedup) isDuplicate(msgType string, signature []byte) bool {
+	h := sha256.Sum256(append([]byte(msgType), signature...))
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if _, ok := d.seen[h]; ok {
+		return true
+	}
+
+	d.seen[h] = struct{}{}
+
+	return false
+}
+
+// forwardBundles forwards bundles from in to out until ctx is canceled, then closes out.
+// Kyber FastSync protocol goroutines exit when a board channel closes, so this stops
+// them without modifying the kyber library.
+func forwardBundles[T any](ctx context.Context, in <-chan T, out chan<- T) {
+	defer close(out)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case msg := <-in:
+			select {
+			case out <- msg:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
 }
 
 func checkNodePubKeyMessage(_ context.Context, peerID peer.ID, msgAny *anypb.Any) error {

--- a/dkg/pedersen/config.go
+++ b/dkg/pedersen/config.go
@@ -60,6 +60,22 @@ func (c Config) Nodes() int {
 	return len(c.PeerMap)
 }
 
+// PeerIDs returns the IDs of all peers participating in the protocol.
+func (c Config) PeerIDs() []peer.ID {
+	pids := make([]peer.ID, 0, len(c.PeerMap))
+	for pid := range c.PeerMap {
+		pids = append(pids, pid)
+	}
+
+	return pids
+}
+
+// collectTimeout bounds waiting for per-peer DKG messages. It equals the configured
+// DKG timeout, since PhaseDuration is derived as timeout/6 by all protocols.
+func (c Config) collectTimeout() time.Duration {
+	return 6 * c.PhaseDuration
+}
+
 func (c Config) ThisNodeIndex() (int, error) {
 	i, ok := c.PeerMap[c.ThisPeerID]
 	if !ok {

--- a/dkg/pedersen/dkg.go
+++ b/dkg/pedersen/dkg.go
@@ -5,16 +5,19 @@ package pedersen
 import (
 	"context"
 	"slices"
+	"time"
 
 	kbls "github.com/drand/kyber-bls12381"
 	kdkg "github.com/drand/kyber/share/dkg"
 	drandbls "github.com/drand/kyber/sign/bdn"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/dkg/share"
+	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/tbls"
 )
 
@@ -125,7 +128,8 @@ func RunDKG(ctx context.Context, config *Config, board *Board, numVals int) ([]s
 func makeNodes(ctx context.Context, config *Config, board *Board) ([]kdkg.Node, map[int][][]byte, error) {
 	var nodes []kdkg.Node
 
-	nodePubKeys, err := readBoardChannel(ctx, board.IncomingNodePubKeys(), len(config.PeerMap))
+	nodePubKeys, err := readBoardChannel(ctx, board.IncomingNodePubKeys(), config.PeerIDs(),
+		func(pk NodePubKeys) peer.ID { return pk.PeerID }, config.collectTimeout())
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "read peer pubkeys")
 	}
@@ -171,7 +175,8 @@ func processKey(ctx context.Context, config *Config, board *Board, key *kdkg.Dis
 		return share.Share{}, errors.Wrap(err, "broadcast share pubkey")
 	}
 
-	valPubKeyShares, err := readBoardChannel(ctx, board.IncomingValidatorPubKeyShares(), len(config.PeerMap))
+	valPubKeyShares, err := readBoardChannel(ctx, board.IncomingValidatorPubKeyShares(), config.PeerIDs(),
+		func(s ValidatorPubKeyShare) peer.ID { return s.PeerID }, config.collectTimeout())
 	if err != nil {
 		return share.Share{}, errors.Wrap(err, "read validator pubkey shares")
 	}
@@ -208,19 +213,63 @@ func processKey(ctx context.Context, config *Config, board *Board, key *kdkg.Dis
 	}, nil
 }
 
-func readBoardChannel[T any](ctx context.Context, ch <-chan T, count int) ([]T, error) {
-	var pubKeys []T
+// readBoardChannel collects exactly one message per expected peer from the given channel,
+// ignoring duplicate deliveries and messages from unexpected peers. It fails with an error
+// naming the missing peers if the collection does not complete within the given timeout,
+// so a dead peer does not hang the ceremony forever.
+func readBoardChannel[T any](ctx context.Context, ch <-chan T, expected []peer.ID, peerIDFn func(T) peer.ID, timeout time.Duration) ([]T, error) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 
-	for range count {
+	expectedSet := make(map[peer.ID]struct{}, len(expected))
+	for _, pid := range expected {
+		expectedSet[pid] = struct{}{}
+	}
+
+	var (
+		msgs []T
+		seen = make(map[peer.ID]struct{}, len(expected))
+	)
+
+	for len(msgs) < len(expected) {
 		select {
-		case pkd := <-ch:
-			pubKeys = append(pubKeys, pkd)
+		case msg := <-ch:
+			pid := peerIDFn(msg)
+			if _, ok := expectedSet[pid]; !ok {
+				continue // Ignore messages from unexpected peers.
+			}
+
+			if _, ok := seen[pid]; ok {
+				continue // Ignore duplicate deliveries.
+			}
+
+			seen[pid] = struct{}{}
+
+			msgs = append(msgs, msg)
+		case <-timer.C:
+			return nil, errors.New("timed out waiting for DKG messages from peers",
+				z.Any("missing_peers", missingPeerNames(expected, seen)),
+				z.Int("received", len(msgs)),
+				z.Int("expected", len(expected)))
 		case <-ctx.Done():
 			return nil, errors.New("context done")
 		}
 	}
 
-	return pubKeys, nil
+	return msgs, nil
+}
+
+// missingPeerNames returns the names of the expected peers that no message was received from.
+func missingPeerNames(expected []peer.ID, seen map[peer.ID]struct{}) []string {
+	var missing []string
+
+	for _, pid := range expected {
+		if _, ok := seen[pid]; !ok {
+			missing = append(missing, p2p.PeerName(pid))
+		}
+	}
+
+	return missing
 }
 
 // validateThreshold verifies that the threshold is between 1 and nodeCount.

--- a/dkg/pedersen/dkg_internal_test.go
+++ b/dkg/pedersen/dkg_internal_test.go
@@ -1,0 +1,196 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package pedersen
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/drand/kyber"
+	kdkg "github.com/drand/kyber/share/dkg"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/log"
+)
+
+func TestReadBoardChannel(t *testing.T) {
+	var (
+		peerA = peer.ID("peer-a")
+		peerB = peer.ID("peer-b")
+		peerC = peer.ID("peer-c")
+	)
+
+	expected := []peer.ID{peerA, peerB, peerC}
+	peerIDFn := func(pk NodePubKeys) peer.ID { return pk.PeerID }
+
+	t.Run("all messages received", func(t *testing.T) {
+		ch := make(chan NodePubKeys, 3)
+		for _, pid := range expected {
+			ch <- NodePubKeys{PeerID: pid}
+		}
+
+		got, err := readBoardChannel(t.Context(), ch, expected, peerIDFn, time.Second)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+	})
+
+	t.Run("timeout reports missing peers", func(t *testing.T) {
+		ch := make(chan NodePubKeys, 3)
+		ch <- NodePubKeys{PeerID: peerA}
+
+		_, err := readBoardChannel(t.Context(), ch, expected, peerIDFn, 100*time.Millisecond)
+		require.ErrorContains(t, err, "timed out waiting")
+	})
+
+	t.Run("duplicates do not mask a missing peer", func(t *testing.T) {
+		ch := make(chan NodePubKeys, 3)
+		ch <- NodePubKeys{PeerID: peerA}
+
+		ch <- NodePubKeys{PeerID: peerA} // Duplicate delivery of peer A.
+
+		ch <- NodePubKeys{PeerID: peerB}
+
+		_, err := readBoardChannel(t.Context(), ch, expected, peerIDFn, 100*time.Millisecond)
+		require.ErrorContains(t, err, "timed out waiting", "peer C is still missing")
+	})
+
+	t.Run("unexpected peers are ignored", func(t *testing.T) {
+		ch := make(chan NodePubKeys, 4)
+		ch <- NodePubKeys{PeerID: peerA}
+
+		ch <- NodePubKeys{PeerID: peer.ID("peer-x")} // Not part of the ceremony.
+
+		ch <- NodePubKeys{PeerID: peerB}
+
+		ch <- NodePubKeys{PeerID: peerC}
+
+		got, err := readBoardChannel(t.Context(), ch, expected, peerIDFn, time.Second)
+		require.NoError(t, err)
+		require.Len(t, got, 3)
+
+		for _, msg := range got {
+			require.NotEqual(t, peer.ID("peer-x"), msg.PeerID)
+		}
+	})
+
+	t.Run("context cancel", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		ch := make(chan NodePubKeys, 3)
+
+		_, err := readBoardChannel(ctx, ch, expected, peerIDFn, time.Second)
+		require.ErrorContains(t, err, "context done")
+	})
+}
+
+func TestForwardBundlesClosesOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+
+	in := make(chan int)
+	out := make(chan int)
+
+	go forwardBundles(ctx, in, out)
+
+	// Values are forwarded while the context is live.
+	go func() { in <- 42 }()
+
+	require.Equal(t, 42, <-out)
+
+	// The output channel is closed when the context is canceled, which stops
+	// kyber FastSync protocol goroutines reading from it.
+	cancel()
+
+	select {
+	case _, ok := <-out:
+		require.False(t, ok, "expected output channel to be closed")
+	case <-time.After(time.Second):
+		t.Fatal("output channel was not closed on context cancel")
+	}
+}
+
+func TestBoardDropsDuplicateBundles(t *testing.T) {
+	board := &Board{
+		logCtx:          log.WithTopic(t.Context(), "pedersen"),
+		config:          &Config{Suite: DefaultSuite},
+		dealCh:          make(chan kdkg.DealBundle, 4),
+		responseCh:      make(chan kdkg.ResponseBundle, 4),
+		justificationCh: make(chan kdkg.JustificationBundle, 4),
+		dedup:           newBundleDedup(),
+	}
+
+	pid := peer.ID("peer-a")
+
+	t.Run("deal bundle", func(t *testing.T) {
+		bundle := kdkg.DealBundle{
+			DealerIndex: 1,
+			Deals:       []kdkg.Deal{{ShareIndex: 1, EncryptedShare: []byte{1, 2, 3}}},
+			Public:      []kyber.Point{RandomPoint(t)},
+			SessionID:   []byte("session"),
+			Signature:   []byte{1, 1, 1},
+		}
+
+		msg, err := DealBundleToProto(bundle)
+		require.NoError(t, err)
+
+		_, _, err = board.handleDealBundleMessage(t.Context(), pid, msg)
+		require.NoError(t, err)
+		require.Len(t, board.dealCh, 1)
+
+		// Identical re-delivery is dropped.
+		_, _, err = board.handleDealBundleMessage(t.Context(), pid, msg)
+		require.NoError(t, err)
+		require.Len(t, board.dealCh, 1)
+
+		// A different bundle from the same dealer passes through.
+		bundle.Signature = []byte{2, 2, 2}
+		msg2, err := DealBundleToProto(bundle)
+		require.NoError(t, err)
+
+		_, _, err = board.handleDealBundleMessage(t.Context(), pid, msg2)
+		require.NoError(t, err)
+		require.Len(t, board.dealCh, 2)
+	})
+
+	t.Run("response bundle", func(t *testing.T) {
+		bundle := kdkg.ResponseBundle{
+			ShareIndex: 1,
+			Responses:  []kdkg.Response{{DealerIndex: 1, Status: true}},
+			SessionID:  []byte("session"),
+			Signature:  []byte{3, 3, 3},
+		}
+
+		msg, err := ResponseBundleToProto(bundle)
+		require.NoError(t, err)
+
+		_, _, err = board.handleResponseBundleMessage(t.Context(), pid, msg)
+		require.NoError(t, err)
+		require.Len(t, board.responseCh, 1)
+
+		_, _, err = board.handleResponseBundleMessage(t.Context(), pid, msg)
+		require.NoError(t, err)
+		require.Len(t, board.responseCh, 1)
+	})
+
+	t.Run("justification bundle", func(t *testing.T) {
+		bundle := kdkg.JustificationBundle{
+			DealerIndex:    1,
+			Justifications: []kdkg.Justification{{ShareIndex: 1, Share: RandomScalar(t)}},
+			SessionID:      []byte("session"),
+			Signature:      []byte{4, 4, 4},
+		}
+
+		msg, err := JustificationBundleToProto(bundle)
+		require.NoError(t, err)
+
+		_, _, err = board.handleJustificationBundleMessage(t.Context(), pid, msg)
+		require.NoError(t, err)
+		require.Len(t, board.justificationCh, 1)
+
+		_, _, err = board.handleJustificationBundleMessage(t.Context(), pid, msg)
+		require.NoError(t, err)
+		require.Len(t, board.justificationCh, 1)
+	})
+}

--- a/dkg/pedersen/reshare.go
+++ b/dkg/pedersen/reshare.go
@@ -13,6 +13,7 @@ import (
 	kdkg "github.com/drand/kyber/share/dkg"
 	drandbls "github.com/drand/kyber/sign/bdn"
 	ssz "github.com/ferranbt/fastssz"
+	"github.com/libp2p/go-libp2p/core/peer"
 
 	"github.com/obolnetwork/charon/app/errors"
 	"github.com/obolnetwork/charon/app/log"
@@ -321,7 +322,8 @@ func broadcastNoneKey(ctx context.Context, config *Config, board *Board) error {
 		return errors.Wrap(err, "broadcast none pubkey")
 	}
 
-	_, err := readBoardChannel(ctx, board.IncomingValidatorPubKeyShares(), len(config.PeerMap))
+	_, err := readBoardChannel(ctx, board.IncomingValidatorPubKeyShares(), config.PeerIDs(),
+		func(s ValidatorPubKeyShare) peer.ID { return s.PeerID }, config.collectTimeout())
 
 	return err
 }

--- a/dkg/protocol.go
+++ b/dkg/protocol.go
@@ -163,23 +163,33 @@ func RunProtocol(ctx context.Context, protocol Protocol, lockFilePath, privateKe
 
 	log.Info(ctx, "Waiting to connect to all peers...")
 
-	nextStepSync, stopSync, err := startSyncProtocol(ctx, thisNode, enrPrivateKey, lock.DefinitionHash, protocolCtx.PeerIDs, cancel, TestConfig{}, config.Nickname)
+	nextStepSync, stopSync, fatalErr, err := startSyncProtocol(ctx, thisNode, enrPrivateKey, lock.DefinitionHash, protocolCtx.PeerIDs, cancel, TestConfig{}, config.Nickname)
 	if err != nil {
+		return err
+	}
+
+	// fatalOr returns the actionable fatal sync failure (e.g. a peer restarting
+	// mid-ceremony) instead of the generic error the interrupted step returned.
+	fatalOr := func(err error) error {
+		if fatal := fatalErr(); fatal != nil {
+			return fatal
+		}
+
 		return err
 	}
 
 	for _, step := range protocol.Steps(protocolCtx) {
 		if err := step.Run(ctx, protocolCtx); err != nil {
-			return err
+			return fatalOr(err)
 		}
 
 		if err := nextStepSync(ctx); err != nil {
-			return errors.Wrap(err, "sync next step")
+			return fatalOr(errors.Wrap(err, "sync next step"))
 		}
 	}
 
 	if err = stopSync(ctx); err != nil {
-		return errors.Wrap(err, "sync shutdown")
+		return fatalOr(errors.Wrap(err, "sync shutdown"))
 	}
 
 	time.Sleep(config.ShutdownDelay)

--- a/dkg/protocol_restart_test.go
+++ b/dkg/protocol_restart_test.go
@@ -1,0 +1,464 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package dkg_test
+
+import (
+	"context"
+	"fmt"
+	"math/rand/v2"
+	"os"
+	"path"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/obolnetwork/charon/app"
+	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/dkg"
+	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/relay"
+)
+
+// TestRunReplaceOperatorProtocol_ChainedPeerRestartFailsFast covers a production incident:
+// a cluster ran two replace-operator ceremonies in a chain, and during the second ceremony
+// one peer restarted its charon process mid-DKG. A restarted process cannot rejoin the
+// ceremony because the alive peers hold per-ceremony in-memory state (sync protocol steps,
+// reliable-broadcast dedup hashes) that the fresh process does not have.
+//
+// The required behavior is to fail fast on all nodes with actionable errors instead of
+// hanging forever:
+//   - the alive peers detect the restarted peer (sync step regression) and abort with an
+//     error instructing all operators to restart the ceremony together, and
+//   - the restarted peer receives the same rejection from its peers and aborts as well.
+func TestRunReplaceOperatorProtocol_ChainedPeerRestartFailsFast(t *testing.T) {
+	const (
+		numValidators    = 1
+		numNodes         = 7
+		threshold        = 5
+		firstReplaceIdx  = 2
+		secondReplaceIdx = 4
+	)
+
+	relayAddr := relay.StartRelay(t.Context(), t)
+
+	srcClusterDir := createTestCluster(t, numNodes, threshold, numValidators)
+	dst1ClusterDir := t.TempDir()
+	dst2ClusterDir := t.TempDir()
+
+	srcLockPath := path.Join(nodeDir(srcClusterDir, 0), clusterLockFile)
+	srcLock, err := dkg.LoadAndVerifyClusterLock(t.Context(), srcLockPath, "", false)
+	require.NoError(t, err)
+
+	// Ceremony 1: replace the operator at firstReplaceIdx with a new operator.
+	// This is the control run proving that a chained setup starts from a healthy state.
+	newOp1Dir := nodeDir(srcClusterDir, numNodes)
+	newOp1ENR := createENR(t, newOp1Dir)
+
+	err = app.CopyFile(srcLockPath, path.Join(newOp1Dir, clusterLockFile))
+	require.NoError(t, err)
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	defer cancel1()
+
+	eg := new(errgroup.Group)
+	for n := range numNodes {
+		eg.Go(func() error {
+			ndir := nodeDir(srcClusterDir, n)
+			if n == firstReplaceIdx {
+				ndir = newOp1Dir
+			}
+
+			replaceConfig := dkg.ReplaceOperatorConfig{
+				LockFilePath:     path.Join(ndir, clusterLockFile),
+				PrivateKeyPath:   p2p.KeyPath(ndir),
+				ValidatorKeysDir: path.Join(ndir, validatorKeysDir),
+				OutputDir:        nodeDir(dst1ClusterDir, n),
+				NewENR:           newOp1ENR,
+				OldENR:           srcLock.Operators[firstReplaceIdx].ENR,
+			}
+
+			err := dkg.RunReplaceOperatorProtocol(ctx1, replaceConfig, createDKGConfig(t, relayAddr))
+			if err != nil {
+				return failNode(t, cancel1, n, err)
+			}
+
+			return nil
+		})
+	}
+
+	require.NoError(t, eg.Wait())
+	verifyClusterValidators(t, numValidators, getNodeDirs(dst1ClusterDir, numNodes))
+	t.Log("Ceremony 1 (control) completed")
+
+	// Ceremony 2: chained on ceremony 1's output, replace the operator at secondReplaceIdx.
+	// A random continuing peer is killed mid-DKG and restarted.
+	lock2Path := path.Join(nodeDir(dst1ClusterDir, 0), clusterLockFile)
+	lock2, err := dkg.LoadAndVerifyClusterLock(t.Context(), lock2Path, "", false)
+	require.NoError(t, err)
+
+	newOp2Dir := nodeDir(srcClusterDir, numNodes+1)
+	newOp2ENR := createENR(t, newOp2Dir)
+
+	err = app.CopyFile(lock2Path, path.Join(newOp2Dir, clusterLockFile))
+	require.NoError(t, err)
+
+	restartIdx := randomNodeExcept(numNodes, secondReplaceIdx)
+	t.Logf("Ceremony 2: replacing operator %d, restarting peer %d mid-DKG", secondReplaceIdx, restartIdx)
+
+	// The restart target logs through a context-scoped watcher (never the global logger,
+	// which would race with logging goroutines of other tests). It is killed only once it
+	// logs "Starting pedersen reshare": reliable broadcast returns only after ALL peers
+	// signed its node pubkey message, so the ceremony state on all alive peers provably
+	// references the first process by then.
+	watcher := newLogWatcher(t)
+	reshareStarted := watcher.watchFor("Starting pedersen reshare")
+
+	ctx2, cancel2 := context.WithCancel(t.Context())
+	defer cancel2()
+
+	runNode := func(ctx context.Context, n int, tag string, watcher *logWatcher) error {
+		ctx = log.WithCtx(ctx, z.Str("test_node_tag", tag))
+		if watcher != nil {
+			ctx = log.WithLogger(ctx, watcher.logger)
+		}
+
+		ndir := nodeDir(dst1ClusterDir, n)
+		if n == secondReplaceIdx {
+			ndir = newOp2Dir
+		}
+
+		replaceConfig := dkg.ReplaceOperatorConfig{
+			LockFilePath:     path.Join(ndir, clusterLockFile),
+			PrivateKeyPath:   p2p.KeyPath(ndir),
+			ValidatorKeysDir: path.Join(ndir, validatorKeysDir),
+			OutputDir:        nodeDir(dst2ClusterDir, n),
+			NewENR:           newOp2ENR,
+			OldENR:           lock2.Operators[secondReplaceIdx].ENR,
+		}
+
+		return dkg.RunReplaceOperatorProtocol(ctx, replaceConfig, createDKGConfig(t, relayAddr))
+	}
+
+	type nodeResult struct {
+		node int
+		err  error
+	}
+
+	aliveResults := make(chan nodeResult, numNodes)
+
+	for n := range numNodes {
+		if n == restartIdx {
+			continue
+		}
+
+		go func() {
+			aliveResults <- nodeResult{node: n, err: runNode(ctx2, n, fmt.Sprintf("alive-node-%d", n), nil)}
+		}()
+	}
+
+	// First instance of the restart target.
+	restartCtx, restartCancel := context.WithCancel(ctx2)
+	defer restartCancel()
+
+	firstRunResult := make(chan error, 1)
+
+	go func() {
+		firstRunResult <- runNode(restartCtx, restartIdx, "restart-target-first-run", watcher)
+	}()
+
+	select {
+	case <-reshareStarted:
+	case err := <-firstRunResult:
+		t.Fatalf("Restart target exited before starting reshare: %v", err)
+	case <-time.After(2 * time.Minute):
+		t.Fatal("Timed out waiting for restart target to start pedersen reshare")
+	}
+
+	restartCancel()
+
+	select {
+	case err := <-firstRunResult:
+		t.Logf("Restart target first run returned after kill: %v", err)
+	case <-time.After(time.Minute):
+		t.Fatal("Restart target first run did not return after context cancel")
+	}
+
+	// Second instance: same node directory, fresh process state. The alive peers must
+	// reject it promptly with an actionable error instead of letting it churn forever.
+	secondRunResult := make(chan error, 1)
+
+	go func() {
+		secondRunResult <- runNode(ctx2, restartIdx, "restart-target-second-run", nil)
+	}()
+
+	select {
+	case err := <-secondRunResult:
+		require.Error(t, err, "restarted peer must not rejoin the ceremony successfully")
+		require.ErrorContains(t, err, "restart the ceremony together")
+		t.Logf("Restarted peer aborted with: %v", err)
+	case <-time.After(2 * time.Minute):
+		t.Fatal("Restarted peer did not fail fast, expected prompt rejection by alive peers")
+	}
+
+	// The alive peers must all abort promptly with diagnosable errors. Depending on where
+	// the abort lands on each node, this is the restart detection (best case), a pedersen
+	// collection timeout, or a kyber DKG abort due to the dead peer's missing deals.
+	deadline := time.After(3 * time.Minute)
+
+	var restartDetected bool
+
+	for range numNodes - 1 {
+		select {
+		case res := <-aliveResults:
+			require.Error(t, res.err, "alive node %d must abort with an error", res.node)
+
+			isRestartErr := strings.Contains(res.err.Error(), "restart the ceremony together")
+			isTimeoutErr := strings.Contains(res.err.Error(), "timed out waiting")
+			isDKGAbort := strings.Contains(res.err.Error(), "pedersen reshare protocol failed")
+			require.True(t, isRestartErr || isTimeoutErr || isDKGAbort,
+				"alive node %d error must be actionable, got: %v", res.node, res.err)
+
+			if isRestartErr {
+				restartDetected = true
+			}
+
+			t.Logf("Alive node %d aborted with: %v", res.node, res.err)
+		case <-deadline:
+			t.Fatal("Alive peers did not fail fast, expected prompt abort after peer restart")
+		}
+	}
+
+	require.True(t, restartDetected, "at least one alive peer must detect the peer restart")
+
+	// No artifacts must have been written by the failed ceremony.
+	for n := range numNodes {
+		require.NoFileExists(t, path.Join(nodeDir(dst2ClusterDir, n), clusterLockFile))
+	}
+}
+
+// TestRunReplaceOperatorProtocol_PeerDeathCollectTimeout proves that when a peer dies
+// mid-DKG and never comes back, the remaining peers do not hang forever waiting for its
+// contributions: the pedersen collection points time out with an error naming the missing peer.
+func TestRunReplaceOperatorProtocol_PeerDeathCollectTimeout(t *testing.T) {
+	const (
+		numValidators = 1
+		numNodes      = 7
+		threshold     = 5
+		replaceIdx    = 2
+	)
+
+	relayAddr := relay.StartRelay(t.Context(), t)
+
+	srcClusterDir := createTestCluster(t, numNodes, threshold, numValidators)
+	dstClusterDir := t.TempDir()
+
+	srcLockPath := path.Join(nodeDir(srcClusterDir, 0), clusterLockFile)
+	srcLock, err := dkg.LoadAndVerifyClusterLock(t.Context(), srcLockPath, "", false)
+	require.NoError(t, err)
+
+	newOpDir := nodeDir(srcClusterDir, numNodes)
+	newOpENR := createENR(t, newOpDir)
+
+	err = app.CopyFile(srcLockPath, path.Join(newOpDir, clusterLockFile))
+	require.NoError(t, err)
+
+	killIdx := randomNodeExcept(numNodes, replaceIdx)
+	t.Logf("Replacing operator %d, killing peer %d mid-DKG without restart", replaceIdx, killIdx)
+
+	// The kill target logs through a context-scoped watcher, see the fail-fast test above.
+	watcher := newLogWatcher(t)
+	reshareStarted := watcher.watchFor("Starting pedersen reshare")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	// Short DKG timeout to keep the collection timeout (and the test) fast.
+	dkgConfig := dkg.Config{
+		ShutdownDelay: 3 * time.Second,
+		Timeout:       30 * time.Second,
+		P2P: p2p.Config{
+			Relays:   []string{relayAddr},
+			TCPAddrs: []string{testutil.AvailableAddr(t).String()},
+		},
+		Log: log.DefaultConfig(),
+	}
+
+	runNode := func(ctx context.Context, n int, tag string, watcher *logWatcher) error {
+		ctx = log.WithCtx(ctx, z.Str("test_node_tag", tag))
+		if watcher != nil {
+			ctx = log.WithLogger(ctx, watcher.logger)
+		}
+
+		ndir := nodeDir(srcClusterDir, n)
+		if n == replaceIdx {
+			ndir = newOpDir
+		}
+
+		replaceConfig := dkg.ReplaceOperatorConfig{
+			LockFilePath:     path.Join(ndir, clusterLockFile),
+			PrivateKeyPath:   p2p.KeyPath(ndir),
+			ValidatorKeysDir: path.Join(ndir, validatorKeysDir),
+			OutputDir:        nodeDir(dstClusterDir, n),
+			NewENR:           newOpENR,
+			OldENR:           srcLock.Operators[replaceIdx].ENR,
+		}
+
+		return dkg.RunReplaceOperatorProtocol(ctx, replaceConfig, dkgConfig)
+	}
+
+	type nodeResult struct {
+		node int
+		err  error
+	}
+
+	aliveResults := make(chan nodeResult, numNodes)
+
+	for n := range numNodes {
+		if n == killIdx {
+			continue
+		}
+
+		go func() {
+			aliveResults <- nodeResult{node: n, err: runNode(ctx, n, fmt.Sprintf("alive-node-%d", n), nil)}
+		}()
+	}
+
+	killCtx, killCancel := context.WithCancel(ctx)
+	defer killCancel()
+
+	killResult := make(chan error, 1)
+
+	go func() {
+		killResult <- runNode(killCtx, killIdx, "kill-target", watcher)
+	}()
+
+	select {
+	case <-reshareStarted:
+	case err := <-killResult:
+		t.Fatalf("Kill target exited before starting reshare: %v", err)
+	case <-time.After(2 * time.Minute):
+		t.Fatal("Timed out waiting for kill target to start pedersen reshare")
+	}
+
+	killCancel()
+
+	select {
+	case err := <-killResult:
+		t.Logf("Kill target returned after kill: %v", err)
+	case <-time.After(time.Minute):
+		t.Fatal("Kill target did not return after context cancel")
+	}
+
+	// All alive peers must abort with a collection timeout error instead of hanging.
+	deadline := time.After(3 * time.Minute)
+
+	for range numNodes - 1 {
+		select {
+		case res := <-aliveResults:
+			require.Error(t, res.err, "alive node %d must abort with an error", res.node)
+			require.ErrorContains(t, res.err, "timed out waiting",
+				"alive node %d must report a collection timeout", res.node)
+			t.Logf("Alive node %d aborted with: %v", res.node, res.err)
+		case <-deadline:
+			t.Fatal("Alive peers did not abort, expected collection timeout after peer death")
+		}
+	}
+}
+
+// randomNodeExcept returns a random node index in [0, numNodes) excluding the given index.
+func randomNodeExcept(numNodes, except int) int {
+	var candidates []int
+
+	for n := range numNodes {
+		if n != except {
+			candidates = append(candidates, n)
+		}
+	}
+
+	return candidates[rand.IntN(len(candidates))]
+}
+
+// logWatcher matches log lines against registered substring watches, closing the watch
+// channel on the first matching line. Its logger is attached to a node's context via
+// log.WithLogger, which avoids mutating the process-global logger: replacing the global
+// logger races with logging goroutines still winding down from other tests.
+type logWatcher struct {
+	logger *zap.Logger
+
+	mu      sync.Mutex
+	watches []*logWatch
+}
+
+type logWatch struct {
+	substrings []string
+	matched    chan struct{}
+	done       bool
+}
+
+func newLogWatcher(t *testing.T) *logWatcher {
+	t.Helper()
+
+	watcher := new(logWatcher)
+	watcher.logger = log.NewConsoleForT(t, watcher)
+
+	return watcher
+}
+
+// watchFor returns a channel that is closed when a single log line contains all the substrings.
+func (w *logWatcher) watchFor(substrings ...string) <-chan struct{} {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	watch := &logWatch{
+		substrings: substrings,
+		matched:    make(chan struct{}),
+	}
+	w.watches = append(w.watches, watch)
+
+	return watch.matched
+}
+
+func (w *logWatcher) Write(p []byte) (int, error) {
+	line := string(p)
+
+	w.mu.Lock()
+	for _, watch := range w.watches {
+		if watch.done {
+			continue
+		}
+
+		match := true
+
+		for _, s := range watch.substrings {
+			if !strings.Contains(line, s) {
+				match = false
+				break
+			}
+		}
+
+		if match {
+			watch.done = true
+			close(watch.matched)
+		}
+	}
+	w.mu.Unlock()
+
+	n, err := os.Stderr.Write(p)
+	if err != nil {
+		return n, errors.Wrap(err, "write stderr")
+	}
+
+	return n, nil
+}
+
+func (*logWatcher) Sync() error {
+	return nil
+}

--- a/dkg/sync/server.go
+++ b/dkg/sync/server.go
@@ -292,6 +292,21 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 		}
 
 		if err := s.updateStep(pID, int(msg.GetStep())); err != nil {
+			// A step regression means the peer (or this node) restarted mid-ceremony with
+			// fresh in-memory state. The ceremony cannot recover from this, so record the
+			// fatal error for the local node and inform the peer so it fails fast too.
+			// Note: in theory a stale message from an abandoned reconnect stream could be
+			// processed after a newer stream advanced the step, mimicking a restart. Step
+			// updates within a stream are sequential and this was never observed in tests;
+			// a per-attempt session nonce would rule it out entirely.
+			err = errors.Wrap(err, "detected peer restart during DKG, ceremony aborted: all operators must stop charon and restart the ceremony together", logOpts...)
+			s.setErr(err)
+
+			resp.Error = err.Error()
+			if werr := writeSizedProto(stream, resp); werr != nil {
+				log.Debug(ctx, "Failed to write restart rejection response", z.Str("peer", p2p.PeerName(pID)))
+			}
+
 			return err
 		}
 

--- a/dkg/sync/server.go
+++ b/dkg/sync/server.go
@@ -291,23 +291,29 @@ func (s *Server) handleStream(ctx context.Context, stream network.Stream) error 
 			log.Info(ctx, fmt.Sprintf("Connected to peer %d of %d", count, s.allCount), logOpts...)
 		}
 
-		if err := s.updateStep(pID, int(msg.GetStep())); err != nil {
-			// A step regression means the peer (or this node) restarted mid-ceremony with
-			// fresh in-memory state. The ceremony cannot recover from this, so record the
-			// fatal error for the local node and inform the peer so it fails fast too.
-			// Note: in theory a stale message from an abandoned reconnect stream could be
-			// processed after a newer stream advanced the step, mimicking a restart. Step
-			// updates within a stream are sequential and this was never observed in tests;
-			// a per-attempt session nonce would rule it out entirely.
-			err = errors.Wrap(err, "detected peer restart during DKG, ceremony aborted: all operators must stop charon and restart the ceremony together", logOpts...)
-			s.setErr(err)
+		// Only track steps of valid peers, so an invalid peer cannot
+		// overwrite the "invalid sync message" error recorded above.
+		if resp.GetError() == "" {
+			if err := s.updateStep(pID, int(msg.GetStep())); err != nil {
+				// Any step inconsistency means a node restarted mid-ceremony with fresh
+				// in-memory state: a step regression means the peer restarted, while an
+				// unknown peer reporting a step beyond 1 means this node restarted.
+				// The ceremony cannot recover from this, so record the fatal error for
+				// the local node and inform the peer so it fails fast too.
+				// Note: in theory a stale message from an abandoned reconnect stream could be
+				// processed after a newer stream advanced the step, mimicking a restart. Step
+				// updates within a stream are sequential and this was never observed in tests;
+				// a per-attempt session nonce would rule it out entirely.
+				err = errors.Wrap(err, "detected inconsistent peer sync state (node restarted mid-ceremony), ceremony aborted: all operators must stop charon and restart the ceremony together", logOpts...)
+				s.setErr(err)
 
-			resp.Error = err.Error()
-			if werr := writeSizedProto(stream, resp); werr != nil {
-				log.Debug(ctx, "Failed to write restart rejection response", z.Str("peer", p2p.PeerName(pID)))
+				resp.Error = err.Error()
+				if werr := writeSizedProto(stream, resp); werr != nil {
+					log.Debug(ctx, "Failed to write restart rejection response", z.Str("peer", p2p.PeerName(pID)))
+				}
+
+				return err
 			}
-
-			return err
 		}
 
 		// Write response message

--- a/dkg/sync/sync_test.go
+++ b/dkg/sync/sync_test.go
@@ -54,6 +54,66 @@ func TestSyncProtocol(t *testing.T) {
 	})
 }
 
+// TestSyncRestartRejected verifies that a peer which restarts mid-ceremony (a fresh
+// client reporting step 0 after the server recorded a higher step) is rejected fast
+// with an actionable error on both sides, instead of reconnect-looping forever.
+func TestSyncRestartRejected(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	hash := testutil.RandomBytes32()
+
+	nodeA, keyA := newTCPNode(t, 0)
+	nodeB, _ := newTCPNode(t, 1)
+
+	serverB := sync.NewServer(nodeB, 1, hash, version.Version)
+	serverB.Start(log.WithTopic(ctx, "serverB"))
+
+	err := nodeA.Connect(ctx, peer.AddrInfo{ID: nodeB.ID(), Addrs: nodeB.Addrs()})
+	require.NoError(t, err)
+
+	hashSigA, err := keyA.Sign(hash)
+	require.NoError(t, err)
+
+	// First client instance from node A, advanced to step 1 (as after the initial
+	// DKG step sync barrier).
+	client1Ctx, client1Cancel := context.WithCancel(ctx)
+	defer client1Cancel()
+
+	client1 := sync.NewClient(nodeA, nodeB.ID(), hashSigA, version.Version, "nodeA", sync.WithPeriod(time.Millisecond*50))
+	client1.SetStep(1)
+
+	go func() {
+		_ = client1.Run(log.WithTopic(client1Ctx, "client1"))
+	}()
+
+	require.NoError(t, serverB.AwaitAllConnected(ctx))
+	require.NoError(t, serverB.AwaitAllAtStep(ctx, 1))
+
+	// Simulate a process restart of node A: kill the first instance and start a
+	// fresh client which reports step 0.
+	client1Cancel()
+
+	client2 := sync.NewClient(nodeA, nodeB.ID(), hashSigA, version.Version, "nodeA", sync.WithPeriod(time.Millisecond*50))
+	errCh := make(chan error, 1)
+
+	go func() {
+		errCh <- client2.Run(log.WithTopic(ctx, "client2"))
+	}()
+
+	select {
+	case err := <-errCh:
+		require.Error(t, err)
+		require.ErrorContains(t, err, "restart the ceremony together")
+	case <-time.After(10 * time.Second):
+		t.Fatal("restarted client did not fail fast, expected rejection by the server")
+	}
+
+	// The server records the fatal condition so the ceremony can be aborted locally.
+	require.Error(t, serverB.Err())
+	require.ErrorContains(t, serverB.Err(), "restart the ceremony together")
+}
+
 func semver(t *testing.T, v string) version.SemVer {
 	t.Helper()
 

--- a/docs/dkg.md
+++ b/docs/dkg.md
@@ -68,6 +68,20 @@ No user input is required, charon does the work and outputs the following files 
 ./charon/exit_data          # JSON file of exit data that ethdo can broadcast
 ```
 
+### Interruptions and restarts during a ceremony
+
+A DKG ceremony (including `dkg` and the `alpha edit` add/remove/replace-operator and reshare
+ceremonies) holds per-ceremony state in memory on every participating node. A charon process
+that stops or restarts mid-ceremony cannot rejoin the run in progress: the remaining peers
+detect the restart and abort with an error instructing all operators to restart the ceremony.
+Likewise, if a peer goes offline and does not come back, the remaining peers time out waiting
+for its contributions and abort with an error naming the missing peer.
+
+Recovery is always the same: **all operators stop charon and re-run the ceremony together.**
+Do not restart your node mid-ceremony while others keep theirs running, and make sure no
+stale charon or DKG processes (e.g. an orphaned container or an auto-restarting pod) are
+still running from a previous attempt before starting a new one.
+
 ## Backing up the ceremony artifacts
 
 Once the ceremony is complete, all participants should take a backup of the created files. In future versions of charon, if a participant loses access to these key shares, it will be possible to use a key re-sharing protocol to swap the participants old keys out of a distributed validator in favour of new keys, allowing the rest of a cluster to recover from a set of lost key shares. However for now, without a backup, the safest thing to do would be to exit the validator.


### PR DESCRIPTION
Makes DKG ceremonies fail fast with actionable errors when a peer restarts or dies mid-ceremony, instead of hanging forever.

- The sync server treats a peer step regression as a fatal peer restart: it aborts the local ceremony and rejects the restarted peer via the existing response error field, so both sides exit with an error instructing all operators to restart the ceremony together. Wire compatible, no new message fields.
- `startSyncProtocol` records the first fatal sync failure; `RunProtocol` and `Run` return it instead of a generic context cancellation.
- Pedersen collection points (node pubkeys, validator pubkey shares) time out after the configured DKG timeout with an error naming the missing peers, and collect exactly one message per expected peer (duplicates and unexpected senders are ignored).
- The lock signature exchange times out instead of blocking on the context forever.
- The final shutdown sync is bounded so a peer dying after the last step cannot hang the process.
- The pedersen board drops duplicate bundle re-deliveries (kyber evicts a dealer on duplicates), logs complaint responses on send and receive, and stops kyber FastSync protocol goroutines on abort by closing forwarded board channels. No kyber changes.
- Documents ceremony interruption recovery in docs/dkg.md.

New integration tests reproduce the production incident: a chained replace-operator ceremony where a peer restarts mid-DKG (previously the restarted peer looped in connect churn and all other peers hung forever), and a ceremony where a peer dies without restarting.

category: refactor
ticket: none
