### PR TITLE
cluster/*: reject lock with val count mismatch

### DIFF
--- a/cluster/lock.go
+++ b/cluster/lock.go
@@ -136,6 +136,12 @@ func (l Lock) VerifyHashes() error {
 		return errors.Wrap(err, "invalid definition")
 	}
 
+	if len(l.Validators) != l.NumValidators {
+		return errors.New("lock validators count mismatch",
+			z.Int("definition_num_validators", l.NumValidators),
+			z.Int("lock_validators", len(l.Validators)))
+	}
+
 	lockHash, err := hashLock(l)
 	if err != nil {
 		return err

--- a/cluster/lock_test.go
+++ b/cluster/lock_test.go
@@ -60,6 +60,29 @@ func TestVerifyLockRejectsExtraShareNotOnPolynomial(t *testing.T) {
 	require.Contains(t, err.Error(), "extra share does not lie on distributed key polynomial")
 }
 
+func TestVerifyLockRejectsValidatorCountMismatch(t *testing.T) {
+	seed := 0
+	random := rand.New(rand.NewSource(int64(seed)))
+	lock, _, _ := cluster.NewForT(t, 2, 3, 4, seed, random)
+
+	// Tamper definition to claim fewer validators than the lock contains,
+	// then recompute all hashes so they verify correctly (models the attack).
+	lock.NumValidators = 1
+	lock.ValidatorAddresses = lock.ValidatorAddresses[:1]
+
+	def, err := lock.SetDefinitionHashes()
+	require.NoError(t, err)
+
+	lock.Definition = def
+
+	lock, err = lock.SetLockHash()
+	require.NoError(t, err)
+
+	err = lock.VerifyHashes()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "lock validators count mismatch")
+}
+
 func TestVerifyLockRejectsDuplicatePublicShares(t *testing.T) {
 	seed := 0
 	random := rand.New(rand.NewSource(int64(seed)))


### PR DESCRIPTION
Reject lock that has mismatch of number of validators with the definition. Essentially happens never, but a safety precaution.

category: misc
ticket: none
