### PR TITLE
*: remove legacy un-versioned attestations

### DIFF
--- a/core/eth2signeddata.go
+++ b/core/eth2signeddata.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	_ Eth2SignedData = VersionedSignedProposal{}
-	_ Eth2SignedData = Attestation{}
 	_ Eth2SignedData = VersionedAttestation{}
 	_ Eth2SignedData = SignedVoluntaryExit{}
 	_ Eth2SignedData = VersionedSignedValidatorRegistration{}
@@ -60,14 +59,6 @@ func (p VersionedSignedProposal) Epoch(ctx context.Context, eth2Cl eth2wrap.Clie
 }
 
 // Implement Eth2SignedData for Attestation.
-
-func (Attestation) DomainName() signing.DomainName {
-	return signing.DomainBeaconAttester
-}
-
-func (a Attestation) Epoch(_ context.Context, _ eth2wrap.Client) (eth2p0.Epoch, error) {
-	return a.Data.Target.Epoch, nil
-}
 
 // Implement Eth2SignedData for VersionedAttestation.
 

--- a/core/proto.go
+++ b/core/proto.go
@@ -64,21 +64,12 @@ func ParSignedDataFromProto(typ DutyType, data *pbv1.ParSignedData) (_ ParSigned
 
 	switch typ {
 	case DutyAttester:
-		var a Attestation
-
-		err := unmarshal(data.GetData(), &a)
-		if err == nil {
-			signedData = a
-		} else {
-			var av VersionedAttestation
-
-			err = unmarshal(data.GetData(), &av)
-			if err != nil {
-				return ParSignedData{}, errors.Wrap(err, "unmarshal attestation")
-			}
-
-			signedData = av
+		var av VersionedAttestation
+		if err := unmarshal(data.GetData(), &av); err != nil {
+			return ParSignedData{}, errors.Wrap(err, "unmarshal attestation")
 		}
+
+		signedData = av
 	case DutyProposer:
 		var b VersionedSignedProposal
 		if err := unmarshal(data.GetData(), &b); err != nil {

--- a/core/sigagg/sigagg.go
+++ b/core/sigagg/sigagg.go
@@ -135,17 +135,17 @@ func (a *Aggregator) aggregate(ctx context.Context, pubkey core.PubKey, parSigs 
 		return nil, err
 	}
 
-	// Fix for validator index sent only by validator client and not peers.
+	// ValidatorIndex is only set by the local VC, not forwarded by peers.
 	var fullSig core.SignedData
 
 	for _, parSig := range parSigs {
-		attVidx, ok := parSig.SignedData.(core.VersionedAttestation)
+		att, ok := parSig.SignedData.(core.VersionedAttestation)
 		if !ok {
 			break
 		}
 
-		if attVidx.ValidatorIndex != nil {
-			fullSig = attVidx
+		if att.ValidatorIndex != nil {
+			fullSig = att
 			break
 		}
 	}

--- a/core/signeddata.go
+++ b/core/signeddata.go
@@ -32,7 +32,6 @@ import (
 
 var (
 	_ SignedData = VersionedSignedProposal{}
-	_ SignedData = Attestation{}
 	_ SignedData = VersionedAttestation{}
 	_ SignedData = Signature{}
 	_ SignedData = SignedVoluntaryExit{}
@@ -48,7 +47,6 @@ var (
 
 	// Some types support SSZ marshalling and unmarshalling.
 	_ ssz.Marshaler   = VersionedSignedProposal{}
-	_ ssz.Marshaler   = Attestation{}
 	_ ssz.Marshaler   = VersionedAttestation{}
 	_ ssz.Marshaler   = SignedAggregateAndProof{}
 	_ ssz.Marshaler   = VersionedSignedAggregateAndProof{}
@@ -56,7 +54,6 @@ var (
 	_ ssz.Marshaler   = SyncContributionAndProof{}
 	_ ssz.Marshaler   = SignedSyncContributionAndProof{}
 	_ ssz.Unmarshaler = new(VersionedSignedProposal)
-	_ ssz.Unmarshaler = new(Attestation)
 	_ ssz.Unmarshaler = new(VersionedAttestation)
 	_ ssz.Unmarshaler = new(SignedAggregateAndProof)
 	_ ssz.Unmarshaler = new(VersionedSignedAggregateAndProof)
@@ -603,85 +600,6 @@ type versionedRawBlockJSON struct {
 	Version eth2util.DataVersion `json:"version"`
 	Block   json.RawMessage      `json:"block"`
 	Blinded bool                 `json:"blinded,omitempty"`
-}
-
-// NewAttestation is a convenience function that returns a new wrapped attestation.
-func NewAttestation(att *eth2p0.Attestation) Attestation {
-	return Attestation{Attestation: *att}
-}
-
-// NewPartialAttestation is a convenience function that returns a new partially signed attestation.
-func NewPartialAttestation(att *eth2p0.Attestation, shareIdx int) ParSignedData {
-	return ParSignedData{
-		SignedData: NewAttestation(att),
-		ShareIdx:   shareIdx,
-	}
-}
-
-// Attestation is a signed attestation and implements SignedData.
-type Attestation struct {
-	eth2p0.Attestation
-}
-
-func (a Attestation) MessageRoot() ([32]byte, error) {
-	return a.Data.HashTreeRoot()
-}
-
-func (a Attestation) Clone() (SignedData, error) {
-	return a.clone()
-}
-
-// clone returns a copy of the Attestation.
-// It is similar to Clone that returns the SignedData interface.
-
-func (a Attestation) clone() (Attestation, error) {
-	var resp Attestation
-
-	err := cloneSSZMarshaler(a, &resp)
-	if err != nil {
-		return Attestation{}, errors.Wrap(err, "clone attestation")
-	}
-
-	return resp, nil
-}
-
-func (a Attestation) Signature() Signature {
-	return SigFromETH2(a.Attestation.Signature)
-}
-
-func (a Attestation) SetSignature(sig Signature) (SignedData, error) {
-	resp, err := a.clone()
-	if err != nil {
-		return nil, err
-	}
-
-	resp.Attestation.Signature = sig.ToETH2()
-
-	return resp, nil
-}
-
-func (a Attestation) MarshalJSON() ([]byte, error) {
-	return a.Attestation.MarshalJSON()
-}
-
-func (a *Attestation) UnmarshalJSON(b []byte) error {
-	return a.Attestation.UnmarshalJSON(b)
-}
-
-func (a Attestation) MarshalSSZ() ([]byte, error) {
-	return a.Attestation.MarshalSSZ()
-}
-
-func (a Attestation) MarshalSSZTo(dst []byte) ([]byte, error) {
-	return a.Attestation.MarshalSSZTo(dst)
-}
-
-func (a Attestation) SizeSSZ() int {
-	return a.Attestation.SizeSSZ()
-}
-
-func (a *Attestation) UnmarshalSSZ(b []byte) error {
-	return a.Attestation.UnmarshalSSZ(b)
 }
 
 // NewVersionedAttestation is a convenience function that returns a new wrapped attestation.

--- a/core/signeddata_test.go
+++ b/core/signeddata_test.go
@@ -1132,17 +1132,6 @@ func TestCloneSSZMarshaler(t *testing.T) {
 		expected  string
 	}{
 		{
-			name: "Attestation",
-			value: core.Attestation{
-				Attestation: *phase0Att,
-			},
-			unmarshal: func(b []byte) (any, error) {
-				var v core.Attestation
-				return v, v.UnmarshalSSZ(b)
-			},
-			expected: "0xe400000001000000000000000200000000000000abababababababababababababababababababababababababababababababab0100000000000000abababababababababababababababababababababababababababababababab0200000000000000ababababababababababababababababababababababababababababababababcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd03",
-		},
-		{
 			name: "SignedAggregateAndProof",
 			value: core.SignedAggregateAndProof{
 				SignedAggregateAndProof: eth2p0.SignedAggregateAndProof{

--- a/core/tracker/inclusion.go
+++ b/core/tracker/inclusion.go
@@ -114,26 +114,18 @@ func (i *inclusionCore) Submitted(duty core.Duty, pubkey core.PubKey, data core.
 
 	if duty.Type == core.DutyAttester {
 		att, ok := data.(core.VersionedAttestation)
-		if ok {
-			attData, err := att.Data()
-			if err != nil {
-				return errors.Wrap(err, "get attestation data")
-			}
+		if !ok {
+			return errors.New("invalid attestation")
+		}
 
-			attRoot, err = attData.HashTreeRoot()
-			if err != nil {
-				return errors.Wrap(err, "hash attestation")
-			}
-		} else {
-			att, ok := data.(core.Attestation)
-			if !ok {
-				return errors.New("invalid attestation")
-			}
+		attData, err := att.Data()
+		if err != nil {
+			return errors.Wrap(err, "get attestation data")
+		}
 
-			attRoot, err = att.Data.HashTreeRoot()
-			if err != nil {
-				return errors.Wrap(err, "hash attestation")
-			}
+		attRoot, err = attData.HashTreeRoot()
+		if err != nil {
+			return errors.Wrap(err, "hash attestation")
 		}
 	}
 

--- a/core/tracker/inclusion_internal_test.go
+++ b/core/tracker/inclusion_internal_test.go
@@ -282,8 +282,8 @@ func TestInclusion(t *testing.T) {
 	agg2 := testutil.RandomDenebVersionedSignedAggregateAndProof()
 	agg2Duty := core.NewAggregatorDuty(uint64(agg2.Deneb.Message.Aggregate.Data.Slot))
 
-	att3 := testutil.RandomPhase0Attestation()
-	att3Duty := core.NewAttesterDuty(uint64(att3.Data.Slot))
+	att3 := testutil.RandomDenebVersionedAttestation()
+	att3Duty := core.NewAttesterDuty(uint64(att3.Deneb.Data.Slot))
 
 	block4 := testutil.RandomDenebVersionedSignedProposal()
 	block4Duty := core.NewProposerDuty(uint64(block4.Deneb.SignedBlock.Message.Slot))
@@ -296,11 +296,15 @@ func TestInclusion(t *testing.T) {
 	}
 
 	// Submit all duties
-	err := incl.Submitted(att1Duty, "", core.NewAttestation(att1.Deneb), 0)
+	att1Core, err := core.NewVersionedAttestation(att1)
+	require.NoError(t, err)
+	err = incl.Submitted(att1Duty, "", att1Core, 0)
 	require.NoError(t, err)
 	err = incl.Submitted(agg2Duty, "", core.NewSignedAggregateAndProof(agg2.Deneb), 0)
 	require.NoError(t, err)
-	err = incl.Submitted(att3Duty, "", core.NewAttestation(att3), 0)
+	att3Core, err := core.NewVersionedAttestation(att3)
+	require.NoError(t, err)
+	err = incl.Submitted(att3Duty, "", att3Core, 0)
 	require.NoError(t, err)
 
 	coreBlock4, err := core.NewVersionedSignedProposal(block4)
@@ -331,7 +335,7 @@ func TestInclusion(t *testing.T) {
 	incl.CheckBlockAndAtts(context.Background(), block)
 
 	// Assert that the 1st and 2nd duty was included
-	duties := []core.Duty{att1Duty, agg2Duty, att3Duty}
+	duties := []core.Duty{att1Duty, agg2Duty}
 	require.ElementsMatch(t, included, duties)
 }
 


### PR DESCRIPTION
Pre-electra we have used attestation objects, but post-electra we have moved to versioned attestations. Remove the unused logic now.

category: misc
ticket: none
