### PR TITLE
core/consensus: fix qbft optimistic first qcommit

### DIFF
--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -48,7 +48,7 @@ var supportedCompareDuties = []core.DutyType{core.DutyAttester}
 
 // newDefinition returns a qbft definition (this is constant across all consensus instances).
 func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTimer,
-	decideCallback func(qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]), compareAttestations bool,
+	decideCallback func(value [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]), compareAttestations bool,
 ) qbft.Definition[core.Duty, [32]byte, proto.Message] {
 	quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
 
@@ -59,14 +59,14 @@ func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTi
 		},
 
 		// Decide sends consensus output to subscribers.
-		Decide: func(ctx context.Context, duty core.Duty, _ [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
+		Decide: func(ctx context.Context, duty core.Duty, valueHash [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
 			msg, ok := qcommit[0].(Msg)
 			if !ok {
 				log.Error(ctx, "Internal error: Invalid message type in qcommit. This indicates a consensus protocol bug that should be reported", nil, z.Str("got_type", fmt.Sprintf("%T", qcommit[0])))
 				return
 			}
 
-			anyValue, ok := msg.Values()[msg.Value()]
+			anyValue, ok := msg.Values()[valueHash]
 			if !ok {
 				log.Error(ctx, "Internal error: Consensus value hash not found in values map. This indicates state inconsistency in the QBFT protocol and should be reported", nil)
 				return
@@ -78,7 +78,7 @@ func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTi
 				return
 			}
 
-			decideCallback(qcommit)
+			decideCallback(valueHash, qcommit)
 
 			for _, sub := range subs() {
 				if err := sub(ctx, duty, value); err != nil {
@@ -565,8 +565,8 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 		span.End()
 	}()
 
-	decideCallback := func(qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
-		round := qcommit[0].Round()
+	decideCallback := func(value [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
+		round := matchingCommitRound(value, qcommit)
 		decided = true
 
 		inst.DecidedAtCh <- time.Now()
@@ -972,6 +972,19 @@ func fmtStepPeers(step roundStep) string {
 	}
 
 	return strings.Join(resp, "")
+}
+
+// matchingCommitRound returns the round from the first COMMIT in qcommit whose
+// value matches the agreed consensus value. It falls back to 0 if no match is
+// found (which should never happen after isJustifiedDecided validation).
+func matchingCommitRound(value [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) int64 {
+	for _, m := range qcommit {
+		if m.Type() == qbft.MsgCommit && m.Value() == value {
+			return m.Round()
+		}
+	}
+
+	return 0
 }
 
 // leader return the deterministic leader index.

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -48,7 +48,7 @@ var supportedCompareDuties = []core.DutyType{core.DutyAttester}
 
 // newDefinition returns a qbft definition (this is constant across all consensus instances).
 func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTimer,
-	decideCallback func(value [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]), compareAttestations bool,
+	decideCallback func(value [32]byte, round int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]), compareAttestations bool,
 ) qbft.Definition[core.Duty, [32]byte, proto.Message] {
 	quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
 
@@ -59,7 +59,7 @@ func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTi
 		},
 
 		// Decide sends consensus output to subscribers.
-		Decide: func(ctx context.Context, duty core.Duty, valueHash [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
+		Decide: func(ctx context.Context, duty core.Duty, valueHash [32]byte, round int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
 			msg, ok := qcommit[0].(Msg)
 			if !ok {
 				log.Error(ctx, "Internal error: Invalid message type in qcommit. This indicates a consensus protocol bug that should be reported", nil, z.Str("got_type", fmt.Sprintf("%T", qcommit[0])))
@@ -78,7 +78,7 @@ func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTi
 				return
 			}
 
-			decideCallback(valueHash, qcommit)
+			decideCallback(valueHash, round, qcommit)
 
 			for _, sub := range subs() {
 				if err := sub(ctx, duty, value); err != nil {
@@ -565,8 +565,7 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 		span.End()
 	}()
 
-	decideCallback := func(value [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
-		round := matchingCommitRound(value, qcommit)
+	decideCallback := func(value [32]byte, round int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
 		decided = true
 
 		inst.DecidedAtCh <- time.Now()
@@ -972,19 +971,6 @@ func fmtStepPeers(step roundStep) string {
 	}
 
 	return strings.Join(resp, "")
-}
-
-// matchingCommitRound returns the round from the first COMMIT in qcommit whose
-// value matches the agreed consensus value. It falls back to 0 if no match is
-// found (which should never happen after isJustifiedDecided validation).
-func matchingCommitRound(value [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) int64 {
-	for _, m := range qcommit {
-		if m.Type() == qbft.MsgCommit && m.Value() == value {
-			return m.Round()
-		}
-	}
-
-	return 0
 }
 
 // leader return the deterministic leader index.

--- a/core/consensus/qbft/qbft.go
+++ b/core/consensus/qbft/qbft.go
@@ -48,7 +48,7 @@ var supportedCompareDuties = []core.DutyType{core.DutyAttester}
 
 // newDefinition returns a qbft definition (this is constant across all consensus instances).
 func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTimer,
-	decideCallback func(value [32]byte, round int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]), compareAttestations bool,
+	decideCallback func(round int64), compareAttestations bool,
 ) qbft.Definition[core.Duty, [32]byte, proto.Message] {
 	quorum := qbft.Definition[core.Duty, [32]byte, proto.Message]{Nodes: nodes}.Quorum()
 
@@ -78,7 +78,7 @@ func newDefinition(nodes int, subs func() []subscriber, roundTimer timer.RoundTi
 				return
 			}
 
-			decideCallback(valueHash, round, qcommit)
+			decideCallback(round)
 
 			for _, sub := range subs() {
 				if err := sub(ctx, duty, value); err != nil {
@@ -565,7 +565,7 @@ func (c *Consensus) runInstance(parent context.Context, duty core.Duty) (err err
 		span.End()
 	}()
 
-	decideCallback := func(value [32]byte, round int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
+	decideCallback := func(round int64) {
 		decided = true
 
 		inst.DecidedAtCh <- time.Now()

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -5,16 +5,23 @@ package qbft
 import (
 	"bytes"
 	"context"
+	"fmt"
+	"math"
+	"math/rand"
 	"testing"
 	"time"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/libp2p/go-libp2p"
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/obolnetwork/charon/app/k1util"
+	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/core/consensus/instance"
 	"github.com/obolnetwork/charon/core/consensus/metrics"
@@ -22,7 +29,10 @@ import (
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
 	coremocks "github.com/obolnetwork/charon/core/mocks"
 	"github.com/obolnetwork/charon/core/qbft"
+	"github.com/obolnetwork/charon/eth2util/enr"
+	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
+	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
 //go:generate go test . -run=TestDebugRoundChange -update
@@ -906,6 +916,217 @@ func TestInstanceIO_MaybeStart(t *testing.T) {
 		require.True(t, ok)
 		require.False(t, inst.MaybeStart())
 	})
+}
+
+// TestDecidedJustificationIgnoresExtraCommits verifies that a MsgDecided containing
+// extra non-matching COMMITs in its justification does not influence the decided value
+// or crash the node. The Decide callback must use the algorithm's agreed value parameter,
+// not qcommit[0], so an attacker-controlled COMMIT at index 0 is harmless.
+func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
+	const (
+		nodes    = 4
+		slot     = 2
+		attacker = 3
+	)
+
+	random := rand.New(rand.NewSource(0))
+	lock, p2pkeys, _ := cluster.NewForT(t, 1, 3, nodes, 0, random)
+
+	var peers []p2p.Peer
+
+	for i := range nodes {
+		record, err := enr.Parse(lock.Operators[i].ENR)
+		require.NoError(t, err)
+
+		p, err := p2p.NewPeerFromENR(record, i)
+		require.NoError(t, err)
+
+		peers = append(peers, p)
+	}
+
+	addr := testutil.AvailableAddr(t)
+	mAddr, err := multiaddr.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", addr.IP, addr.Port))
+	require.NoError(t, err)
+
+	priv := (*libp2pcrypto.Secp256k1PrivateKey)(p2pkeys[0])
+	h, err := libp2p.New(libp2p.Identity(priv), libp2p.ListenAddrs(mAddr))
+	testutil.SkipIfBindErr(t, err)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = h.Close() })
+
+	deadliner := coremocks.NewDeadliner(t)
+	deadliner.On("Add", mock.Anything).Maybe().Return(core.DeadlineScheduled)
+	deadliner.On("C").Maybe().Return((<-chan core.Duty)(make(chan core.Duty)))
+
+	bmock, err := beaconmock.New(t.Context(), beaconmock.WithGenesisTime(time.Time{}))
+	require.NoError(t, err)
+
+	c, err := NewConsensus(t.Context(), bmock, h, new(p2p.Sender), peers, p2pkeys[0],
+		deadliner, func(core.Duty) bool { return true }, func(*pbv1.SniffedConsensusInstance) {}, false)
+	require.NoError(t, err)
+
+	results := make(chan core.UnsignedDataSet, 1)
+
+	c.Subscribe(func(_ context.Context, _ core.Duty, set core.UnsignedDataSet) error {
+		results <- set
+		return nil
+	})
+	c.Start(t.Context())
+
+	// Build two distinct values: the legitimately agreed one and a rogue one.
+	newValue := func() (*anypb.Any, [32]byte) {
+		set := core.UnsignedDataSet{testutil.RandomCorePubKey(t): testutil.RandomCoreAttestationData(t)}
+		pb, err2 := core.UnsignedDataSetToProto(set)
+		require.NoError(t, err2)
+
+		hash, err2 := hashProto(pb)
+		require.NoError(t, err2)
+
+		a, err2 := anypb.New(pb)
+		require.NoError(t, err2)
+
+		return a, hash
+	}
+
+	sign := func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg {
+		m := &pbv1.QBFTMsg{
+			Type:      int64(typ),
+			Duty:      &pbv1.Duty{Slot: slot, Type: int32(core.DutyAttester)},
+			PeerIdx:   peerIdx,
+			Round:     round,
+			ValueHash: valueHash[:],
+		}
+
+		signed, err2 := signMsg(m, key)
+		require.NoError(t, err2)
+
+		return signed
+	}
+
+	agreedAny, agreedHash := newValue()
+	rogueAny, rogueHash := newValue()
+	require.NotEqual(t, agreedHash, rogueHash)
+
+	// runSubtest proposes the agreed value on the given duty, injects a crafted MsgDecided
+	// with the provided justification, and asserts the victim decides on the agreed value
+	// without panicking.
+	nextSlot := uint64(slot)
+	runSubtest := func(t *testing.T, name string, justification []*pbv1.QBFTMsg) {
+		t.Helper()
+
+		t.Run(name, func(t *testing.T) {
+			testDuty := core.Duty{Type: core.DutyAttester, Slot: nextSlot}
+			nextSlot++
+
+			signForDuty := func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg {
+				m := &pbv1.QBFTMsg{
+					Type:      int64(typ),
+					Duty:      &pbv1.Duty{Slot: testDuty.Slot, Type: int32(core.DutyAttester)},
+					PeerIdx:   peerIdx,
+					Round:     round,
+					ValueHash: valueHash[:],
+				}
+
+				signed, err2 := signMsg(m, key)
+				require.NoError(t, err2)
+
+				return signed
+			}
+
+			// Re-sign justification messages with the correct duty slot.
+			var resignedJust []*pbv1.QBFTMsg
+			for _, j := range justification {
+				resignedJust = append(resignedJust, signForDuty(
+					p2pkeys[j.GetPeerIdx()],
+					qbft.MsgType(j.GetType()),
+					j.GetPeerIdx(),
+					j.GetRound(),
+					[32]byte(j.GetValueHash()),
+				))
+			}
+
+			agreedSet, err := core.UnsignedDataSetFromProto(core.DutyAttester, mustUnmarshalUDS(t, agreedAny))
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+			defer cancel()
+
+			proposeErr := make(chan error, 1)
+			go func() { proposeErr <- c.Propose(ctx, testDuty, agreedSet) }()
+
+			time.Sleep(200 * time.Millisecond)
+
+			decided := &pbv1.QBFTConsensusMsg{
+				Msg:           signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, agreedHash),
+				Justification: resignedJust,
+				Values:        []*anypb.Any{agreedAny, rogueAny},
+			}
+
+			require.NotPanics(t, func() {
+				_, _, err = c.handle(ctx, "attacker", decided)
+				require.NoError(t, err)
+			})
+
+			select {
+			case got := <-results:
+				gotPb, err := core.UnsignedDataSetToProto(got)
+				require.NoError(t, err)
+
+				gotHash, err := hashProto(gotPb)
+				require.NoError(t, err)
+
+				require.Equal(t, agreedHash, gotHash, "must decide on the agreed value")
+			case <-ctx.Done():
+				t.Fatal("timed out — node may have crashed")
+			}
+
+			cancel()
+			<-proposeErr
+		})
+	}
+
+	// Template justification messages (slot is overridden by runSubtest).
+	honestCommits := []*pbv1.QBFTMsg{
+		sign(p2pkeys[1], qbft.MsgCommit, 1, 1, agreedHash),
+		sign(p2pkeys[2], qbft.MsgCommit, 2, 1, agreedHash),
+		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, agreedHash),
+	}
+
+	rogueFirst := append([]*pbv1.QBFTMsg{
+		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+	}, honestCommits...)
+
+	rogueLast := append(append([]*pbv1.QBFTMsg{}, honestCommits...),
+		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+	)
+
+	rogueMiddle := []*pbv1.QBFTMsg{
+		sign(p2pkeys[1], qbft.MsgCommit, 1, 1, agreedHash),
+		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+		sign(p2pkeys[2], qbft.MsgCommit, 2, 1, agreedHash),
+		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, agreedHash),
+	}
+
+	overflowFirst := append([]*pbv1.QBFTMsg{
+		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, math.MaxInt64-1, rogueHash),
+	}, honestCommits...)
+
+	runSubtest(t, "rogue commit at start", rogueFirst)
+	runSubtest(t, "rogue commit at end", rogueLast)
+	runSubtest(t, "rogue commit in middle", rogueMiddle)
+	runSubtest(t, "overflow round at start", overflowFirst)
+}
+
+func mustUnmarshalUDS(t *testing.T, a *anypb.Any) *pbv1.UnsignedDataSet {
+	t.Helper()
+
+	m, err := a.UnmarshalNew()
+	require.NoError(t, err)
+
+	set, ok := m.(*pbv1.UnsignedDataSet)
+	require.True(t, ok)
+
+	return set
 }
 
 func signConsensusMsg(t *testing.T, msg *pbv1.QBFTConsensusMsg, privKey *k1.PrivateKey, duty core.Duty) *pbv1.QBFTConsensusMsg {

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -1054,7 +1054,9 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 			proposeErr := make(chan error, 1)
 			go func() { proposeErr <- c.Propose(ctx, testDuty, agreedSet) }()
 
-			time.Sleep(200 * time.Millisecond)
+			require.Eventually(t, func() bool {
+				return c.getInstanceIO(testDuty).Running.Load()
+			}, 5*time.Second, 10*time.Millisecond)
 
 			decided := &pbv1.QBFTConsensusMsg{
 				Msg:           signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, agreedHash),

--- a/core/consensus/qbft/qbft_internal_test.go
+++ b/core/consensus/qbft/qbft_internal_test.go
@@ -918,11 +918,33 @@ func TestInstanceIO_MaybeStart(t *testing.T) {
 	})
 }
 
-// TestDecidedJustificationIgnoresExtraCommits verifies that a MsgDecided containing
-// extra non-matching COMMITs in its justification does not influence the decided value
-// or crash the node. The Decide callback must use the algorithm's agreed value parameter,
-// not qcommit[0], so an attacker-controlled COMMIT at index 0 is harmless.
-func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
+// TestDecidedMessageScenarios verifies how a node handles crafted MsgDecided messages:
+//
+//   - A justification containing extra non-matching COMMITs must not influence the
+//     decided value or crash the node. The Decide callback must use the algorithm's
+//     agreed value parameter, not qcommit[0], so an attacker-controlled COMMIT at
+//     index 0 is harmless.
+//   - The decided value must come from the quorum, never from the node's own
+//     (differing) local proposal.
+//   - Malformed decided messages (missing values, unjustified round or quorum) must
+//     be rejected or dropped without corrupting the instance: a subsequent valid
+//     decided message must still decide the agreed value.
+//
+// All scenarios run both with and without attestation comparison (the
+// chain_split_halt feature): the Compare flow only gates the PREPARE step on
+// justified PRE-PREPAREs and must not affect decided message handling.
+func TestDecidedMessageScenarios(t *testing.T) {
+	t.Run("compare disabled", func(t *testing.T) {
+		testDecidedMessageScenarios(t, false)
+	})
+	t.Run("compare enabled", func(t *testing.T) {
+		testDecidedMessageScenarios(t, true)
+	})
+}
+
+func testDecidedMessageScenarios(t *testing.T, compareAttestations bool) {
+	t.Helper()
+
 	const (
 		nodes    = 4
 		slot     = 2
@@ -962,7 +984,7 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 	require.NoError(t, err)
 
 	c, err := NewConsensus(t.Context(), bmock, h, new(p2p.Sender), peers, p2pkeys[0],
-		deadliner, func(core.Duty) bool { return true }, func(*pbv1.SniffedConsensusInstance) {}, false)
+		deadliner, func(core.Duty) bool { return true }, func(*pbv1.SniffedConsensusInstance) {}, compareAttestations)
 	require.NoError(t, err)
 
 	results := make(chan core.UnsignedDataSet, 1)
@@ -988,9 +1010,9 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 		return a, hash
 	}
 
-	sign := func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg {
+	signCommit := func(key *k1.PrivateKey, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg {
 		m := &pbv1.QBFTMsg{
-			Type:      int64(typ),
+			Type:      int64(qbft.MsgCommit),
 			Duty:      &pbv1.Duty{Slot: slot, Type: int32(core.DutyAttester)},
 			PeerIdx:   peerIdx,
 			Round:     round,
@@ -1005,33 +1027,83 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 
 	agreedAny, agreedHash := newValue()
 	rogueAny, rogueHash := newValue()
+	localAny, _ := newValue()
+
 	require.NotEqual(t, agreedHash, rogueHash)
 
-	// runSubtest proposes the agreed value on the given duty, injects a crafted MsgDecided
+	nextSlot := uint64(slot)
+
+	// startInstance proposes the given value on a fresh duty and returns the duty,
+	// a per-duty signing function, the propose error channel and a context.
+	startInstance := func(t *testing.T, propose *anypb.Any) (
+		core.Duty,
+		func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg,
+		chan error,
+		context.Context,
+		context.CancelFunc,
+	) {
+		t.Helper()
+
+		testDuty := core.Duty{Type: core.DutyAttester, Slot: nextSlot}
+		nextSlot++
+
+		signForDuty := func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg {
+			m := &pbv1.QBFTMsg{
+				Type:      int64(typ),
+				Duty:      &pbv1.Duty{Slot: testDuty.Slot, Type: int32(core.DutyAttester)},
+				PeerIdx:   peerIdx,
+				Round:     round,
+				ValueHash: valueHash[:],
+			}
+
+			signed, err2 := signMsg(m, key)
+			require.NoError(t, err2)
+
+			return signed
+		}
+
+		proposeSet, err := core.UnsignedDataSetFromProto(core.DutyAttester, mustUnmarshalUDS(t, propose))
+		require.NoError(t, err)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+
+		proposeErr := make(chan error, 1)
+		go func() { proposeErr <- c.Propose(ctx, testDuty, proposeSet) }()
+
+		require.Eventually(t, func() bool {
+			return c.getInstanceIO(testDuty).Running.Load()
+		}, 5*time.Second, 10*time.Millisecond)
+
+		return testDuty, signForDuty, proposeErr, ctx, cancel
+	}
+
+	// expectDecided asserts the subscriber receives the agreed value before the context expires.
+	expectDecided := func(t *testing.T, ctx context.Context) {
+		t.Helper()
+
+		select {
+		case got := <-results:
+			gotPb, err := core.UnsignedDataSetToProto(got)
+			require.NoError(t, err)
+
+			gotHash, err := hashProto(gotPb)
+			require.NoError(t, err)
+
+			require.Equal(t, agreedHash, gotHash, "must decide on the agreed value")
+		case <-ctx.Done():
+			t.Fatal("timed out — node may have crashed")
+		}
+	}
+
+	// runSubtest proposes the given value on a fresh duty, injects a crafted MsgDecided
 	// with the provided justification, and asserts the victim decides on the agreed value
 	// without panicking.
-	nextSlot := uint64(slot)
-	runSubtest := func(t *testing.T, name string, justification []*pbv1.QBFTMsg) {
+	runSubtest := func(t *testing.T, name string, propose *anypb.Any, justification []*pbv1.QBFTMsg) {
 		t.Helper()
 
 		t.Run(name, func(t *testing.T) {
-			testDuty := core.Duty{Type: core.DutyAttester, Slot: nextSlot}
-			nextSlot++
-
-			signForDuty := func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg {
-				m := &pbv1.QBFTMsg{
-					Type:      int64(typ),
-					Duty:      &pbv1.Duty{Slot: testDuty.Slot, Type: int32(core.DutyAttester)},
-					PeerIdx:   peerIdx,
-					Round:     round,
-					ValueHash: valueHash[:],
-				}
-
-				signed, err2 := signMsg(m, key)
-				require.NoError(t, err2)
-
-				return signed
-			}
+			_, signForDuty, proposeErr, ctx, cancel := startInstance(t, propose)
+			defer cancel()
 
 			// Re-sign justification messages with the correct duty slot.
 			var resignedJust []*pbv1.QBFTMsg
@@ -1045,19 +1117,6 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 				))
 			}
 
-			agreedSet, err := core.UnsignedDataSetFromProto(core.DutyAttester, mustUnmarshalUDS(t, agreedAny))
-			require.NoError(t, err)
-
-			ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
-			defer cancel()
-
-			proposeErr := make(chan error, 1)
-			go func() { proposeErr <- c.Propose(ctx, testDuty, agreedSet) }()
-
-			require.Eventually(t, func() bool {
-				return c.getInstanceIO(testDuty).Running.Load()
-			}, 5*time.Second, 10*time.Millisecond)
-
 			decided := &pbv1.QBFTConsensusMsg{
 				Msg:           signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, agreedHash),
 				Justification: resignedJust,
@@ -1065,22 +1124,54 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 			}
 
 			require.NotPanics(t, func() {
-				_, _, err = c.handle(ctx, "attacker", decided)
+				_, _, err := c.handle(ctx, "attacker", decided)
 				require.NoError(t, err)
 			})
 
-			select {
-			case got := <-results:
-				gotPb, err := core.UnsignedDataSetToProto(got)
-				require.NoError(t, err)
+			expectDecided(t, ctx)
 
-				gotHash, err := hashProto(gotPb)
-				require.NoError(t, err)
+			cancel()
+			<-proposeErr
+		})
+	}
 
-				require.Equal(t, agreedHash, gotHash, "must decide on the agreed value")
-			case <-ctx.Done():
-				t.Fatal("timed out — node may have crashed")
+	// runRejectSubtest proposes the agreed value on a fresh duty and injects a bad
+	// MsgDecided that must not decide anything: either handle rejects it outright
+	// (wantHandleErr) or the qbft instance drops it as unjustified. A subsequent
+	// valid MsgDecided must still decide the agreed value, proving the bad message
+	// neither decided nor corrupted the instance.
+	runRejectSubtest := func(t *testing.T, name, wantHandleErr string,
+		buildBad func(signForDuty func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg) *pbv1.QBFTConsensusMsg,
+	) {
+		t.Helper()
+
+		t.Run(name, func(t *testing.T) {
+			_, signForDuty, proposeErr, ctx, cancel := startInstance(t, agreedAny)
+			defer cancel()
+
+			require.NotPanics(t, func() {
+				_, _, err := c.handle(ctx, "attacker", buildBad(signForDuty))
+				if wantHandleErr != "" {
+					require.ErrorContains(t, err, wantHandleErr)
+				} else {
+					require.NoError(t, err)
+				}
+			})
+
+			good := &pbv1.QBFTConsensusMsg{
+				Msg: signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, agreedHash),
+				Justification: []*pbv1.QBFTMsg{
+					signForDuty(p2pkeys[1], qbft.MsgCommit, 1, 1, agreedHash),
+					signForDuty(p2pkeys[2], qbft.MsgCommit, 2, 1, agreedHash),
+					signForDuty(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, agreedHash),
+				},
+				Values: []*anypb.Any{agreedAny},
 			}
+
+			_, _, err := c.handle(ctx, "attacker", good)
+			require.NoError(t, err)
+
+			expectDecided(t, ctx)
 
 			cancel()
 			<-proposeErr
@@ -1089,34 +1180,96 @@ func TestDecidedJustificationIgnoresExtraCommits(t *testing.T) {
 
 	// Template justification messages (slot is overridden by runSubtest).
 	honestCommits := []*pbv1.QBFTMsg{
-		sign(p2pkeys[1], qbft.MsgCommit, 1, 1, agreedHash),
-		sign(p2pkeys[2], qbft.MsgCommit, 2, 1, agreedHash),
-		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, agreedHash),
+		signCommit(p2pkeys[1], 1, 1, agreedHash),
+		signCommit(p2pkeys[2], 2, 1, agreedHash),
+		signCommit(p2pkeys[attacker], attacker, 1, agreedHash),
 	}
 
 	rogueFirst := append([]*pbv1.QBFTMsg{
-		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+		signCommit(p2pkeys[attacker], attacker, 1, rogueHash),
 	}, honestCommits...)
 
 	rogueLast := append(append([]*pbv1.QBFTMsg{}, honestCommits...),
-		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+		signCommit(p2pkeys[attacker], attacker, 1, rogueHash),
 	)
 
 	rogueMiddle := []*pbv1.QBFTMsg{
-		sign(p2pkeys[1], qbft.MsgCommit, 1, 1, agreedHash),
-		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
-		sign(p2pkeys[2], qbft.MsgCommit, 2, 1, agreedHash),
-		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, agreedHash),
+		signCommit(p2pkeys[1], 1, 1, agreedHash),
+		signCommit(p2pkeys[attacker], attacker, 1, rogueHash),
+		signCommit(p2pkeys[2], 2, 1, agreedHash),
+		signCommit(p2pkeys[attacker], attacker, 1, agreedHash),
 	}
 
 	overflowFirst := append([]*pbv1.QBFTMsg{
-		sign(p2pkeys[attacker], qbft.MsgCommit, attacker, math.MaxInt64-1, rogueHash),
+		signCommit(p2pkeys[attacker], attacker, math.MaxInt64-1, rogueHash),
 	}, honestCommits...)
 
-	runSubtest(t, "rogue commit at start", rogueFirst)
-	runSubtest(t, "rogue commit at end", rogueLast)
-	runSubtest(t, "rogue commit in middle", rogueMiddle)
-	runSubtest(t, "overflow round at start", overflowFirst)
+	runSubtest(t, "rogue commit at start", agreedAny, rogueFirst)
+	runSubtest(t, "rogue commit at end", agreedAny, rogueLast)
+	runSubtest(t, "rogue commit in middle", agreedAny, rogueMiddle)
+	runSubtest(t, "overflow round at start", agreedAny, overflowFirst)
+
+	// The node's own (differing) local proposal must never leak into the decision:
+	// the subscriber must receive the quorum-agreed value.
+	runSubtest(t, "local proposal differs from decided value", localAny, honestCommits)
+
+	runRejectSubtest(t, "decided value missing from values", "value hash not found in values",
+		func(signForDuty func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg) *pbv1.QBFTConsensusMsg {
+			// The decided message claims the rogue value but does not include it in
+			// its values, only the agreed one. Decoding must fail, so the node can
+			// never be tricked into deciding a value it does not have.
+			return &pbv1.QBFTConsensusMsg{
+				Msg: signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, rogueHash),
+				Justification: []*pbv1.QBFTMsg{
+					signForDuty(p2pkeys[1], qbft.MsgCommit, 1, 1, rogueHash),
+					signForDuty(p2pkeys[2], qbft.MsgCommit, 2, 1, rogueHash),
+					signForDuty(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+				},
+				Values: []*anypb.Any{agreedAny},
+			}
+		})
+
+	runRejectSubtest(t, "justification value missing from values", "value hash not found in values",
+		func(signForDuty func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg) *pbv1.QBFTConsensusMsg {
+			// The justification references the rogue value which is absent from values.
+			return &pbv1.QBFTConsensusMsg{
+				Msg: signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, agreedHash),
+				Justification: []*pbv1.QBFTMsg{
+					signForDuty(p2pkeys[1], qbft.MsgCommit, 1, 1, agreedHash),
+					signForDuty(p2pkeys[2], qbft.MsgCommit, 2, 1, agreedHash),
+					signForDuty(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+				},
+				Values: []*anypb.Any{agreedAny},
+			}
+		})
+
+	runRejectSubtest(t, "decided round not matching justification commits", "",
+		func(signForDuty func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg) *pbv1.QBFTConsensusMsg {
+			// The decided message claims round 2 while all commits are for round 1.
+			// The message passes wire validation but must be dropped as unjustified.
+			return &pbv1.QBFTConsensusMsg{
+				Msg: signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 2, rogueHash),
+				Justification: []*pbv1.QBFTMsg{
+					signForDuty(p2pkeys[1], qbft.MsgCommit, 1, 1, rogueHash),
+					signForDuty(p2pkeys[2], qbft.MsgCommit, 2, 1, rogueHash),
+					signForDuty(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+				},
+				Values: []*anypb.Any{agreedAny, rogueAny},
+			}
+		})
+
+	runRejectSubtest(t, "decided with insufficient justification", "",
+		func(signForDuty func(key *k1.PrivateKey, typ qbft.MsgType, peerIdx, round int64, valueHash [32]byte) *pbv1.QBFTMsg) *pbv1.QBFTConsensusMsg {
+			// Only two commits back the decided message; quorum is three.
+			return &pbv1.QBFTConsensusMsg{
+				Msg: signForDuty(p2pkeys[attacker], qbft.MsgDecided, attacker, 1, rogueHash),
+				Justification: []*pbv1.QBFTMsg{
+					signForDuty(p2pkeys[1], qbft.MsgCommit, 1, 1, rogueHash),
+					signForDuty(p2pkeys[attacker], qbft.MsgCommit, attacker, 1, rogueHash),
+				},
+				Values: []*anypb.Any{agreedAny, rogueAny},
+			}
+		})
 }
 
 func mustUnmarshalUDS(t *testing.T, a *anypb.Any) *pbv1.UnsignedDataSet {
@@ -1129,6 +1282,93 @@ func mustUnmarshalUDS(t *testing.T, a *anypb.Any) *pbv1.UnsignedDataSet {
 	require.True(t, ok)
 
 	return set
+}
+
+// TestAttestationChecker verifies the chain_split_halt comparator: identical
+// attestation data passes, any source/target vote mismatch fails, and leader
+// validators unknown to the local set are skipped.
+func TestAttestationChecker(t *testing.T) {
+	pubkey := testutil.RandomCorePubKey(t)
+	attData := testutil.RandomCoreAttestationData(t)
+
+	toProto := func(t *testing.T, pk core.PubKey, data core.AttestationData) *pbv1.UnsignedDataSet {
+		t.Helper()
+
+		set, err := core.UnsignedDataSetToProto(core.UnsignedDataSet{pk: data})
+		require.NoError(t, err)
+
+		return set
+	}
+
+	cloneAtt := func(t *testing.T) core.AttestationData {
+		t.Helper()
+
+		dup, err := attData.Clone()
+		require.NoError(t, err)
+
+		att, ok := dup.(core.AttestationData)
+		require.True(t, ok)
+
+		return att
+	}
+
+	local := toProto(t, pubkey, attData)
+
+	tests := []struct {
+		name    string
+		mutate  func(*core.AttestationData)
+		wantErr string
+	}{
+		{
+			name: "identical attestation data",
+		},
+		{
+			name:    "source epoch differs",
+			mutate:  func(a *core.AttestationData) { a.Data.Source.Epoch++ },
+			wantErr: "source epoch differs",
+		},
+		{
+			name:    "source root differs",
+			mutate:  func(a *core.AttestationData) { a.Data.Source.Root[0]++ },
+			wantErr: "source root differs",
+		},
+		{
+			name:    "target epoch differs",
+			mutate:  func(a *core.AttestationData) { a.Data.Target.Epoch++ },
+			wantErr: "target epoch differs",
+		},
+		{
+			name:    "target root differs",
+			mutate:  func(a *core.AttestationData) { a.Data.Target.Root[0]++ },
+			wantErr: "target root differs",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			leaderAtt := cloneAtt(t)
+			if test.mutate != nil {
+				test.mutate(&leaderAtt)
+			}
+
+			err := attestationChecker(t.Context(), toProto(t, pubkey, leaderAtt), local)
+			if test.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.wantErr)
+			}
+		})
+	}
+
+	t.Run("unknown validator is skipped", func(t *testing.T) {
+		// Leader proposes for a validator the local node has no data for: a
+		// conflicting vote cannot be detected, so it is skipped with a warning.
+		leaderAtt := cloneAtt(t)
+		leaderAtt.Data.Target.Epoch++
+
+		err := attestationChecker(t.Context(), toProto(t, testutil.RandomCorePubKey(t), leaderAtt), local)
+		require.NoError(t, err)
+	})
 }
 
 func signConsensusMsg(t *testing.T, msg *pbv1.QBFTConsensusMsg, privKey *k1.PrivateKey, duty core.Duty) *pbv1.QBFTConsensusMsg {

--- a/core/consensus/qbft/sniffed_internal_test.go
+++ b/core/consensus/qbft/sniffed_internal_test.go
@@ -79,7 +79,7 @@ func testSniffedInstance(ctx context.Context, t *testing.T, instance *pbv1.Sniff
 
 			return nil
 		}}
-	}, timer.NewIncreasingRoundTimer(), func(_ [32]byte, _ int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {}, false)
+	}, timer.NewIncreasingRoundTimer(), func(int64) {}, false)
 
 	recvBuffer := make(chan qbft.Msg[core.Duty, [32]byte, proto.Message], len(instance.GetMsgs()))
 

--- a/core/consensus/qbft/sniffed_internal_test.go
+++ b/core/consensus/qbft/sniffed_internal_test.go
@@ -79,7 +79,7 @@ func testSniffedInstance(ctx context.Context, t *testing.T, instance *pbv1.Sniff
 
 			return nil
 		}}
-	}, timer.NewIncreasingRoundTimer(), func(_ [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {}, false)
+	}, timer.NewIncreasingRoundTimer(), func(_ [32]byte, _ int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {}, false)
 
 	recvBuffer := make(chan qbft.Msg[core.Duty, [32]byte, proto.Message], len(instance.GetMsgs()))
 

--- a/core/consensus/qbft/sniffed_internal_test.go
+++ b/core/consensus/qbft/sniffed_internal_test.go
@@ -79,7 +79,7 @@ func testSniffedInstance(ctx context.Context, t *testing.T, instance *pbv1.Sniff
 
 			return nil
 		}}
-	}, timer.NewIncreasingRoundTimer(), func(qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {}, false)
+	}, timer.NewIncreasingRoundTimer(), func(_ [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {}, false)
 
 	recvBuffer := make(chan qbft.Msg[core.Duty, [32]byte, proto.Message], len(instance.GetMsgs()))
 

--- a/core/consensus/qbft/strategysim_internal_test.go
+++ b/core/consensus/qbft/strategysim_internal_test.go
@@ -494,7 +494,7 @@ func newSimDefinition(nodes int, roundTimer timer.RoundTimer,
 		IsLeader: func(duty core.Duty, round, process int64) bool {
 			return leader(duty, round, nodes) == process
 		},
-		Decide: func(ctx context.Context, duty core.Duty, _ [32]byte, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
+		Decide: func(ctx context.Context, duty core.Duty, _ [32]byte, _ int64, qcommit []qbft.Msg[core.Duty, [32]byte, proto.Message]) {
 			decideCallback(qcommit)
 		},
 		Compare: func(ctx context.Context, qcommit qbft.Msg[core.Duty, [32]byte, proto.Message], inputValueSourceCh <-chan proto.Message, inputValueSource proto.Message, returnErr chan error, returnRes chan proto.Message) {

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -224,6 +224,7 @@ func Run[I any, V comparable, C any](ctx context.Context, d Definition[I, V, C],
 		compareFailureRound   int64
 		preparedJustification []Msg[I, V, C]
 		qCommit               []Msg[I, V, C]
+		qCommitValue          V
 		buffer                = make(map[int64][]Msg[I, V, C])
 		dedupRules            = make(map[dedupKey]bool)
 		decidedResends        = make(map[int64]decidedResend) // Bounds MsgDecided rebroadcasts by peer source.
@@ -357,7 +358,7 @@ func Run[I any, V comparable, C any](ctx context.Context, d Definition[I, V, C],
 			if len(qCommit) > 0 {
 				if msg.Source() != process && msg.Type() == MsgRoundChange && // Algorithm 3:17
 					allowDecidedResend(msg.Source(), msg.Round()) {
-					err = broadcastMsg(MsgDecided, qCommit[0].Value(), qCommit)
+					err = broadcastMsg(MsgDecided, qCommitValue, qCommit)
 				}
 
 				break
@@ -422,6 +423,7 @@ func Run[I any, V comparable, C any](ctx context.Context, d Definition[I, V, C],
 				changeRound(msg.Round(), rule)
 
 				qCommit = justification
+				qCommitValue = msg.Value()
 
 				stopTimer()
 

--- a/core/qbft/qbft.go
+++ b/core/qbft/qbft.go
@@ -39,7 +39,7 @@ type Definition[I any, V comparable, C any] struct {
 	// Compare is an opt-in feature that should instantly return nil on returnErr channel if it is not turned on.
 	Compare func(ctx context.Context, qcommit Msg[I, V, C], inputValueSourceCh <-chan C, inputValueSource C, returnErr chan error, returnValue chan C)
 	// Decide is called when consensus has been reached on a value.
-	Decide func(ctx context.Context, instance I, value V, qcommit []Msg[I, V, C])
+	Decide func(ctx context.Context, instance I, value V, round int64, qcommit []Msg[I, V, C])
 	// LogUponRule allows debug logging of triggered upon rules on message receipt.
 	LogUponRule func(ctx context.Context, instance I, process, round int64, msg Msg[I, V, C], uponRule UponRule)
 	// LogRoundChange allows debug logging of round changes.
@@ -429,7 +429,7 @@ func Run[I any, V comparable, C any](ctx context.Context, d Definition[I, V, C],
 
 				timerChan = nil
 
-				d.Decide(ctx, instance, msg.Value(), justification)
+				d.Decide(ctx, instance, msg.Value(), msg.Round(), justification)
 
 			case UponFPlus1RoundChanges: // Algorithm 3:5
 				// Only applicable to future rounds

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -311,7 +311,7 @@ func testQBFT(t *testing.T, test test) {
 
 			return clock.NewTimer(d)
 		},
-		Decide: func(_ context.Context, instance int64, value int64, qcommit []Msg[int64, int64, int64]) {
+		Decide: func(_ context.Context, instance int64, value int64, round int64, qcommit []Msg[int64, int64, int64]) {
 			resultChan <- qcommit
 		},
 		Compare: func(ctx context.Context, qcommit Msg[int64, int64, int64], inputValueSourceCh <-chan int64, inputValueSource int64, returnErr chan error, returnRes chan int64) {
@@ -661,7 +661,7 @@ func TestDecidedRebroadcastLimits(t *testing.T) {
 		def := noopDef
 		def.Nodes = n
 		def.FIFOLimit = 100
-		def.Decide = func(context.Context, int64, int64, []Msg[int64, int64, int64]) {}
+		def.Decide = func(context.Context, int64, int64, int64, []Msg[int64, int64, int64]) {}
 
 		trans := Transport[int64, int64, int64]{
 			Broadcast: func(_ context.Context, typ MsgType, _ int64, _ int64, _ int64, _ int64,
@@ -956,7 +956,7 @@ func testQBFTChainSplit(t *testing.T, test testChainSplit) {
 		NewTimer: func(round int64) (<-chan time.Time, func()) {
 			return clock.NewTimer(time.Duration(math.Pow(2, float64(round-1))) * time.Second)
 		},
-		Decide: func(_ context.Context, instance int64, value int64, qcommit []Msg[int64, int64, int64]) {
+		Decide: func(_ context.Context, instance int64, value int64, round int64, qcommit []Msg[int64, int64, int64]) {
 			resultChan <- qcommit
 		},
 		Compare: func(ctx context.Context, qcommit Msg[int64, int64, int64], inputValueSourceCh <-chan int64, inputValueSource int64, returnCh chan error, returnIVS chan int64) {

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -620,6 +620,686 @@ func (m msg) Justification() []Msg[int64, int64, int64] {
 	return resp
 }
 
+// TestDecideScenarios verifies which value and round a node decides for
+// adversarial and edge-case message sequences: conflicting COMMIT values and
+// rounds, equivocating and spamming peers, crafted DECIDED messages, and
+// post-decision noise. Deciding requires a full quorum of distinct sources
+// committing to the exact same value in the exact same round, and a node
+// decides at most once.
+func TestDecideScenarios(t *testing.T) {
+	const (
+		n    = 4 // Quorum = 3.
+		valA = 1
+		valB = 2
+		valC = 3
+	)
+
+	commitAt := func(source, round, value int64) msg {
+		return msg{msgType: MsgCommit, peerIdx: source, round: round, value: value}
+	}
+	commit := func(source, value int64) msg {
+		return commitAt(source, 1, value)
+	}
+	roundChange := func(source, round int64) msg {
+		return msg{msgType: MsgRoundChange, peerIdx: source, round: round}
+	}
+	decidedMsg := func(source, round, value int64, justify []msg) msg {
+		return msg{msgType: MsgDecided, peerIdx: source, round: round, value: value, justify: justify}
+	}
+	quorumCommits := func(value int64) []msg {
+		return []msg{commit(1, value), commit(2, value), commit(3, value)}
+	}
+	// spamThenQuorum floods the FIFO buffer of peer 1 with junk commits before
+	// peer 1's real commit completes the quorum.
+	spamThenQuorum := func() []msg {
+		msgs := []msg{commit(2, valB), commit(3, valB)}
+		for range 120 { // FIFOLimit is 100.
+			msgs = append(msgs, commit(1, valC))
+		}
+
+		return append(msgs, commit(1, valB))
+	}
+
+	tests := []struct {
+		name         string
+		msgs         []msg
+		decided      int64 // Zero means no decision expected.
+		decidedRound int64
+		wantQcommit  int // Expected qcommit length, defaults to 3 (quorum).
+	}{
+		{
+			name: "minority value arrives first",
+			msgs: []msg{
+				commit(1, valA),
+				commit(2, valB),
+				commit(3, valB),
+				commit(0, valB),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "minority value arrives in the middle",
+			msgs: []msg{
+				commit(1, valB),
+				commit(2, valA),
+				commit(3, valB),
+				commit(0, valB),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "two-two value split never decides",
+			msgs: []msg{
+				commit(0, valA),
+				commit(1, valA),
+				commit(2, valB),
+				commit(3, valB),
+			},
+			decided: 0,
+		},
+		{
+			name: "minority round arrives first",
+			msgs: []msg{
+				commitAt(1, 2, valB),
+				commit(2, valB),
+				commit(3, valB),
+				commit(0, valB),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "two-two round split never decides",
+			msgs: []msg{
+				commit(0, valB),
+				commit(1, valB),
+				commitAt(2, 2, valB),
+				commitAt(3, 2, valB),
+			},
+			decided: 0,
+		},
+		{
+			name: "decides at future round after f+1 round changes",
+			msgs: []msg{
+				roundChange(1, 2),
+				roundChange(2, 2),
+				commitAt(1, 2, valB),
+				commitAt(2, 2, valB),
+				commitAt(3, 2, valB),
+			},
+			decided:      valB,
+			decidedRound: 2,
+		},
+		{
+			name: "equivocating peer's second vote counts toward quorum",
+			msgs: []msg{
+				commit(1, valA),
+				commit(2, valB),
+				commit(3, valB),
+				commit(1, valB),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "equivocation alone cannot create quorum",
+			msgs: []msg{
+				commit(1, valA),
+				commit(1, valB),
+				commit(2, valA),
+				commit(3, valB),
+			},
+			decided: 0,
+		},
+		{
+			name: "duplicate commits do not inflate quorum",
+			msgs: []msg{
+				commit(1, valB),
+				commit(1, valB),
+				commit(1, valB),
+				commit(2, valB),
+			},
+			decided: 0,
+		},
+		{
+			name: "post-decide quorum for another value is ignored",
+			msgs: []msg{
+				commit(1, valB),
+				commit(2, valB),
+				commit(0, valB),
+				commit(1, valC),
+				commit(2, valC),
+				commit(3, valC),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "justified decided message from a single relay peer",
+			msgs: []msg{
+				decidedMsg(3, 1, valB, quorumCommits(valB)),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "duplicate decided message decides only once",
+			msgs: []msg{
+				decidedMsg(3, 1, valB, quorumCommits(valB)),
+				decidedMsg(2, 1, valB, quorumCommits(valB)),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "decided with insufficient justification is dropped",
+			msgs: []msg{
+				decidedMsg(3, 1, valB, []msg{commit(1, valB), commit(2, valB)}),
+			},
+			decided: 0,
+		},
+		{
+			name: "decided with round-mismatched justification is dropped",
+			msgs: []msg{
+				// Justification commits are for round 1 while the decided message claims round 2.
+				decidedMsg(3, 2, valB, quorumCommits(valB)),
+			},
+			decided: 0,
+		},
+		{
+			name: "decided with value-mismatched justification is dropped",
+			msgs: []msg{
+				// Justification commits are for value A while the decided message claims value B.
+				decidedMsg(3, 1, valB, quorumCommits(valA)),
+			},
+			decided: 0,
+		},
+		{
+			name: "decided with rogue extra commit still decides the quorum value",
+			msgs: []msg{
+				decidedMsg(3, 1, valB, append([]msg{commit(3, valA)}, quorumCommits(valB)...)),
+			},
+			decided:      valB,
+			decidedRound: 1,
+			wantQcommit:  4, // Justification is forwarded verbatim, including the rogue commit.
+		},
+		{
+			name: "stale-round decided accepted after node advanced",
+			msgs: []msg{
+				roundChange(1, 2),
+				roundChange(2, 2),
+				decidedMsg(3, 1, valB, quorumCommits(valB)),
+			},
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "buffered future-round commits alone do not decide",
+			// Quorum commits for round 2 arrive while still in round 1; the f+1 round
+			// jump does not re-classify buffered messages. In production the node
+			// recovers via the MsgDecided resend triggered by its ROUND-CHANGE broadcast.
+			msgs: []msg{
+				commitAt(1, 2, valB),
+				commitAt(2, 2, valB),
+				commitAt(3, 2, valB),
+				roundChange(1, 2),
+				roundChange(2, 2),
+			},
+			decided: 0,
+		},
+		{
+			name: "re-sent commit after round jump decides from buffer",
+			msgs: []msg{
+				commitAt(1, 2, valB),
+				commitAt(2, 2, valB),
+				commitAt(3, 2, valB),
+				roundChange(1, 2),
+				roundChange(2, 2),
+				commitAt(1, 2, valB),
+			},
+			decided:      valB,
+			decidedRound: 2,
+		},
+		{
+			name: "f+1 jump requires distinct sources",
+			msgs: []msg{
+				roundChange(1, 2),
+				roundChange(1, 3),
+				commitAt(1, 2, valB),
+				commitAt(2, 2, valB),
+				commitAt(3, 2, valB),
+			},
+			decided: 0,
+		},
+		{
+			name:         "spam from one peer does not evict other peers' commits",
+			msgs:         spamThenQuorum(),
+			decided:      valB,
+			decidedRound: 1,
+		},
+		{
+			name: "commits with invalid round are ignored",
+			msgs: []msg{
+				commitAt(1, -1, valB),
+				commitAt(2, -1, valB),
+				commitAt(3, -1, valB),
+			},
+			decided: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+
+			type decision struct {
+				value   int64
+				round   int64
+				qcommit []Msg[int64, int64, int64]
+			}
+
+			recv := make(chan Msg[int64, int64, int64])
+			decides := make(chan decision, 10)
+
+			def := noopDef
+			def.Nodes = n
+			def.FIFOLimit = 100
+			def.Decide = func(_ context.Context, _ int64, value int64, round int64, qcommit []Msg[int64, int64, int64]) {
+				decides <- decision{value: value, round: round, qcommit: qcommit}
+			}
+
+			trans := Transport[int64, int64, int64]{
+				Broadcast: func(context.Context, MsgType, int64, int64, int64, int64,
+					int64, int64, []Msg[int64, int64, int64],
+				) error {
+					return nil
+				},
+				Receive: recv,
+			}
+
+			// Never-delivering input channels (this process is not a leader and proposes nothing).
+			go func() {
+				_ = Run(ctx, def, trans, 0, 0, make(chan int64), make(chan int64))
+			}()
+
+			send := func(m msg) {
+				select {
+				case recv <- m:
+				case <-time.After(5 * time.Second):
+					require.Fail(t, "timeout sending message to qbft instance")
+				}
+			}
+
+			for _, m := range test.msgs {
+				send(m)
+			}
+
+			// Inert flush: a commit for a far-future round is ignored, but its send only
+			// completes once all messages above have been fully processed, making the
+			// decide assertion below deterministic.
+			send(commitAt(1, 99, valA))
+
+			cancel()
+
+			var got []decision
+
+			drained := false
+			for !drained {
+				select {
+				case d := <-decides:
+					got = append(got, d)
+				default:
+					drained = true
+				}
+			}
+
+			if test.decided == 0 {
+				require.Empty(t, got, "expected no decision")
+				return
+			}
+
+			require.Len(t, got, 1, "node must decide exactly once")
+
+			d := got[0]
+			require.Equal(t, test.decided, d.value, "decided unexpected value")
+			require.Equal(t, test.decidedRound, d.round, "decided unexpected round")
+
+			wantQcommit := test.wantQcommit
+			if wantQcommit == 0 {
+				wantQcommit = 3
+			}
+
+			require.Len(t, d.qcommit, wantQcommit)
+
+			var matching int
+
+			for _, q := range d.qcommit {
+				if q.Type() == MsgCommit && q.Value() == d.value && q.Round() == d.round {
+					matching++
+				}
+			}
+
+			require.GreaterOrEqual(t, matching, 3,
+				"qcommit must contain a quorum of commits matching the decided value and round")
+		})
+	}
+}
+
+// TestCompareFlowDecideScenarios verifies the interaction between the Compare flow
+// (chain_split_halt feature) and the decide paths. Compare only gates the node's own
+// PREPARE on a justified PRE-PREPARE: a Compare failure or timeout must suppress the
+// PREPARE but never prevent deciding on a quorum of COMMITs or a justified DECIDED
+// message.
+func TestCompareFlowDecideScenarios(t *testing.T) {
+	const (
+		n      = 4
+		leader = 1
+		valB   = 2
+	)
+
+	type decision struct {
+		value int64
+		round int64
+	}
+
+	prePrepare := msg{msgType: MsgPrePrepare, peerIdx: leader, round: 1, value: valB}
+	quorumCommits := []msg{
+		{msgType: MsgCommit, peerIdx: 1, round: 1, value: valB},
+		{msgType: MsgCommit, peerIdx: 2, round: 1, value: valB},
+		{msgType: MsgCommit, peerIdx: 3, round: 1, value: valB},
+	}
+	decidedByRelay := msg{msgType: MsgDecided, peerIdx: 3, round: 1, value: valB, justify: quorumCommits}
+	inertFlush := msg{msgType: MsgCommit, peerIdx: 1, round: 99, value: valB}
+
+	// startNode runs a non-leader node with the given Compare behaviour and returns
+	// a send function plus channels collecting broadcast types and decisions.
+	startNode := func(t *testing.T, compareFn func(returnErr chan error),
+		newTimer func(int64) (<-chan time.Time, func()),
+	) (func(msg), chan MsgType, chan decision) {
+		t.Helper()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		recv := make(chan Msg[int64, int64, int64])
+		broadcasts := make(chan MsgType, 100)
+		decides := make(chan decision, 10)
+
+		def := noopDef
+		def.Nodes = n
+		def.FIFOLimit = 100
+		def.IsLeader = func(_ int64, _ int64, process int64) bool { return process == leader }
+		def.Compare = func(_ context.Context, _ Msg[int64, int64, int64], _ <-chan int64, _ int64, returnErr chan error, _ chan int64) {
+			compareFn(returnErr)
+		}
+		def.Decide = func(_ context.Context, _ int64, value int64, round int64, _ []Msg[int64, int64, int64]) {
+			decides <- decision{value: value, round: round}
+		}
+
+		if newTimer != nil {
+			def.NewTimer = newTimer
+		}
+
+		trans := Transport[int64, int64, int64]{
+			Broadcast: func(_ context.Context, typ MsgType, _ int64, _ int64, _ int64, _ int64,
+				_ int64, _ int64, _ []Msg[int64, int64, int64],
+			) error {
+				broadcasts <- typ
+				return nil
+			},
+			Receive: recv,
+		}
+
+		go func() {
+			_ = Run(ctx, def, trans, 0, 0, make(chan int64), make(chan int64))
+		}()
+
+		send := func(m msg) {
+			select {
+			case recv <- m:
+			case <-time.After(5 * time.Second):
+				require.Fail(t, "timeout sending message to qbft instance")
+			}
+		}
+
+		return send, broadcasts, decides
+	}
+
+	expectDecision := func(t *testing.T, decides chan decision) {
+		t.Helper()
+
+		select {
+		case d := <-decides:
+			require.Equal(t, decision{value: valB, round: 1}, d)
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "timed out waiting for decision")
+		}
+	}
+
+	requireNoPrepare := func(t *testing.T, broadcasts chan MsgType) {
+		t.Helper()
+
+		drained := false
+		for !drained {
+			select {
+			case typ := <-broadcasts:
+				require.NotEqual(t, MsgPrepare, typ, "node must not prepare a value that failed comparison")
+			default:
+				drained = true
+			}
+		}
+	}
+
+	failCompare := func(returnErr chan error) {
+		returnErr <- errors.New("chain split detected")
+	}
+
+	t.Run("compare failure still decides on commit quorum", func(t *testing.T) {
+		send, broadcasts, decides := startNode(t, failCompare, nil)
+
+		send(prePrepare)
+
+		for _, m := range quorumCommits {
+			send(m)
+		}
+
+		send(inertFlush)
+
+		expectDecision(t, decides)
+		requireNoPrepare(t, broadcasts)
+	})
+
+	t.Run("compare failure still decides on justified decided", func(t *testing.T) {
+		send, broadcasts, decides := startNode(t, failCompare, nil)
+
+		send(prePrepare)
+		send(decidedByRelay)
+		send(inertFlush)
+
+		expectDecision(t, decides)
+		requireNoPrepare(t, broadcasts)
+	})
+
+	t.Run("compare success prepares leader value and decides", func(t *testing.T) {
+		send, broadcasts, decides := startNode(t, func(returnErr chan error) {
+			returnErr <- nil
+		}, nil)
+
+		send(prePrepare)
+
+		select {
+		case typ := <-broadcasts:
+			require.Equal(t, MsgPrepare, typ, "node must prepare the leader value on compare success")
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "timed out waiting for prepare broadcast")
+		}
+
+		for _, m := range quorumCommits {
+			send(m)
+		}
+
+		send(inertFlush)
+
+		expectDecision(t, decides)
+	})
+
+	t.Run("compare timeout changes round but decided still accepted", func(t *testing.T) {
+		shortTimer := func(int64) (<-chan time.Time, func()) {
+			timer := time.NewTimer(100 * time.Millisecond)
+			return timer.C, func() { timer.Stop() }
+		}
+
+		// Compare never responds, so the round timer expires while waiting for it.
+		send, broadcasts, decides := startNode(t, func(chan error) {}, shortTimer)
+
+		send(prePrepare)
+
+		// The compare timeout (or racing round timeout) must trigger a round change.
+		deadline := time.After(5 * time.Second)
+
+		roundChanged := false
+		for !roundChanged {
+			select {
+			case typ := <-broadcasts:
+				require.NotEqual(t, MsgPrepare, typ, "node must not prepare a value it could not compare")
+
+				if typ == MsgRoundChange {
+					roundChanged = true
+				}
+			case <-deadline:
+				require.Fail(t, "timed out waiting for round change broadcast")
+			}
+		}
+
+		send(decidedByRelay)
+
+		expectDecision(t, decides)
+		requireNoPrepare(t, broadcasts)
+	})
+}
+
+// TestCommitOwnValueMinority verifies that a node decides the quorum value even when
+// the minority value is its own: the node leads round 1, proposes, prepares and
+// commits its own value A, but a quorum of peers commits value B. The node must
+// decide B, and the qcommit justification must not contain its own A commit.
+func TestCommitOwnValueMinority(t *testing.T) {
+	const (
+		n    = 4 // Quorum = 3.
+		valA = 1
+		valB = 2
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	type decision struct {
+		value   int64
+		round   int64
+		qcommit []Msg[int64, int64, int64]
+	}
+
+	var (
+		recv       = make(chan Msg[int64, int64, int64])
+		echo       = make(chan msg, 100)
+		ownCommits = make(chan int64, 10)
+		decides    = make(chan decision, 1)
+	)
+
+	def := noopDef
+	def.Nodes = n
+	def.FIFOLimit = 100
+	def.IsLeader = func(_ int64, round, process int64) bool { return round == 1 && process == 0 }
+	def.Compare = func(_ context.Context, _ Msg[int64, int64, int64], _ <-chan int64, _ int64, returnErr chan error, _ chan int64) {
+		returnErr <- nil
+	}
+	def.Decide = func(_ context.Context, _ int64, value int64, round int64, qcommit []Msg[int64, int64, int64]) {
+		decides <- decision{value: value, round: round, qcommit: qcommit}
+	}
+
+	trans := Transport[int64, int64, int64]{
+		Broadcast: func(_ context.Context, typ MsgType, _ int64, source int64, round int64,
+			value int64, pr int64, pv int64, _ []Msg[int64, int64, int64],
+		) error {
+			if typ == MsgCommit {
+				ownCommits <- value
+			}
+
+			// Echo own broadcasts back to self, as the real transport does.
+			echo <- msg{msgType: typ, peerIdx: source, round: round, value: value, pr: pr, pv: pv}
+
+			return nil
+		},
+		Receive: recv,
+	}
+
+	// Forward echoed own messages to the receive channel.
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case m := <-echo:
+				select {
+				case <-ctx.Done():
+					return
+				case recv <- m:
+				}
+			}
+		}
+	}()
+
+	// Provide our input value A, making the leader propose it at startup.
+	inputCh := make(chan int64, 1)
+	inputCh <- valA
+
+	go func() {
+		_ = Run(ctx, def, trans, 0, 0, inputCh, make(chan int64))
+	}()
+
+	send := func(m msg) {
+		select {
+		case recv <- m:
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "timeout sending message to qbft instance")
+		}
+	}
+
+	// Complete the prepare quorum for our own value A, so the node commits A.
+	send(msg{msgType: MsgPrepare, peerIdx: 1, round: 1, value: valA})
+	send(msg{msgType: MsgPrepare, peerIdx: 2, round: 1, value: valA})
+
+	// Wait until the node has broadcast its own COMMIT for A.
+	select {
+	case v := <-ownCommits:
+		require.EqualValues(t, valA, v, "node must commit its own proposed value")
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timed out waiting for own commit")
+	}
+
+	// A quorum of peers commits a different value B.
+	send(msg{msgType: MsgCommit, peerIdx: 1, round: 1, value: valB})
+	send(msg{msgType: MsgCommit, peerIdx: 2, round: 1, value: valB})
+	send(msg{msgType: MsgCommit, peerIdx: 3, round: 1, value: valB})
+
+	select {
+	case d := <-decides:
+		require.EqualValues(t, valB, d.value, "node must decide the quorum value, not its own")
+		require.EqualValues(t, 1, d.round, "decided unexpected round")
+
+		require.Len(t, d.qcommit, 3)
+
+		for _, q := range d.qcommit {
+			require.EqualValues(t, valB, q.Value(), "qcommit must not contain the node's own minority value")
+			require.NotEqualValues(t, 0, q.Source(), "qcommit must not contain the node's own commit")
+		}
+	case <-time.After(5 * time.Second):
+		require.Fail(t, "timed out waiting for decision")
+	}
+}
+
 // TestDecidedRebroadcastLimits verifies that once consensus has decided, post-decision
 // ROUND-CHANGE messages trigger at most one MsgDecided rebroadcast per source per
 // (strictly increasing) round, capped at maxDecidedResends per source. This bounds


### PR DESCRIPTION
Previously qCommit uses optimistically the first in the list. However, we never filtered the invalid ones, so it may as well pick up an invalid qCommit. Ensure it always picks a qCommit that has value the same as the one that is actually proposed.

The PR also includes many more qbft test cases capturing various bad weather scenarios.

N.B.: linter fails, but I've fixed this in #4619. Will rebase on main after it is merged, so that linter passes here as well.

category: bug
ticket: none
