### PR TITLE
app/peerinfo: set 1MB limit to the peer info messages

### DIFF
--- a/app/peerinfo/adhoc.go
+++ b/app/peerinfo/adhoc.go
@@ -27,7 +27,7 @@ func DoOnce(ctx context.Context, p2pNode host.Host, peerID peer.ID) (*pbv1.PeerI
 	resp := new(pbv1.PeerInfo)
 
 	err := p2p.SendReceive(ctx, p2pNode, peerID, req, resp, protocolID2,
-		p2p.WithSendReceiveRTT(rttCallback), p2p.WithSendMetricTopic("peerinfo_adhoc"))
+		p2p.WithSendReceiveRTT(rttCallback), p2p.WithSendMetricTopic("peerinfo_adhoc"), p2p.WithReadLimit(maxPeerInfoMsgSize))
 	if err != nil {
 		return nil, 0, false, err
 	}

--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -26,8 +26,9 @@ import (
 )
 
 const (
-	period                  = time.Minute
-	protocolID2 protocol.ID = "/charon/peerinfo/2.0.0"
+	period                         = time.Minute
+	protocolID2        protocol.ID = "/charon/peerinfo/2.0.0"
+	maxPeerInfoMsgSize             = 1 << 20 // 1MB, PeerInfo messages are < 1KB in practice.
 )
 
 var gitHashMatch = regexp.MustCompile("^[0-9a-f]{7}$")
@@ -105,6 +106,7 @@ func newInternal(p2pNode host.Host, peers []peer.ID, version version.SemVer, loc
 				Nickname:          nickname,
 			}, true, nil
 		},
+		p2p.WithReadLimit(maxPeerInfoMsgSize),
 	)
 
 	// Maps peers to their nickname
@@ -197,7 +199,7 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 
 			resp := new(pbv1.PeerInfo)
 
-			err := p.sendFunc(ctx, p.p2pNode, peerID, req, resp, protocolID2, p2p.WithSendReceiveRTT(rttCallback), p2p.WithSendMetricTopic("peerinfo"))
+			err := p.sendFunc(ctx, p.p2pNode, peerID, req, resp, protocolID2, p2p.WithSendReceiveRTT(rttCallback), p2p.WithSendMetricTopic("peerinfo"), p2p.WithReadLimit(maxPeerInfoMsgSize))
 			if err != nil {
 				return // Logging handled by send func.
 			} else if resp.GetSentAt() == nil || resp.GetStartedAt() == nil {


### PR DESCRIPTION
Limit the size of the peer info message (they are realistically ~1KB).

category: misc
ticket: none
