### PR TITLE
*: close streams on all SendReceive and Send paths

### DIFF
--- a/p2p/sender.go
+++ b/p2p/sender.go
@@ -317,6 +317,7 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 	if err != nil {
 		return errors.Wrap(err, "new stream", z.Any("protocols", o.protocols))
 	}
+	defer s.Close()
 
 	protoLabel = string(s.Protocol())
 
@@ -361,18 +362,6 @@ func SendReceive(ctx context.Context, p2pNode host.Host, peerID peer.ID,
 		return errors.Wrap(err, "read response", z.Any("protocol", s.Protocol()))
 	}
 
-	if err = s.Close(); err != nil {
-		// This close error doesn't require a retry or warning mechanism since the message was
-		// correctly sent to the destination. However, it is still unknown what/who is causing the
-		// stream to be canceled. This error appears much more frequently when QUIC is enabled.
-		if isCanceledStreamErr(err) {
-			log.Debug(ctx, "Closing canceled stream", z.Err(err), z.Any("protocol", s.Protocol()))
-			return nil
-		}
-
-		return errors.Wrap(err, "close stream", z.Any("protocol", s.Protocol()))
-	}
-
 	o.rttCallback(time.Since(t0))
 
 	return nil
@@ -402,6 +391,7 @@ func Send(ctx context.Context, p2pNode host.Host, protoID protocol.ID, peerID pe
 	if err != nil {
 		return errors.Wrap(err, "p2pNode stream")
 	}
+	defer s.Close()
 
 	protoLabel = string(s.Protocol())
 
@@ -416,18 +406,6 @@ func Send(ctx context.Context, p2pNode host.Host, protoID protocol.ID, peerID pe
 
 	if err = writeFunc(s).WriteMsg(msg); err != nil {
 		return errors.Wrap(err, "write message", z.Any("protocol", s.Protocol()))
-	}
-
-	if err := s.Close(); err != nil {
-		// This close error doesn't require a retry or warning mechanism since the message was
-		// correctly sent to the destination. However, it is still unknown what/who is causing the
-		// stream to be canceled. This error appears much more frequently when QUIC is enabled.
-		if isCanceledStreamErr(err) {
-			log.Debug(ctx, "Closing canceled stream", z.Err(err), z.Any("protocol", s.Protocol()))
-			return nil
-		}
-
-		return errors.Wrap(err, "close stream", z.Any("protocol", s.Protocol()))
 	}
 
 	return nil

--- a/p2p/sender_test.go
+++ b/p2p/sender_test.go
@@ -84,6 +84,40 @@ func TestWithReadLimit(t *testing.T) {
 	}
 }
 
+func TestSendReceiveClosesStreamOnError(t *testing.T) {
+	server := testutil.CreateHost(t, testutil.AvailableAddr(t))
+	client := testutil.CreateHost(t, testutil.AvailableAddr(t))
+
+	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), peerstore.PermanentAddrTTL)
+
+	protocolID := protocol.ID("testprotocol")
+
+	p2p.RegisterHandler("test", server, protocolID,
+		func() proto.Message { return new(pbv1.Duty) },
+		func(context.Context, peer.ID, proto.Message) (proto.Message, bool, error) {
+			time.Sleep(time.Second)
+			return nil, false, nil
+		})
+
+	// Send multiple requests that will all time out on read.
+	for range 5 {
+		err := p2p.SendReceive(context.Background(), client, server.ID(),
+			new(pbv1.Duty), new(pbv1.Duty), protocolID, p2p.WithSendTimeout(time.Millisecond))
+		require.Error(t, err)
+	}
+
+	// Allow streams to fully close.
+	time.Sleep(100 * time.Millisecond)
+
+	var openStreams int
+	for _, conn := range client.Network().ConnsToPeer(server.ID()) {
+		openStreams += len(conn.GetStreams())
+	}
+
+	require.Zero(t, openStreams,
+		"all streams must be closed after failed SendReceive calls")
+}
+
 func TestWithSendTimeout(t *testing.T) {
 	servers := []host.Host{testutil.CreateHost(t, testutil.AvailableAddr(t)), testutil.CreateQUICHost(t, testutil.AvailableUDPAddr(t))}
 	clients := []host.Host{testutil.CreateHost(t, testutil.AvailableAddr(t)), testutil.CreateQUICHost(t, testutil.AvailableUDPAddr(t))}


### PR DESCRIPTION
Previously we have not closed the stream of Send and SendReceive. Which in occasions of nodes failing to receive it leaked the stream.

category: bug
ticket: none
