### PR TITLE
*: fix libp2p logger routing

### DIFF
--- a/app/log/slog.go
+++ b/app/log/slog.go
@@ -59,7 +59,9 @@ func (h *slogHandler) Handle(_ context.Context, rec slog.Record) error {
 		return true
 	})
 
-	ce := LoggerCore().Check(entry, nil)
+	// Read the global logger core directly (unlocked), matching getLogger's hot
+	// path, rather than LoggerCore which locks on every record.
+	ce := logger.Core().Check(entry, nil)
 	if ce == nil {
 		return nil
 	}

--- a/app/log/slog.go
+++ b/app/log/slog.go
@@ -1,0 +1,201 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package log
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+
+	"go.uber.org/zap/zapcore"
+)
+
+// SlogHandler returns a slog.Handler that writes records to the global charon logger.
+// It routes go-libp2p's slog based (gologshim) logs into charon logging, since those
+// bypass the go-log primary zap core.
+//
+// Per-subsystem levels are controlled by the GOLOG_LOG_LEVEL environment variable
+// (comma-separated [subsystem=]level pairs, e.g. "net/identify=debug") with a fallback
+// level of error, matching gologshim defaults. The subsystem is detected from the
+// "logger" attribute that gologshim attaches to each of its loggers.
+func SlogHandler() slog.Handler {
+	levels := slogLevels()
+
+	return &slogHandler{
+		levels: levels,
+		level:  levels.fallback,
+	}
+}
+
+// slogHandler implements slog.Handler by writing records to the global logger core.
+type slogHandler struct {
+	fields []zapcore.Field
+	groups []string
+	levels *slogLevelConfig
+	level  slog.Level
+}
+
+func (h *slogHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *slogHandler) Handle(_ context.Context, rec slog.Record) error {
+	entry := zapcore.Entry{
+		Level:   toZapLevel(rec.Level),
+		Time:    rec.Time,
+		Message: rec.Message,
+		Caller:  toZapCaller(rec.PC),
+	}
+
+	fields := make([]zapcore.Field, 0, len(h.fields)+rec.NumAttrs()+1)
+	fields = append(fields, zapcore.Field{Key: "topic", Type: zapcore.StringType, String: "libp2p"})
+	fields = append(fields, h.fields...)
+
+	rec.Attrs(func(a slog.Attr) bool {
+		fields = append(fields, h.toZapField(a))
+		return true
+	})
+
+	ce := LoggerCore().Check(entry, nil)
+	if ce == nil {
+		return nil
+	}
+
+	ce.Write(fields...)
+
+	return nil
+}
+
+func (h *slogHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	resp := h.clone()
+
+	for _, a := range attrs {
+		if a.Key == "logger" && a.Value.Kind() == slog.KindString {
+			// Gologshim identifies each subsystem via the "logger" attribute,
+			// which determines its GOLOG_LOG_LEVEL based level.
+			resp.level = h.levels.levelFor(a.Value.String())
+		}
+
+		resp.fields = append(resp.fields, h.toZapField(a))
+	}
+
+	return resp
+}
+
+func (h *slogHandler) WithGroup(name string) slog.Handler {
+	resp := h.clone()
+	resp.groups = append(resp.groups, name)
+
+	return resp
+}
+
+// clone returns a copy of the handler with fields and groups slices safe to append to.
+func (h *slogHandler) clone() *slogHandler {
+	return &slogHandler{
+		fields: append([]zapcore.Field(nil), h.fields...),
+		groups: append([]string(nil), h.groups...),
+		levels: h.levels,
+		level:  h.level,
+	}
+}
+
+// toZapField converts a slog attribute to a zap field, prefixing open group names.
+func (h *slogHandler) toZapField(a slog.Attr) zapcore.Field {
+	key := a.Key
+	if len(h.groups) > 0 {
+		key = strings.Join(h.groups, ".") + "." + key
+	}
+
+	return zapcore.Field{Key: key, Type: zapcore.ReflectType, Interface: a.Value.Resolve().Any()}
+}
+
+// toZapLevel maps a slog level to the closest zap level.
+func toZapLevel(level slog.Level) zapcore.Level {
+	switch {
+	case level >= slog.LevelError:
+		return zapcore.ErrorLevel
+	case level >= slog.LevelWarn:
+		return zapcore.WarnLevel
+	case level >= slog.LevelInfo:
+		return zapcore.InfoLevel
+	default:
+		return zapcore.DebugLevel
+	}
+}
+
+// toZapCaller resolves a slog record program counter to a zap entry caller.
+func toZapCaller(pc uintptr) zapcore.EntryCaller {
+	if pc == 0 {
+		return zapcore.EntryCaller{}
+	}
+
+	frame, _ := runtime.CallersFrames([]uintptr{pc}).Next()
+	if frame.PC == 0 {
+		return zapcore.EntryCaller{}
+	}
+
+	return zapcore.EntryCaller{
+		Defined:  true,
+		PC:       frame.PC,
+		File:     frame.File,
+		Line:     frame.Line,
+		Function: frame.Function,
+	}
+}
+
+// slogLevelConfig holds per-subsystem slog levels parsed from GOLOG_LOG_LEVEL.
+type slogLevelConfig struct {
+	fallback slog.Level
+	systems  map[string]slog.Level
+}
+
+// levelFor returns the level for the given subsystem, or the fallback level.
+func (c *slogLevelConfig) levelFor(system string) slog.Level {
+	level, ok := c.systems[system]
+	if !ok {
+		return c.fallback
+	}
+
+	return level
+}
+
+// slogLevels returns the levels parsed from the GOLOG_LOG_LEVEL environment
+// variable, mirroring gologshim (and go-log) semantics.
+var slogLevels = sync.OnceValue(func() *slogLevelConfig {
+	return parseSlogLevels(os.Getenv("GOLOG_LOG_LEVEL"))
+})
+
+// parseSlogLevels parses a comma-separated list of [subsystem=]level pairs,
+// invalid entries are ignored and the fallback level defaults to error.
+func parseSlogLevels(env string) *slogLevelConfig {
+	resp := &slogLevelConfig{
+		fallback: slog.LevelError,
+		systems:  make(map[string]slog.Level),
+	}
+
+	for kvs := range strings.SplitSeq(env, ",") {
+		if kvs == "" {
+			continue
+		}
+
+		kv := strings.SplitN(kvs, "=", 2)
+
+		var level slog.Level
+
+		err := level.UnmarshalText([]byte(kv[len(kv)-1]))
+		if err != nil {
+			continue // Ignore invalid levels.
+		}
+
+		if len(kv) == 1 {
+			resp.fallback = level
+		} else {
+			resp.systems[kv[0]] = level
+		}
+	}
+
+	return resp
+}

--- a/app/log/slog_internal_test.go
+++ b/app/log/slog_internal_test.go
@@ -1,0 +1,85 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package log
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestParseSlogLevels(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		fallback slog.Level
+		systems  map[string]slog.Level
+	}{
+		{
+			name:     "empty defaults to error",
+			env:      "",
+			fallback: slog.LevelError,
+			systems:  map[string]slog.Level{},
+		},
+		{
+			name:     "per system levels",
+			env:      "observedaddrs=debug,net/identify=debug",
+			fallback: slog.LevelError,
+			systems: map[string]slog.Level{
+				"observedaddrs": slog.LevelDebug,
+				"net/identify":  slog.LevelDebug,
+			},
+		},
+		{
+			name:     "fallback and system",
+			env:      "warn,autonat=info",
+			fallback: slog.LevelWarn,
+			systems:  map[string]slog.Level{"autonat": slog.LevelInfo},
+		},
+		{
+			name:     "invalid entries ignored",
+			env:      "bogus=notalevel,autonat=debug",
+			fallback: slog.LevelError,
+			systems:  map[string]slog.Level{"autonat": slog.LevelDebug},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := parseSlogLevels(test.env)
+			require.Equal(t, test.fallback, c.fallback)
+			require.Equal(t, test.systems, c.systems)
+		})
+	}
+}
+
+func TestSlogHandler(t *testing.T) {
+	var buf bytes.Buffer
+
+	InitConsoleForT(t, zapcore.AddSync(&buf))
+
+	levels := parseSlogLevels("net/identify=debug")
+	h := slog.Handler(&slogHandler{levels: levels, level: levels.fallback})
+
+	// Subsystem with debug enabled writes debug records to the charon logger.
+	identify := slog.New(h.WithAttrs([]slog.Attr{slog.String("logger", "net/identify")}))
+	identify.Debug("updating snapshot", "seq", 1)
+
+	require.Contains(t, buf.String(), "updating snapshot")
+	require.Contains(t, buf.String(), "net/identify")
+	require.Contains(t, buf.String(), "libp2p")
+
+	// Subsystem at fallback level drops debug and info records.
+	buf.Reset()
+
+	other := slog.New(h.WithAttrs([]slog.Attr{slog.String("logger", "swarm")}))
+	other.Debug("dropped")
+	other.Info("also dropped")
+	require.Empty(t, buf.String())
+
+	// But writes error records.
+	other.Error("failed to listen", "err", "address in use")
+	require.Contains(t, buf.String(), "failed to listen")
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -9,6 +9,8 @@ import (
 	"net/url"
 	"strings"
 
+	libp2plog "github.com/ipfs/go-log/v2"
+	"github.com/libp2p/go-libp2p/gologshim"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -192,6 +194,14 @@ func titledHelp(cmd *cobra.Command) {
 // printFlags INFO logs all the given flags in alphabetical order.
 func printFlags(ctx context.Context, flags *pflag.FlagSet) {
 	log.Info(ctx, "Parsed config", flagsToLogFields(flags)...)
+}
+
+// routeLibP2PLogs routes libp2p logs to the charon logger; go-log based libp2p loggers
+// via the go-log primary zap core and slog based (gologshim) loggers via the slog bridge.
+// Must be called after log.InitLogger and before any libp2p activity.
+func routeLibP2PLogs() {
+	libp2plog.SetPrimaryCore(log.LoggerCore())
+	gologshim.SetDefaultHandler(log.SlogHandler())
 }
 
 // printLicense INFO logs the license notice.

--- a/cmd/dkg.go
+++ b/cmd/dkg.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
@@ -45,7 +44,7 @@ this command at the same time.`,
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printLicense(cmd.Context())
 			printFlags(cmd.Context(), cmd.Flags())

--- a/cmd/edit_addoperators.go
+++ b/cmd/edit_addoperators.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app"
@@ -34,7 +33,7 @@ func newAddOperatorsCmd(runFunc func(context.Context, dkg.AddOperatorsConfig, dk
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			return runFunc(cmd.Context(), config, dkgConfig)
 		},

--- a/cmd/edit_addvalidators.go
+++ b/cmd/edit_addvalidators.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app"
@@ -55,7 +54,7 @@ func newAddValidatorsCmd(runFunc func(context.Context, addValidatorsConfig) erro
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			return runFunc(cmd.Context(), config)
 		},

--- a/cmd/edit_recreateprivatekeys.go
+++ b/cmd/edit_recreateprivatekeys.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app"
@@ -30,7 +29,7 @@ func newRecreatePrivateKeysCmd(runFunc func(context.Context, dkg.ReshareConfig) 
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			return runFunc(cmd.Context(), config)
 		},

--- a/cmd/edit_removeoperators.go
+++ b/cmd/edit_removeoperators.go
@@ -7,7 +7,6 @@ import (
 	"slices"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app"
@@ -34,7 +33,7 @@ func newRemoveOperatorsCmd(runFunc func(context.Context, dkg.RemoveOperatorsConf
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			return runFunc(cmd.Context(), config, dkgConfig)
 		},

--- a/cmd/edit_replaceoperator.go
+++ b/cmd/edit_replaceoperator.go
@@ -8,7 +8,6 @@ import (
 	"slices"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app"
@@ -36,7 +35,7 @@ func newReplaceOperatorCmd(runFunc func(context.Context, dkg.ReplaceOperatorConf
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			return runFunc(cmd.Context(), config, dkgConfig)
 		},

--- a/cmd/exit_broadcast.go
+++ b/cmd/exit_broadcast.go
@@ -16,7 +16,6 @@ import (
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -46,7 +45,7 @@ func newBcastFullExitCmd(runFunc func(context.Context, exitConfig) error) *cobra
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printFlags(cmd.Context(), cmd.Flags())
 

--- a/cmd/exit_delete.go
+++ b/cmd/exit_delete.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -33,7 +32,7 @@ func newDeleteExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Co
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printFlags(cmd.Context(), cmd.Flags())
 

--- a/cmd/exit_fetch.go
+++ b/cmd/exit_fetch.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -37,7 +36,7 @@ func newFetchExitCmd(runFunc func(context.Context, exitConfig) error) *cobra.Com
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printFlags(cmd.Context(), cmd.Flags())
 

--- a/cmd/exit_list.go
+++ b/cmd/exit_list.go
@@ -9,7 +9,6 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -32,7 +31,7 @@ func newListActiveValidatorsCmd(runFunc func(context.Context, exitConfig) error)
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printFlags(cmd.Context(), cmd.Flags())
 

--- a/cmd/exit_sign.go
+++ b/cmd/exit_sign.go
@@ -9,7 +9,6 @@ import (
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2v1 "github.com/attestantio/go-eth2-client/api/v1"
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/errors"
@@ -37,7 +36,7 @@ func newSignPartialExitCmd(runFunc func(context.Context, exitConfig) error) *cob
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printFlags(cmd.Context(), cmd.Flags())
 

--- a/cmd/relay.go
+++ b/cmd/relay.go
@@ -5,7 +5,6 @@ package cmd
 import (
 	"context"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 
 	"github.com/obolnetwork/charon/app/log"
@@ -25,7 +24,7 @@ func newRelayCmd(runFunc func(context.Context, relay.Config) error) *cobra.Comma
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printLicense(cmd.Context())
 			printFlags(cmd.Context(), cmd.Flags())

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"time"
 
-	libp2plog "github.com/ipfs/go-log/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"golang.org/x/net/idna"
@@ -36,7 +35,7 @@ func newRunCmd(runFunc func(context.Context, app.Config) error, unsafe bool) *co
 				return err
 			}
 
-			libp2plog.SetPrimaryCore(log.LoggerCore()) // Set libp2p logger to use charon logger
+			routeLibP2PLogs() // Route libp2p logging to charon logger
 
 			printLicense(cmd.Context())
 			printFlags(cmd.Context(), cmd.Flags())

--- a/core/qbft/qbft_internal_test.go
+++ b/core/qbft/qbft_internal_test.go
@@ -1563,7 +1563,7 @@ func TestEquivocatingLeaderDoublePrepare(t *testing.T) {
 	def.Compare = func(_ context.Context, _ Msg[int64, int64, int64], _ <-chan int64, _ int64, returnErr chan error, _ chan int64) {
 		returnErr <- nil
 	}
-	def.Decide = func(context.Context, int64, int64, []Msg[int64, int64, int64]) {}
+	def.Decide = func(context.Context, int64, int64, int64, []Msg[int64, int64, int64]) {}
 
 	trans := Transport[int64, int64, int64]{
 		Broadcast: func(_ context.Context, typ MsgType, _ int64, _ int64, _ int64, value int64, _ int64, _ int64, _ []Msg[int64, int64, int64]) error {
@@ -1638,7 +1638,7 @@ func TestZeroValuePrePrepareRejected(t *testing.T) {
 	def.Compare = func(_ context.Context, _ Msg[int64, int64, int64], _ <-chan int64, _ int64, returnErr chan error, _ chan int64) {
 		returnErr <- nil
 	}
-	def.Decide = func(context.Context, int64, int64, []Msg[int64, int64, int64]) {}
+	def.Decide = func(context.Context, int64, int64, int64, []Msg[int64, int64, int64]) {}
 
 	trans := Transport[int64, int64, int64]{
 		Broadcast: func(_ context.Context, typ MsgType, _ int64, _ int64, _ int64, value int64, _ int64, _ int64, _ []Msg[int64, int64, int64]) error {


### PR DESCRIPTION
Previously the logger didn't parse properly the logs received from golibp2p.

category: bug
ticket: none
