### PR TITLE
app/peerinfo: add dv_client field to peerinfo protocol

### DIFF
--- a/app/peerinfo/metrics.go
+++ b/app/peerinfo/metrics.go
@@ -68,4 +68,11 @@ var (
 		Help:        "Constant gauge with nickname label set to peer's charon nickname.",
 		ConstLabels: nil,
 	}, []string{"peer", "peer_nickname"})
+
+	peerDVTypeGauge = promauto.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Subsystem: "peerinfo",
+		Name:      "dv_type",
+		Help:      "Constant gauge with dv_type label set to the peer's distributed validator client type.",
+	}, []string{"peer", "dv_type"})
 )

--- a/app/peerinfo/metrics.go
+++ b/app/peerinfo/metrics.go
@@ -69,10 +69,10 @@ var (
 		ConstLabels: nil,
 	}, []string{"peer", "peer_nickname"})
 
-	peerDVTypeGauge = promauto.NewResetGaugeVec(prometheus.GaugeOpts{
+	peerDVClientGauge = promauto.NewResetGaugeVec(prometheus.GaugeOpts{
 		Namespace: "app",
 		Subsystem: "peerinfo",
-		Name:      "dv_type",
-		Help:      "Constant gauge with dv_type label set to the peer's distributed validator client type.",
-	}, []string{"peer", "dv_type"})
+		Name:      "dv_client",
+		Help:      "Constant gauge with dv_client label set to the peer's distributed validator client type.",
+	}, []string{"peer", "dv_client"})
 )

--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -30,7 +30,7 @@ const (
 	protocolID2        protocol.ID = "/charon/peerinfo/2.0.0"
 	maxPeerInfoMsgSize             = 1 << 20 // 1MB, PeerInfo messages are < 1KB in practice.
 
-	DVTypeCharon = "charon"
+	DVClientCharon = "charon"
 )
 
 var gitHashMatch = regexp.MustCompile("^[0-9a-f]{7}$")
@@ -55,7 +55,7 @@ func New(p2pNode host.Host, peers []peer.ID, version version.SemVer, lockHash []
 	peerVersion.WithLabelValues(name, version.String()).Set(1)
 	peerGitHash.WithLabelValues(name, gitHash).Set(1)
 	peerNickname.WithLabelValues(name, nickname).Set(1)
-	peerDVTypeGauge.WithLabelValues(name, DVTypeCharon).Set(1)
+	peerDVClientGauge.WithLabelValues(name, DVClientCharon).Set(1)
 	peerStartGauge.WithLabelValues(name).Set(float64(time.Now().Unix()))
 
 	if builderEnabled {
@@ -107,7 +107,7 @@ func newInternal(p2pNode host.Host, peers []peer.ID, version version.SemVer, loc
 				StartedAt:         startTime,
 				BuilderApiEnabled: builderAPIEnabled,
 				Nickname:          nickname,
-				DvType:            DVTypeCharon,
+				DvClient:          DVClientCharon,
 			}, true, nil
 		},
 		p2p.WithReadLimit(maxPeerInfoMsgSize),
@@ -192,7 +192,7 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			StartedAt:         p.startTime,
 			BuilderApiEnabled: p.builderAPIEnabled,
 			Nickname:          p.nicknames[p2p.PeerName(p.p2pNode.ID())],
-			DvType:            DVTypeCharon,
+			DvClient:          DVClientCharon,
 		}
 
 		go func(peerID peer.ID) {
@@ -234,15 +234,15 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			actualSentAt := resp.GetSentAt().AsTime()
 			clockOffset := actualSentAt.Sub(expectedSentAt)
 
-			peerDvType := resp.GetDvType()
-			if peerDvType == "" {
-				peerDvType = DVTypeCharon
+			peerDvClient := resp.GetDvClient()
+			if peerDvClient == "" {
+				peerDvClient = DVClientCharon
 			}
 
-			peerDVTypeGauge.Reset(name)
-			peerDVTypeGauge.WithLabelValues(name, peerDvType).Set(1)
+			peerDVClientGauge.Reset(name)
+			peerDVClientGauge.WithLabelValues(name, peerDvClient).Set(1)
 
-			if peerDvType == DVTypeCharon {
+			if peerDvClient == DVClientCharon {
 				if err := supportedPeerVersion(resp.GetCharonVersion(), version.Supported()); err != nil {
 					peerCompatibleGauge.WithLabelValues(name).Set(0)
 

--- a/app/peerinfo/peerinfo.go
+++ b/app/peerinfo/peerinfo.go
@@ -29,6 +29,8 @@ const (
 	period                         = time.Minute
 	protocolID2        protocol.ID = "/charon/peerinfo/2.0.0"
 	maxPeerInfoMsgSize             = 1 << 20 // 1MB, PeerInfo messages are < 1KB in practice.
+
+	DVTypeCharon = "charon"
 )
 
 var gitHashMatch = regexp.MustCompile("^[0-9a-f]{7}$")
@@ -53,6 +55,7 @@ func New(p2pNode host.Host, peers []peer.ID, version version.SemVer, lockHash []
 	peerVersion.WithLabelValues(name, version.String()).Set(1)
 	peerGitHash.WithLabelValues(name, gitHash).Set(1)
 	peerNickname.WithLabelValues(name, nickname).Set(1)
+	peerDVTypeGauge.WithLabelValues(name, DVTypeCharon).Set(1)
 	peerStartGauge.WithLabelValues(name).Set(float64(time.Now().Unix()))
 
 	if builderEnabled {
@@ -104,6 +107,7 @@ func newInternal(p2pNode host.Host, peers []peer.ID, version version.SemVer, loc
 				StartedAt:         startTime,
 				BuilderApiEnabled: builderAPIEnabled,
 				Nickname:          nickname,
+				DvType:            DVTypeCharon,
 			}, true, nil
 		},
 		p2p.WithReadLimit(maxPeerInfoMsgSize),
@@ -188,6 +192,7 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			StartedAt:         p.startTime,
 			BuilderApiEnabled: p.builderAPIEnabled,
 			Nickname:          p.nicknames[p2p.PeerName(p.p2pNode.ID())],
+			DvType:            DVTypeCharon,
 		}
 
 		go func(peerID peer.ID) {
@@ -229,21 +234,29 @@ func (p *PeerInfo) sendOnce(ctx context.Context, now time.Time) {
 			actualSentAt := resp.GetSentAt().AsTime()
 			clockOffset := actualSentAt.Sub(expectedSentAt)
 
-			if err := supportedPeerVersion(resp.GetCharonVersion(), version.Supported()); err != nil {
-				peerCompatibleGauge.WithLabelValues(name).Set(0) // Set to false
-
-				// Log as error since user action required
-				log.Error(ctx, "Peer is running an incompatible Charon version. Please coordinate with the peer to upgrade or downgrade to a compatible version", err,
-					z.Str("peer", name),
-					z.Str("peer_version", resp.GetCharonVersion()),
-					z.Any("supported_versions", version.Supported()),
-					p.versionFilters[peerID],
-				)
-
-				return
+			peerDvType := resp.GetDvType()
+			if peerDvType == "" {
+				peerDvType = DVTypeCharon
 			}
 
-			// Set peer compatibility to true.
+			peerDVTypeGauge.Reset(name)
+			peerDVTypeGauge.WithLabelValues(name, peerDvType).Set(1)
+
+			if peerDvType == DVTypeCharon {
+				if err := supportedPeerVersion(resp.GetCharonVersion(), version.Supported()); err != nil {
+					peerCompatibleGauge.WithLabelValues(name).Set(0)
+
+					log.Error(ctx, "Peer is running an incompatible Charon version. Please coordinate with the peer to upgrade or downgrade to a compatible version", err,
+						z.Str("peer", name),
+						z.Str("peer_version", resp.GetCharonVersion()),
+						z.Any("supported_versions", version.Supported()),
+						p.versionFilters[peerID],
+					)
+
+					return
+				}
+			}
+
 			peerCompatibleGauge.WithLabelValues(name).Set(1)
 
 			p.metricSubmitter(peerID, clockOffset, resp.GetCharonVersion(), resp.GetGitHash(), resp.GetStartedAt().AsTime(), resp.GetBuilderApiEnabled(), resp.GetNickname())

--- a/app/peerinfo/peerinfo_internal_test.go
+++ b/app/peerinfo/peerinfo_internal_test.go
@@ -106,7 +106,7 @@ func TestPeerBuilderAPIEnabledGauge(t *testing.T) {
 	}
 }
 
-func TestDVTypeVersionCheck(t *testing.T) {
+func TestDVClientVersionCheck(t *testing.T) {
 	now := time.Now()
 	lockHash := []byte("abcdef")
 
@@ -122,49 +122,49 @@ func TestDVTypeVersionCheck(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		dvType          string
+		dvClient        string
 		peerVersion     string
 		expectSubmitted bool
 		expectCompat    float64
-		expectDvType    string
+		expectDvClient  string
 	}{
 		{
 			name:            "non-charon skips version check",
-			dvType:          "pluto",
+			dvClient:        "pluto",
 			peerVersion:     "v0.0.1",
 			expectSubmitted: true,
 			expectCompat:    1,
-			expectDvType:    "pluto",
+			expectDvClient:  "pluto",
 		},
 		{
-			name:            "empty dv_type defaults to charon and checks version",
-			dvType:          "",
+			name:            "empty dv_client defaults to charon and checks version",
+			dvClient:        "",
 			peerVersion:     "v0.0.1",
 			expectSubmitted: false,
 			expectCompat:    0,
-			expectDvType:    DVTypeCharon,
+			expectDvClient:  DVClientCharon,
 		},
 		{
 			name:            "charon with supported version passes",
-			dvType:          DVTypeCharon,
+			dvClient:        DVClientCharon,
 			peerVersion:     version.Supported()[0].String(),
 			expectSubmitted: true,
 			expectCompat:    1,
-			expectDvType:    DVTypeCharon,
+			expectDvClient:  DVClientCharon,
 		},
 		{
 			name:            "charon with unsupported version fails",
-			dvType:          DVTypeCharon,
+			dvClient:        DVClientCharon,
 			peerVersion:     "v0.0.1",
 			expectSubmitted: false,
 			expectCompat:    0,
-			expectDvType:    DVTypeCharon,
+			expectDvClient:  DVClientCharon,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// Register a custom handler on the server with the test's dv_type and version.
+			// Register a custom handler on the server with the test's dv_client and version.
 			p2p.RegisterHandler("peerinfo", server, protocolID2,
 				func() proto.Message { return new(pbv1.PeerInfo) },
 				func(context.Context, peer.ID, proto.Message) (proto.Message, bool, error) {
@@ -174,7 +174,7 @@ func TestDVTypeVersionCheck(t *testing.T) {
 						GitHash:       gitCommit,
 						SentAt:        timestamppb.New(now),
 						StartedAt:     timestamppb.New(now),
-						DvType:        test.dvType,
+						DvClient:      test.dvClient,
 					}, true, nil
 				},
 				p2p.WithReadLimit(maxPeerInfoMsgSize),
@@ -218,8 +218,8 @@ func TestDVTypeVersionCheck(t *testing.T) {
 			compatVal := promtestutil.ToFloat64(peerCompatibleGauge.WithLabelValues(serverName))
 			require.InDelta(t, test.expectCompat, compatVal, 0)
 
-			dvTypeVal := promtestutil.ToFloat64(peerDVTypeGauge.WithLabelValues(serverName, test.expectDvType))
-			require.InDelta(t, 1, dvTypeVal, 0)
+			dvClientVal := promtestutil.ToFloat64(peerDVClientGauge.WithLabelValues(serverName, test.expectDvClient))
+			require.InDelta(t, 1, dvClientVal, 0)
 
 			require.Equal(t, test.expectSubmitted, submitted)
 		})

--- a/app/peerinfo/peerinfo_internal_test.go
+++ b/app/peerinfo/peerinfo_internal_test.go
@@ -3,14 +3,20 @@
 package peerinfo
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/peerstore"
 	promtestutil "github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	pbv1 "github.com/obolnetwork/charon/app/peerinfo/peerinfopb/v1"
 	"github.com/obolnetwork/charon/app/version"
 	"github.com/obolnetwork/charon/p2p"
 	"github.com/obolnetwork/charon/testutil"
@@ -96,6 +102,126 @@ func TestPeerBuilderAPIEnabledGauge(t *testing.T) {
 			if err := promtestutil.CollectAndCompare(peerBuilderAPIEnabledGauge, strings.NewReader(expectedMetric), "app_peerinfo_builder_api_enabled"); err != nil {
 				require.NoError(t, err, "failed to collect metric")
 			}
+		})
+	}
+}
+
+func TestDVTypeVersionCheck(t *testing.T) {
+	now := time.Now()
+	lockHash := []byte("abcdef")
+
+	const gitCommit = "1234567"
+
+	server := testutil.CreateHost(t, testutil.AvailableAddr(t))
+	client := testutil.CreateHost(t, testutil.AvailableAddr(t))
+
+	server.Peerstore().AddAddrs(client.ID(), client.Addrs(), peerstore.PermanentAddrTTL)
+	client.Peerstore().AddAddrs(server.ID(), server.Addrs(), peerstore.PermanentAddrTTL)
+
+	peers := []peer.ID{client.ID(), server.ID()}
+
+	tests := []struct {
+		name            string
+		dvType          string
+		peerVersion     string
+		expectSubmitted bool
+		expectCompat    float64
+		expectDvType    string
+	}{
+		{
+			name:            "non-charon skips version check",
+			dvType:          "pluto",
+			peerVersion:     "v0.0.1",
+			expectSubmitted: true,
+			expectCompat:    1,
+			expectDvType:    "pluto",
+		},
+		{
+			name:            "empty dv_type defaults to charon and checks version",
+			dvType:          "",
+			peerVersion:     "v0.0.1",
+			expectSubmitted: false,
+			expectCompat:    0,
+			expectDvType:    DVTypeCharon,
+		},
+		{
+			name:            "charon with supported version passes",
+			dvType:          DVTypeCharon,
+			peerVersion:     version.Supported()[0].String(),
+			expectSubmitted: true,
+			expectCompat:    1,
+			expectDvType:    DVTypeCharon,
+		},
+		{
+			name:            "charon with unsupported version fails",
+			dvType:          DVTypeCharon,
+			peerVersion:     "v0.0.1",
+			expectSubmitted: false,
+			expectCompat:    0,
+			expectDvType:    DVTypeCharon,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Register a custom handler on the server with the test's dv_type and version.
+			p2p.RegisterHandler("peerinfo", server, protocolID2,
+				func() proto.Message { return new(pbv1.PeerInfo) },
+				func(context.Context, peer.ID, proto.Message) (proto.Message, bool, error) {
+					return &pbv1.PeerInfo{
+						CharonVersion: test.peerVersion,
+						LockHash:      lockHash,
+						GitHash:       gitCommit,
+						SentAt:        timestamppb.New(now),
+						StartedAt:     timestamppb.New(now),
+						DvType:        test.dvType,
+					}, true, nil
+				},
+				p2p.WithReadLimit(maxPeerInfoMsgSize),
+			)
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var submitted bool
+
+			tickProvider := func() (<-chan time.Time, func()) {
+				ch := make(chan time.Time, 1)
+				ch <- now
+
+				return ch, func() {}
+			}
+
+			metricSubmitter := func(peer.ID, time.Duration, string, string, time.Time, bool, string) {
+				submitted = true
+
+				cancel()
+			}
+
+			pi := newInternal(client, peers, version.Supported()[0], lockHash, gitCommit,
+				p2p.SendReceive, p2p.RegisterHandler,
+				tickProvider, func() time.Time { return now }, metricSubmitter, false, "test")
+
+			// Run until the single tick is processed.
+			go pi.Run(ctx)
+
+			if test.expectSubmitted {
+				<-ctx.Done()
+			} else {
+				// Give the goroutine time to process the tick.
+				time.Sleep(500 * time.Millisecond)
+				cancel()
+			}
+
+			serverName := p2p.PeerName(server.ID())
+
+			compatVal := promtestutil.ToFloat64(peerCompatibleGauge.WithLabelValues(serverName))
+			require.InDelta(t, test.expectCompat, compatVal, 0)
+
+			dvTypeVal := promtestutil.ToFloat64(peerDVTypeGauge.WithLabelValues(serverName, test.expectDvType))
+			require.InDelta(t, 1, dvTypeVal, 0)
+
+			require.Equal(t, test.expectSubmitted, submitted)
 		})
 	}
 }

--- a/app/peerinfo/peerinfopb/v1/peerinfo.pb.go
+++ b/app/peerinfo/peerinfopb/v1/peerinfo.pb.go
@@ -31,7 +31,7 @@ type PeerInfo struct {
 	StartedAt         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=started_at,json=startedAt,proto3,oneof" json:"started_at,omitempty"`
 	BuilderApiEnabled bool                   `protobuf:"varint,6,opt,name=builder_api_enabled,json=builderApiEnabled,proto3" json:"builder_api_enabled,omitempty"`
 	Nickname          string                 `protobuf:"bytes,7,opt,name=nickname,proto3" json:"nickname,omitempty"`
-	DvType            string                 `protobuf:"bytes,8,opt,name=dv_type,json=dvType,proto3" json:"dv_type,omitempty"`
+	DvClient          string                 `protobuf:"bytes,8,opt,name=dv_client,json=dvClient,proto3" json:"dv_client,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -115,9 +115,9 @@ func (x *PeerInfo) GetNickname() string {
 	return ""
 }
 
-func (x *PeerInfo) GetDvType() string {
+func (x *PeerInfo) GetDvClient() string {
 	if x != nil {
-		return x.DvType
+		return x.DvClient
 	}
 	return ""
 }
@@ -126,7 +126,7 @@ var File_app_peerinfo_peerinfopb_v1_peerinfo_proto protoreflect.FileDescriptor
 
 const file_app_peerinfo_peerinfopb_v1_peerinfo_proto_rawDesc = "" +
 	"\n" +
-	")app/peerinfo/peerinfopb/v1/peerinfo.proto\x12\x1aapp.peerinfo.peerinfopb.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe3\x02\n" +
+	")app/peerinfo/peerinfopb/v1/peerinfo.proto\x12\x1aapp.peerinfo.peerinfopb.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe7\x02\n" +
 	"\bPeerInfo\x12%\n" +
 	"\x0echaron_version\x18\x01 \x01(\tR\rcharonVersion\x12\x1b\n" +
 	"\tlock_hash\x18\x02 \x01(\fR\blockHash\x128\n" +
@@ -135,8 +135,8 @@ const file_app_peerinfo_peerinfopb_v1_peerinfo_proto_rawDesc = "" +
 	"\n" +
 	"started_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\tstartedAt\x88\x01\x01\x12.\n" +
 	"\x13builder_api_enabled\x18\x06 \x01(\bR\x11builderApiEnabled\x12\x1a\n" +
-	"\bnickname\x18\a \x01(\tR\bnickname\x12\x17\n" +
-	"\adv_type\x18\b \x01(\tR\x06dvTypeB\n" +
+	"\bnickname\x18\a \x01(\tR\bnickname\x12\x1b\n" +
+	"\tdv_client\x18\b \x01(\tR\bdvClientB\n" +
 	"\n" +
 	"\b_sent_atB\r\n" +
 	"\v_started_atB:Z8github.com/obolnetwork/charon/app/peerinfo/peerinfopb/v1b\x06proto3"

--- a/app/peerinfo/peerinfopb/v1/peerinfo.pb.go
+++ b/app/peerinfo/peerinfopb/v1/peerinfo.pb.go
@@ -31,6 +31,7 @@ type PeerInfo struct {
 	StartedAt         *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=started_at,json=startedAt,proto3,oneof" json:"started_at,omitempty"`
 	BuilderApiEnabled bool                   `protobuf:"varint,6,opt,name=builder_api_enabled,json=builderApiEnabled,proto3" json:"builder_api_enabled,omitempty"`
 	Nickname          string                 `protobuf:"bytes,7,opt,name=nickname,proto3" json:"nickname,omitempty"`
+	DvType            string                 `protobuf:"bytes,8,opt,name=dv_type,json=dvType,proto3" json:"dv_type,omitempty"`
 	unknownFields     protoimpl.UnknownFields
 	sizeCache         protoimpl.SizeCache
 }
@@ -114,11 +115,18 @@ func (x *PeerInfo) GetNickname() string {
 	return ""
 }
 
+func (x *PeerInfo) GetDvType() string {
+	if x != nil {
+		return x.DvType
+	}
+	return ""
+}
+
 var File_app_peerinfo_peerinfopb_v1_peerinfo_proto protoreflect.FileDescriptor
 
 const file_app_peerinfo_peerinfopb_v1_peerinfo_proto_rawDesc = "" +
 	"\n" +
-	")app/peerinfo/peerinfopb/v1/peerinfo.proto\x12\x1aapp.peerinfo.peerinfopb.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xca\x02\n" +
+	")app/peerinfo/peerinfopb/v1/peerinfo.proto\x12\x1aapp.peerinfo.peerinfopb.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xe3\x02\n" +
 	"\bPeerInfo\x12%\n" +
 	"\x0echaron_version\x18\x01 \x01(\tR\rcharonVersion\x12\x1b\n" +
 	"\tlock_hash\x18\x02 \x01(\fR\blockHash\x128\n" +
@@ -127,7 +135,8 @@ const file_app_peerinfo_peerinfopb_v1_peerinfo_proto_rawDesc = "" +
 	"\n" +
 	"started_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampH\x01R\tstartedAt\x88\x01\x01\x12.\n" +
 	"\x13builder_api_enabled\x18\x06 \x01(\bR\x11builderApiEnabled\x12\x1a\n" +
-	"\bnickname\x18\a \x01(\tR\bnicknameB\n" +
+	"\bnickname\x18\a \x01(\tR\bnickname\x12\x17\n" +
+	"\adv_type\x18\b \x01(\tR\x06dvTypeB\n" +
 	"\n" +
 	"\b_sent_atB\r\n" +
 	"\v_started_atB:Z8github.com/obolnetwork/charon/app/peerinfo/peerinfopb/v1b\x06proto3"

--- a/app/peerinfo/peerinfopb/v1/peerinfo.proto
+++ b/app/peerinfo/peerinfopb/v1/peerinfo.proto
@@ -14,7 +14,7 @@ message PeerInfo {
   optional google.protobuf.Timestamp started_at = 5;
   bool                      builder_api_enabled = 6;
   string                               nickname = 7;
-  string                                dv_type = 8;
+  string                              dv_client = 8;
 
   // NOTE: Always populate timestamps when sending, then make them required after subsequent release.
 }

--- a/app/peerinfo/peerinfopb/v1/peerinfo.proto
+++ b/app/peerinfo/peerinfopb/v1/peerinfo.proto
@@ -14,6 +14,7 @@ message PeerInfo {
   optional google.protobuf.Timestamp started_at = 5;
   bool                      builder_api_enabled = 6;
   string                               nickname = 7;
+  string                                dv_type = 8;
 
   // NOTE: Always populate timestamps when sending, then make them required after subsequent release.
 }

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,6 +41,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_peer_name` | Gauge | Constant gauge with label set to the name of the cluster peer | `peer_name` |
 | `app_peerinfo_builder_api_enabled` | Gauge | Set to 1 if builder API is enabled on this peer, else 0 if disabled. | `peer` |
 | `app_peerinfo_clock_offset_seconds` | Gauge | Peer clock offset in seconds | `peer` |
+| `app_peerinfo_dv_type` | Gauge | Constant gauge with dv_type label set to the peer`s distributed validator client type. | `peer, dv_type` |
 | `app_peerinfo_git_commit` | Gauge | Constant gauge with git_hash label set to peer`s git commit hash. | `peer, git_hash` |
 | `app_peerinfo_index` | Gauge | Constant gauge set to the peer index in the cluster definition | `peer` |
 | `app_peerinfo_nickname` | Gauge | Constant gauge with nickname label set to peer`s charon nickname. | `peer, peer_nickname` |

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -41,7 +41,7 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_peer_name` | Gauge | Constant gauge with label set to the name of the cluster peer | `peer_name` |
 | `app_peerinfo_builder_api_enabled` | Gauge | Set to 1 if builder API is enabled on this peer, else 0 if disabled. | `peer` |
 | `app_peerinfo_clock_offset_seconds` | Gauge | Peer clock offset in seconds | `peer` |
-| `app_peerinfo_dv_type` | Gauge | Constant gauge with dv_type label set to the peer`s distributed validator client type. | `peer, dv_type` |
+| `app_peerinfo_dv_client` | Gauge | Constant gauge with dv_client label set to the peer`s distributed validator client type. | `peer, dv_client` |
 | `app_peerinfo_git_commit` | Gauge | Constant gauge with git_hash label set to peer`s git commit hash. | `peer, git_hash` |
 | `app_peerinfo_index` | Gauge | Constant gauge set to the peer index in the cluster definition | `peer` |
 | `app_peerinfo_nickname` | Gauge | Constant gauge with nickname label set to peer`s charon nickname. | `peer, peer_nickname` |


### PR DESCRIPTION
Add `dv_client` field to the `PeerInfo` protobuf message. Charon sets it to "charon". Peers with a different `dv_client` (e.g. "Pluto") skip the `SemVer` compatibility check. Empty `dv_client` from older nodes defaults to "charon" for backwards compatibility. Also exposes `app_peerinfo_dv_client` metric for dashboard use.

category: feature
ticket: none