### PR TITLE
dkg: validate cluster definition threshold

### DIFF
--- a/app/log/config.go
+++ b/app/log/config.go
@@ -264,39 +264,51 @@ func NewConsoleForT(_ *testing.T, ws zapcore.WriteSyncer, opts ...func(*zapcore.
 }
 
 // InitConsoleForT initialises a global console logger for testing purposes.
+// The previous global logger is restored on test cleanup.
 func InitConsoleForT(t *testing.T, ws zapcore.WriteSyncer, opts ...func(*zapcore.EncoderConfig)) {
 	t.Helper()
-
-	initMu.Lock()
-	defer initMu.Unlock()
-
-	logger = NewConsoleForT(t, ws, opts...)
+	setLoggerForT(t, NewConsoleForT(t, zapcore.Lock(ws), opts...))
 }
 
 // InitJSONForT initialises a json logger for testing purposes.
+// The previous global logger is restored on test cleanup.
 func InitJSONForT(t *testing.T, ws zapcore.WriteSyncer, opts ...func(*zapcore.EncoderConfig)) {
 	t.Helper()
 
-	initMu.Lock()
-	defer initMu.Unlock()
-
-	var err error
-
-	logger, err = newStructuredLogger("json", zapcore.DebugLevel, true, ws, defaultCallerSkip, opts...)
+	l, err := newStructuredLogger("json", zapcore.DebugLevel, true, zapcore.Lock(ws), defaultCallerSkip, opts...)
 	require.NoError(t, err)
+
+	setLoggerForT(t, l)
 }
 
 // InitLogfmtForT initialises a logfmt logger for testing purposes.
+// The previous global logger is restored on test cleanup.
 func InitLogfmtForT(t *testing.T, ws zapcore.WriteSyncer, opts ...func(*zapcore.EncoderConfig)) {
+	t.Helper()
+
+	l, err := newStructuredLogger("logfmt", zapcore.DebugLevel, false, zapcore.Lock(ws), defaultCallerSkip, opts...)
+	require.NoError(t, err)
+
+	setLoggerForT(t, l)
+}
+
+// setLoggerForT sets the global logger and restores the previous logger on test cleanup.
+// Note the write syncer must be safe for concurrent use since logging may happen from multiple goroutines.
+func setLoggerForT(t *testing.T, l zapLogger) {
 	t.Helper()
 
 	initMu.Lock()
 	defer initMu.Unlock()
 
-	var err error
+	prev := logger
+	logger = l
 
-	logger, err = newStructuredLogger("logfmt", zapcore.DebugLevel, false, ws, defaultCallerSkip, opts...)
-	require.NoError(t, err)
+	t.Cleanup(func() {
+		initMu.Lock()
+		defer initMu.Unlock()
+
+		logger = prev
+	})
 }
 
 // Stop stops all log processors.

--- a/app/log/config_internal_test.go
+++ b/app/log/config_internal_test.go
@@ -9,10 +9,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"sync"
 	"testing"
 
 	"github.com/golang/snappy"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/protobuf/proto"
 
 	pbv1 "github.com/obolnetwork/charon/app/log/loki/lokipb/v1"
@@ -66,6 +69,56 @@ func TestLokiCaller(t *testing.T) {
 
 	Info(context.Background(), "test")
 	<-done
+}
+
+var initForTFuncs = map[string]func(*testing.T, zapcore.WriteSyncer, ...func(*zapcore.EncoderConfig)){
+	"console": InitConsoleForT,
+	"logfmt":  InitLogfmtForT,
+	"json":    InitJSONForT,
+}
+
+func TestInitForTRestoresLogger(t *testing.T) {
+	for name, initFunc := range initForTFuncs {
+		t.Run(name, func(t *testing.T) {
+			var buf zaptest.Buffer
+
+			t.Run("install", func(t *testing.T) {
+				initFunc(t, &buf)
+				Debug(context.Background(), "inside test")
+				require.Contains(t, buf.String(), "inside test")
+			})
+
+			// The previous logger must be restored on test cleanup,
+			// so this log must not be written to the buffer.
+			lenBefore := buf.Len()
+
+			Debug(context.Background(), "after test")
+			require.Equal(t, lenBefore, buf.Len())
+		})
+	}
+}
+
+func TestInitForTConcurrentLogging(t *testing.T) {
+	for name, initFunc := range initForTFuncs {
+		t.Run(name, func(t *testing.T) {
+			// zaptest.Buffer is not safe for concurrent use, the
+			// initialisers must synchronise writes to it.
+			var buf zaptest.Buffer
+
+			initFunc(t, &buf)
+
+			var wg sync.WaitGroup
+			for range 8 {
+				wg.Go(func() {
+					for range 100 {
+						Debug(context.Background(), "concurrent log")
+					}
+				})
+			}
+
+			wg.Wait()
+		})
+	}
 }
 
 func decode(t *testing.T, b []byte) *pbv1.PushRequest {

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -172,6 +172,10 @@ func Run(ctx context.Context, conf Config) (err error) {
 		return errors.New("only v1.6.0 and newer cluster definition versions supported")
 	}
 
+	if err := checkThreshold(ctx, def.Threshold, len(def.Operators)); err != nil {
+		return err
+	}
+
 	if err := validateKeymanagerFlags(ctx, conf.KeymanagerAddr, conf.KeymanagerAuthToken); err != nil {
 		return err
 	}
@@ -1277,6 +1281,27 @@ func writeLockToAPI(ctx context.Context, publishAddr string, lock cluster.Lock, 
 	log.Debug(ctx, "Published lock file to api")
 
 	return cl.LaunchpadURLForLock(lock), nil
+}
+
+// checkThreshold returns an error if the threshold is out of bounds and
+// logs a warning if it differs from the recommended value for the number of operators.
+func checkThreshold(ctx context.Context, threshold, numOperators int) error {
+	const minThreshold = 2
+
+	if threshold < minThreshold {
+		return errors.New("threshold below minimum", z.Int("threshold", threshold), z.Int("min", minThreshold))
+	}
+
+	if threshold > numOperators {
+		return errors.New("threshold exceeds number of operators", z.Int("threshold", threshold), z.Int("operators", numOperators))
+	}
+
+	if safe := cluster.Threshold(numOperators); threshold != safe {
+		log.Warn(ctx, "Cluster definition threshold differs from recommended value, this will affect cluster safety",
+			nil, z.Int("threshold", threshold), z.Int("safe_threshold", safe))
+	}
+
+	return nil
 }
 
 // validateKeymanagerFlags returns an error if one keymanager flag is present but the other is not.

--- a/dkg/dkg_internal_test.go
+++ b/dkg/dkg_internal_test.go
@@ -8,7 +8,9 @@ import (
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
 
+	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/dkg/share"
 	"github.com/obolnetwork/charon/eth2util"
@@ -196,6 +198,68 @@ func TestValidateKeymanagerFlags(t *testing.T) {
 			err := validateKeymanagerFlags(context.Background(), tt.addr, tt.authToken)
 			if tt.errMsg != "" {
 				require.ErrorContains(t, err, tt.errMsg)
+			}
+		})
+	}
+}
+
+func TestCheckThreshold(t *testing.T) {
+	tests := []struct {
+		name         string
+		threshold    int
+		numOperators int
+		errMsg       string
+		warnMsg      string
+	}{
+		{
+			name:         "safe threshold",
+			threshold:    3,
+			numOperators: 4,
+		},
+		{
+			name:         "unsafe low threshold",
+			threshold:    2,
+			numOperators: 4,
+			warnMsg:      "Cluster definition threshold differs from recommended value",
+		},
+		{
+			name:         "unsafe high threshold",
+			threshold:    4,
+			numOperators: 4,
+			warnMsg:      "Cluster definition threshold differs from recommended value",
+		},
+		{
+			name:         "threshold below minimum",
+			threshold:    1,
+			numOperators: 4,
+			errMsg:       "threshold below minimum",
+		},
+		{
+			name:         "threshold exceeds number of operators",
+			threshold:    5,
+			numOperators: 4,
+			errMsg:       "threshold exceeds number of operators",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf zaptest.Buffer
+
+			log.InitLogfmtForT(t, &buf)
+
+			err := checkThreshold(context.Background(), tt.threshold, tt.numOperators)
+			if tt.errMsg != "" {
+				require.ErrorContains(t, err, tt.errMsg)
+				return
+			}
+
+			require.NoError(t, err)
+
+			if tt.warnMsg != "" {
+				require.Contains(t, buf.String(), tt.warnMsg)
+			} else {
+				require.Empty(t, buf.String())
 			}
 		})
 	}


### PR DESCRIPTION
Add threshold validation to `charon dkg`. The cluster definition threshold is now rejected with an error when below 2 or above the number of operators, and a warning is logged when it differs from the recommended `ceil(2n/3)` value.

Previously `charon dkg` ran the ceremony with any threshold in the definition file. `charon create dkg` already validates and warns on non-default thresholds, but definitions from other sources (URL, handcrafted JSON) reached the DKG ceremony unchecked. An unsafe threshold (e.g. 2 in a 4-operator cluster) allows fewer members than intended to reconstruct the validator key.

The check runs after the definition is loaded, covering both the definition file path and the append-validators path.

Also makes the `app/log` test initializers (`InitConsoleForT`, `InitJSONForT`, `InitLogfmtForT`) safe for use in packages with concurrent logging: the write syncer is now wrapped with `zapcore.Lock` and the previous global logger is restored on test cleanup. Previously the initializers replaced the global logger permanently, so tests running afterwards in the same package wrote to the test buffer, racing on unsynchronized writers (caught by CI in `TestFrostDKG` running after the new `TestCheckThreshold`).

category: bug
ticket: none