### PR TITLE
cluster: dedup definition peers by peer ID

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -11,10 +11,12 @@ import (
 	"strings"
 	"testing"
 
+	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/cluster"
 	"github.com/obolnetwork/charon/eth2util"
+	"github.com/obolnetwork/charon/eth2util/enr"
 	"github.com/obolnetwork/charon/testutil"
 )
 
@@ -314,6 +316,60 @@ func TestDefinitionPeers(t *testing.T) {
 	for i, peer := range peers {
 		require.Equal(t, i, peer.Index)
 		require.Equal(t, names[i], peer.Name)
+	}
+}
+
+func TestDefinitionPeersDuplicatePeerID(t *testing.T) {
+	newENR := func(key *k1.PrivateKey, opts ...enr.Option) string {
+		record, err := enr.New(key, opts...)
+		require.NoError(t, err)
+
+		return record.String()
+	}
+
+	dupKey, err := k1.GeneratePrivateKey()
+	require.NoError(t, err)
+
+	// Two distinct ENR strings encoding the same public key, so the same peer ID.
+	dupENR1 := newENR(dupKey)
+	dupENR2 := newENR(dupKey, enr.WithTCP(3610))
+	require.NotEqual(t, dupENR1, dupENR2)
+
+	uniqueENR := func() string {
+		key, err := k1.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		return newENR(key)
+	}
+
+	tests := []struct {
+		name string
+		enrs []string
+	}{
+		{
+			name: "duplicate peer ids with distinct enrs",
+			enrs: []string{uniqueENR(), dupENR1, dupENR2, uniqueENR()},
+		},
+		{
+			name: "duplicate peer ids at tail",
+			enrs: []string{uniqueENR(), uniqueENR(), dupENR1, dupENR2},
+		},
+		{
+			name: "duplicate identical enrs",
+			enrs: []string{uniqueENR(), dupENR1, dupENR1, uniqueENR()},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var def cluster.Definition
+			for _, e := range tt.enrs {
+				def.Operators = append(def.Operators, cluster.Operator{ENR: e})
+			}
+
+			_, err := def.Peers()
+			require.ErrorContains(t, err, "definition contains duplicate peer ids")
+		})
 	}
 }
 

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -386,14 +386,10 @@ func validateSignatureLength(version string, sig []byte, fieldName string) error
 func (d Definition) Peers() ([]p2p.Peer, error) {
 	var resp []p2p.Peer
 
-	dedup := make(map[string]bool)
+	// Dedup by peer ID (not ENR string) since distinct ENRs can encode the same public key.
+	dedup := make(map[peer.ID]bool)
+
 	for i, operator := range d.Operators {
-		if dedup[operator.ENR] {
-			return nil, errors.New("definition contains duplicate peer enrs", z.Str("enr", operator.ENR))
-		}
-
-		dedup[operator.ENR] = true
-
 		record, err := enr.Parse(operator.ENR)
 		if err != nil {
 			return nil, errors.Wrap(err, "decode enr", z.Str("enr", operator.ENR))
@@ -403,6 +399,12 @@ func (d Definition) Peers() ([]p2p.Peer, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if dedup[p.ID] {
+			return nil, errors.New("definition contains duplicate peer ids", z.Str("enr", operator.ENR), z.Str("peer", p.Name))
+		}
+
+		dedup[p.ID] = true
 
 		resp = append(resp, p)
 	}


### PR DESCRIPTION
Deduplicate operators in `Definition.Peers()` by derived peer ID instead of by raw ENR string, and rename the error to `definition contains duplicate peer ids`.

Two distinct ENR strings can encode the same public key (e.g. different sequence numbers or extra fields), producing the same libp2p peer ID. Such definitions passed the previous ENR-string dedup and collapsed the `peerMap` built in `dkg.Run` (`NodeIdx` returns the first matching operator index), which made `newFrostP2P` panic with an index out-of-range when a surviving `PeerIdx` exceeded the map length. When the duplicated operator was last, the ceremony instead proceeded with an inconsistent peer map.

Peer-ID dedup subsumes the ENR-string check, since identical ENR strings always yield identical peer IDs. All callers of `Peers()` (dkg ceremony, node run, edit protocols) now reject such definitions with a clean error.

category: bug
ticket: none