### PR TITLE
cluster: fix dead deposit amounts validation in unmarshalers

### DIFF
--- a/cluster/cluster_test.go
+++ b/cluster/cluster_test.go
@@ -317,6 +317,81 @@ func TestDefinitionPeers(t *testing.T) {
 	}
 }
 
+func TestUnmarshalDefinitionDepositAmounts(t *testing.T) {
+	defJSON := func(version, depositAmounts, compounding string) string {
+		return `{
+			"version": "` + version + `",
+			"num_validators": 1,
+			"validators": [{"fee_recipient_address": "", "withdrawal_address": ""}],
+			"operators": [],
+			"deposit_amounts": ` + depositAmounts + `,
+			"compounding": ` + compounding + `}`
+	}
+
+	const (
+		oneGwei       = `["1"]` // Below 1ETH minimum.
+		thirtyTwoEth  = `["16000000000","16000000000"]`
+		fortyEightEth = `["48000000000"]` // Valid only for compounding validators.
+	)
+
+	tests := []struct {
+		name   string
+		json   string
+		errMsg string
+	}{
+		{
+			name:   "v1.8 invalid amounts",
+			json:   defJSON(v1_8, oneGwei, "false"),
+			errMsg: "invalid deposit amounts",
+		},
+		{
+			name:   "v1.9 invalid amounts",
+			json:   defJSON(v1_9, oneGwei, "false"),
+			errMsg: "invalid deposit amounts",
+		},
+		{
+			name:   "v1.10 invalid amounts",
+			json:   defJSON(v1_10, oneGwei, "false"),
+			errMsg: "invalid deposit amounts",
+		},
+		{
+			name:   "v1.11 invalid amounts",
+			json:   defJSON(v1_11, oneGwei, "false"),
+			errMsg: "invalid deposit amounts",
+		},
+		{
+			name:   "v1.11 amount too large without compounding",
+			json:   defJSON(v1_11, fortyEightEth, "false"),
+			errMsg: "invalid deposit amounts",
+		},
+		{
+			name: "v1.11 large amount valid with compounding",
+			json: defJSON(v1_11, fortyEightEth, "true"),
+		},
+		{
+			name: "v1.8 valid amounts",
+			json: defJSON(v1_8, thirtyTwoEth, "false"),
+		},
+		{
+			name: "v1.8 no amounts",
+			json: defJSON(v1_8, "[]", "false"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var def cluster.Definition
+
+			err := json.Unmarshal([]byte(tt.json), &def)
+			if tt.errMsg != "" {
+				require.ErrorContains(t, err, tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 // TestV1x11SafeSignatures tests that v1.11 supports variable-length signatures (Safe multisig).
 func TestV1x11SafeSignatures(t *testing.T) {
 	r := rand.New(rand.NewSource(1))

--- a/cluster/definition.go
+++ b/cluster/definition.go
@@ -933,7 +933,8 @@ func unmarshalDefinitionV1x8(data []byte) (def Definition, err error) {
 		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
-	if err := deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding); err != nil {
+	// Definition versions prior to v1.10 don't support compounding.
+	if err := deposit.VerifyDepositAmounts(defJSON.DepositAmounts, false); err != nil {
 		return Definition{}, errors.Wrap(err, "invalid deposit amounts")
 	}
 
@@ -968,7 +969,8 @@ func unmarshalDefinitionV1x9(data []byte) (def Definition, err error) {
 		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
-	if err := deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding); err != nil {
+	// Definition versions prior to v1.10 don't support compounding.
+	if err := deposit.VerifyDepositAmounts(defJSON.DepositAmounts, false); err != nil {
 		return Definition{}, errors.Wrap(err, "invalid deposit amounts")
 	}
 
@@ -1004,7 +1006,7 @@ func unmarshalDefinitionV1x10to11(data []byte) (def Definition, err error) {
 		return Definition{}, errors.New("num_validators does not match validators length")
 	}
 
-	if err := deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding); err != nil {
+	if err := deposit.VerifyDepositAmounts(defJSON.DepositAmounts, defJSON.Compounding); err != nil {
 		return Definition{}, errors.Wrap(err, "invalid deposit amounts")
 	}
 


### PR DESCRIPTION
Validate the parsed deposit amounts instead of the zero-valued named return in the v1.8, v1.9 and v1.10-11 definition unmarshalers.

The checks called `deposit.VerifyDepositAmounts(def.DepositAmounts, def.Compounding)` where `def` is the named return value, still zero at that point — the parsed data lives in `defJSON`. `VerifyDepositAmounts(nil, false)` returns nil via its empty-slice early return, so the checks always passed and definitions with invalid deposit amounts (below the 1ETH minimum, above the maximum, or summing to less than 32ETH) unmarshaled without error. The bug dates back to the introduction of partial deposits in v1.8 and was copied into the v1.9 and v1.10-11 unmarshalers.

The v1.8 and v1.9 unmarshalers now pass `compounding=false` since those versions don't support compounding; the v1.10-11 unmarshaler passes the parsed compounding flag so large amounts are only accepted for compounding validators.

Note this is defense in depth: the DKG path already re-validates amounts after loading (`dkg/disk.go`), but other consumers of definition/lock unmarshaling relied on the dead check.

category: bug
ticket: none
