### PR TITLE
core/parsigex: bound work triggered by received messages

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -672,7 +672,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 			return err
 		}
 
-		parSigEx = parsigex.NewParSigEx(p2pNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc, gaterFunc)
+		parSigEx = parsigex.NewParSigEx(p2pNode, sender.SendAsync, nodeIdx.PeerIdx, peerIDs, verifyFunc, gaterFunc, deadlineFunc, len(lock.Validators))
 	}
 
 	sigAgg, err := sigagg.New(lock.Threshold, sigagg.NewVerifier(eth2Cl))

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -63,7 +63,9 @@ func NewParSigEx(p2pNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []
 
 	newReq := func() proto.Message { return new(pbv1.ParSigExMsg) }
 
-	p2pOpts = append([]p2p.SendRecvOption{p2p.WithReadLimit(maxMsgSize)}, p2pOpts...)
+	// Applied last so the cap holds regardless of the caller's options, including any
+	// protocols they add (WithDelimitedProtocol registers readers at the p2p default).
+	p2pOpts = append(p2pOpts, p2p.WithReadLimit(maxMsgSize))
 	p2p.RegisterHandler(
 		"parsigex",
 		p2pNode,

--- a/core/parsigex/parsigex.go
+++ b/core/parsigex/parsigex.go
@@ -34,25 +34,36 @@ var setVerificationDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
 
 const protocolID2 = "/charon/parsigex/2.0.0"
 
+// maxMsgSize caps the wire size of a parsigex message. Legitimate messages hold at most one
+// partial signature per cluster validator, so this is orders of magnitude above normal usage.
+// It bounds the buffer a peer can make this node allocate before the message is even parsed.
+const maxMsgSize = 32 * 1024 * 1024 // 32MB
+
 // Protocols returns the supported protocols of this package in order of precedence.
 func Protocols() []protocol.ID {
 	return []protocol.ID{protocolID2}
 }
 
+// NewParSigEx returns a new ParSigEx. maxSetSize is the maximum number of partial signatures
+// in a received set, which is the number of validators in the cluster.
 func NewParSigEx(p2pNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []peer.ID,
 	verifyFunc func(context.Context, peer.ID, core.Duty, core.PubKey, core.ParSignedData) error,
-	gaterFunc core.DutyGaterFunc, p2pOpts ...p2p.SendRecvOption,
+	gaterFunc core.DutyGaterFunc, deadlineFunc core.DeadlineFunc, maxSetSize int, p2pOpts ...p2p.SendRecvOption,
 ) *ParSigEx {
 	parSigEx := &ParSigEx{
-		p2pNode:    p2pNode,
-		sendFunc:   sendFunc,
-		peerIdx:    peerIdx,
-		peers:      peers,
-		verifyFunc: verifyFunc,
-		gaterFunc:  gaterFunc,
+		p2pNode:      p2pNode,
+		sendFunc:     sendFunc,
+		peerIdx:      peerIdx,
+		peers:        peers,
+		verifyFunc:   verifyFunc,
+		gaterFunc:    gaterFunc,
+		deadlineFunc: deadlineFunc,
+		maxSetSize:   maxSetSize,
 	}
 
 	newReq := func() proto.Message { return new(pbv1.ParSigExMsg) }
+
+	p2pOpts = append([]p2p.SendRecvOption{p2p.WithReadLimit(maxMsgSize)}, p2pOpts...)
 	p2p.RegisterHandler(
 		"parsigex",
 		p2pNode,
@@ -68,13 +79,15 @@ func NewParSigEx(p2pNode host.Host, sendFunc p2p.SendFunc, peerIdx int, peers []
 // ParSigEx exchanges partially signed duty data sets.
 // It ensures that all partial signatures are persisted by all peers.
 type ParSigEx struct {
-	p2pNode    host.Host
-	sendFunc   p2p.SendFunc
-	peerIdx    int
-	peers      []peer.ID
-	verifyFunc func(context.Context, peer.ID, core.Duty, core.PubKey, core.ParSignedData) error
-	gaterFunc  core.DutyGaterFunc
-	subs       []func(context.Context, core.Duty, core.ParSignedDataSet) error
+	p2pNode      host.Host
+	sendFunc     p2p.SendFunc
+	peerIdx      int
+	peers        []peer.ID
+	verifyFunc   func(context.Context, peer.ID, core.Duty, core.PubKey, core.ParSignedData) error
+	gaterFunc    core.DutyGaterFunc
+	deadlineFunc core.DeadlineFunc
+	maxSetSize   int
+	subs         []func(context.Context, core.Duty, core.ParSignedDataSet) error
 }
 
 func (m *ParSigEx) handle(ctx context.Context, sender peer.ID, req proto.Message) (proto.Message, bool, error) {
@@ -92,6 +105,20 @@ func (m *ParSigEx) handle(ctx context.Context, sender peer.ID, req proto.Message
 
 	if !m.gaterFunc(duty) {
 		return nil, false, errors.New("invalid duty")
+	}
+
+	// The duty gater only bounds how far in the future a duty may be. Drop duties whose deadline
+	// has already passed here, before decoding and verifying, since parsigdb would discard them
+	// anyway. Duty types that never expire (exits, builder registrations) are exempt.
+	if deadline, canExpire := m.deadlineFunc(duty); canExpire && deadline.Before(time.Now()) {
+		return nil, false, errors.New("duty deadline expired")
+	}
+
+	// Legitimate sets hold at most one partial signature per cluster validator. Reject larger
+	// sets before decoding, since each entry is unmarshalled before any of it is authenticated.
+	if len(pb.GetDataSet().GetSet()) > m.maxSetSize {
+		return nil, false, errors.New("partial signature set too large",
+			z.Int("size", len(pb.GetDataSet().GetSet())), z.Int("max", m.maxSetSize))
 	}
 
 	set, err := core.ParSignedDataSetFromProto(duty.Type, pb.GetDataSet())

--- a/core/parsigex/parsigex_internal_test.go
+++ b/core/parsigex/parsigex_internal_test.go
@@ -32,6 +32,8 @@ func newTestMsg(t *testing.T, duty core.Duty, numEntries int) *pbv1.ParSigExMsg 
 		set[testutil.RandomCorePubKey(t)] = newData()
 	}
 
+	require.Len(t, set, numEntries)
+
 	setPb, err := core.ParSignedDataSetToProto(set)
 	require.NoError(t, err)
 

--- a/core/parsigex/parsigex_internal_test.go
+++ b/core/parsigex/parsigex_internal_test.go
@@ -1,0 +1,109 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package parsigex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/core"
+	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
+	"github.com/obolnetwork/charon/testutil"
+)
+
+// newTestMsg returns a parsigex message for the duty containing numEntries partial signatures.
+func newTestMsg(t *testing.T, duty core.Duty, numEntries int) *pbv1.ParSigExMsg {
+	t.Helper()
+
+	newData := func() core.ParSignedData {
+		if duty.Type == core.DutyExit {
+			return core.NewPartialSignedVoluntaryExit(testutil.RandomExit(), 1)
+		}
+
+		return core.NewPartialSignedRandao(123, testutil.RandomEth2Signature(), 1)
+	}
+
+	set := make(core.ParSignedDataSet)
+	for range numEntries {
+		set[testutil.RandomCorePubKey(t)] = newData()
+	}
+
+	setPb, err := core.ParSignedDataSetToProto(set)
+	require.NoError(t, err)
+
+	return &pbv1.ParSigExMsg{
+		Duty:    core.DutyToProto(duty),
+		DataSet: setPb,
+	}
+}
+
+// newTestParSigEx returns a ParSigEx and a pointer to the number of verifyFunc calls it made.
+func newTestParSigEx(maxSetSize int, deadlineFunc core.DeadlineFunc) (*ParSigEx, *int) {
+	var verifyCalls int
+
+	return &ParSigEx{
+		verifyFunc: func(context.Context, peer.ID, core.Duty, core.PubKey, core.ParSignedData) error {
+			verifyCalls++
+			return nil
+		},
+		gaterFunc:    func(core.Duty) bool { return true },
+		maxSetSize:   maxSetSize,
+		deadlineFunc: deadlineFunc,
+	}, &verifyCalls
+}
+
+func TestHandleDropsExpiredDuty(t *testing.T) {
+	expiredDuty := core.Duty{Slot: 1, Type: core.DutyRandao}
+
+	// Deadline for the duty has already passed.
+	deadlineFunc := func(core.Duty) (time.Time, bool) {
+		return time.Now().Add(-time.Hour), true
+	}
+
+	parSigEx, verifyCalls := newTestParSigEx(10, deadlineFunc)
+
+	_, _, err := parSigEx.handle(context.Background(), "", newTestMsg(t, expiredDuty, 1))
+	require.ErrorContains(t, err, "duty deadline expired")
+	require.Zero(t, *verifyCalls, "expired duty must be dropped before signature verification")
+}
+
+func TestHandleAllowsExemptDuty(t *testing.T) {
+	// Exits and builder registrations never expire, so they must be processed
+	// regardless of how old their slot is.
+	exemptDuty := core.Duty{Slot: 1, Type: core.DutyExit}
+
+	deadlineFunc := func(core.Duty) (time.Time, bool) {
+		return time.Time{}, false // Never expires.
+	}
+
+	parSigEx, verifyCalls := newTestParSigEx(10, deadlineFunc)
+
+	_, _, err := parSigEx.handle(context.Background(), "", newTestMsg(t, exemptDuty, 1))
+	require.NoError(t, err)
+	require.Equal(t, 1, *verifyCalls)
+}
+
+func TestHandleDropsOversizedSet(t *testing.T) {
+	duty := core.Duty{Slot: 1, Type: core.DutyRandao}
+
+	deadlineFunc := func(core.Duty) (time.Time, bool) {
+		return time.Now().Add(time.Hour), true
+	}
+
+	const maxSetSize = 4
+
+	parSigEx, verifyCalls := newTestParSigEx(maxSetSize, deadlineFunc)
+
+	_, _, err := parSigEx.handle(context.Background(), "", newTestMsg(t, duty, maxSetSize+1))
+	require.ErrorContains(t, err, "partial signature set too large")
+	require.Zero(t, *verifyCalls, "oversized set must be dropped before signature verification")
+
+	// A set at the limit is still processed.
+	_, _, err = parSigEx.handle(context.Background(), "", newTestMsg(t, duty, maxSetSize))
+	require.NoError(t, err)
+	require.Equal(t, maxSetSize, *verifyCalls)
+}

--- a/core/parsigex/parsigex_test.go
+++ b/core/parsigex/parsigex_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	eth2api "github.com/attestantio/go-eth2-client/api"
 	eth2spec "github.com/attestantio/go-eth2-client/spec"
@@ -81,13 +82,17 @@ func TestParSigEx(t *testing.T) {
 		return true
 	}
 
+	deadlineFunc := func(core.Duty) (time.Time, bool) {
+		return time.Now().Add(time.Hour), true
+	}
+
 	var wg sync.WaitGroup
 
 	// create ParSigEx components for each host
 	for i := range n {
 		wg.Add(n - 1)
 
-		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, verifyFunc, gaterFunc)
+		sigex := parsigex.NewParSigEx(hosts[i], p2p.Send, i, peers, verifyFunc, gaterFunc, deadlineFunc, 1)
 		sigex.Subscribe(func(_ context.Context, d core.Duty, set core.ParSignedDataSet) error {
 			defer wg.Done()
 

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -260,7 +260,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 		sigLock,
 		sigDepositData,
 		sigValidatorRegistration,
-	}, conf.Timeout)
+	}, conf.Timeout, totalValidators)
 	if err != nil {
 		return err
 	}

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -250,12 +250,12 @@ func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, set map[core.Pu
 	return nil
 }
 
-// noopDeadliner is a deadliner that does nothing.
 // neverExpires is a core.DeadlineFunc for duties that never expire.
 func neverExpires(core.Duty) (time.Time, bool) {
 	return time.Time{}, false
 }
 
+// noopDeadliner is a deadliner that does nothing.
 type noopDeadliner struct{}
 
 func (noopDeadliner) Add(core.Duty) core.DeadlineStatus {

--- a/dkg/exchanger.go
+++ b/dkg/exchanger.go
@@ -69,7 +69,7 @@ type exchanger struct {
 	timeout       time.Duration
 }
 
-func newExchanger(p2pNode host.Host, peerIdx int, peers []peer.ID, peerMap map[peer.ID]cluster.NodeIdx, sigTypes []sigType, timeout time.Duration) (*exchanger, error) {
+func newExchanger(p2pNode host.Host, peerIdx int, peers []peer.ID, peerMap map[peer.ID]cluster.NodeIdx, sigTypes []sigType, timeout time.Duration, numVals int) (*exchanger, error) {
 	if peerIdx < 0 || peerIdx >= len(peers) {
 		return nil, errors.New("peer index out of range", z.Int("peer_idx", peerIdx), z.Int("num_peers", len(peers)))
 	}
@@ -110,8 +110,9 @@ func newExchanger(p2pNode host.Host, peerIdx int, peers []peer.ID, peerMap map[p
 
 	ex := &exchanger{
 		// threshold is len(peers) to wait until we get all the partial sigs from all the peers per DV
-		sigdb:    parsigdb.NewMemDB(len(peers), noopDeadliner{}, parsigdb.NewMemDBMetadata(0, time.Now())), // metadata timestamps are used for metrics, irrelevant for DKG
-		sigex:    parsigex.NewParSigEx(p2pNode, p2p.Send, peerIdx, peers, verifyShareIdx, dutyGaterFunc, p2p.WithSendTimeout(timeout), p2p.WithReceiveTimeout(timeout)),
+		sigdb: parsigdb.NewMemDB(len(peers), noopDeadliner{}, parsigdb.NewMemDBMetadata(0, time.Now())), // metadata timestamps are used for metrics, irrelevant for DKG
+		// DKG duty slots are sigType constants, not beacon slots, so duties never expire.
+		sigex:    parsigex.NewParSigEx(p2pNode, p2p.Send, peerIdx, peers, verifyShareIdx, dutyGaterFunc, neverExpires, numVals, p2p.WithSendTimeout(timeout), p2p.WithReceiveTimeout(timeout)),
 		sigTypes: st,
 		sigData: dataByPubkey{
 			store: sigTypeStore{},
@@ -250,6 +251,11 @@ func (e *exchanger) pushPsigs(_ context.Context, duty core.Duty, set map[core.Pu
 }
 
 // noopDeadliner is a deadliner that does nothing.
+// neverExpires is a core.DeadlineFunc for duties that never expire.
+func neverExpires(core.Duty) (time.Time, bool) {
+	return time.Time{}, false
+}
+
 type noopDeadliner struct{}
 
 func (noopDeadliner) Add(core.Duty) core.DeadlineStatus {

--- a/dkg/exchanger_internal_test.go
+++ b/dkg/exchanger_internal_test.go
@@ -106,7 +106,7 @@ func TestExchanger(t *testing.T) {
 	}
 
 	for i := range nodes {
-		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), expectedSigTypes, 8*time.Second)
+		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), expectedSigTypes, 8*time.Second, dvs)
 		require.NoError(t, err)
 
 		exchangers = append(exchangers, ex)
@@ -203,7 +203,7 @@ func TestExchangerPushPsigsNeverBlocks(t *testing.T) {
 	h := testutil.CreateHost(t, testutil.AvailableAddr(t))
 	peers := []peer.ID{h.ID()}
 
-	ex, err := newExchanger(h, 0, peers, positionalPeerMap(peers), []sigType{sigLock}, time.Second)
+	ex, err := newExchanger(h, 0, peers, positionalPeerMap(peers), []sigType{sigLock}, time.Second, 1)
 	require.NoError(t, err)
 
 	duty := core.NewSignatureDuty(uint64(sigLock))
@@ -286,7 +286,7 @@ func TestExchangerRejectsMismatchedShareIndex(t *testing.T) {
 
 	exchangers := make([]*exchanger, nodes)
 	for i := range nodes {
-		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), []sigType{sigLock}, 8*time.Second)
+		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), []sigType{sigLock}, 8*time.Second, 1)
 		require.NoError(t, err)
 
 		exchangers[i] = ex
@@ -397,7 +397,7 @@ func TestNewExchangerRejectsIncompletePeerMap(t *testing.T) {
 		h.ID(): {PeerIdx: 0, ShareIdx: 1},
 	}
 
-	_, err := newExchanger(h, 0, peers, peerMap, []sigType{sigLock}, time.Second)
+	_, err := newExchanger(h, 0, peers, peerMap, []sigType{sigLock}, time.Second, 1)
 	require.ErrorContains(t, err, "missing valid share index")
 }
 
@@ -438,7 +438,7 @@ func TestExchangerTimeout(t *testing.T) {
 	var exchangers []*exchanger
 
 	for i := range nodes {
-		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), []sigType{sigLock}, 2*time.Second)
+		ex, err := newExchanger(hosts[i], i, peers, positionalPeerMap(peers), []sigType{sigLock}, 2*time.Second, 1)
 		require.NoError(t, err)
 
 		exchangers = append(exchangers, ex)

--- a/dkg/protocol_addoperators.go
+++ b/dkg/protocol_addoperators.go
@@ -85,7 +85,7 @@ func (p *addOperatorsProtocol) PostInit(ctx context.Context, pctx *ProtocolConte
 
 	p.allENRs = append(p.allENRs, p.newENRs...)
 
-	sigEx, err := newExchanger(pctx.ThisNode, pctx.ThisNodeIdx.PeerIdx, pctx.PeerIDs, pctx.PeerMap, []sigType{sigLock}, pctx.Config.Timeout)
+	sigEx, err := newExchanger(pctx.ThisNode, pctx.ThisNodeIdx.PeerIdx, pctx.PeerIDs, pctx.PeerMap, []sigType{sigLock}, pctx.Config.Timeout, len(pctx.Lock.Validators))
 	if err != nil {
 		return err
 	}

--- a/dkg/protocol_removeoperators.go
+++ b/dkg/protocol_removeoperators.go
@@ -164,7 +164,7 @@ func (p *removeOperatorsProtocol) PostInit(ctx context.Context, pctx *ProtocolCo
 			ShareIdx: peerMap[pctx.ThisPeerID].ShareIdx,
 		}
 
-		sigEx, err := newExchanger(pctx.ThisNode, nodeIdx, newPeerIDs, exchangerPeerMap, []sigType{sigLock}, pctx.Config.Timeout)
+		sigEx, err := newExchanger(pctx.ThisNode, nodeIdx, newPeerIDs, exchangerPeerMap, []sigType{sigLock}, pctx.Config.Timeout, len(pctx.Lock.Validators))
 		if err != nil {
 			return err
 		}

--- a/dkg/protocol_replaceoperator.go
+++ b/dkg/protocol_replaceoperator.go
@@ -103,7 +103,7 @@ func (p *replaceOperatorProtocol) GetPeers(lock *cluster.Lock) ([]p2p.Peer, erro
 }
 
 func (p *replaceOperatorProtocol) PostInit(ctx context.Context, pctx *ProtocolContext) error {
-	sigEx, err := newExchanger(pctx.ThisNode, pctx.ThisNodeIdx.PeerIdx, pctx.PeerIDs, pctx.PeerMap, []sigType{sigLock}, pctx.Config.Timeout)
+	sigEx, err := newExchanger(pctx.ThisNode, pctx.ThisNodeIdx.PeerIdx, pctx.PeerIDs, pctx.PeerMap, []sigType{sigLock}, pctx.Config.Timeout, len(pctx.Lock.Validators))
 	if err != nil {
 		return err
 	}

--- a/dkg/protocol_reshare.go
+++ b/dkg/protocol_reshare.go
@@ -49,7 +49,7 @@ func (*reshareProtocol) GetPeers(lock *cluster.Lock) ([]p2p.Peer, error) {
 }
 
 func (p *reshareProtocol) PostInit(ctx context.Context, pctx *ProtocolContext) error {
-	sigEx, err := newExchanger(pctx.ThisNode, pctx.ThisNodeIdx.PeerIdx, pctx.PeerIDs, pctx.PeerMap, []sigType{sigLock}, pctx.Config.Timeout)
+	sigEx, err := newExchanger(pctx.ThisNode, pctx.ThisNodeIdx.PeerIdx, pctx.PeerIDs, pctx.PeerMap, []sigType{sigLock}, pctx.Config.Timeout, len(pctx.Lock.Validators))
 	if err != nil {
 		return err
 	}

--- a/dkg/protocolsteps_internal_test.go
+++ b/dkg/protocolsteps_internal_test.go
@@ -142,7 +142,7 @@ func TestUpdateLockProtocolStep(t *testing.T) {
 	shares := valKeysToSharesNode0(t, valKeys, lock.Validators)
 
 	host := testutil.CreateHost(t, testutil.AvailableAddr(t))
-	sigex, err := newExchanger(host, 0, []peer.ID{host.ID()}, positionalPeerMap([]peer.ID{host.ID()}), []sigType{sigLock}, 10*time.Second)
+	sigex, err := newExchanger(host, 0, []peer.ID{host.ID()}, positionalPeerMap([]peer.ID{host.ID()}), []sigType{sigLock}, 10*time.Second, 1)
 	require.NoError(t, err)
 
 	pctx := &ProtocolContext{


### PR DESCRIPTION
Add three guards before the expensive decode and signature verification in the parsigex handler, so a peer cannot make a node do unbounded work.

- **Message size.** Cap the wire size at 32MB via `p2p.WithReadLimit`. Parsigex registered with no options and so used the 128MB default, while consensus (32MB) and peerinfo (1MB) already set tighter limits. The reader allocates the full declared length before reading the body, so this bounds allocation before parsing.
- **Set cardinality.** Reject sets holding more partial signatures than the cluster has validators. `ParSignedDataSetFromProto` SSZ/JSON unmarshals every entry before any of it is authenticated, so cardinality — not signature verification — drove decode and allocation cost.
- **Expired duties.** Drop duties whose deadline has passed. `NewDutyGater` only bounds how far in the *future* a duty may be (its doc notes past duties are the Deadliner's job), but the deadliner runs in `parsigdb.StoreExternal`, downstream of verification. Partial signatures for arbitrarily old slots therefore reached full verification before being discarded, which also meant the work was not rate-limited by the duty schedule.

Duty types that never expire (exits, builder registrations) are exempt from the deadline check. DKG duty slots are `sigType` constants rather than beacon slots, so the DKG exchanger passes a never-expires deadline func and the number of validators as the set bound.

Note this hardens parsigex only. The same 128MB default applies to the priority protocol and the DKG handlers, and charon disables the libp2p resource manager entirely (`libp2p.ResourceManager(new(network.NullResourceManager))` in `app/app.go`), which leaves inbound concurrent streams unbounded since yamux delegates that limit to the resource manager. Both are worth addressing separately.

category: bug
ticket: none