### PR TITLE
dkg/bcast: bind broadcast signatures to cluster session

### DIFF
--- a/dkg/bcast/client.go
+++ b/dkg/bcast/client.go
@@ -51,7 +51,7 @@ func (c *client) Broadcast(ctx context.Context, msgID string, msg proto.Message)
 		return errors.Wrap(err, "new any")
 	}
 
-	hash, err := c.hashFunc(anyMsg)
+	hash, err := c.hashFunc(msgID, anyMsg)
 	if err != nil {
 		return errors.Wrap(err, "hash any")
 	}

--- a/dkg/bcast/helpers.go
+++ b/dkg/bcast/helpers.go
@@ -12,15 +12,18 @@ import (
 )
 
 const (
-	protocolIDPrefix = "/charon/dkg/bcast/1.0.0"
+	// Note: v2.0.0 binds signed hashes to the session hash and message ID,
+	// the version bump makes mixed-version ceremonies fail at stream negotiation
+	// instead of at signature verification.
+	protocolIDPrefix = "/charon/dkg/bcast/2.0.0"
 	protocolIDSig    = protocolIDPrefix + "/sig"
 	protocolIDMsg    = protocolIDPrefix + "/msg"
 	receiveTimeout   = time.Minute                    // Allow for peers to be out of sync, with some sending messages much earlier and having to wait.
 	sendTimeout      = receiveTimeout + 2*time.Second // Allow for server to timeout first.
 )
 
-// hashFunc is a function that hashes a any-wrapped protobuf message.
-type hashFunc func(*anypb.Any) ([]byte, error)
+// hashFunc is a function that hashes a message ID and a any-wrapped protobuf message.
+type hashFunc func(string, *anypb.Any) ([]byte, error)
 
 // Callback is a function that is called when a reliably-broadcast message was successfully received.
 type Callback func(ctx context.Context, peerID peer.ID, msgID string, msg proto.Message) error

--- a/dkg/bcast/impl.go
+++ b/dkg/bcast/impl.go
@@ -83,8 +83,13 @@ func newHashAny(sessionHash []byte) hashFunc {
 	return func(msgID string, anyPB *anypb.Any) ([]byte, error) {
 		h := sha256.New()
 		for _, field := range [][]byte{sessionHash, []byte(msgID), []byte(anyPB.GetTypeUrl()), anyPB.GetValue()} {
-			_ = binary.Write(h, binary.BigEndian, uint64(len(field)))
-			_, _ = h.Write(field)
+			if err := binary.Write(h, binary.BigEndian, uint64(len(field))); err != nil {
+				return nil, errors.Wrap(err, "write field length")
+			}
+
+			if _, err := h.Write(field); err != nil {
+				return nil, errors.Wrap(err, "write field")
+			}
 		}
 
 		return h.Sum(nil), nil

--- a/dkg/bcast/impl.go
+++ b/dkg/bcast/impl.go
@@ -5,6 +5,7 @@ package bcast
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"sync"
 
 	k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
@@ -55,31 +56,39 @@ func (c *Component) Broadcast(ctx context.Context, msgID string, msg proto.Messa
 }
 
 // New registers a new reliable-broadcast server and returns a reliable-broadcast client function.
-func New(p2pNode host.Host, peers []peer.ID, secret *k1.PrivateKey) *Component {
+// All messages are bound to sessionHash, so signatures from other sessions fail verification.
+func New(p2pNode host.Host, peers []peer.ID, secret *k1.PrivateKey, sessionHash []byte) *Component {
 	c := Component{
 		allowedMsgIDs: map[string]struct{}{},
 		secret:        secret,
 		peers:         peers,
 	}
 
+	hashFunc := newHashAny(sessionHash)
 	signFunc := c.newK1Signer()
-	verifyFunc := c.newPeerK1Verifier()
+	verifyFunc := c.newPeerK1Verifier(hashFunc)
 
-	cl := newClient(p2pNode, peers, p2p.SendReceive, p2p.Send, hashAny, signFunc, verifyFunc)
+	cl := newClient(p2pNode, peers, p2p.SendReceive, p2p.Send, hashFunc, signFunc, verifyFunc)
 
 	c.broadcastFunc = cl.Broadcast
-	c.srv = newServer(p2pNode, signFunc, hashAny, verifyFunc)
+	c.srv = newServer(p2pNode, signFunc, hashFunc, verifyFunc)
 
 	return &c
 }
 
-// hashAny is a function that hashes a any-wrapped protobuf message.
-func hashAny(anyPB *anypb.Any) ([]byte, error) {
-	h := sha256.New()
-	_, _ = h.Write([]byte(anyPB.GetTypeUrl()))
-	_, _ = h.Write(anyPB.GetValue())
+// newHashAny returns a function that hashes a message ID and a any-wrapped protobuf
+// message, binding them to the session hash. Fields are length-prefixed to
+// avoid ambiguous concatenation.
+func newHashAny(sessionHash []byte) hashFunc {
+	return func(msgID string, anyPB *anypb.Any) ([]byte, error) {
+		h := sha256.New()
+		for _, field := range [][]byte{sessionHash, []byte(msgID), []byte(anyPB.GetTypeUrl()), anyPB.GetValue()} {
+			_ = binary.Write(h, binary.BigEndian, uint64(len(field)))
+			_, _ = h.Write(field)
+		}
 
-	return h.Sum(nil), nil
+		return h.Sum(nil), nil
+	}
 }
 
 // newK1Signer returns a function that signs a hash using the given private key.
@@ -94,7 +103,7 @@ func (c *Component) newK1Signer() func(string, []byte) ([]byte, error) {
 }
 
 // newPeerK1Verifier returns a function that verifies a hash using the given peer IDs (public keys).
-func (c *Component) newPeerK1Verifier() func(string, *anypb.Any, [][]byte) error {
+func (c *Component) newPeerK1Verifier(hashFunc hashFunc) func(string, *anypb.Any, [][]byte) error {
 	return func(msgID string, anyPB *anypb.Any, sigs [][]byte) error {
 		if len(sigs) != len(c.peers) {
 			return errors.New("invalid number of signatures")
@@ -104,7 +113,7 @@ func (c *Component) newPeerK1Verifier() func(string, *anypb.Any, [][]byte) error
 			return errors.New("invalid message id")
 		}
 
-		hash, err := hashAny(anyPB)
+		hash, err := hashFunc(msgID, anyPB)
 		if err != nil {
 			return errors.Wrap(err, "hash any")
 		}

--- a/dkg/bcast/impl_internal_test.go
+++ b/dkg/bcast/impl_internal_test.go
@@ -1,0 +1,42 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package bcast
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func TestNewHashAny(t *testing.T) {
+	anyPB := &anypb.Any{TypeUrl: "typeURL", Value: []byte("value")}
+
+	hash := func(session []byte, msgID string, anyPB *anypb.Any) []byte {
+		h, err := newHashAny(session)(msgID, anyPB)
+		require.NoError(t, err)
+
+		return h
+	}
+
+	base := hash([]byte("session"), "msgID", anyPB)
+
+	// Deterministic.
+	require.Equal(t, base, hash([]byte("session"), "msgID", anyPB))
+
+	// Sensitive to each field.
+	require.NotEqual(t, base, hash([]byte("other session"), "msgID", anyPB))
+	require.NotEqual(t, base, hash([]byte("session"), "other msgID", anyPB))
+	require.NotEqual(t, base, hash([]byte("session"), "msgID", &anypb.Any{TypeUrl: "other typeURL", Value: []byte("value")}))
+	require.NotEqual(t, base, hash([]byte("session"), "msgID", &anypb.Any{TypeUrl: "typeURL", Value: []byte("other value")}))
+
+	// Length prefixes prevent ambiguous concatenation of adjacent fields.
+	require.NotEqual(t,
+		hash([]byte("sessionX"), "msgID", anyPB),
+		hash([]byte("session"), "XmsgID", anyPB),
+	)
+	require.NotEqual(t,
+		hash([]byte("session"), "msgIDX", anyPB),
+		hash([]byte("session"), "msgID", &anypb.Any{TypeUrl: "XtypeURL", Value: []byte("value")}),
+	)
+}

--- a/dkg/bcast/impl_test.go
+++ b/dkg/bcast/impl_test.go
@@ -84,7 +84,7 @@ func TestBCast(t *testing.T) {
 			return nil
 		}
 
-		bcastFunc := bcast.New(tcpNodes[i], peers, secrets[i])
+		bcastFunc := bcast.New(tcpNodes[i], peers, secrets[i], []byte("session hash"))
 
 		bcastFunc.RegisterMessageIDFuncs(msgID1, callback, checkMessage)
 		bcastFunc.RegisterMessageIDFuncs(msgID2, callback, checkMessage)
@@ -148,4 +148,62 @@ func TestBCast(t *testing.T) {
 	err = bcasts[0](ctx, p0Result.MsgID, p0Result.Msg)
 	require.NoError(t, err)
 	assertResults(t, p0Result, peers[0])
+}
+
+// TestBCastSessionHashMismatch ensures that messages signed in one session
+// cannot be verified in another, binding broadcasts to the cluster session.
+func TestBCastSessionHashMismatch(t *testing.T) {
+	const (
+		n     = 2
+		msgID = "msgID"
+	)
+
+	var (
+		ctx      = context.Background()
+		secrets  []*k1.PrivateKey
+		tcpNodes []host.Host
+		peers    []peer.ID
+		bcasts   []bcast.BroadcastFunc
+	)
+
+	for range n {
+		secret, err := k1.GeneratePrivateKey()
+		require.NoError(t, err)
+
+		secrets = append(secrets, secret)
+
+		tcpNode := testutil.CreateHostWithIdentity(t, testutil.AvailableAddr(t), secret)
+		tcpNodes = append(tcpNodes, tcpNode)
+
+		peers = append(peers, tcpNode.ID())
+	}
+
+	for i := range n {
+		for j := range n {
+			tcpNodes[i].Peerstore().AddAddrs(tcpNodes[j].ID(), tcpNodes[j].Addrs(), peerstore.PermanentAddrTTL)
+		}
+	}
+
+	callback := func(context.Context, peer.ID, string, proto.Message) error {
+		return nil
+	}
+	checkMessage := func(_ context.Context, _ peer.ID, msgAny *anypb.Any) error {
+		var ts timestamppb.Timestamp
+		if err := msgAny.UnmarshalTo(&ts); err != nil {
+			return errors.Wrap(err, "anypb error")
+		}
+
+		return nil
+	}
+
+	// Each peer runs with a different session hash.
+	for i := range n {
+		bcastFunc := bcast.New(tcpNodes[i], peers, secrets[i], []byte{byte(i)})
+		bcastFunc.RegisterMessageIDFuncs(msgID, callback, checkMessage)
+		bcasts = append(bcasts, bcastFunc.Broadcast)
+	}
+
+	// Signatures from a peer in a different session must not verify.
+	err := bcasts[0](ctx, msgID, timestamppb.Now())
+	require.ErrorContains(t, err, "verify signatures")
 }

--- a/dkg/bcast/server.go
+++ b/dkg/bcast/server.go
@@ -117,7 +117,7 @@ func (s *server) handleSigRequest(ctx context.Context, pID peer.ID, m proto.Mess
 		return nil, false, errors.Wrap(err, "signature request message check")
 	}
 
-	reqMessageHash, err := s.hashFunc(req.GetMessage())
+	reqMessageHash, err := s.hashFunc(req.GetId(), req.GetMessage())
 	if err != nil {
 		return nil, false, errors.Wrap(err, "hash any")
 	}

--- a/dkg/dkg.go
+++ b/dkg/dkg.go
@@ -266,7 +266,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	}
 
 	// Register libp2p handlers
-	caster := bcast.New(p2pNode, peerIDs, key)
+	caster := bcast.New(p2pNode, peerIDs, key, def.DefinitionHash)
 
 	// register bcast callbacks for frostp2p
 	tp, err := newFrostP2P(p2pNode, peerMap, caster, def.Threshold, newValidators)

--- a/dkg/nodesigs_internal_test.go
+++ b/dkg/nodesigs_internal_test.go
@@ -69,7 +69,7 @@ func TestSigsExchange(t *testing.T) {
 	}
 
 	for i := range n {
-		component := bcast.New(tcpNodes[i], peers, secrets[i])
+		component := bcast.New(tcpNodes[i], peers, secrets[i], []byte("session hash"))
 		nsigs = append(nsigs, newNodeSigBcast(
 			clusterPeers,
 			cluster.NodeIdx{PeerIdx: i},
@@ -160,7 +160,7 @@ func TestSigsCallbacks(t *testing.T) {
 		}
 	}
 
-	component := bcast.New(tcpNodes[0], peers, secrets[0])
+	component := bcast.New(tcpNodes[0], peers, secrets[0], []byte("session hash"))
 
 	ns := newNodeSigBcast(
 		clusterPeers,

--- a/dkg/pedersen/testutils.go
+++ b/dkg/pedersen/testutils.go
@@ -74,7 +74,7 @@ func ConnectTestNodes(t *testing.T, nodes []*TestNode) {
 func (n *TestNode) InitBoard(t *testing.T, threshold int, peers []peer.ID, peerMap map[peer.ID]cluster.NodeIdx, session []byte) {
 	t.Helper()
 
-	bc := bcast.New(n.NodeHost, peers, n.NodeSecret)
+	bc := bcast.New(n.NodeHost, peers, n.NodeSecret, session)
 	logCtx := log.WithCtx(t.Context(), z.Int("index", n.NodeIdx.PeerIdx))
 	n.Config = NewConfig(n.NodeHost.ID(), peerMap, threshold, session, 3*time.Second, nil)
 	n.Board = NewBoard(logCtx, n.NodeHost, n.Config, bc)

--- a/dkg/protocol_addoperators.go
+++ b/dkg/protocol_addoperators.go
@@ -91,7 +91,9 @@ func (p *addOperatorsProtocol) PostInit(ctx context.Context, pctx *ProtocolConte
 	}
 
 	pctx.SigExchanger = sigEx
-	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey)
+	// Bind broadcasts to the lock hash since it changes with every cluster mutation,
+	// preventing replay of messages from previous ceremonies of the same cluster.
+	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey, pctx.Lock.LockHash)
 	pctx.NodeSigCaster = newNodeSigBcast(pctx.Peers, pctx.ThisNodeIdx, pctx.Caster)
 
 	newPeerIDs := pctx.PeerIDs[len(pctx.Lock.Operators):]

--- a/dkg/protocol_removeoperators.go
+++ b/dkg/protocol_removeoperators.go
@@ -150,7 +150,9 @@ func (p *removeOperatorsProtocol) PostInit(ctx context.Context, pctx *ProtocolCo
 	}
 
 	// The broadcaster is created for all participating nodes, because it is used by the board and the node signature caster.
-	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey)
+	// Bind broadcasts to the lock hash since it changes with every cluster mutation,
+	// preventing replay of messages from previous ceremonies of the same cluster.
+	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey, pctx.Lock.LockHash)
 	pctx.NodeSigCaster = newNodeSigBcast(pctx.Peers, pctx.ThisNodeIdx, pctx.Caster)
 
 	if !p.oldNode {

--- a/dkg/protocol_replaceoperator.go
+++ b/dkg/protocol_replaceoperator.go
@@ -109,7 +109,9 @@ func (p *replaceOperatorProtocol) PostInit(ctx context.Context, pctx *ProtocolCo
 	}
 
 	pctx.SigExchanger = sigEx
-	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey)
+	// Bind broadcasts to the lock hash since it changes with every cluster mutation,
+	// preventing replay of messages from previous ceremonies of the same cluster.
+	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey, pctx.Lock.LockHash)
 	pctx.NodeSigCaster = newNodeSigBcast(pctx.Peers, pctx.ThisNodeIdx, pctx.Caster)
 
 	// For replace operator: identify the old and new peer IDs at the replacement position.

--- a/dkg/protocol_reshare.go
+++ b/dkg/protocol_reshare.go
@@ -55,7 +55,9 @@ func (p *reshareProtocol) PostInit(ctx context.Context, pctx *ProtocolContext) e
 	}
 
 	pctx.SigExchanger = sigEx
-	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey)
+	// Bind broadcasts to the lock hash since it changes with every cluster mutation,
+	// preventing replay of messages from previous ceremonies of the same cluster.
+	pctx.Caster = bcast.New(pctx.ThisNode, pctx.PeerIDs, pctx.ENRPrivateKey, pctx.Lock.LockHash)
 	pctx.NodeSigCaster = newNodeSigBcast(pctx.Peers, pctx.ThisNodeIdx, pctx.Caster)
 
 	pedersenReshareConfig := pedersen.NewReshareConfig(len(pctx.Lock.Validators), pctx.Lock.Threshold, nil, nil)

--- a/dkg/protocolsteps_internal_test.go
+++ b/dkg/protocolsteps_internal_test.go
@@ -194,7 +194,7 @@ func TestUpdateNodeSignaturesProtocolStep(t *testing.T) {
 
 	for n := range numNodes {
 		group.Go(func() error {
-			caster := bcast.New(nodes[n].NodeHost, peers, nodeKeys[n])
+			caster := bcast.New(nodes[n].NodeHost, peers, nodeKeys[n], lock.DefinitionHash)
 			nodeSigCaster := newNodeSigBcast(allPeers, cluster.NodeIdx{PeerIdx: n, ShareIdx: n + 1}, caster)
 
 			step := &updateNodeSignaturesProtocolStep{}


### PR DESCRIPTION
Bind reliable-broadcast signatures to the cluster session and message ID. Previously the signed hash covered only the protobuf type URL and value, so signatures stayed valid across DKG sessions and message IDs, allowing replay of captured messages into other ceremonies of the same cluster.

The signed hash is now the length-prefixed sha256 of (session hash, message ID, type URL, value). The initial DKG binds the definition hash; the add/remove/replace-operator and reshare protocols bind the lock hash, which changes with every cluster mutation, so messages from earlier ceremonies of the same cluster fail verification. The bcast libp2p protocol ID is bumped to 2.0.0 so mixed-version peers fail at stream negotiation instead of at signature verification.

category: bug
ticket: none