### PR TITLE
app/log: fix slog handler panic on named types

### DIFF
--- a/app/log/slog.go
+++ b/app/log/slog.go
@@ -51,6 +51,12 @@ func (h *slogHandler) Handle(_ context.Context, rec slog.Record) error {
 	// Never let a logging panic crash the process.
 	defer func() {
 		if r := recover(); r != nil {
+			defer func() {
+				if r2 := recover(); r2 != nil {
+					fmt.Fprintf(os.Stderr, "slog handler panic (logging also failed): %v\n", r)
+				}
+			}()
+
 			Error(context.Background(), "Libp2p slog handler panic, log line dropped",
 				errors.New("slog handler panic", z.Str("panic", fmt.Sprint(r))))
 		}

--- a/app/log/slog.go
+++ b/app/log/slog.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/zap/zapcore"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/z"
 )
 
 // SlogHandler returns a slog.Handler that writes records to the global charon logger.
@@ -46,13 +47,12 @@ func (h *slogHandler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= h.level
 }
 
-func (h *slogHandler) Handle(_ context.Context, rec slog.Record) (err error) {
+func (h *slogHandler) Handle(_ context.Context, rec slog.Record) error {
 	// Never let a logging panic crash the process.
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "slog handler panic (dropped log): %v\n", r)
-
-			err = errors.New("slog handler panic")
+			Error(context.Background(), "Libp2p slog handler panic, log line dropped",
+				errors.New("slog handler panic", z.Str("panic", fmt.Sprint(r))))
 		}
 	}()
 

--- a/app/log/slog.go
+++ b/app/log/slog.go
@@ -1,9 +1,11 @@
 // Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
 
+//nolint:revive,nolintlint // somehow the nolintlint linter catches revive as unnecessary, while it is
 package log
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"runtime"
@@ -11,6 +13,8 @@ import (
 	"sync"
 
 	"go.uber.org/zap/zapcore"
+
+	"github.com/obolnetwork/charon/app/errors"
 )
 
 // SlogHandler returns a slog.Handler that writes records to the global charon logger.
@@ -42,7 +46,16 @@ func (h *slogHandler) Enabled(_ context.Context, level slog.Level) bool {
 	return level >= h.level
 }
 
-func (h *slogHandler) Handle(_ context.Context, rec slog.Record) error {
+func (h *slogHandler) Handle(_ context.Context, rec slog.Record) (err error) {
+	// Never let a logging panic crash the process.
+	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "slog handler panic (dropped log): %v\n", r)
+
+			err = errors.New("slog handler panic")
+		}
+	}()
+
 	entry := zapcore.Entry{
 		Level:   toZapLevel(rec.Level),
 		Time:    rec.Time,
@@ -105,13 +118,15 @@ func (h *slogHandler) clone() *slogHandler {
 }
 
 // toZapField converts a slog attribute to a zap field, prefixing open group names.
+// All values are stringified to avoid zapcore.ReflectType, which panics in the
+// logfmt encoder on named types (e.g. protocol.ID).
 func (h *slogHandler) toZapField(a slog.Attr) zapcore.Field {
 	key := a.Key
 	if len(h.groups) > 0 {
 		key = strings.Join(h.groups, ".") + "." + key
 	}
 
-	return zapcore.Field{Key: key, Type: zapcore.ReflectType, Interface: a.Value.Resolve().Any()}
+	return zapcore.Field{Key: key, Type: zapcore.StringType, String: fmt.Sprint(a.Value.Resolve().Any())}
 }
 
 // toZapLevel maps a slog level to the closest zap level.

--- a/app/log/slog_internal_test.go
+++ b/app/log/slog_internal_test.go
@@ -83,3 +83,40 @@ func TestSlogHandler(t *testing.T) {
 	other.Error("failed to listen", "err", "address in use")
 	require.Contains(t, buf.String(), "failed to listen")
 }
+
+// namedString is a named string type like protocol.ID that is not plain string.
+type namedString string
+
+func TestSlogHandlerNamedTypes(t *testing.T) {
+	var buf bytes.Buffer
+
+	InitLogfmtForT(t, zapcore.AddSync(&buf))
+
+	levels := parseSlogLevels("identify=debug")
+	h := slog.Handler(&slogHandler{levels: levels, level: levels.fallback})
+	identify := slog.New(h.WithAttrs([]slog.Attr{slog.String("logger", "identify")}))
+
+	// Logging a slice of named-string types (like []protocol.ID) previously
+	// panicked because logfmt's AppendReflected asserts interface{} to string.
+	protocols := []namedString{"/proto/1.0", "/proto/2.0"}
+
+	require.NotPanics(t, func() {
+		identify.Debug("sending identify", "protocols", protocols)
+	})
+
+	require.Contains(t, buf.String(), "sending identify")
+	require.Contains(t, buf.String(), "/proto/1.0")
+
+	// Float, int, bool, and duration values must also survive logfmt encoding.
+	buf.Reset()
+	require.NotPanics(t, func() {
+		identify.Debug("peer stats",
+			"score", 3.14,
+			"conns", 42,
+			"relay", true,
+		)
+	})
+
+	require.Contains(t, buf.String(), "3.14")
+	require.Contains(t, buf.String(), "42")
+}

--- a/app/log/slog_internal_test.go
+++ b/app/log/slog_internal_test.go
@@ -107,7 +107,7 @@ func TestSlogHandlerNamedTypes(t *testing.T) {
 	require.Contains(t, buf.String(), "sending identify")
 	require.Contains(t, buf.String(), "/proto/1.0")
 
-	// Float, int, bool, and duration values must also survive logfmt encoding.
+	// Float, int, and bool values must also survive logfmt encoding.
 	buf.Reset()
 	require.NotPanics(t, func() {
 		identify.Debug("peer stats",
@@ -119,4 +119,5 @@ func TestSlogHandlerNamedTypes(t *testing.T) {
 
 	require.Contains(t, buf.String(), "3.14")
 	require.Contains(t, buf.String(), "42")
+	require.Contains(t, buf.String(), "true")
 }


### PR DESCRIPTION
Stringify all `slog` values via `fmt.Sprint` instead of using `zapcore.ReflectType`, which panics in the `logfmt` encoder on named types like `protocol.ID`.
Add a recover guard in `Handle` so future encoding panics drop the log line instead of crashing the process.

category: bug
ticket: none
