### PR TITLE
core/priority: gate duties received from peers

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -716,7 +716,7 @@ func wireCoreWorkflow(ctx context.Context, life *lifecycle.Manager, conf Config,
 	// Priority protocol always uses QBFTv2.
 	isync, err := wirePrioritise(ctx, conf, life, p2pNode, peerIDs, lock.Threshold,
 		sender.SendReceive, defaultConsensus, sched, p2pKey, deadlineFunc,
-		consensusController, lock.ConsensusProtocol)
+		consensusController, lock.ConsensusProtocol, gaterFunc)
 	if err != nil {
 		return err
 	}
@@ -773,6 +773,7 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, p
 	peers []peer.ID, threshold int, sendFunc p2p.SendReceiveFunc, coreCons core.Consensus,
 	sched core.Scheduler, p2pKey *k1.PrivateKey, deadlineFunc func(duty core.Duty) (time.Time, bool),
 	consensusController core.ConsensusController, clusterPreferredProtocol string,
+	gaterFunc core.DutyGaterFunc,
 ) (*infosync.Component, error) {
 	cons, ok := coreCons.(*qbft.Consensus)
 	if !ok {
@@ -785,7 +786,7 @@ func wirePrioritise(ctx context.Context, conf Config, life *lifecycle.Manager, p
 	const exchangeTimeout = time.Second * 6
 
 	prio, err := priority.NewComponent(ctx, p2pNode, peers, threshold,
-		sendFunc, p2p.RegisterHandler, cons, exchangeTimeout, p2pKey, deadlineFunc)
+		sendFunc, p2p.RegisterHandler, cons, exchangeTimeout, p2pKey, deadlineFunc, gaterFunc)
 	if err != nil {
 		return nil, err
 	}

--- a/core/gater_test.go
+++ b/core/gater_test.go
@@ -54,3 +54,49 @@ func TestDutyGater(t *testing.T) {
 	require.False(t, gater(core.Duty{Slot: 2, Type: 100}))
 	require.False(t, gater(core.Duty{Slot: 3, Type: 1000}))
 }
+
+// TestDutyGaterInfoSync asserts the gater allows the info sync duties that infosync
+// triggers in the last slot of each epoch. The priority protocol gates these duties on
+// receipt, so rejecting them here would stall cluster wide priority resolution.
+func TestDutyGaterInfoSync(t *testing.T) {
+	const (
+		slotDuration  = 12 * time.Second
+		slotsPerEpoch = 32
+		epoch         = 100
+	)
+
+	genesis := time.Now()
+
+	bmock, err := beaconmock.New(
+		t.Context(),
+		beaconmock.WithGenesisTime(genesis),
+		beaconmock.WithSlotDuration(slotDuration),
+		beaconmock.WithSlotsPerEpoch(slotsPerEpoch),
+	)
+	require.NoError(t, err)
+
+	// The slot infosync triggers on, being the last of its epoch.
+	triggerSlot := uint64(epoch*slotsPerEpoch + slotsPerEpoch - 1)
+
+	tests := []struct {
+		name     string
+		recvSlot uint64
+	}{
+		{name: "received in trigger slot", recvSlot: triggerSlot},
+		// A peer lagging into the next epoch must still accept it, otherwise clock
+		// skew across the cluster would drop legitimate exchanges.
+		{name: "received in next epoch", recvSlot: triggerSlot + 1},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			now := genesis.Add(slotDuration * time.Duration(test.recvSlot))
+
+			gater, err := core.NewDutyGater(t.Context(), bmock,
+				core.WithDutyGaterForT(t, func() time.Time { return now }, 2))
+			require.NoError(t, err)
+
+			require.True(t, gater(core.NewInfoSyncDuty(triggerSlot)))
+		})
+	}
+}

--- a/core/priority/component.go
+++ b/core/priority/component.go
@@ -53,6 +53,7 @@ type ScoredPriority struct {
 func NewComponent(ctx context.Context, p2pNode host.Host, peers []peer.ID, minRequired int, sendFunc p2p.SendReceiveFunc,
 	registerHandlerFunc p2p.RegisterHandlerFunc, consensus Consensus,
 	exchangeTimeout time.Duration, privkey *k1.PrivateKey, deadlineFunc func(duty core.Duty) (time.Time, bool),
+	gaterFunc core.DutyGaterFunc,
 ) (*Component, error) {
 	verifier, err := newMsgVerifier(peers)
 	if err != nil {
@@ -62,7 +63,7 @@ func NewComponent(ctx context.Context, p2pNode host.Host, peers []peer.ID, minRe
 	deadliner := core.NewDeadliner(ctx, "priority", deadlineFunc)
 
 	prioritiser := newInternal(p2pNode, peers, minRequired, sendFunc, registerHandlerFunc,
-		consensus, verifier, exchangeTimeout, deadliner)
+		consensus, verifier, exchangeTimeout, deadliner, gaterFunc)
 
 	return &Component{
 		peerID:       p2pNode.ID(),

--- a/core/priority/prioritiser.go
+++ b/core/priority/prioritiser.go
@@ -78,17 +78,17 @@ type request struct {
 func NewForT(_ *testing.T, p2pNode host.Host, peers []peer.ID, minRequired int,
 	sendFunc p2p.SendReceiveFunc, registerHandlerFunc p2p.RegisterHandlerFunc,
 	consensus Consensus, msgValidator msgValidator, exchangeTimeout time.Duration,
-	deadliner core.Deadliner,
+	deadliner core.Deadliner, gaterFunc core.DutyGaterFunc,
 ) *Prioritiser {
 	return newInternal(p2pNode, peers, minRequired, sendFunc, registerHandlerFunc,
-		consensus, msgValidator, exchangeTimeout, deadliner)
+		consensus, msgValidator, exchangeTimeout, deadliner, gaterFunc)
 }
 
 // newInternal returns a new prioritiser, it is the constructor.
 func newInternal(p2pNode host.Host, peers []peer.ID, minRequired int,
 	sendFunc p2p.SendReceiveFunc, registerHandlerFunc p2p.RegisterHandlerFunc,
 	consensus Consensus, msgValidator msgValidator,
-	exchangeTimeout time.Duration, deadliner core.Deadliner,
+	exchangeTimeout time.Duration, deadliner core.Deadliner, gaterFunc core.DutyGaterFunc,
 ) *Prioritiser {
 	// Create log filters
 	noSupportFilters := make(map[peer.ID]z.Field)
@@ -105,6 +105,7 @@ func newInternal(p2pNode host.Host, peers []peer.ID, minRequired int,
 		msgValidator:     msgValidator,
 		exchangeTimeout:  exchangeTimeout,
 		deadliner:        deadliner,
+		gaterFunc:        gaterFunc,
 		quit:             make(chan struct{}),
 		noSupportFilters: noSupportFilters,
 		skipAllFilter:    log.Filter(),
@@ -163,6 +164,7 @@ type Prioritiser struct {
 	peers            []peer.ID
 	consensus        Consensus
 	msgValidator     msgValidator
+	gaterFunc        core.DutyGaterFunc
 	subs             []subscriber
 	noSupportFilters map[peer.ID]z.Field
 	skipAllFilter    z.Field
@@ -222,16 +224,22 @@ func (p *Prioritiser) handleRequest(ctx context.Context, pID peer.ID, msg *pbv1.
 		return nil, errors.Wrap(err, "invalid priority message")
 	}
 
+	duty := core.DutyFromProto(msg.GetDuty())
+
+	// Gate before any per-duty state is allocated below, otherwise a peer can retain
+	// unbounded deadliner and request buffer entries by varying the duty slot.
+	if !p.gaterFunc(duty) {
+		return nil, errors.New("invalid duty", z.Any("duty", duty))
+	}
+
+	if status := p.deadliner.Add(duty); status == core.DeadlineExpired || status == core.DeadlineExempt {
+		return nil, errors.New("duty expired or exempt", z.Any("duty", duty))
+	}
+
 	response := make(chan *pbv1.PriorityMsg, 1) // Ensure responding goroutine never blocks.
 	req := request{
 		Msg:      msg,
 		Response: response,
-	}
-
-	duty := core.DutyFromProto(msg.GetDuty())
-
-	if status := p.deadliner.Add(duty); status == core.DeadlineExpired || status == core.DeadlineExempt {
-		return nil, errors.New("duty expired or exempt", z.Any("duty", duty))
 	}
 
 	reqBuffer := p.getReqBuffer(duty)

--- a/core/priority/prioritiser_internal_test.go
+++ b/core/priority/prioritiser_internal_test.go
@@ -3,13 +3,23 @@
 package priority
 
 import (
+	"context"
 	"encoding/hex"
+	"slices"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/obolnetwork/charon/core"
 	pbv1 "github.com/obolnetwork/charon/core/corepb/v1"
+	"github.com/obolnetwork/charon/p2p"
+	"github.com/obolnetwork/charon/testutil"
 )
 
 func TestHashProto(t *testing.T) {
@@ -62,4 +72,145 @@ func TestHashProto(t *testing.T) {
 			require.Equal(t, tt.expected, "0x"+hex.EncodeToString(got[:]))
 		})
 	}
+}
+
+// gaterSlot is the highest duty slot allowed by the gater used in the tests below.
+const gaterSlot = 100
+
+// TestHandleRequestGatesDuty asserts a gated duty is rejected before any per-duty
+// state is allocated for it, while an allowed duty still reaches the deadliner and
+// gets a request buffer.
+func TestHandleRequestGatesDuty(t *testing.T) {
+	tests := []struct {
+		name      string
+		slot      uint64
+		wantErr   string
+		wantState bool
+	}{
+		{
+			name:    "gated far future duty",
+			slot:    gaterSlot + 1,
+			wantErr: "invalid duty",
+		},
+		{
+			name: "allowed duty",
+			slot: gaterSlot,
+			// No instance runs for an unsolicited request, so it blocks until the context expires.
+			wantErr:   "timeout waiting for proposed priorities",
+			wantState: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pID, deadliner, p := newGatedPrioritiser(t)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancel()
+
+			_, err := p.handleRequest(ctx, pID, infoSyncMsg(pID, test.slot))
+			require.ErrorContains(t, err, test.wantErr)
+
+			p.reqMu.Lock()
+			gotBuffers := len(p.reqBuffers)
+			p.reqMu.Unlock()
+
+			if test.wantState {
+				require.Len(t, deadliner.Added(), 1)
+				require.Equal(t, 1, gotBuffers)
+			} else {
+				require.Empty(t, deadliner.Added(), "gated duty must not reach the deadliner")
+				require.Zero(t, gotBuffers, "gated duty must not retain a request buffer")
+			}
+		})
+	}
+}
+
+// TestHandleRequestFloodGated asserts a peer flooding distinct far-future duty slots
+// retains no per-duty state. Ungated, each distinct slot leaked a deadliner entry that
+// only expires at its (far future) deadline plus a request buffer keyed by that duty.
+func TestHandleRequestFloodGated(t *testing.T) {
+	pID, deadliner, p := newGatedPrioritiser(t)
+
+	for i := range uint64(100) {
+		// Gated requests return immediately. The timeout only bounds an ungated
+		// request, which blocks forever waiting on an instance that never runs.
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+
+		_, err := p.handleRequest(ctx, pID, infoSyncMsg(pID, gaterSlot+1+i))
+
+		cancel()
+
+		require.ErrorContains(t, err, "invalid duty")
+	}
+
+	p.reqMu.Lock()
+	defer p.reqMu.Unlock()
+
+	require.Empty(t, p.reqBuffers)
+	require.Empty(t, deadliner.Added())
+}
+
+// newGatedPrioritiser returns a prioritiser gating duties above gaterSlot, along with
+// the peer ID it accepts requests from and the deadliner it was wired with.
+func newGatedPrioritiser(t *testing.T) (peer.ID, *recordingDeadliner, *Prioritiser) {
+	t.Helper()
+
+	pID, err := p2p.PeerIDFromKey(testutil.GenerateInsecureK1Key(t, 0).PubKey())
+	require.NoError(t, err)
+
+	deadliner := new(recordingDeadliner)
+
+	p := newInternal(nil, []peer.ID{pID}, 1, nil, nopRegisterHandler, nopConsensus{},
+		func(*pbv1.PriorityMsg) error { return nil }, time.Hour, deadliner,
+		func(duty core.Duty) bool { return duty.Slot <= gaterSlot })
+
+	return pID, deadliner, p
+}
+
+func infoSyncMsg(pID peer.ID, slot uint64) *pbv1.PriorityMsg {
+	return &pbv1.PriorityMsg{
+		Duty:   core.DutyToProto(core.NewInfoSyncDuty(slot)),
+		PeerId: pID.String(),
+	}
+}
+
+// recordingDeadliner records the duties added to it. It implements core.Deadliner.
+type recordingDeadliner struct {
+	mu    sync.Mutex
+	added []core.Duty
+}
+
+func (d *recordingDeadliner) Add(duty core.Duty) core.DeadlineStatus {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.added = append(d.added, duty)
+
+	return core.DeadlineScheduled
+}
+
+func (*recordingDeadliner) C() <-chan core.Duty { return nil }
+
+func (d *recordingDeadliner) Added() []core.Duty {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	return slices.Clone(d.added)
+}
+
+// nopConsensus implements Consensus and does nothing.
+type nopConsensus struct{}
+
+func (nopConsensus) ProposePriority(context.Context, core.Duty, *pbv1.PriorityResult) error {
+	return nil
+}
+
+func (nopConsensus) SubscribePriority(func(context.Context, core.Duty, *pbv1.PriorityResult) error) {
+}
+
+// nopRegisterHandler implements p2p.RegisterHandlerFunc and registers nothing.
+func nopRegisterHandler(string, host.Host, protocol.ID, func() proto.Message,
+	p2p.HandlerFunc, ...p2p.SendRecvOption,
+) {
 }

--- a/core/priority/prioritiser_test.go
+++ b/core/priority/prioritiser_test.go
@@ -69,7 +69,7 @@ func TestPrioritiser(t *testing.T) {
 		}
 
 		prio := priority.NewForT(t, tcpNode, peers, n, p2p.SendReceive, p2p.RegisterHandler,
-			consensus, msgValidator, time.Hour, deadliner)
+			consensus, msgValidator, time.Hour, deadliner, allowAllDuties)
 
 		prio.Subscribe(func(_ context.Context, duty core.Duty, result *pbv1.PriorityResult) error {
 			require.Len(t, result.GetTopics(), 1)
@@ -325,8 +325,11 @@ func newTestPrioritiser(t *testing.T, p2pNode host.Host, peers []peer.ID, send p
 	t.Helper()
 
 	return priority.NewForT(t, p2pNode, peers, len(peers), send, register, consensus,
-		func(*pbv1.PriorityMsg) error { return nil }, time.Hour, deadliner)
+		func(*pbv1.PriorityMsg) error { return nil }, time.Hour, deadliner, allowAllDuties)
 }
+
+// allowAllDuties is a core.DutyGaterFunc that gates nothing.
+func allowAllDuties(core.Duty) bool { return true }
 
 // testConsensus is a mock consensus implementation that "decides" on the first proposal.
 // It also expects all proposals to be identical.


### PR DESCRIPTION
The priority protocol handler uses the duty slot from the received message. A cluster peer can retain a deadliner entry and a request buffer per distinct slot, neither of which is released until the deadline it supplied expires.

Gate duties received from peers with `core.DutyGaterFunc` before allocating any per-duty state, matching what parsigex and the consensus components already do. The gater bounds duties to the current epoch plus two and rejects invalid duty types. Duties initiated locally stay ungated, they come from the scheduler.

Info sync duties are triggered for the last slot of the current epoch, so they sit well inside the gater's bound. `TestDutyGaterInfoSync` pins that, including for a peer lagging into the next epoch.

category: bug
ticket: none
