### PR TITLE
p2p: remove noisy QUIC happy-path debug logs

### DIFF
--- a/p2p/p2p.go
+++ b/p2p/p2p.go
@@ -461,7 +461,6 @@ func UpgradeToQUICConnections(p2pNode host.Host, peerIDs []peer.ID) lifecycle.Ho
 
 	forceQUICConn := func(ctx context.Context) {
 		if !isQUICEnabled(p2pNode) {
-			log.Debug(ctx, "QUIC feature not enabled on this node")
 			return // doesn't support QUIC
 		}
 
@@ -481,8 +480,6 @@ func UpgradeToQUICConnections(p2pNode host.Host, peerIDs []peer.ID) lifecycle.Ho
 			}
 
 			if hasDirectQUICConn(conns) {
-				log.Debug(ctx, "Direct QUIC connection to peer already established", z.Str("peer", PeerName(p)), z.Any("conns", conns))
-
 				// Remove unwanted TCP connections
 				for _, conn := range conns {
 					addr := conn.RemoteMultiaddr()


### PR DESCRIPTION
Remove two debug log lines from `forceQUICConn` that fire every minute on the happy path, producing unnecessary noise:

- `"QUIC feature not enabled on this node"` — logged every tick when QUIC is disabled; the feature state is already visible in the startup config.
- `"Direct QUIC connection to peer already established"` — logged every tick per peer when QUIC is healthy; steady state doesn't need logging, only transitions do.

category: refactor
ticket: none