### PR TITLE
dkg: improved reshare logging

### DIFF
--- a/dkg/pedersen/dkg.go
+++ b/dkg/pedersen/dkg.go
@@ -118,6 +118,8 @@ func RunDKG(ctx context.Context, config *Config, board *Board, numVals int) ([]s
 
 			shares = append(shares, share)
 		}
+
+		log.Info(ctx, "DKG for key successful", z.Int("key", i+1), z.Int("total", numVals))
 	}
 
 	log.Info(ctx, "Pedersen DKG completed.")

--- a/dkg/pedersen/logger.go
+++ b/dkg/pedersen/logger.go
@@ -31,7 +31,7 @@ func (l *kyberLogger) Error(keyvals ...any) {
 
 func (l *kyberLogger) Info(keyvals ...any) {
 	msg, _ := concatKeyVals(keyvals)
-	log.Info(l.logCtx, msg)
+	log.Debug(l.logCtx, msg)
 }
 
 func concatKeyVals(keyvals []any) (str string, err error) {

--- a/dkg/pedersen/reshare.go
+++ b/dkg/pedersen/reshare.go
@@ -310,6 +310,8 @@ func RunReshareDKG(ctx context.Context, config *Config, board *Board, shares []s
 				newShares = append(newShares, newShare)
 			}
 		}
+
+		log.Info(ctx, "Reshare for key successful", z.Int("key", shareNum+1), z.Int("total", config.Reshare.TotalShares))
 	}
 
 	log.Info(ctx, "Pedersen reshare completed.")


### PR DESCRIPTION
- Underlying kyber messages are logged as Debug (was Info).
- Added reshare progression logging (Kth key / Total).

category: refactor
ticket: none
