### PR TITLE
app: fix flaky TestStartChecker

### DIFF
--- a/app/monitoringapi_internal_test.go
+++ b/app/monitoringapi_internal_test.go
@@ -163,10 +163,13 @@ func TestStartChecker(t *testing.T) {
 					return true
 				}, waitFor, tickInterval)
 			} else {
+				// Don't advance the clock further: only one vapi call was sent, so the checker
+				// observing two more epoch rollovers would swap it out and permanently flip
+				// readiness to errReadyVCNotConnected. The ticks already fired above are enough
+				// for the checker to evaluate readiness as nil, which is then stable.
 				require.Eventually(t, func() bool {
-					advanceClock(t, ctx, clock, slotDuration)
 					return readyErrFunc() == nil
-				}, waitFor, tickInterval)
+				}, 5*time.Second, tickInterval)
 			}
 		})
 	}


### PR DESCRIPTION
Stop advancing the fake clock inside the success-path `Eventually` of `TestStartChecker`. The clock advances were unsynchronized with the ready-checker goroutine, so under CI load it could observe two epoch rollovers with only the single recorded vapi call, permanently flipping readiness to `errReadyVCNotConnected` and failing the test. The ticks fired by the two initial advances are sufficient, and the ready state is then stable, so the test now just polls for it.

category: test
ticket: none