### PR TITLE
app/eth2wrap: add fork readiness metrics

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -329,7 +329,7 @@ func Run(ctx context.Context, conf Config) (err error) {
 	consensusDebugger := consensus.NewDebugger()
 
 	wireMonitoringAPI(ctx, life, conf.MonitoringAddr, conf.DebugAddr, p2pNode, eth2Cl, conf.BeaconNodeAddrs, eth1Cl,
-		peerIDs, promRegistry, consensusDebugger, pubkeys, vapiCalls, len(lock.Validators))
+		peerIDs, promRegistry, consensusDebugger, pubkeys, vapiCalls, len(lock.Validators), validatorapi.SeenVCUserAgents)
 
 	err = wireCoreWorkflow(ctx, life, conf, lock, nodeIdx, p2pNode, p2pKey, eth2Cl, subEth2Cl,
 		peerIDs, sender, consensusDebugger, pubkeys, sseListener, vapiCallsFunc)

--- a/app/eth2wrap/eth2wrap.go
+++ b/app/eth2wrap/eth2wrap.go
@@ -146,6 +146,7 @@ func newBeaconClient(timeout time.Duration, forkVersion [4]byte, headers map[str
 
 		return adaptedCl, nil
 	})
+	cl.confAddress = address
 
 	return cl
 }

--- a/app/eth2wrap/forkreadiness.go
+++ b/app/eth2wrap/forkreadiness.go
@@ -53,23 +53,34 @@ func StartForkReadinessMetric(ctx context.Context, client eth2client.SpecProvide
 	clk clockwork.Clock,
 ) {
 	go func() {
-		applied, err := FetchForkConfig(ctx, client)
-		if err != nil {
-			log.Error(ctx, "Failed to fetch startup fork schedule for fork readiness metrics", err)
-			return
-		}
-
-		for fork, fs := range applied {
-			if fs.Epoch != math.MaxUint64 {
-				appliedForkEpochGauge.WithLabelValues(forkMetricLabel(fork.String())).Set(float64(fs.Epoch))
-			}
-		}
+		var applied ForkForkSchedule
 
 		ticker := clk.NewTicker(10 * time.Minute)
 		defer ticker.Stop()
 
 		for {
-			evaluateForkReadiness(ctx, client, nodeVersions, vcUserAgents, applied)
+			// Capture the startup fork schedule on the first successful fetch, retrying on
+			// later ticks so a transient error does not disable the metric permanently.
+			// The spec is cached at startup, so this observes the same schedule the other
+			// components applied.
+			if applied == nil {
+				var err error
+
+				applied, err = FetchForkConfig(ctx, client)
+				if err != nil {
+					log.Warn(ctx, "Failed to fetch startup fork schedule for fork readiness metrics", err)
+				} else {
+					for fork, fs := range applied {
+						if fs.Epoch != math.MaxUint64 {
+							appliedForkEpochGauge.WithLabelValues(forkMetricLabel(fork.String())).Set(float64(fs.Epoch))
+						}
+					}
+				}
+			}
+
+			if applied != nil {
+				evaluateForkReadiness(ctx, client, nodeVersions, vcUserAgents, applied)
+			}
 
 			select {
 			case <-ctx.Done():

--- a/app/eth2wrap/forkreadiness.go
+++ b/app/eth2wrap/forkreadiness.go
@@ -1,0 +1,223 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import (
+	"context"
+	"math"
+	"strings"
+	"time"
+
+	eth2client "github.com/attestantio/go-eth2-client"
+	"github.com/attestantio/go-eth2-client/api"
+	"github.com/jonboulle/clockwork"
+
+	"github.com/obolnetwork/charon/app/log"
+	"github.com/obolnetwork/charon/app/version"
+	"github.com/obolnetwork/charon/app/z"
+)
+
+const (
+	forkComponentCharon          = "charon"
+	forkComponentBeaconNode      = "beacon_node"
+	forkComponentValidatorClient = "validator_client"
+	forkComponentExecutionLayer  = "execution_layer"
+
+	forkStatusReady           = "ready"
+	forkStatusRestartRequired = "restart_required"
+	forkStatusUpgradeRequired = "upgrade_required"
+	forkStatusUnknown         = "unknown"
+)
+
+// NodeClientVersions holds the client versions reported by a configured beacon node.
+// Empty versions indicate the version could not be determined.
+type NodeClientVersions struct {
+	// Address is the beacon node address.
+	Address string
+	// BeaconNode is the beacon node version string.
+	BeaconNode string
+	// ExecutionClient is the execution engine version string, only published by beacon
+	// nodes supporting the node version V2 endpoint.
+	ExecutionClient string
+}
+
+// StartForkReadinessMetric starts a goroutine that periodically compares the beacon node's
+// current fork schedule against the schedule charon applied at startup, populating the fork
+// readiness metrics and warning when charon requires a restart or an upgrade.
+//
+// go-eth2-client refreshes its cached network spec every 5 minutes, so each tick observes a
+// recent spec even though charon's components only apply the spec at startup.
+func StartForkReadinessMetric(ctx context.Context, client eth2client.SpecProvider,
+	nodeVersions func(context.Context) []NodeClientVersions,
+	vcUserAgents func() []string,
+	clk clockwork.Clock,
+) {
+	go func() {
+		applied, err := FetchForkConfig(ctx, client)
+		if err != nil {
+			log.Error(ctx, "Failed to fetch startup fork schedule for fork readiness metrics", err)
+			return
+		}
+
+		for fork, fs := range applied {
+			if fs.Epoch != math.MaxUint64 {
+				appliedForkEpochGauge.WithLabelValues(forkMetricLabel(fork.String())).Set(float64(fs.Epoch))
+			}
+		}
+
+		ticker := clk.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+
+		for {
+			evaluateForkReadiness(ctx, client, nodeVersions, vcUserAgents, applied)
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.Chan():
+			}
+		}
+	}()
+}
+
+// evaluateForkReadiness populates the fork readiness metrics from the beacon node's current
+// fork schedule and warns about forks that require a charon restart or upgrade.
+func evaluateForkReadiness(ctx context.Context, client eth2client.SpecProvider,
+	nodeVersions func(context.Context) []NodeClientVersions,
+	vcUserAgents func() []string,
+	applied ForkForkSchedule,
+) {
+	current, err := FetchForkConfig(ctx, client)
+	if err != nil {
+		log.Warn(ctx, "Failed to fetch current fork schedule for fork readiness metrics", err)
+		return
+	}
+
+	specResp, err := client.Spec(ctx, &api.SpecOpts{})
+	if err != nil {
+		log.Warn(ctx, "Failed to fetch network spec for fork readiness metrics", err)
+		return
+	}
+
+	networkForkEpochGauge.Reset()
+	forkReadinessGauge.Reset()
+
+	versions := nodeVersions(ctx)
+	vcAgents := vcUserAgents()
+
+	for fork, cur := range current {
+		var (
+			label        = forkMetricLabel(fork.String())
+			app          = applied[fork]
+			curScheduled = cur.Epoch != math.MaxUint64
+			appScheduled = app.Epoch != math.MaxUint64
+		)
+
+		if curScheduled {
+			networkForkEpochGauge.WithLabelValues(label).Set(float64(cur.Epoch))
+		}
+
+		if !curScheduled && !appScheduled {
+			continue // Fork not scheduled on the network, nothing to be ready for.
+		}
+
+		if cur == app {
+			forkReadinessGauge.WithLabelValues(label, forkComponentCharon, forkStatusReady, "").Set(1)
+		} else {
+			forkReadinessGauge.WithLabelValues(label, forkComponentCharon, forkStatusRestartRequired, "").Set(1)
+			log.Warn(ctx, "Beacon node fork schedule differs from the schedule charon applied at startup. Restart charon to apply the current fork schedule", nil,
+				z.Str("fork", label),
+				z.U64("network_epoch", uint64(cur.Epoch)),
+				z.U64("applied_epoch", uint64(app.Epoch)))
+		}
+
+		if !curScheduled {
+			continue // Client support only applies to forks scheduled on the network.
+		}
+
+		for _, nv := range versions {
+			setClientForkReadiness(ctx, label, forkComponentBeaconNode, nv.Address, nv.BeaconNode,
+				minimumBeaconNodeVersionByFork[fork],
+				"Beacon node version does not support a scheduled fork. Upgrade the beacon node before the fork activates")
+
+			setClientForkReadiness(ctx, label, forkComponentExecutionLayer, nv.Address, nv.ExecutionClient,
+				minimumExecutionEngineVersionByFork[fork],
+				"Execution engine version does not support a scheduled fork. Upgrade the execution engine before the fork activates")
+		}
+
+		for _, agent := range vcAgents {
+			setClientForkReadiness(ctx, label, forkComponentValidatorClient, agent, agent,
+				minimumValidatorClientVersionByFork[fork],
+				"Validator client version does not support a scheduled fork. Upgrade the validator client before the fork activates")
+		}
+	}
+
+	for name, epoch := range unknownScheduledForks(specResp.Data) {
+		networkForkEpochGauge.WithLabelValues(name).Set(float64(epoch))
+		forkReadinessGauge.WithLabelValues(name, forkComponentCharon, forkStatusUpgradeRequired, "").Set(1)
+		log.Warn(ctx, "Beacon node scheduled a fork that this charon version does not support. Upgrade charon before the fork activates", nil,
+			z.Str("fork", name),
+			z.U64("network_epoch", epoch))
+	}
+}
+
+// unknownScheduledForks returns the scheduled forks in the network spec that are unknown to
+// this charon version, mapped to their activation epochs.
+func unknownScheduledForks(spec map[string]any) map[string]uint64 {
+	resp := make(map[string]uint64)
+
+	for key := range spec {
+		name, ok := strings.CutSuffix(key, "_FORK_VERSION")
+		if !ok || name == "GENESIS" || isKnownFork(name) {
+			continue
+		}
+
+		epoch, ok := spec[name+"_FORK_EPOCH"].(uint64)
+		if !ok || epoch == math.MaxUint64 {
+			continue // Fork not scheduled.
+		}
+
+		resp[forkMetricLabel(name)] = epoch
+	}
+
+	return resp
+}
+
+// isKnownFork returns true if the provided fork name, as published in the network spec
+// (e.g. "GLOAS"), is known to this charon version.
+func isKnownFork(name string) bool {
+	for _, label := range forkLabels {
+		if label == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+// forkMetricLabel returns the metric label for the provided spec fork name.
+func forkMetricLabel(name string) string {
+	return strings.ToLower(name)
+}
+
+// setClientForkReadiness sets the fork readiness gauge for a single client of the provided
+// component and warns if the client requires an upgrade for the fork. Empty client versions
+// resolve to an unknown status.
+func setClientForkReadiness(ctx context.Context, fork string, component string, instance string,
+	clientVersion string, minVersions map[string]version.SemVer, upgradeMsg string,
+) {
+	status, clVer, minVer := forkStatusUnknown, "", ""
+	if clientVersion != "" {
+		status, clVer, minVer = checkClientForkSupport(minVersions, clientVersion)
+	}
+
+	forkReadinessGauge.WithLabelValues(fork, component, status, instance).Set(1)
+
+	if status == forkStatusUpgradeRequired {
+		log.Warn(ctx, upgradeMsg, nil,
+			z.Str("fork", fork),
+			z.Str("instance", instance),
+			z.Str("client_version", clVer),
+			z.Str("minimum_required", minVer))
+	}
+}

--- a/app/eth2wrap/forkreadiness_internal_test.go
+++ b/app/eth2wrap/forkreadiness_internal_test.go
@@ -1,0 +1,152 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import (
+	"context"
+	"maps"
+	"math"
+	"testing"
+
+	"github.com/attestantio/go-eth2-client/api"
+	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/obolnetwork/charon/app/version"
+)
+
+// testSpec returns a minimal network spec with all known forks scheduled at epoch 0 except
+// the provided overrides.
+func testSpec(overrides map[string]any) map[string]any {
+	spec := map[string]any{"GENESIS_FORK_VERSION": eth2p0.Version{}}
+
+	for fork, label := range forkLabels {
+		spec[label+"_FORK_VERSION"] = eth2p0.Version{byte(fork)}
+		spec[label+"_FORK_EPOCH"] = uint64(0)
+	}
+
+	maps.Copy(spec, overrides)
+
+	return spec
+}
+
+func specProvider(spec map[string]any) stubSpecProvider {
+	return stubSpecProvider{resp: &api.Response[map[string]any]{Data: spec}}
+}
+
+func TestEvaluateForkReadiness(t *testing.T) {
+	tests := []struct {
+		name    string
+		applied map[string]any // Spec at charon startup.
+		current map[string]any // Spec published by the beacon node now.
+		fork    string
+		status  string
+	}{
+		{
+			name:    "ready",
+			applied: testSpec(nil),
+			current: testSpec(nil),
+			fork:    "electra",
+			status:  forkStatusReady,
+		},
+		{
+			name:    "restart required",
+			applied: testSpec(map[string]any{"GLOAS_FORK_EPOCH": uint64(math.MaxUint64)}),
+			current: testSpec(map[string]any{"GLOAS_FORK_EPOCH": uint64(4096)}),
+			fork:    "gloas",
+			status:  forkStatusRestartRequired,
+		},
+		{
+			name:    "upgrade required",
+			applied: testSpec(nil),
+			current: testSpec(map[string]any{
+				"HEZE_FORK_VERSION": eth2p0.Version{0x90},
+				"HEZE_FORK_EPOCH":   uint64(8192),
+			}),
+			fork:   "heze",
+			status: forkStatusUpgradeRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			applied, err := FetchForkConfig(t.Context(), specProvider(tt.applied))
+			require.NoError(t, err)
+
+			noVersions := func(context.Context) []NodeClientVersions { return nil }
+			noAgents := func() []string { return nil }
+			evaluateForkReadiness(t.Context(), specProvider(tt.current), noVersions, noAgents, applied)
+
+			require.InDelta(t, 1,
+				testutil.ToFloat64(forkReadinessGauge.WithLabelValues(tt.fork, forkComponentCharon, tt.status, "")), 0)
+		})
+	}
+}
+
+func TestUnknownScheduledForks(t *testing.T) {
+	spec := testSpec(map[string]any{
+		"HEZE_FORK_VERSION":  eth2p0.Version{0x90},   // Unknown scheduled fork.
+		"HEZE_FORK_EPOCH":    uint64(8192),           // Unknown scheduled fork.
+		"IZMIR_FORK_VERSION": eth2p0.Version{0xa0},   // Unknown unscheduled fork.
+		"IZMIR_FORK_EPOCH":   uint64(math.MaxUint64), // Unknown unscheduled fork.
+		"OSAKA_FORK_VERSION": eth2p0.Version{0xb0},   // Unknown fork without an epoch.
+	})
+
+	require.Equal(t, map[string]uint64{"heze": 8192}, unknownScheduledForks(spec))
+}
+
+func TestEvaluateBNForkReadiness(t *testing.T) {
+	// Set a minimum Lighthouse version for the electra fork.
+	minVersion, err := version.Parse("v9.0.1")
+	require.NoError(t, err)
+
+	minGeth, err := version.Parse("v1.16.7")
+	require.NoError(t, err)
+
+	oldBN, oldVC, oldEL := minimumBeaconNodeVersionByFork, minimumValidatorClientVersionByFork, minimumExecutionEngineVersionByFork
+	minimumBeaconNodeVersionByFork = map[Fork]map[string]version.SemVer{Electra: {"Lighthouse": minVersion}}
+	minimumValidatorClientVersionByFork = map[Fork]map[string]version.SemVer{Electra: {"Lighthouse": minVersion}}
+	minimumExecutionEngineVersionByFork = map[Fork]map[string]version.SemVer{Electra: {"Geth": minGeth}}
+
+	t.Cleanup(func() {
+		minimumBeaconNodeVersionByFork, minimumValidatorClientVersionByFork, minimumExecutionEngineVersionByFork = oldBN, oldVC, oldEL
+	})
+
+	spec := testSpec(nil)
+
+	applied, err := FetchForkConfig(t.Context(), specProvider(spec))
+	require.NoError(t, err)
+
+	versions := func(context.Context) []NodeClientVersions {
+		return []NodeClientVersions{
+			{Address: "bn1", BeaconNode: "Lighthouse/v9.0.1-abcdef", ExecutionClient: "Geth/v1.16.7/abcdef"}, // Meets the minimum.
+			{Address: "bn2", BeaconNode: "Lighthouse/v9.0.0-abcdef"},                                         // Below the minimum, no EL version.
+			{Address: "bn3", BeaconNode: "teku/v25.9.3", ExecutionClient: "Geth/v1.15.0/abcdef"},             // No BN expectation, EL below minimum.
+			{Address: "bn4", BeaconNode: "custom-build"},                                                     // Unparsable version.
+		}
+	}
+
+	agents := func() []string {
+		return []string{
+			"Lighthouse/v9.0.1-abcdef", // Meets the minimum.
+			"Vouch/v1.12.0",            // No expectation set.
+		}
+	}
+
+	evaluateForkReadiness(t.Context(), specProvider(spec), versions, agents, applied)
+
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentBeaconNode, forkStatusReady, "bn1")), 0)
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentBeaconNode, forkStatusUpgradeRequired, "bn2")), 0)
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentBeaconNode, forkStatusReady, "bn3")), 0)
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentBeaconNode, forkStatusUnknown, "bn4")), 0)
+
+	// Execution layer rows.
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentExecutionLayer, forkStatusReady, "bn1")), 0)
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentExecutionLayer, forkStatusUnknown, "bn2")), 0)
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentExecutionLayer, forkStatusUpgradeRequired, "bn3")), 0)
+
+	// Validator client rows.
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentValidatorClient, forkStatusReady, "Lighthouse/v9.0.1-abcdef")), 0)
+	require.InDelta(t, 1, testutil.ToFloat64(forkReadinessGauge.WithLabelValues("electra", forkComponentValidatorClient, forkStatusReady, "Vouch/v1.12.0")), 0)
+}

--- a/app/eth2wrap/lazy.go
+++ b/app/eth2wrap/lazy.go
@@ -29,8 +29,16 @@ func newLazy(provider func(context.Context) (Client, error)) *lazy {
 	}
 }
 
+// configuredAddress returns the original configured beacon node address of this client,
+// used to match configured addresses since Address returns the masked form.
+func (l *lazy) configuredAddress() string {
+	return l.confAddress
+}
+
 // lazy is a client that is created on demand.
 type lazy struct {
+	confAddress string
+
 	providerMu sync.Mutex
 	provider   func(context.Context) (Client, error)
 

--- a/app/eth2wrap/metrics.go
+++ b/app/eth2wrap/metrics.go
@@ -23,6 +23,27 @@ var (
 		Help:      "Total number of times the cache was missed",
 	}, []string{"endpoint"})
 
+	networkForkEpochGauge = promauto.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Subsystem: "fork",
+		Name:      "network_epoch",
+		Help:      "Constant gauge with the scheduled activation epoch per fork as published by the beacon node",
+	}, []string{"fork"})
+
+	appliedForkEpochGauge = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Subsystem: "fork",
+		Name:      "applied_epoch",
+		Help:      "Constant gauge with the fork activation epoch charon applied at startup",
+	}, []string{"fork"})
+
+	forkReadinessGauge = promauto.NewResetGaugeVec(prometheus.GaugeOpts{
+		Namespace: "app",
+		Subsystem: "fork",
+		Name:      "readiness",
+		Help:      "Constant gauge set to 1 per fork and component with the fork readiness status: ready, restart_required, upgrade_required or unknown. The address label is set for per-beacon-node rows",
+	}, []string{"fork", "component", "status", "address"})
+
 	invalidatedCacheDueReorgCount = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: "app",
 		Subsystem: "cache",

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -7,6 +7,9 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/url"
+	"regexp"
+	"strings"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
@@ -70,9 +73,13 @@ func (m multi) ClientForAddress(addr string) Client {
 		return m
 	}
 
+	// Client addresses are stored in masked form (credentials, path and query redacted by
+	// go-eth2-client), so normalize the provided address the same way before matching.
+	masked := maskedAddress(addr)
+
 	// Find client matching the address
 	for _, cl := range m.clients {
-		if cl.Address() == addr {
+		if cl.Address() == addr || cl.Address() == masked {
 			return multi{
 				clients:   []Client{cl},
 				fallbacks: m.fallbacks,
@@ -83,7 +90,7 @@ func (m multi) ClientForAddress(addr string) Client {
 
 	// Address not found in clients, check fallbacks
 	for _, cl := range m.fallbacks {
-		if cl.Address() == addr {
+		if cl.Address() == addr || cl.Address() == masked {
 			return multi{
 				clients:   []Client{cl},
 				fallbacks: nil,
@@ -287,3 +294,37 @@ func (m multi) Proxy(ctx context.Context, req *http.Request) (*http.Response, er
 
 	return res0, err
 }
+
+// maskedAddress returns the provided beacon node address in the masked form used by client
+// Address(): scheme prefixed, trailing path slash trimmed, and credentials, path and query
+// masked. It mirrors go-eth2-client's address parsing so configured addresses can be matched
+// against client addresses.
+func maskedAddress(addr string) string {
+	if !strings.HasPrefix(addr, "http") {
+		addr = "http://" + addr
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil {
+		return addr
+	}
+
+	u.Path = strings.TrimSuffix(u.Path, "/")
+
+	if _, ok := u.User.Password(); ok {
+		u.User = url.UserPassword(u.User.Username(), "xxxxx")
+	}
+
+	if u.Path != "" {
+		u.Path = "xxxxx"
+	}
+
+	if u.RawQuery != "" {
+		u.RawQuery = maskQueryRegex.ReplaceAllString(u.RawQuery, "=xxxxx$2")
+	}
+
+	return u.String()
+}
+
+// maskQueryRegex masks query parameter values, mirroring go-eth2-client's address masking.
+var maskQueryRegex = regexp.MustCompile("=([^&]*)(&)?")

--- a/app/eth2wrap/multi.go
+++ b/app/eth2wrap/multi.go
@@ -7,9 +7,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"net/url"
-	"regexp"
-	"strings"
 
 	eth2p0 "github.com/attestantio/go-eth2-client/spec/phase0"
 
@@ -73,13 +70,9 @@ func (m multi) ClientForAddress(addr string) Client {
 		return m
 	}
 
-	// Client addresses are stored in masked form (credentials, path and query redacted by
-	// go-eth2-client), so normalize the provided address the same way before matching.
-	masked := maskedAddress(addr)
-
 	// Find client matching the address
 	for _, cl := range m.clients {
-		if cl.Address() == addr || cl.Address() == masked {
+		if matchesAddress(cl, addr) {
 			return multi{
 				clients:   []Client{cl},
 				fallbacks: m.fallbacks,
@@ -90,7 +83,7 @@ func (m multi) ClientForAddress(addr string) Client {
 
 	// Address not found in clients, check fallbacks
 	for _, cl := range m.fallbacks {
-		if cl.Address() == addr || cl.Address() == masked {
+		if matchesAddress(cl, addr) {
 			return multi{
 				clients:   []Client{cl},
 				fallbacks: nil,
@@ -295,36 +288,18 @@ func (m multi) Proxy(ctx context.Context, req *http.Request) (*http.Response, er
 	return res0, err
 }
 
-// maskedAddress returns the provided beacon node address in the masked form used by client
-// Address(): scheme prefixed, trailing path slash trimmed, and credentials, path and query
-// masked. It mirrors go-eth2-client's address parsing so configured addresses can be matched
-// against client addresses.
-func maskedAddress(addr string) string {
-	if !strings.HasPrefix(addr, "http") {
-		addr = "http://" + addr
+// matchesAddress returns true if the client corresponds to the provided configured beacon
+// node address. Clients constructed from a configured address match on the original address,
+// since Address returns the masked form (credentials, path and query redacted) which is both
+// lossy and ambiguous between endpoints on the same host.
+func matchesAddress(cl Client, addr string) bool {
+	type configuredAddresser interface {
+		configuredAddress() string
 	}
 
-	u, err := url.Parse(addr)
-	if err != nil {
-		return addr
+	if ca, ok := cl.(configuredAddresser); ok && ca.configuredAddress() == addr {
+		return true
 	}
 
-	u.Path = strings.TrimSuffix(u.Path, "/")
-
-	if _, ok := u.User.Password(); ok {
-		u.User = url.UserPassword(u.User.Username(), "xxxxx")
-	}
-
-	if u.Path != "" {
-		u.Path = "xxxxx"
-	}
-
-	if u.RawQuery != "" {
-		u.RawQuery = maskQueryRegex.ReplaceAllString(u.RawQuery, "=xxxxx$2")
-	}
-
-	return u.String()
+	return cl.Address() == addr
 }
-
-// maskQueryRegex masks query parameter values, mirroring go-eth2-client's address masking.
-var maskQueryRegex = regexp.MustCompile("=([^&]*)(&)?")

--- a/app/eth2wrap/multi_internal_test.go
+++ b/app/eth2wrap/multi_internal_test.go
@@ -1,0 +1,51 @@
+// Copyright © 2022-2026 Obol Labs Inc. Licensed under the terms of a Business Source License 1.1
+
+package eth2wrap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientForAddressConfigured asserts that configured addresses match their clients via the
+// original configured address, since client Address() returns the masked form (credentials,
+// path and query redacted) which is ambiguous between endpoints on the same host.
+func TestClientForAddressConfigured(t *testing.T) {
+	newConfClient := func(confAddr string) Client {
+		l := newLazy(nil)
+		l.confAddress = confAddr
+
+		return l
+	}
+
+	var (
+		// Two endpoints on the same host differ only by path, which the masked form hides.
+		clientA = newConfClient("http://bn.example.com:5052/node-a")
+		clientB = newConfClient("http://bn.example.com:5052/node-b")
+		// Credentials and scheme-less forms are also lost in the masked form.
+		clientC = newConfClient("http://user:secret@bn-c.example.com:5052")
+		clientD = newConfClient("bn-d.example.com:5052")
+	)
+
+	m := multi{clients: []Client{clientA, clientB, clientC, clientD}}
+
+	scoped := m.ClientForAddress("http://bn.example.com:5052/node-b")
+	require.Same(t, clientB, scoped.(multi).clients[0])
+
+	scoped = m.ClientForAddress("http://user:secret@bn-c.example.com:5052")
+	require.Same(t, clientC, scoped.(multi).clients[0])
+
+	scoped = m.ClientForAddress("bn-d.example.com:5052")
+	require.Same(t, clientD, scoped.(multi).clients[0])
+
+	// Unknown addresses return the unscoped multi client.
+	unscoped := m.ClientForAddress("http://unknown.example.com:5052")
+	require.Len(t, unscoped.(multi).clients, 4)
+
+	// Fallbacks are matched the same way.
+	mf := multi{clients: []Client{clientA}, fallbacks: []Client{clientC}}
+
+	scoped = mf.ClientForAddress("http://user:secret@bn-c.example.com:5052")
+	require.Same(t, clientC, scoped.(multi).clients[0])
+}

--- a/app/eth2wrap/multi_test.go
+++ b/app/eth2wrap/multi_test.go
@@ -233,3 +233,28 @@ func TestMulti_ClientForAddress(t *testing.T) {
 		require.Equal(t, "http://bn1:5051", scoped.Address())
 	})
 }
+
+func TestMulti_ClientForAddressMasked(t *testing.T) {
+	// Client addresses are stored in masked form (scheme prefixed, credentials redacted),
+	// while operators configure raw addresses. ClientForAddress must still scope correctly.
+	// Note the target client is deliberately not first: an unscoped multi falls back to the
+	// first client's address, which would falsely satisfy the assertions below.
+	clientA := mocks.NewClient(t)
+	clientA.On("Address").Return("http://bn-a.example.com:5052").Maybe()
+
+	clientB := mocks.NewClient(t)
+	clientB.On("Address").Return("http://user:xxxxx@bn-b.example.com:5052").Maybe()
+
+	clientC := mocks.NewClient(t)
+	clientC.On("Address").Return("http://bn-c.example.com:5052").Maybe()
+
+	m := eth2wrap.NewMultiForT([]eth2wrap.Client{clientA, clientB, clientC}, nil)
+
+	// Raw configured address with credentials matches the client's masked address.
+	scoped := m.ClientForAddress("http://user:secret@bn-b.example.com:5052")
+	require.Equal(t, "http://user:xxxxx@bn-b.example.com:5052", scoped.Address())
+
+	// Scheme-less configured address matches the scheme-prefixed client address.
+	scoped = m.ClientForAddress("bn-c.example.com:5052")
+	require.Equal(t, "http://bn-c.example.com:5052", scoped.Address())
+}

--- a/app/eth2wrap/multi_test.go
+++ b/app/eth2wrap/multi_test.go
@@ -233,28 +233,3 @@ func TestMulti_ClientForAddress(t *testing.T) {
 		require.Equal(t, "http://bn1:5051", scoped.Address())
 	})
 }
-
-func TestMulti_ClientForAddressMasked(t *testing.T) {
-	// Client addresses are stored in masked form (scheme prefixed, credentials redacted),
-	// while operators configure raw addresses. ClientForAddress must still scope correctly.
-	// Note the target client is deliberately not first: an unscoped multi falls back to the
-	// first client's address, which would falsely satisfy the assertions below.
-	clientA := mocks.NewClient(t)
-	clientA.On("Address").Return("http://bn-a.example.com:5052").Maybe()
-
-	clientB := mocks.NewClient(t)
-	clientB.On("Address").Return("http://user:xxxxx@bn-b.example.com:5052").Maybe()
-
-	clientC := mocks.NewClient(t)
-	clientC.On("Address").Return("http://bn-c.example.com:5052").Maybe()
-
-	m := eth2wrap.NewMultiForT([]eth2wrap.Client{clientA, clientB, clientC}, nil)
-
-	// Raw configured address with credentials matches the client's masked address.
-	scoped := m.ClientForAddress("http://user:secret@bn-b.example.com:5052")
-	require.Equal(t, "http://user:xxxxx@bn-b.example.com:5052", scoped.Address())
-
-	// Scheme-less configured address matches the scheme-prefixed client address.
-	scoped = m.ClientForAddress("bn-c.example.com:5052")
-	require.Equal(t, "http://bn-c.example.com:5052", scoped.Address())
-}

--- a/app/eth2wrap/version.go
+++ b/app/eth2wrap/version.go
@@ -29,6 +29,20 @@ var (
 	}
 
 	incompatibleBeaconNodeVersion = map[string][]version.SemVer{}
+
+	// The following tables define the minimum client versions required to support a scheduled
+	// fork. Clients absent from a fork's map have no expectation set. Populated as clients cut
+	// fork-ready releases, e.g.:
+	//  Gloas: {"Lighthouse": minLighthouseGloasVersion},
+
+	// minimumBeaconNodeVersionByFork defines the minimum beacon node versions per fork.
+	minimumBeaconNodeVersionByFork = map[Fork]map[string]version.SemVer{}
+
+	// minimumValidatorClientVersionByFork defines the minimum validator client versions per fork.
+	minimumValidatorClientVersionByFork = map[Fork]map[string]version.SemVer{}
+
+	// minimumExecutionEngineVersionByFork defines the minimum execution engine versions per fork.
+	minimumExecutionEngineVersionByFork = map[Fork]map[string]version.SemVer{}
 )
 
 type BeaconNodeVersionStatus int
@@ -98,4 +112,32 @@ func CheckBeaconNodeVersion(ctx context.Context, bnVersion string) {
 	case VersionOK:
 		// Do nothing
 	}
+}
+
+// checkClientForkSupport checks a client version string (formatted "Name/vX.Y.Z...", as
+// published by beacon nodes, execution engines and validator client user agents) against the
+// provided per-client fork minimums. It returns the fork readiness status, the current
+// version and the minimum required version.
+func checkClientForkSupport(minVersions map[string]version.SemVer, clientVersion string) (status string, clVer string, minVer string) {
+	matches := versionExtractRegex.FindStringSubmatch(clientVersion)
+	if len(matches) != 3 {
+		return forkStatusUnknown, "", ""
+	}
+
+	parsed, err := version.Parse("v" + matches[2])
+	if err != nil {
+		return forkStatusUnknown, "", ""
+	}
+
+	minVersion, ok := minVersions[matches[1]]
+	if !ok {
+		// No expectation set for this client.
+		return forkStatusReady, parsed.String(), ""
+	}
+
+	if version.Compare(parsed, minVersion) == -1 {
+		return forkStatusUpgradeRequired, parsed.String(), minVersion.String()
+	}
+
+	return forkStatusReady, parsed.String(), minVersion.String()
 }

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -59,8 +59,12 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, d
 		var resp []eth2wrap.NodeClientVersions
 
 		for _, addr := range beaconNodeAddrs {
-			bnVersion, eeVersion, _ := fetchBeaconAndExecutionVersion(ctx, eth2Cl.ClientForAddress(addr), addr)
-			resp = append(resp, eth2wrap.NodeClientVersions{Address: addr, BeaconNode: bnVersion, ExecutionClient: eeVersion})
+			scopedClient := eth2Cl.ClientForAddress(addr)
+			bnVersion, eeVersion, _ := fetchBeaconAndExecutionVersion(ctx, scopedClient, addr)
+
+			// Address returns the masked address (credentials, path and query redacted by
+			// go-eth2-client), safe for metric labels and logs.
+			resp = append(resp, eth2wrap.NodeClientVersions{Address: scopedClient.Address(), BeaconNode: bnVersion, ExecutionClient: eeVersion})
 		}
 
 		return resp

--- a/app/monitoringapi.go
+++ b/app/monitoringapi.go
@@ -51,9 +51,22 @@ func wireMonitoringAPI(ctx context.Context, life *lifecycle.Manager, promAddr, d
 	p2pNode host.Host, eth2Cl eth2wrap.Client, beaconNodeAddrs []string, eth1Cl eth1wrap.EthClientRunner,
 	peerIDs []peer.ID, registry *prometheus.Registry, consensusDebugger http.Handler,
 	pubkeys []core.PubKey, vapiCalls <-chan struct{},
-	numValidators int,
+	numValidators int, vcUserAgents func() []string,
 ) {
 	consensusAndExecutionVersionMetric(ctx, eth2Cl, beaconNodeAddrs, eth1Cl, clockwork.NewRealClock())
+
+	nodeVersions := func(ctx context.Context) []eth2wrap.NodeClientVersions {
+		var resp []eth2wrap.NodeClientVersions
+
+		for _, addr := range beaconNodeAddrs {
+			bnVersion, eeVersion, _ := fetchBeaconAndExecutionVersion(ctx, eth2Cl.ClientForAddress(addr), addr)
+			resp = append(resp, eth2wrap.NodeClientVersions{Address: addr, BeaconNode: bnVersion, ExecutionClient: eeVersion})
+		}
+
+		return resp
+	}
+
+	eth2wrap.StartForkReadinessMetric(ctx, eth2Cl, nodeVersions, vcUserAgents, clockwork.NewRealClock())
 
 	mux := http.NewServeMux()
 

--- a/core/validatorapi/metrics.go
+++ b/core/validatorapi/metrics.go
@@ -3,8 +3,10 @@
 package validatorapi
 
 import (
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -101,4 +103,44 @@ func isNumeric(s string) bool {
 	return !strings.ContainsFunc(s, func(r rune) bool {
 		return r < '0' || r > '9'
 	})
+}
+
+// vcUserAgentRegistry tracks validator client user agents recently seen on API requests,
+// so fork readiness checks can evaluate the connected validator clients.
+var vcUserAgentRegistry = struct {
+	sync.Mutex
+
+	agents map[string]time.Time
+}{agents: make(map[string]time.Time)}
+
+// vcUserAgentTTL bounds how long a user agent is considered connected after its last request.
+const vcUserAgentTTL = time.Hour
+
+// recordVCUserAgent records a validator client user agent seen on an API request.
+func recordVCUserAgent(agent string) {
+	vcUserAgentRegistry.Lock()
+	defer vcUserAgentRegistry.Unlock()
+
+	vcUserAgentRegistry.agents[agent] = time.Now()
+}
+
+// SeenVCUserAgents returns the validator client user agents seen recently on API requests.
+func SeenVCUserAgents() []string {
+	vcUserAgentRegistry.Lock()
+	defer vcUserAgentRegistry.Unlock()
+
+	var resp []string
+
+	for agent, seen := range vcUserAgentRegistry.agents {
+		if time.Since(seen) > vcUserAgentTTL {
+			delete(vcUserAgentRegistry.agents, agent)
+			continue
+		}
+
+		resp = append(resp, agent)
+	}
+
+	slices.Sort(resp)
+
+	return resp
 }

--- a/core/validatorapi/metrics.go
+++ b/core/validatorapi/metrics.go
@@ -113,13 +113,32 @@ var vcUserAgentRegistry = struct {
 	agents map[string]time.Time
 }{agents: make(map[string]time.Time)}
 
-// vcUserAgentTTL bounds how long a user agent is considered connected after its last request.
-const vcUserAgentTTL = time.Hour
+const (
+	// vcUserAgentTTL bounds how long a user agent is considered connected after its last request.
+	vcUserAgentTTL = time.Hour
+	// maxVCUserAgents bounds the registry size (and the resulting metric cardinality) since
+	// user agents are untrusted request input. New agents are dropped when the registry is
+	// full; expired entries make room again. Validator clients connect continuously, so
+	// legitimate agents recorded early are retained.
+	maxVCUserAgents = 10
+)
 
 // recordVCUserAgent records a validator client user agent seen on an API request.
 func recordVCUserAgent(agent string) {
 	vcUserAgentRegistry.Lock()
 	defer vcUserAgentRegistry.Unlock()
+
+	if _, ok := vcUserAgentRegistry.agents[agent]; !ok {
+		for existing, seen := range vcUserAgentRegistry.agents {
+			if time.Since(seen) > vcUserAgentTTL {
+				delete(vcUserAgentRegistry.agents, existing)
+			}
+		}
+
+		if len(vcUserAgentRegistry.agents) >= maxVCUserAgents {
+			return
+		}
+	}
 
 	vcUserAgentRegistry.agents[agent] = time.Now()
 }

--- a/core/validatorapi/metrics_internal_test.go
+++ b/core/validatorapi/metrics_internal_test.go
@@ -3,7 +3,9 @@
 package validatorapi
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -73,4 +75,35 @@ func TestProxyPathLabelBoundedCardinality(t *testing.T) {
 	a := proxyPathLabel("/eth/v2/beacon/blocks/0x0342020caa311b9f104cd1b223872b7d416d868d2e5add744e7af8265ba435ff")
 	b := proxyPathLabel("/eth/v2/beacon/blocks/0x04639c0c1fff050014a818280fcd12dc8880077583e83fee738afd74ade618c0")
 	require.Equal(t, a, b)
+}
+
+func TestVCUserAgentRegistry(t *testing.T) {
+	t.Cleanup(func() {
+		vcUserAgentRegistry.Lock()
+		vcUserAgentRegistry.agents = make(map[string]time.Time)
+		vcUserAgentRegistry.Unlock()
+	})
+
+	recordVCUserAgent("Lighthouse/v9.0.1")
+	recordVCUserAgent("Vouch/v1.12.0")
+	recordVCUserAgent("Lighthouse/v9.0.1") // Duplicates refresh, not grow.
+
+	require.Equal(t, []string{"Lighthouse/v9.0.1", "Vouch/v1.12.0"}, SeenVCUserAgents())
+
+	// The registry is bounded: agents beyond the cap are dropped.
+	for i := range maxVCUserAgents * 2 {
+		recordVCUserAgent(fmt.Sprintf("agent-%d", i))
+	}
+
+	require.Len(t, SeenVCUserAgents(), maxVCUserAgents)
+
+	// Expired agents are pruned, making room for new ones.
+	vcUserAgentRegistry.Lock()
+	for agent := range vcUserAgentRegistry.agents {
+		vcUserAgentRegistry.agents[agent] = time.Now().Add(-2 * vcUserAgentTTL)
+	}
+	vcUserAgentRegistry.Unlock()
+
+	recordVCUserAgent("teku/v25.9.3")
+	require.Equal(t, []string{"teku/v25.9.3"}, SeenVCUserAgents())
 }

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -432,6 +432,7 @@ func wrap(endpoint string, handler handlerFunc, encodings []contentType) http.Ha
 
 			vcUserAgentGauge.Reset()
 			vcUserAgentGauge.WithLabelValues(userAgent).Set(1)
+			recordVCUserAgent(userAgent)
 		}
 
 		body, err := io.ReadAll(r.Body)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -30,6 +30,9 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | `app_eth2_using_fallback` | Gauge | Indicates if client is using fallback (1) or primary (0) beacon node |  |
 | `app_execution_layer_version` | Gauge | Constant gauge with labels set to the version of the upstream execution layer | `version` |
 | `app_feature_flags` | Gauge | Constant gauge with custom enabled feature flags | `feature_flags` |
+| `app_fork_applied_epoch` | Gauge | Constant gauge with the fork activation epoch charon applied at startup | `fork` |
+| `app_fork_network_epoch` | Gauge | Constant gauge with the scheduled activation epoch per fork as published by the beacon node | `fork` |
+| `app_fork_readiness` | Gauge | Constant gauge set to 1 per fork and component with the fork readiness status: ready, restart_required, upgrade_required or unknown. The address label is set for per-beacon-node rows | `fork, component, status, address` |
 | `app_git_commit` | Gauge | Constant gauge with label set to current git commit hash | `git_hash` |
 | `app_health_checks` | Gauge | Application health checks by name and severity. Set to 1 for failing, 0 for ok. | `severity, name, description` |
 | `app_health_checks_failed_total` | Counter | Total number of times each health check has been observed failing. Allows querying historical failures via increase(). | `severity, name, description` |


### PR DESCRIPTION
Add `app_fork_readiness{fork, component, status, address}` evaluated every 10 minutes against the beacon node network spec (refreshed client-side every 5 minutes), so operators get alerted before fork activation. Components: `charon` (`restart_required` when the live fork schedule diverges from the startup snapshot, `upgrade_required` when the spec contains a fork unknown to this build), plus per-instance `beacon_node`, `execution_layer` (via node version v2) and `validator_client` (via recently seen user agents) checked against per-fork minimum version tables in `eth2wrap/version.go`. Also adds `app_fork_network_epoch`/`app_fork_applied_epoch` gauges and repeating warning logs with the remedy per unready component. The minimum version tables ship empty and get populated as clients cut fork-ready releases.

category: feature
ticket: #4324