### PR TITLE
core/validatorapi: optional committee index param

### DIFF
--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -261,8 +261,9 @@ func (f *Fetcher) fetchAttesterDataWithClient(ctx context.Context, slot uint64, 
 		if !ok {
 			var err error
 
-			// The committee index is kept for backwards compatibility with pre-electra forks,
-			// post-electra beacon nodes ignore the deprecated committee_index query parameter.
+			// The committee index is kept for backwards compatibility with pre-electra forks.
+			// Per the spec the deprecated committee_index parameter may always be 0 for electra
+			// and later slots, and should be omitted for gloas and later slots.
 			opts := &eth2api.AttestationDataOpts{
 				Slot:           eth2p0.Slot(slot),
 				CommitteeIndex: commIdx,

--- a/core/fetcher/fetcher.go
+++ b/core/fetcher/fetcher.go
@@ -261,6 +261,8 @@ func (f *Fetcher) fetchAttesterDataWithClient(ctx context.Context, slot uint64, 
 		if !ok {
 			var err error
 
+			// The committee index is kept for backwards compatibility with pre-electra forks,
+			// post-electra beacon nodes ignore the deprecated committee_index query parameter.
 			opts := &eth2api.AttestationDataOpts{
 				Slot:           eth2p0.Slot(slot),
 				CommitteeIndex: commIdx,

--- a/core/validatorapi/router.go
+++ b/core/validatorapi/router.go
@@ -545,9 +545,15 @@ func attestationData(p eth2client.AttestationDataProvider) handlerFunc {
 			return nil, nil, err
 		}
 
-		commIdx, err := uintQuery(query, "committee_index")
-		if err != nil {
-			return nil, nil, err
+		// The committee_index parameter is deprecated: post-electra it may always be 0 and
+		// post-gloas spec-compliant validator clients should omit it entirely, so default to 0.
+		var commIdx uint64
+
+		if query.Has("committee_index") {
+			commIdx, err = uintQuery(query, "committee_index")
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 
 		opts := &eth2api.AttestationDataOpts{

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -2622,6 +2622,40 @@ func nest(data any, nests ...string) any {
 }
 
 func TestPayloadAttestationRoutes(t *testing.T) {
+	t.Run("attestation data without deprecated committee_index", func(t *testing.T) {
+		expected := testutil.RandomAttestationDataPhase0()
+		expected.Slot = 42
+
+		handler := testHandler{
+			AttestationDataFunc: func(_ context.Context, opts *eth2api.AttestationDataOpts) (*eth2api.Response[*eth2p0.AttestationData], error) {
+				require.Equal(t, eth2p0.Slot(42), opts.Slot)
+				require.Equal(t, eth2p0.CommitteeIndex(0), opts.CommitteeIndex)
+
+				return wrapResponse(expected), nil
+			},
+		}
+
+		callback := func(ctx context.Context, baseURL string) {
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/eth/v1/validator/attestation_data?slot=42", nil)
+			require.NoError(t, err)
+
+			resp, err := new(http.Client).Do(req)
+			require.NoError(t, err)
+
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var res struct {
+				Data *eth2p0.AttestationData `json:"data"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+			require.Equal(t, expected, res.Data)
+		}
+
+		testRawRouter(t, handler, callback)
+	})
+
 	t.Run("payload_attestation_data", func(t *testing.T) {
 		expected := testutil.RandomPayloadAttestationData()
 		expected.Slot = 42

--- a/core/validatorapi/router_internal_test.go
+++ b/core/validatorapi/router_internal_test.go
@@ -2621,41 +2621,43 @@ func nest(data any, nests ...string) any {
 	return res
 }
 
+// TestAttestationDataRoutes covers the attestation_data endpoint, asserting the deprecated
+// committee_index query parameter may be omitted.
+func TestAttestationDataRoutes(t *testing.T) {
+	expected := testutil.RandomAttestationDataPhase0()
+	expected.Slot = 42
+
+	handler := testHandler{
+		AttestationDataFunc: func(_ context.Context, opts *eth2api.AttestationDataOpts) (*eth2api.Response[*eth2p0.AttestationData], error) {
+			require.Equal(t, eth2p0.Slot(42), opts.Slot)
+			require.Equal(t, eth2p0.CommitteeIndex(0), opts.CommitteeIndex)
+
+			return wrapResponse(expected), nil
+		},
+	}
+
+	callback := func(ctx context.Context, baseURL string) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/eth/v1/validator/attestation_data?slot=42", nil)
+		require.NoError(t, err)
+
+		resp, err := new(http.Client).Do(req)
+		require.NoError(t, err)
+
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var res struct {
+			Data *eth2p0.AttestationData `json:"data"`
+		}
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
+		require.Equal(t, expected, res.Data)
+	}
+
+	testRawRouter(t, handler, callback)
+}
+
 func TestPayloadAttestationRoutes(t *testing.T) {
-	t.Run("attestation data without deprecated committee_index", func(t *testing.T) {
-		expected := testutil.RandomAttestationDataPhase0()
-		expected.Slot = 42
-
-		handler := testHandler{
-			AttestationDataFunc: func(_ context.Context, opts *eth2api.AttestationDataOpts) (*eth2api.Response[*eth2p0.AttestationData], error) {
-				require.Equal(t, eth2p0.Slot(42), opts.Slot)
-				require.Equal(t, eth2p0.CommitteeIndex(0), opts.CommitteeIndex)
-
-				return wrapResponse(expected), nil
-			},
-		}
-
-		callback := func(ctx context.Context, baseURL string) {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/eth/v1/validator/attestation_data?slot=42", nil)
-			require.NoError(t, err)
-
-			resp, err := new(http.Client).Do(req)
-			require.NoError(t, err)
-
-			defer resp.Body.Close()
-
-			require.Equal(t, http.StatusOK, resp.StatusCode)
-
-			var res struct {
-				Data *eth2p0.AttestationData `json:"data"`
-			}
-			require.NoError(t, json.NewDecoder(resp.Body).Decode(&res))
-			require.Equal(t, expected, res.Data)
-		}
-
-		testRawRouter(t, handler, callback)
-	})
-
 	t.Run("payload_attestation_data", func(t *testing.T) {
 		expected := testutil.RandomPayloadAttestationData()
 		expected.Slot = 42

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -318,8 +318,9 @@ func attest(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, slot
 	)
 
 	for commIdx, duties := range dutyByComm {
-		// The committee index is kept for backwards compatibility with pre-electra forks,
-		// post-electra beacon nodes ignore the deprecated committee_index query parameter.
+		// The committee index is kept for backwards compatibility with pre-electra forks.
+		// Per the spec the deprecated committee_index parameter may always be 0 for electra
+		// and later slots, and should be omitted for gloas and later slots.
 		opts := &eth2api.AttestationDataOpts{
 			Slot:           slot,
 			CommitteeIndex: commIdx,

--- a/testutil/validatormock/attest.go
+++ b/testutil/validatormock/attest.go
@@ -318,6 +318,8 @@ func attest(ctx context.Context, eth2Cl eth2wrap.Client, signFunc SignFunc, slot
 	)
 
 	for commIdx, duties := range dutyByComm {
+		// The committee index is kept for backwards compatibility with pre-electra forks,
+		// post-electra beacon nodes ignore the deprecated committee_index query parameter.
 		opts := &eth2api.AttestationDataOpts{
 			Slot:           slot,
 			CommitteeIndex: commIdx,


### PR DESCRIPTION
Make the deprecated `committee_index` query parameter optional on `GET /eth/v1/validator/attestation_data`, defaulting to 0 — post-gloas spec-compliant validator clients omit it and previously got a 400. Charon's own outgoing requests keep setting it for backwards compatibility with pre-electra forks, with comments noting post-electra beacon nodes ignore it.

category: feature
ticket: #4324