### PR TITLE
core/app: fork-aware slot fraction timings

### DIFF
--- a/app/sse/listener.go
+++ b/app/sse/listener.go
@@ -19,6 +19,7 @@ import (
 	"github.com/obolnetwork/charon/app/eth2wrap"
 	"github.com/obolnetwork/charon/app/log"
 	"github.com/obolnetwork/charon/app/z"
+	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/eth2util"
 )
 
@@ -44,9 +45,10 @@ type listener struct {
 	blockGossipTimes map[uint64]map[string]time.Time
 
 	// immutable fields
-	genesisTime   time.Time
-	slotDuration  time.Duration
-	slotsPerEpoch uint64
+	genesisTime    time.Time
+	slotDuration   time.Duration
+	slotsPerEpoch  uint64
+	slotOffsetFunc core.SlotOffsetFunc
 }
 
 var _ Listener = (*listener)(nil)
@@ -64,6 +66,11 @@ func StartListener(ctx context.Context, eth2Cl eth2wrap.Client, addresses, heade
 		return nil, err
 	}
 
+	slotOffsetFunc, err := core.NewSlotOffsetFunc(ctx, eth2Cl)
+	if err != nil {
+		return nil, err
+	}
+
 	l := &listener{
 		chainReorgSubs:   make([]ChainReorgEventHandlerFunc, 0),
 		headSubs:         make([]HeadEventHandlerFunc, 0),
@@ -71,6 +78,7 @@ func StartListener(ctx context.Context, eth2Cl eth2wrap.Client, addresses, heade
 		genesisTime:      genesisTime,
 		slotDuration:     slotDuration,
 		slotsPerEpoch:    slotsPerEpoch,
+		slotOffsetFunc:   slotOffsetFunc,
 	}
 
 	parsedHeaders, err := eth2util.ParseHTTPHeaders(headers)
@@ -232,8 +240,9 @@ func (p *listener) handleBlockGossipEvent(ctx context.Context, event *event, add
 	}
 
 	delay, ok := p.computeDelay(slot, event.Timestamp, func(delay time.Duration) bool {
-		// Beacon node should receive a block via P2P or API between 0/3 and 1/3 of the slot's timeframe.
-		return delay < (p.slotDuration / 3)
+		// Beacon node should receive a block via P2P or API before the attestation due offset,
+		// a third of the slot pre-gloas and a quarter from the gloas fork onwards.
+		return delay < p.attestationOffset(slot)
 	})
 	if !ok {
 		log.Debug(ctx, "Beacon node received block_gossip event too late", z.U64("slot", slot), z.Str("delay", delay.String()))
@@ -265,8 +274,9 @@ func (p *listener) handleBlockEvent(ctx context.Context, event *event, addr stri
 	}
 
 	delay, ok := p.computeDelay(slot, event.Timestamp, func(delay time.Duration) bool {
-		// Beacon node should import a block to its fork-choice between 0/3 and 1/3 of the slot's timeframe.
-		return delay < (p.slotDuration / 3)
+		// Beacon node should import a block to its fork-choice before the attestation due offset,
+		// a third of the slot pre-gloas and a quarter from the gloas fork onwards.
+		return delay < p.attestationOffset(slot)
 	})
 	if !ok {
 		log.Debug(ctx, "Beacon node received block event too late", z.U64("slot", slot), z.Str("delay", delay.String()))
@@ -323,6 +333,12 @@ func parseRoot(hexRoot string) (eth2p0.Root, error) {
 }
 
 // computeDelay computes the delay between start of the slot and receiving the event.
+// attestationOffset returns the intra slot offset at which attestation data is due for the
+// provided slot, before which beacon nodes are expected to have received the slot's block.
+func (p *listener) attestationOffset(slot uint64) time.Duration {
+	return p.slotOffsetFunc(core.Duty{Slot: slot, Type: core.DutyAttester})
+}
+
 func (p *listener) computeDelay(slot uint64, eventTS time.Time, delayOKFunc func(delay time.Duration) bool) (time.Duration, bool) {
 	slotStartTime := p.genesisTime.Add(time.Duration(slot) * p.slotDuration)
 	delay := eventTS.Sub(slotStartTime)

--- a/app/sse/listener.go
+++ b/app/sse/listener.go
@@ -239,11 +239,8 @@ func (p *listener) handleBlockGossipEvent(ctx context.Context, event *event, add
 		return errors.Wrap(err, "parse slot to uint64", z.Str("addr", addr))
 	}
 
-	delay, ok := p.computeDelay(slot, event.Timestamp, func(delay time.Duration) bool {
-		// Beacon node should receive a block via P2P or API before the attestation due offset,
-		// a third of the slot pre-gloas and a quarter from the gloas fork onwards.
-		return delay < p.attestationOffset(slot)
-	})
+	// Beacon node should receive a block via P2P or API before the attestation due offset.
+	delay, ok := p.computeDelay(slot, event.Timestamp, p.blockOnTimeFunc(slot))
 	if !ok {
 		log.Debug(ctx, "Beacon node received block_gossip event too late", z.U64("slot", slot), z.Str("delay", delay.String()))
 	}
@@ -273,11 +270,8 @@ func (p *listener) handleBlockEvent(ctx context.Context, event *event, addr stri
 		return errors.Wrap(err, "parse slot to uint64", z.Str("addr", addr))
 	}
 
-	delay, ok := p.computeDelay(slot, event.Timestamp, func(delay time.Duration) bool {
-		// Beacon node should import a block to its fork-choice before the attestation due offset,
-		// a third of the slot pre-gloas and a quarter from the gloas fork onwards.
-		return delay < p.attestationOffset(slot)
-	})
+	// Beacon node should import a block to its fork-choice before the attestation due offset.
+	delay, ok := p.computeDelay(slot, event.Timestamp, p.blockOnTimeFunc(slot))
 	if !ok {
 		log.Debug(ctx, "Beacon node received block event too late", z.U64("slot", slot), z.Str("delay", delay.String()))
 	}
@@ -335,8 +329,17 @@ func parseRoot(hexRoot string) (eth2p0.Root, error) {
 // computeDelay computes the delay between start of the slot and receiving the event.
 // attestationOffset returns the intra slot offset at which attestation data is due for the
 // provided slot, before which beacon nodes are expected to have received the slot's block.
+// It is a third of the slot pre-gloas and a quarter from the gloas fork onwards.
 func (p *listener) attestationOffset(slot uint64) time.Duration {
 	return p.slotOffsetFunc(core.Duty{Slot: slot, Type: core.DutyAttester})
+}
+
+// blockOnTimeFunc returns a function reporting whether a block related delay is
+// within the attestation due offset of the provided slot.
+func (p *listener) blockOnTimeFunc(slot uint64) func(time.Duration) bool {
+	return func(delay time.Duration) bool {
+		return delay < p.attestationOffset(slot)
+	}
 }
 
 func (p *listener) computeDelay(slot uint64, eventTS time.Time, delayOKFunc func(delay time.Duration) bool) (time.Duration, bool) {

--- a/app/sse/listener_internal_test.go
+++ b/app/sse/listener_internal_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/obolnetwork/charon/app/errors"
+	"github.com/obolnetwork/charon/app/eth2wrap"
+	"github.com/obolnetwork/charon/core"
 	"github.com/obolnetwork/charon/testutil/beaconmock"
 )
 
@@ -120,6 +122,7 @@ func TestHandleEvents(t *testing.T) {
 				slotDuration:   12 * time.Second,
 				slotsPerEpoch:  32,
 				genesisTime:    time.Date(2020, 12, 1, 12, 0, 23, 0, time.UTC),
+				slotOffsetFunc: func(core.Duty) time.Duration { return 4 * time.Second },
 			}
 
 			err := l.eventHandler(t.Context(), test.event, "test")
@@ -182,6 +185,28 @@ func TestSubscribeNotifyHeadEvent(t *testing.T) {
 	require.Equal(t, eth2p0.Slot(100), reportedSlots[0])
 	require.Equal(t, eth2p0.Slot(100), reportedSlots[1])
 	require.Equal(t, eth2p0.Slot(101), reportedSlots[2])
+}
+
+func TestAttestationOffset(t *testing.T) {
+	// Schedule gloas at epoch 2, so with 16 slots per epoch the threshold migrates at slot 32.
+	bmock, err := beaconmock.New(t.Context(),
+		beaconmock.WithSlotsPerEpoch(16),
+		beaconmock.WithSpecOverride("GLOAS_FORK_VERSION", "0x07000000"),
+		beaconmock.WithSpecOverride("GLOAS_FORK_EPOCH", "2"),
+	)
+	require.NoError(t, err)
+
+	slotOffsetFunc, err := core.NewSlotOffsetFunc(t.Context(), bmock)
+	require.NoError(t, err)
+
+	slotDuration, _, err := eth2wrap.FetchSlotsConfig(t.Context(), bmock)
+	require.NoError(t, err)
+
+	l := &listener{slotOffsetFunc: slotOffsetFunc}
+
+	// A third of the slot pre-gloas, a quarter from the fork onwards.
+	require.Equal(t, slotDuration/3, l.attestationOffset(31))
+	require.Equal(t, slotDuration/4, l.attestationOffset(32))
 }
 
 func TestComputeDelay(t *testing.T) {

--- a/app/sse/metrics.go
+++ b/app/sse/metrics.go
@@ -20,8 +20,8 @@ var (
 		Namespace: "app",
 		Subsystem: "beacon_node",
 		Name:      "sse_head_delay",
-		Help:      "Delay in seconds between slot start and head update, supplied by beacon node's SSE endpoint. Values between 8s and 12s for Ethereum mainnet are considered safe.",
-		Buckets:   []float64{2, 4, 6, 8, 10, 12},
+		Help:      "Delay in seconds between slot start and head update, supplied by beacon node's SSE endpoint. Values up to the end of the slot (12s for Ethereum mainnet) are considered safe.",
+		Buckets:   []float64{1, 2, 3, 4, 5, 6, 8, 9, 10, 12},
 	}, []string{"addr"})
 
 	sseChainReorgDepthHistogram = promauto.NewHistogramVec(prometheus.HistogramOpts{
@@ -36,7 +36,7 @@ var (
 		Namespace: "app",
 		Subsystem: "beacon_node",
 		Name:      "sse_block_gossip",
-		Help:      "Block reception via gossip delay, supplied by beacon node's SSE endpoint. Values between 0s and 4s for Ethereum mainnet are considered safe",
+		Help:      "Block reception via gossip delay, supplied by beacon node's SSE endpoint. Values below the attestation due offset (4s pre-gloas, 3s post-gloas for Ethereum mainnet) are considered safe",
 		Buckets:   []float64{0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 6, 8, 10, 12},
 	}, []string{"addr"})
 
@@ -44,7 +44,7 @@ var (
 		Namespace: "app",
 		Subsystem: "beacon_node",
 		Name:      "sse_block",
-		Help:      "Block imported into fork choice delay, supplied by beacon node's SSE endpoint. Values between 0s and 4s for Ethereum mainnet are considered safe",
+		Help:      "Block imported into fork choice delay, supplied by beacon node's SSE endpoint. Values below the attestation due offset (4s pre-gloas, 3s post-gloas for Ethereum mainnet) are considered safe",
 		Buckets:   []float64{0.5, 1, 1.5, 2, 2.5, 3, 3.5, 4, 4.5, 5, 6, 8, 10, 12},
 	}, []string{"addr"})
 

--- a/core/deadline.go
+++ b/core/deadline.go
@@ -98,6 +98,13 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 		return nil, err
 	}
 
+	timing, err := eth2wrap.FetchSlotTimingConfig(ctx, eth2Cl)
+	if err != nil {
+		return nil, err
+	}
+
+	slotOffset := newSlotOffsetFunc(slotDuration, slotsPerEpoch, timing)
+
 	return func(duty Duty) (time.Time, bool) {
 		switch duty.Type {
 		case DutyExit, DutyBuilderRegistration:
@@ -115,7 +122,9 @@ func NewDutyDeadlineFunc(ctx context.Context, eth2Cl eth2wrap.Client) (DeadlineF
 		//nolint: revive // prioritise clarity
 		switch duty.Type {
 		case DutyProposer, DutyRandao:
-			duration = slotDuration / 3
+			// A proposal's useful life ends once attesters vote at the attestation due offset,
+			// a third of the slot pre-gloas and a quarter from the gloas fork onwards.
+			duration = slotOffset(Duty{Slot: duty.Slot, Type: DutyAttester})
 		case DutySyncMessage, DutySyncContribution:
 			duration = slotDuration
 		case DutyAttester, DutyAggregator:

--- a/core/deadline_test.go
+++ b/core/deadline_test.go
@@ -197,6 +197,24 @@ func TestNewDutyDeadlineFunc(t *testing.T) {
 			require.Equal(t, time.Millisecond, end.Sub(now))
 		})
 	}
+
+	t.Run("proposer and randao deadline post gloas", func(t *testing.T) {
+		gloasBmock, err := beaconmock.New(t.Context(),
+			beaconmock.WithSpecOverride("GLOAS_FORK_VERSION", "0x07000000"),
+			beaconmock.WithSpecOverride("GLOAS_FORK_EPOCH", "0"),
+		)
+		require.NoError(t, err)
+
+		gloasDeadlineFunc, err := core.NewDutyDeadlineFunc(t.Context(), gloasBmock)
+		require.NoError(t, err)
+
+		// The proposal deadline follows the attestation due offset, a quarter of the slot post-gloas.
+		for _, duty := range []core.Duty{core.NewProposerDuty(currentSlot), core.NewRandaoDuty(currentSlot)} {
+			end, ok := gloasDeadlineFunc(duty)
+			require.True(t, ok)
+			require.Equal(t, now.Add(slotDuration/4+margin), end)
+		}
+	})
 }
 
 // addDuties runs a goroutine which adds the duties to the deadliner channel.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,11 +14,11 @@ when storing metrics from multiple nodes or clusters in one Prometheus instance.
 | Name | Type | Help | Labels |
 |---|---|---|---|
 | `app_beacon_node_peers` | Gauge | Gauge set to the peer count of the upstream beacon node |  |
-| `app_beacon_node_sse_block` | Histogram | Block imported into fork choice delay, supplied by beacon node`s SSE endpoint. Values between 0s and 4s for Ethereum mainnet are considered safe | `addr` |
-| `app_beacon_node_sse_block_gossip` | Histogram | Block reception via gossip delay, supplied by beacon node`s SSE endpoint. Values between 0s and 4s for Ethereum mainnet are considered safe | `addr` |
+| `app_beacon_node_sse_block` | Histogram | Block imported into fork choice delay, supplied by beacon node`s SSE endpoint. Values below the attestation due offset (4s pre-gloas, 3s post-gloas for Ethereum mainnet) are considered safe | `addr` |
+| `app_beacon_node_sse_block_gossip` | Histogram | Block reception via gossip delay, supplied by beacon node`s SSE endpoint. Values below the attestation due offset (4s pre-gloas, 3s post-gloas for Ethereum mainnet) are considered safe | `addr` |
 | `app_beacon_node_sse_block_processing_time` | Histogram | Time in seconds between block gossip and head events, indicating block processing time. Lower values indicate better CPU/disk/RAM performance. | `addr` |
 | `app_beacon_node_sse_chain_reorg_depth` | Histogram | Chain reorg depth, supplied by beacon node`s SSE endpoint | `addr` |
-| `app_beacon_node_sse_head_delay` | Histogram | Delay in seconds between slot start and head update, supplied by beacon node`s SSE endpoint. Values between 8s and 12s for Ethereum mainnet are considered safe. | `addr` |
+| `app_beacon_node_sse_head_delay` | Histogram | Delay in seconds between slot start and head update, supplied by beacon node`s SSE endpoint. Values up to the end of the slot (12s for Ethereum mainnet) are considered safe. | `addr` |
 | `app_beacon_node_sse_head_slot` | Gauge | Current beacon node head slot, supplied by beacon node`s SSE endpoint | `addr` |
 | `app_beacon_node_version` | Gauge | Constant gauge with labels set to the version and beacon_id of the upstream beacon node | `version, beacon_id` |
 | `app_cache_hits_total` | Counter | Total number of times the cache was used | `endpoint` |


### PR DESCRIPTION
Make the remaining thirds-based intra-slot timings fork-aware for the gloas quarter-slot schedule: the proposer/randao duty deadline now follows the attestation due offset (4s pre-gloas, 3s post) via `newSlotOffsetFunc`, and the SSE block/block-gossip lateness thresholds resolve the same offset per slot instead of a hardcoded `slotDuration/3`. Also refit `sse_head_delay` histogram buckets with quarter-slot boundaries (3s/9s, keeping 4s so existing dashboard queries are unaffected) and reword the thirds-era metric help texts.

category: feature
ticket: #4324