### PR TITLE
app/eth1wrap: avoid startup hang

### DIFF
--- a/app/eth1wrap/eth1wrap_internal_test.go
+++ b/app/eth1wrap/eth1wrap_internal_test.go
@@ -5,6 +5,8 @@ package eth1wrap
 import (
 	"context"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -167,4 +169,79 @@ func TestNoopClientCreation(t *testing.T) {
 
 	require.NotNil(t, client, "Client should be created")
 	require.IsType(t, noopClient{}, client, "Client should be a noopClient")
+}
+
+// TestMaybeReconnectBlocksWhenFull documents that maybeReconnect does a
+// blocking send on a buffer-1 channel. Callers that hold cl.Mutex across this
+// send (ClientVersion, VerifySmartContractBasedSignature) can deadlock when
+// Run is not draining reconnectCh — e.g. hung BlockNumber against a silent EL.
+// See https://github.com/ObolNetwork/charon/issues/4689
+func TestMaybeReconnectBlocksWhenFull(t *testing.T) {
+	cl := &client{reconnectCh: make(chan struct{}, 1)}
+	cl.maybeReconnect()
+	require.Len(t, cl.reconnectCh, 1)
+
+	done := make(chan struct{})
+	go func() {
+		cl.maybeReconnect()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("maybeReconnect should block when reconnectCh is full")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: blocked on channel send.
+	}
+
+	<-cl.reconnectCh // unblock the goroutine
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("maybeReconnect did not unblock after drain")
+	}
+}
+
+// TestClientVersionDeadlocksOnFullReconnectCh reproduces charon#4689:
+// ClientVersion holds the mutex across CallContext and maybeReconnect.
+// With a full reconnectCh and a silent/hanging EL RPC, ClientVersion never
+// returns even after its context times out — wedging WaitConnected / startup.
+//
+// Expected healthy behavior: return once ctx is done. Current code hangs.
+func TestClientVersionDeadlocksOnFullReconnectCh(t *testing.T) {
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	srv.Start()
+
+	ethCl, err := ethclient.Dial(srv.URL)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		ethCl.Close()
+		srv.CloseClientConnections()
+		go srv.Close()
+	})
+
+	cl := &client{
+		eth1client:  ethCl,
+		reconnectCh: make(chan struct{}, 1),
+	}
+	cl.reconnectCh <- struct{}{} // already full (Run stuck / prior failures)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = cl.ClientVersion(ctx)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		// Fixed: ClientVersion respects ctx and does not block forever on reconnect.
+	case <-time.After(2 * time.Second):
+		t.Fatal("ClientVersion hung after RPC ctx timeout with full reconnectCh (charon#4689)")
+	}
 }

--- a/app/eth1wrap/eth1wrap_internal_test.go
+++ b/app/eth1wrap/eth1wrap_internal_test.go
@@ -171,12 +171,9 @@ func TestNoopClientCreation(t *testing.T) {
 	require.IsType(t, noopClient{}, client, "Client should be a noopClient")
 }
 
-// TestMaybeReconnectBlocksWhenFull documents that maybeReconnect does a
-// blocking send on a buffer-1 channel. Callers that hold cl.Mutex across this
-// send (ClientVersion, VerifySmartContractBasedSignature) can deadlock when
-// Run is not draining reconnectCh — e.g. hung BlockNumber against a silent EL.
-// See https://github.com/ObolNetwork/charon/issues/4689
-func TestMaybeReconnectBlocksWhenFull(t *testing.T) {
+// TestMaybeReconnectNonBlockingWhenFull ensures maybeReconnect does not block
+// when reconnectCh is already full (charon#4689).
+func TestMaybeReconnectNonBlockingWhenFull(t *testing.T) {
 	cl := &client{reconnectCh: make(chan struct{}, 1)}
 	cl.maybeReconnect()
 	require.Len(t, cl.reconnectCh, 1)
@@ -189,16 +186,9 @@ func TestMaybeReconnectBlocksWhenFull(t *testing.T) {
 
 	select {
 	case <-done:
-		t.Fatal("maybeReconnect should block when reconnectCh is full")
+		// Expected: non-blocking drop when already signaled.
 	case <-time.After(200 * time.Millisecond):
-		// Expected: blocked on channel send.
-	}
-
-	<-cl.reconnectCh // unblock the goroutine
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("maybeReconnect did not unblock after drain")
+		t.Fatal("maybeReconnect blocked when reconnectCh is full")
 	}
 }
 

--- a/app/eth1wrap/runner.go
+++ b/app/eth1wrap/runner.go
@@ -153,13 +153,14 @@ func (cl *client) Run(ctx context.Context) {
 // VerifySmartContractBasedSignature returns true if sig is a valid signature of hash according to ERC-1271.
 func (cl *client) VerifySmartContractBasedSignature(contractAddress string, hash [32]byte, sig []byte) (bool, error) {
 	cl.Lock()
-	defer cl.Unlock()
+	eth1client := cl.eth1client
+	cl.Unlock()
 
-	if cl.eth1client == nil {
+	if eth1client == nil {
 		return false, ErrEthClientNotConnected
 	}
 
-	erc1271, err := cl.erc1271FactoryFn(contractAddress, cl.eth1client)
+	erc1271, err := cl.erc1271FactoryFn(contractAddress, eth1client)
 	if err != nil {
 		cl.maybeReconnect()
 		return false, err
@@ -189,15 +190,18 @@ func (noopClient) ClientVersion(_ context.Context) (string, error) {
 
 // ClientVersion returns the execution engine client version string via web3_clientVersion RPC.
 func (cl *client) ClientVersion(ctx context.Context) (string, error) {
+	// Do not hold the mutex across the RPC call or maybeReconnect: a hanging EL
+	// otherwise deadlocks WaitConnected / startup (charon#4689).
 	cl.Lock()
-	defer cl.Unlock()
+	eth1client := cl.eth1client
+	cl.Unlock()
 
-	if cl.eth1client == nil {
+	if eth1client == nil {
 		return "", ErrEthClientNotConnected
 	}
 
 	var ver string
-	if err := cl.eth1client.Client().CallContext(ctx, &ver, "web3_clientVersion"); err != nil {
+	if err := eth1client.Client().CallContext(ctx, &ver, "web3_clientVersion"); err != nil {
 		cl.maybeReconnect()
 		return "", errors.Wrap(err, "get execution layer client version")
 	}
@@ -205,17 +209,29 @@ func (cl *client) ClientVersion(ctx context.Context) (string, error) {
 	return ver, nil
 }
 
+// maybeReconnect signals Run to reconnect. Non-blocking so callers never hang
+// when reconnectCh is already full (e.g. Run stuck on a silent EL).
 func (cl *client) maybeReconnect() {
-	cl.reconnectCh <- struct{}{}
+	select {
+	case cl.reconnectCh <- struct{}{}:
+	default:
+	}
 }
 
 func (cl *client) checkClientIsAlive(ctx context.Context) bool {
-	if cl.eth1client == nil {
+	cl.Lock()
+	eth1client := cl.eth1client
+	cl.Unlock()
+
+	if eth1client == nil {
 		return false
 	}
 
-	// Simple lightweight check if RPC is alive
-	if _, err := cl.eth1client.BlockNumber(ctx); err != nil {
+	// Bound the probe so a silent EL cannot wedge the Run loop forever.
+	ctx, cancel := context.WithTimeout(ctx, defaultConnectTimeout)
+	defer cancel()
+
+	if _, err := eth1client.BlockNumber(ctx); err != nil {
 		return false
 	}
 


### PR DESCRIPTION
Avoid eth1wrap startup deadlock when the execution client accepts connections but never answers JSON-RPC.

Make reconnect signaling non-blocking and do not hold the client mutex across RPC calls, so WaitConnected can time out instead of wedging the process. Also bound the Run-loop liveness probe. Adds regression tests for the ClientVersion hang and non-blocking reconnect signal.

category: bug
ticket: #4689